### PR TITLE
fix: 대시보드 proposal 버그 fix

### DIFF
--- a/src/server/lib/opAuth.ts
+++ b/src/server/lib/opAuth.ts
@@ -1,10 +1,9 @@
 import { timingSafeEqual } from "node:crypto";
 import type { Database } from "bun:sqlite";
-import { isPinSessionValid } from "./approvals";
 
 export interface TrustedActor {
   actor: string;
-  source: "pin_session" | "op_token" | "loopback_dashboard";
+  source: "op_token" | "loopback_dashboard";
 }
 
 export interface AuthResult {
@@ -57,9 +56,6 @@ export function tokenMatches(provided: string | undefined, expected: string): bo
 }
 
 export function trustedActorFromHeaders(headers: Headers): AuthResult {
-  const pinSession = headers.get("x-pin-session") ?? undefined;
-  if (isPinSessionValid(pinSession)) return { ok: true, actor: { actor: leadActorId(), source: "pin_session" } };
-
   const actor = String(headers.get("x-actor-id") ?? "").trim();
   if (!ACTOR_RE.test(actor)) return { ok: false, error: "x_actor_id_required", status: 403 };
   const provided = headers.get("x-op-token") ?? undefined;
@@ -74,10 +70,7 @@ export function trustedActorFromRequest(
   opts: { loopbackDashboardActor?: string } = {},
 ): AuthResult {
   const headers = request.headers;
-  const hasExplicitAuth =
-    headers.has("x-pin-session") ||
-    headers.has("x-op-token") ||
-    headers.has("x-actor-id");
+  const hasExplicitAuth = headers.has("x-op-token") || headers.has("x-actor-id");
   const fromHeaders = trustedActorFromHeaders(headers);
   if (fromHeaders.ok || hasExplicitAuth) return fromHeaders;
   const actor = opts.loopbackDashboardActor;


### PR DESCRIPTION
opAuth 에서 PIN(x-pin-session) 인증 경로 제거. loopback 대시보드 신뢰·공용 op-token 유지. approvals 실행승인 PIN 은 별개라 보존. 검증: typecheck clean, 인증 테스트 159 pass.