### PR TITLE
fix(claude): preserve approved access on reactivation

### DIFF
--- a/src/server/lib/activation.ts
+++ b/src/server/lib/activation.ts
@@ -587,7 +587,7 @@ export async function activateMember(db: Database, input: ActivateInput): Promis
       if (isTier2Outbound(id)) installOutboundHook(id, { dryRun: false }); // Phase1 live 실전송
       else if (isTier2Shadow(id)) installOutboundHook(id, { dryRun: true }); // Phase0 shadow: 훅 로그만(무영향)
       seedClaudeTrust(id);               // ~/.claude.json projects 시드 → 신규 workspace trust 프롬프트 hang 방지(하네스 #2)
-      seedClaudeAccess(id);              // access.json 시드(오너 DM 페어링) — 도출 불가 시 skip(버스/그룹 도달, DM 수동)(하네스 #1)
+      seedClaudeAccess(id);              // access.json 시드 — 재활성화 시 승인 allowFrom 보존, 미승인/첫 멤버만 pairing 기본값(하네스 #1)
       // ★재활성화 stale false-pass 차단(하네스 HIGH, GD 2026-07-02): 죽은 봇의 옛 tmux 세션·bot.pid가 남으면 poller-gate가 첫 iteration에서 즉시 거짓통과(귀머거리 봇이 합류로).
       //   재활성화 전에 세션 kill + stale bot.pid 제거 → idempotent 가드 우회하고 항상 fresh 기동 → 새로 쓰인 bot.pid만 게이트 통과(codex activation.ts:263 stale삭제와 동형).
       killClaudeTmux(id);

