### PR TITLE
fix(op): claude-only 팀 @all/승인 콜백 '권한 없음' — approvalAllowedIds owner_chat_id 폴백

### DIFF
--- a/src/server/workers/telegramCapture.ts
+++ b/src/server/workers/telegramCapture.ts
@@ -442,12 +442,25 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
   // 승인 탭 인가: env allowlist + Settings 자동감지 lead_telegram_id(setting) 둘 다 허용.
   const APPROVAL_ALLOW = (process.env.APPROVAL_ALLOWED_USER_IDS ?? "").split(",").map((s) => s.trim()).filter(Boolean);
   function approvalAllowedIds(): string[] {
-    let detected: string | null = null;
-    try {
-      const row = deps.db.prepare("SELECT value FROM setting WHERE key = 'lead_telegram_id'").get() as { value: string } | undefined;
-      detected = row?.value?.trim() ?? null;
-    } catch { /* best-effort */ }
-    return [...new Set([...APPROVAL_ALLOW, ...(detected ? [detected] : [])])];
+    const readSetting = (key: string): string | null => {
+      try {
+        const row = deps.db.prepare("SELECT value FROM setting WHERE key = ?").get(key) as { value: string } | undefined;
+        const v = row?.value?.trim();
+        return v && v.length ? v : null;
+      } catch { return null; }
+    };
+    const ids = [...APPROVAL_ALLOW];
+    const lead = readSetting("lead_telegram_id");
+    if (lead) ids.push(lead);
+    // 폴백: lead_telegram_id 미설정이어도 owner_chat_id(=팀장 텔레그램 user id, claude 페어링/설정에서 채워짐)로
+    //   op 승인·@all 콜백 인가. ★claude-only 팀은 detect-lead-id 를 돌리기 전까지 lead_telegram_id 가 비어
+    //   approvalAllowedIds()=[] → 모든 @all·승인 콜백이 fail-closed 로 "권한 없음" 막힘(owner_chat_id 는 이미
+    //   채워져 있는데 인가에 안 쓰였다). owner_chat_id 는 같은 팀장 텔레그램 id 라 안전한 폴백이고, 빈 값이면
+    //   아무것도 안 더해 fail-closed 불변식(empty=deny-all)은 유지된다. 음수 그룹 chat_id 는 콜백 from.id(양수
+    //   user id)와 일치할 수 없으니 오인가 방지로 숫자 user id 만 받는다.★
+    const owner = readSetting("owner_chat_id");
+    if (owner && /^\d+$/.test(owner)) ids.push(owner);
+    return [...new Set(ids)];
   }
   async function tg(method: string, payload: Record<string, unknown>): Promise<any> {
     try {


### PR DESCRIPTION
## 요약

**claude-only 팀에서 op 봇의 `@all` 전체전송 확인·민감 실행 승인 버튼을 팀장이 눌러도 "권한 없음(Not authorized)"** 으로 막히는 문제를 수정합니다. `approvalAllowedIds()` 가 `lead_telegram_id` 만 보고 이미 채워진 `owner_chat_id` 를 인가 폴백으로 쓰지 않던 것이 원인입니다.

## 증상 (실제 재현)

깨끗한 macOS 에 b3os 신규 설치 → claude 팀원 2명 영입 → 팀방(System OP) 셋업 → 라우터 ON 까지 정상. 그룹에서 `@all 이건 다 들려?` 입력 시 op 봇이 정상적으로 `⚠️ 전체(@all) 메시지예요 — 팀원 2명에게 보낼까요? [✅전송][❌취소]` 확인 버튼을 띄움. 그런데 **팀장(그룹 소유자)이 [✅전송]을 누르면 텔레그램 네이티브 알림으로 "권한 없음"** 이 뜨고 전송이 거부됨. (민감 실행 승인 `apv:`/`rej:` 버튼도 동일.)

## 원인

`src/server/workers/telegramCapture.ts` 의 콜백 인가 `isAuthorized()` 는 fail-closed 설계로, 누른 사람 `from.id` 가 `approvalAllowedIds()` 에 있어야 통과합니다(2026-07-02, 빈 목록=all-allow fail-open 갭을 막기 위해 도입 — 올바른 방향).

문제는 `approvalAllowedIds()` 의 소스가 **`APPROVAL_ALLOWED_USER_IDS`(env) + `lead_telegram_id`(setting)** 둘뿐이라는 점입니다:

```ts
function approvalAllowedIds(): string[] {
  const row = deps.db.prepare("SELECT value FROM setting WHERE key = 'lead_telegram_id'").get() ...
  return [...new Set([...APPROVAL_ALLOW, ...(detected ? [detected] : [])])];
}
```

- **claude_channel 런타임은 `lead_telegram_id` 를 자동으로 채우지 않습니다.** claude 는 봇 DM 접근을 `owner_chat_id` / `access.json` 페어링 경로로 관리하며, `lead_telegram_id` 는 `POST /system-op/detect-lead-id`(수동/대시보드) 를 돌려야 채워집니다.
- 그래서 claude-only 팀은 팀방 셋업 직후 `APPROVAL_ALLOW`(env 미설정) + `lead_telegram_id`(미설정) = **빈 배열** → `isAuthorized()` 가 팀장 본인조차 거부 → 모든 op 승인/@all 콜백이 "권한 없음".
- 정작 **`owner_chat_id` 는 이미 팀장 텔레그램 user id 로 채워져 있는데**(설정 또는 claude 첫 페어링에서 도출→persist) 인가에 쓰이지 않았습니다. `lead_telegram_id` 와 `owner_chat_id` 는 사실상 같은 값(팀장 텔레그램 user id)입니다.

## 수정

`lead_telegram_id` 가 비었을 때 `owner_chat_id` 를 **폴백 인가 id** 로 추가합니다.

```ts
const ids = [...APPROVAL_ALLOW];
const lead = readSetting("lead_telegram_id");
if (lead) ids.push(lead);
const owner = readSetting("owner_chat_id");
if (owner && /^\d+$/.test(owner)) ids.push(owner);   // 숫자 user id 만
return [...new Set(ids)];
```

**fail-closed 불변식 유지 확인:**
- `owner_chat_id` 가 비면 아무것도 안 더함 → `empty=deny-all` 그대로. "그룹 2번째 사람이 restart/deploy" 갭 재발 없음.
- 폴백 대상은 팀장 본인 텔레그램 id 하나뿐 — 권한 확대 아님(원래 인가돼야 할 사람).
- 그룹 chat_id(음수)는 콜백 `from.id`(양수 user id)와 절대 일치하지 않으므로, 오인가 방지로 `^\d+$`(선행 `-` 없는 숫자 user id)만 폴백으로 받음.

## 검증

- `tsc --noEmit` 통과.
- 재현: claude-only 팀에서 `@all` → [✅전송] → "권한 없음".
- 로컬에서 `POST /system-op/detect-lead-id` 로 `lead_telegram_id` 를 채우니 즉시 통과 → `approvalAllowedIds()` 가 비어서 막힌 것임을 확인. 본 PR 은 `detect-lead-id` 를 수동으로 안 돌려도 `owner_chat_id` 로 처음부터 인가되게 하는 근본 수정.

## 참고 (동일 계열)

이건 #7(첫 claude 팀원 `tmux_session` 유실)과 같은 **"claude-only 첫 설치에서 owner/lead 식별자 연결 누락"** 계열입니다. b3os 온보딩이 팀방 셋업 시 `lead_telegram_id` 를 자동으로 잡아주게 하는 흐름(예: `detect-group` 성공 직후 `detect-lead-id` 도 함께 시도)도 별도로 고려할 만합니다 — 이 PR 범위 밖.
