### PR TITLE
fix(proposals): 승인/반려 버튼 무반응 — dataset 속성명 불일치 수정

### DIFF
--- a/src/web/components/ProposalsView.ts
+++ b/src/web/components/ProposalsView.ts
@@ -556,7 +556,7 @@ export function renderProposalsView(root: HTMLElement): void {
     root.querySelectorAll<HTMLButtonElement>("[data-owner-decision]").forEach((b) =>
       b.addEventListener("click", () => {
         if (!detail) return;
-        const to = b.dataset.gdDecision;
+        const to = b.dataset.ownerDecision;
         if (!to) return;
         const label = to === "accepted" ? pick("승인", "Approve") : to === "rejected" ? pick("반려", "Reject") : pick("수정요청", "Revise");
         const comment = window.prompt(pick(`${label} 사유/코멘트를 입력하세요.`, `Enter a reason/comment for ${label}.`), "");


### PR DESCRIPTION
## 문제
대시보드 Proposals 화면에서 팀장이 **승인/반려** 버튼을 눌러도 아무 반응이 없음(사유 입력 prompt 조차 안 뜸).

## 근본 원인
`src/web/components/ProposalsView.ts` — 버튼은 `data-owner-decision`(=`dataset.ownerDecision`)으로 정의(229–230행)돼 있는데, 클릭 핸들러는 값을 `b.dataset.gdDecision`(=`data-gd-decision`)으로 읽음(559행). 존재하지 않는 속성이라 항상 `undefined` → 바로 다음 줄 `if (!to) return;` 에서 즉시 리턴 → prompt·fetch 없이 완전 무반응.

## 수정
```diff
- const to = b.dataset.gdDecision;
+ const to = b.dataset.ownerDecision;
```
1줄 변경 (`ProposalsView.ts:559`).

## 검증
- `tsc --noEmit` 통과 (에러 0)
- `vite build` 성공 (352 modules, built in ~0.9s)
- 백엔드 `POST /api/proposals/:id/transition` 은 정상 확인: 코멘트 없이 호출 시 409(`결정에는 실행 지시 코멘트 필수`) 가드, 코멘트 포함 시 전이. 즉 버튼→핸들러 연결만 끊긴 상태였음.

## 리스크
저위험 — 프론트 한 줄, 로직/백엔드 변경 없음. 반영 후 대시보드 재빌드 필요.