### PR TITLE
feat(claude): 팀원 tmux 기동에 --permission-mode auto (헤드리스 자율)

### DIFF
--- a/src/server/runtimes/claude/start-telegram-channel.sh
+++ b/src/server/runtimes/claude/start-telegram-channel.sh
@@ -172,17 +172,29 @@ fi
 
 # ─── Spawn ────────────────────────────────────────────────────────────────
 
+# 권한 모드 — 봇 tmux 세션엔 사람이 붙어있지 않아 권한 프롬프트에 답할 수 없다.
+# 그래서 auto(분류기가 안전한 bash 는 자동 승인, 위험·유출·force-push 는 차단)로 기동한다.
+# ★CLI 플래그라 유저/프로젝트 settings.json 과 무관하게 확실히 적용★ — 프로젝트 스코프의
+# permissions.defaultMode:"auto" 는 Claude Code v2.1.142+ 에서 무시되므로 settings 로는 못 켠다.
+# env override: CLAUDE_PERMISSION_MODE=default(사람 승인)·acceptEdits·bypassPermissions 등.
+# 빈 문자열이면 플래그를 생략(멤버 settings.json 에 위임). fresh·resume(리스타트) 양쪽 다 적용.
+CLAUDE_PERMISSION_MODE="${CLAUDE_PERMISSION_MODE-auto}"
+PERM_FLAG=""
+if [[ -n "$CLAUDE_PERMISSION_MODE" ]]; then
+  PERM_FLAG=$(printf ' --permission-mode %q' "$CLAUDE_PERMISSION_MODE")
+fi
+
 # Quote-safe inline command for tmux: use printf %q on paths.
 # TELEGRAM_STATE_DIR tells the channels plugin which state dir to use.
 # --resume 시 --continue 추가 (working dir 의 마지막 세션 이어서)
 if [[ $RESUME_FLAG -eq 1 ]]; then
-  INNER_CMD=$(printf 'TELEGRAM_STATE_DIR=%q %q --channels plugin:%s --model %q --continue' \
-    "$STATE_DIR" "$CLAUDE_BIN" "$PLUGIN" "$CLAUDE_MODEL")
-  echo "RESUME mode — claude --continue --model $CLAUDE_MODEL (이전 세션 이어서)"
+  INNER_CMD="$(printf 'TELEGRAM_STATE_DIR=%q %q --channels plugin:%s --model %q' \
+    "$STATE_DIR" "$CLAUDE_BIN" "$PLUGIN" "$CLAUDE_MODEL")$PERM_FLAG --continue"
+  echo "RESUME mode — claude --continue --model $CLAUDE_MODEL --permission-mode ${CLAUDE_PERMISSION_MODE:-<none>} (이전 세션 이어서)"
 else
-  INNER_CMD=$(printf 'TELEGRAM_STATE_DIR=%q %q --channels plugin:%s --model %q' \
-    "$STATE_DIR" "$CLAUDE_BIN" "$PLUGIN" "$CLAUDE_MODEL")
-  echo "FRESH mode — claude --model $CLAUDE_MODEL"
+  INNER_CMD="$(printf 'TELEGRAM_STATE_DIR=%q %q --channels plugin:%s --model %q' \
+    "$STATE_DIR" "$CLAUDE_BIN" "$PLUGIN" "$CLAUDE_MODEL")$PERM_FLAG"
+  echo "FRESH mode — claude --model $CLAUDE_MODEL --permission-mode ${CLAUDE_PERMISSION_MODE:-<none>}"
 fi
 
 tmux new-session -d -s "$SESSION_NAME" -c "$WORKDIR" "$INNER_CMD"


### PR DESCRIPTION
## 무엇을
claude 런타임 팀원의 tmux 기동 명령(`start-telegram-channel.sh`)에 `--permission-mode auto` 를 추가. fresh·resume(리스타트) 양쪽 모두 적용.

## 왜
봇 tmux 세션엔 사람이 붙어있지 않아 권한 프롬프트에 답할 수 없다 → 승인이 필요한 순간 멈춘다. `auto` 모드는 분류기가 안전한 bash 를 자동 승인하고 위험·유출·force-push 는 차단하므로, 봇이 자율로 돌면서도 안전 바닥을 유지한다.

★왜 CLI 플래그인가★: 프로젝트 스코프 `settings.json` 의 `permissions.defaultMode:"auto"` 는 Claude Code v2.1.142+ 에서 **무시된다**(체크인된 repo 가 스스로 권한 부여하는 것 방지). 그래서 settings 로는 못 켠다. CLI 플래그는 유저/프로젝트 settings 와 무관하게, 그리고 그것들을 override 해서 확실히 적용된다 → settings.json 을 전혀 건드리지 않는다.

## env override
- `CLAUDE_PERMISSION_MODE=auto`(기본) · `default`(사람 승인) · `acceptEdits` · `bypassPermissions` 등
- 빈 문자열이면 플래그 생략(멤버 settings.json 에 위임)

## 검증 (실측)
- `--help`: `--permission-mode` 유효값에 `auto` 확인 (acceptEdits/auto/bypassPermissions/manual/dontAsk/plan)
- 헤드리스: `claude --permission-mode auto -p "...echo..."` → bash 프롬프트 없이 자동 실행(exit 0)
- tmux: `--permission-mode auto` → pane "⏵⏵ auto mode on" / `--permission-mode acceptEdits` → "⏵⏵ accept edits on" (이 머신 글로벌이 auto 인데도 acceptEdits 가 뜸 = ★플래그가 글로벌 override 확정★)
- `bash -n` 문법 OK, INNER_CMD 렌더 4케이스(fresh/resume/override/opt-out) 정확
- 이 스크립트/spawn 참조 테스트 0 → 회귀 위험 없음

## 롤백
`CLAUDE_PERMISSION_MODE=` (빈값) 로 플래그 생략, 또는 이 커밋 revert.