--- a/src/server/runtimes/claude/launcher.ts
+++ b/src/server/runtimes/claude/launcher.ts
@@ -304,11 +304,21 @@ export function seedClaudeTrust(id: string): void {
 }
 
 /** GD DM 페어링 자동 시드(하네스 #1): 기존 claude 멤버 access.json 의 allowFrom(인스턴스 오너 DM id)을 새 봇 access.json 에 시드.
- *  도출 불가(첫 claude 멤버)면 skip — 봇은 뜨고 버스/그룹은 도달, GD DM은 수동 페어링(DM→code→promote). */
+ *  재활성화 대상에 이미 승인된 allowFrom 이 있으면 파일 전체를 보존한다. 도출 불가(첫 claude 멤버)면
+ *  pairing 기본값을 시드해 봇/그룹은 즉시 도달하고 GD DM은 수동 페어링(DM→code→promote)한다. */
 export function seedClaudeAccess(id: string): void {
   assertId(id);
   const p = claudeBridgePaths(id);
   try {
+    const targetAccess = `${p.stateDir}/access.json`;
+    if (existsSync(targetAccess)) {
+      try {
+        const current = JSON.parse(readFileSync(targetAccess, "utf-8"));
+        const approved = Array.isArray(current.allowFrom)
+          && current.allowFrom.some((senderId: unknown) => /^\d+$/.test(String(senderId).trim()));
+        if (approved) return; // 재활성화로 기존 승인·그룹·pending 정책을 초기값에 덮어쓰지 않는다.
+      } catch { /* 손상 파일은 아래 정상 시드로 복구 */ }
+    }
     let ownerId: string | null = null;
     let refGroups: Record<string, unknown> = {}; // ★참조봇의 팀방 groups 정책도 복사 — 안 하면 새 봇 access.groups={}라 팀방 응답 안 됨(server.ts:198 access.groups 체크). GD 2026-07-01 지적.
     const chDir = `${HOME}/.claude/channels`;
@@ -331,12 +341,12 @@ export function seedClaudeAccess(id: string): void {
     // ackReaction: 봇이 메시지 받으면 👀 리액션(server.ts:950 access.ackReaction 있어야 붙음). 없으면 claude 봇 리액션 안 뜸(codex는 브리지 경로라 별개). GD 2026-07-01.
     if (ownerId) {
       // 참조봇 있음: owner DM allowlist + 참조봇 groups 복사.
-      writeFileSync(`${p.stateDir}/access.json`, JSON.stringify({ dmPolicy: "allowlist", allowFrom: [ownerId], groups: refGroups, pending: {}, ackReaction: "👀" }, null, 2), "utf-8");
+      writeFileSync(targetAccess, JSON.stringify({ dmPolicy: "allowlist", allowFrom: [ownerId], groups: refGroups, pending: {}, ackReaction: "👀" }, null, 2), "utf-8");
     } else {
       // ★첫 claude 멤버(참조봇 없음): access.json 자체가 없으면 플러그인 assertAllowedChat이 그룹 응답을 거부(받되 답 못함, 하네스 Gap A HIGH). capture group id로 groups seed → 그룹 참여 가능. DM은 수동 페어링(pairing)로 안전 fallback. GD 2026-07-02.
       const gid = getCaptureGroupId();
       const groups = gid ? { [gid]: { requireMention: true, allowFrom: [] as string[] } } : {};
-      writeFileSync(`${p.stateDir}/access.json`, JSON.stringify({ dmPolicy: "pairing", allowFrom: [], groups, pending: {}, ackReaction: "👀" }, null, 2), "utf-8");
+      writeFileSync(targetAccess, JSON.stringify({ dmPolicy: "pairing", allowFrom: [], groups, pending: {}, ackReaction: "👀" }, null, 2), "utf-8");
     }
   } catch { /* best-effort */ }
 }

--- a/src/server/runtimes/claude/seedClaudeAccess.test.ts
+++ b/src/server/runtimes/claude/seedClaudeAccess.test.ts
@@ -1,0 +1,92 @@
+// seedClaudeAccess — 재활성화 시 승인된 DM allowlist 보존 + 첫 멤버 pairing 시드 회귀 검증.
+// ★실 FS 격리: 각 케이스를 임시 HOME의 별도 Bun 프로세스에서 실행해 라이브 ~/.claude를 절대 건드리지 않는다.
+import { afterEach, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let tmpDirs: string[] = [];
+
+function setupHome(): string {
+  const home = mkdtempSync(join(tmpdir(), "b3os-seedaccess-"));
+  tmpDirs.push(home);
+  return home;
+}
+
+function accessPath(home: string, id: string): string {
+  return join(home, ".claude", "channels", `telegram-${id}`, "access.json");
+}
+
+function writeAccess(home: string, id: string, access: unknown): void {
+  const path = accessPath(home, id);
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, JSON.stringify(access, null, 2) + "\n", "utf-8");
+}
+
+function readAccess(home: string, id: string): any {
+  return JSON.parse(readFileSync(accessPath(home, id), "utf-8"));
+}
+
+function runSeed(home: string, id: string, captureGroupId = ""): void {
+  const launcherUrl = new URL("./launcher.ts", import.meta.url).href;
+  const proc = Bun.spawnSync({
+    cmd: [process.execPath, "-e", `import { seedClaudeAccess } from ${JSON.stringify(launcherUrl)}; seedClaudeAccess(${JSON.stringify(id)});`],
+    env: { ...process.env, HOME: home, B3RYS_MEMBERS_ROOT: join(home, "members"), CAPTURE_GROUP_ID: captureGroupId },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(new TextDecoder().decode(proc.stderr)).toBe("");
+  expect(proc.exitCode).toBe(0);
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
+  tmpDirs = [];
+});
+
+test("재활성화 대상에 승인 allowFrom이 있으면 access.json 전체를 그대로 보존한다", () => {
+  const home = setupHome();
+  const approved = {
+    dmPolicy: "allowlist",
+    allowFrom: ["1000000001"],
+    groups: { "-100123": { requireMention: false, allowFrom: ["2000000002"] } },
+    pending: { old: { senderId: "3000000003" } },
+    ackReaction: "✅",
+  };
+  writeAccess(home, "bill", approved);
+  const before = readFileSync(accessPath(home, "bill"), "utf-8");
+
+  runSeed(home, "bill");
+
+  expect(readFileSync(accessPath(home, "bill"), "utf-8")).toBe(before);
+  expect(readAccess(home, "bill")).toEqual(approved);
+});
+
+test("첫 claude 멤버는 기존대로 pairing과 capture group 기본값을 시드한다", () => {
+  const home = setupHome();
+
+  runSeed(home, "bill", "-1001234567890");
+
+  expect(readAccess(home, "bill")).toEqual({
+    dmPolicy: "pairing",
+    allowFrom: [],
+    groups: { "-1001234567890": { requireMention: true, allowFrom: [] } },
+    pending: {},
+    ackReaction: "👀",
+  });
+});
+
+test("대상 access.json에 승인 allowFrom이 없으면 기존 pairing 기본값으로 다시 시드한다", () => {
+  const home = setupHome();
+  writeAccess(home, "bill", { dmPolicy: "allowlist", allowFrom: [], groups: { stale: {} }, pending: { stale: {} } });
+
+  runSeed(home, "bill");
+
+  expect(readAccess(home, "bill")).toEqual({
+    dmPolicy: "pairing",
+    allowFrom: [],
+    groups: {},
+    pending: {},
+    ackReaction: "👀",
+  });
+});


### PR DESCRIPTION
재활성화(activate 재호출)가 첫-멤버 access.json 시드를 pairing 기본값으로 되돌려 GD DM 승인을 리셋하던 버그 fix. seedClaudeAccess가 대상 access.json에 승인된 allowFrom(숫자 senderId)이 있으면 파일 보존, 없거나 첫 멤버일 때만 기존 시드. FS격리 회귀 3케이스(RED→GREEN), 51 pass, typecheck 통과. fresh-clone 온보딩 크리티컬.