### PR TITLE
fix(activate): 첫 claude 팀원 tmux_session 유실 — 봇 살아있는데 대시보드 offline

### DIFF
--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1619,11 +1619,18 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
         if (t && !t.hermes_profile) { t.hermes_profile = agent.id; writeAgents(list); }
       } catch { /* best-effort */ }
     }
-    // claude_channel 활성화 성공 → tmux_session(claude-<id>) 레지스트리 기록. 봇 세션은 claude-<id> 관례로
+    // claude_channel → tmux_session(claude-<id>) 레지스트리 기록. 봇 세션은 claude-<id> 관례로
     //   뜨지만 recruit는 이 필드를 null로 남긴다. statusProbe(null이면 즉시 offline 판정)·wakeDispatcher(null이면
     //   no_tmux_session_for 로 버스 주입 실패) 둘 다 이 필드를 보므로, activate가 안 채우면 봇이 살아있어도
     //   빨강+라우팅 불통이 된다(OWNER 맥북 클린설치서 발견 2026-07-03). hermes_profile 패턴과 동형.
-    if (result.ok && agent.runtime === "claude_channel") {
+    // ★게이트는 result.ok 가 아니라 "runtime 단계 성공"으로 한다★ — 첫 claude 팀원은 activate 가 access.json 을
+    //   pairing(빈 allowFrom)으로 재시드하므로 essentials 단계가 실패해 result.ok=false 가 되지만, 이는 사람이
+    //   아직 DM 페어링을 승인하지 않은 정상 대기 상태일 뿐 봇 tmux 세션은 이미 결정적 이름 claude-<id> 로 떠 있다.
+    //   result.ok 로 게이팅하면 첫 팀원은 이 블록을 통째로 놓쳐 봇이 살아 응답해도 대시보드 빨강+라우팅 불통이 된다.
+    //   runtime 단계 성공 = 세션 기동 확인 이므로 페어링 게이트와 무관하게 필드를 채운다.
+    const claudeRuntimeUp = agent.runtime === "claude_channel"
+      && result.steps.some((s) => s.step === "runtime" && s.ok);
+    if (claudeRuntimeUp) {
       try {
         const list = readAgents();
         const t = list.find((a) => a.id === agent.id);


### PR DESCRIPTION
## 요약

첫 `claude_channel` 팀원이 **봇은 살아서 정상 응답하는데도 대시보드에 offline(빨강)** 으로 뜨고, 그룹 라우팅(wakeDispatcher)이 `no_tmux_session_for` 로 실패하는 문제를 수정합니다.

## 증상 (실제 재현)

깨끗한 macOS 에 b3os 스킬로 신규 설치 → 첫 팀원(claude_channel) 영입 → activate → 텔레그램 DM 페어링 승인까지 정상 진행. 봇은 tmux 세션 `claude-lisa` 에서 실제로 메시지를 받고 응답함. 그런데:

- 대시보드: `Lisa offline` (빨강), Live 패널 `로그 없음 — tmux 세션 확인`, 최근 활동 `—`
- `GET /team/api/agents` → `tmux_session: null`, `status.state: "offline"`, `tmux_pid: null`
- `agents.json` / `team.db` 의 agent 행에 `tmux_session` 필드가 **누락**

## 원인

`src/server/routes/settings.ts` 의 activate 핸들러에서 claude 의 `tmux_session`(= `claude-<id>`)을 레지스트리에 기록하는 블록이 **`result.ok` 로 게이팅**돼 있었습니다.

```ts
if (result.ok && agent.runtime === "claude_channel") { ... t.tmux_session = sess ... }
```

`result.ok` = `doActivateMember` 의 `steps.every(s => s.ok)` 입니다. 그런데 **첫 claude 팀원**은:

1. activate 가 `launcher.ts` 에서 access.json 을 `{ dmPolicy: "pairing", allowFrom: [] }` 로 재시드 (승계할 기존 claude 멤버가 없으므로 정상 동작)
2. `checkEssentialSettings` 의 claude 체크가 `allowFrom` 비어있음을 **essentials 실패**로 판정 (`runtimeEssentials.ts` `hasJsonArrayKey(access.json, "allowFrom")`)
3. → `result.ok = false` → **`tmux_session` 기록 블록 통째로 스킵**

하지만 `allowFrom` 이 빈 것은 **사람이 아직 DM 6자리 페어링을 승인하지 않은 정상 대기 상태**일 뿐이고, 봇 tmux 세션(`runtime` 단계 `ok:true`, `poller` 단계 `bot.pid` 확인)은 이미 결정적 이름 `claude-<id>` 로 떠 있습니다.

즉 **"페어링 대기(정상)"가 "활성화 실패"로 취급되어, 살아있는 세션의 식별자 기록을 막는** 것이 근본 원인입니다. 코드 주석(1622–1625)이 이 증상("빨강+라우팅 불통", OWNER 맥북 클린설치서 발견 2026-07-03)을 이미 문서화해 두었으나, 가드 조건이 여전히 첫-팀원 케이스를 놓치고 있었습니다.

## 수정

`tmux_session` 기록 게이트를 `result.ok` → **"runtime 단계 성공"** 으로 변경. `runtime` 단계 `ok` = 봇 tmux 세션 기동 확인이므로, 페어링 essentials 게이트와 무관하게 결정적 이름을 채웁니다.

```ts
const claudeRuntimeUp = agent.runtime === "claude_channel"
  && result.steps.some((s) => s.step === "runtime" && s.ok);
if (claudeRuntimeUp) { ... t.tmux_session = `claude-${agent.id}` ... }
```

- 세션 이름이 결정적(`claude-<id>`)이라 안전 — `launcher.ts:273`, `agentControl.ts:98/195` 등 전역에서 같은 관례 사용.
- 2번째+ 팀원(allowlist 승계로 essentials 바로 통과)에는 영향 없음 — runtime 단계는 어차피 성공하므로 동작 동일.
- `hermes_profile` 을 쓰는 바로 위 블록과 동형이되, claude 만 첫-팀원 페어링 게이트가 있으므로 claude 게이트만 완화.

## 검증

- `tsc --noEmit` 통과.
- 수정 전: 첫 팀원 `tmux_session: null` → offline.
- 로컬 핫픽스로 `agents.json` 에 `tmux_session: "claude-lisa"` 를 넣고 서버 재기동하니 즉시 `state: "running"`, `tmux_pid` 확인, 대시보드 green — 이 필드 하나가 원인임을 확인. 본 PR 은 그 필드가 activate 때 자동으로 채워지도록 근본 수정.

## 참고 (후속 논의거리 — 이 PR 범위 밖)

`checkEssentialSettings` 가 첫 claude 팀원의 "빈 allowFrom(페어링 대기)"을 essentials 실패로 보아 `result.ok=false` 를 만드는 것 자체는 그대로 둡니다(활성화 응답이 여전히 `ok:false` 로 뜸). 이게 의도인지(= 페어링 전엔 미완료로 표기) 아니면 첫-팀원 페어링 대기를 별도 상태로 구분할지는 별도 판단이 필요해 보입니다. 본 PR 은 "살아있는 세션의 식별자 유실"이라는 명확한 버그만 최소 수정합니다.
