### PR TITLE
fix(web): replace native dialogs with in-page modals

### DIFF
--- a/src/web/components/AgentConfig.ts
+++ b/src/web/components/AgentConfig.ts
@@ -11,6 +11,7 @@ import { renderAgentSlack } from "./AgentSlack";
 import { renderIcon, agentIconName, downloadAgentIconJpg } from "../icons";
 import { AGENT_ICON_COLORS, renderAgentIcon, iconColorHex } from "../agentColors";
 import { pick } from "../i18n";
+import { showConfirm } from "./dialogs";
 
 // 아이콘 선택지(icons.ts ICONS 키 중 페르소나/역할에 어울리는 것).
 const ICON_CHOICES = [
@@ -75,33 +76,6 @@ function revealExpandedSection(section: HTMLElement): void {
         scroller.scrollBy({ top: bottomOverflow, behavior: "smooth" });
       }
     });
-  });
-}
-
-// 인앱 확인 모달 — native confirm() 대신(WKWebView 앱 호환 + 팀원명 크게·굵게 스타일 가능).
-// bodyHtml 은 신뢰된 문자열(호출부에서 escape 처리). 확인=resolve(true), 취소/backdrop/Esc=false.
-function confirmModal(bodyHtml: string, opts: { danger?: boolean; okLabel?: string } = {}): Promise<boolean> {
-  return new Promise((resolve) => {
-    const overlay = document.createElement("div");
-    overlay.className = "fixed inset-0 z-[100] flex items-center justify-center bg-black/55 backdrop-blur-sm p-4";
-    const okCls = opts.danger ? "bg-status-blocked/90 hover:bg-status-blocked text-white" : "bg-accent-green/90 hover:bg-accent-green text-white";
-    const okLabel = opts.okLabel ?? pick("확인", "Confirm");
-    overlay.innerHTML = `
-      <div class="max-w-sm w-full rounded-xl bg-surface-2 border border-surface-3 shadow-2xl p-5" role="dialog" aria-modal="true">
-        <div class="text-sm text-slate-300 leading-relaxed mb-5">${bodyHtml}</div>
-        <div class="flex justify-end gap-2">
-          <button data-mc="cancel" class="px-4 py-2 rounded-md text-sm font-medium text-slate-300 border border-surface-3 hover:bg-surface-3">${pick("취소", "Cancel")}</button>
-          <button data-mc="ok" class="px-4 py-2 rounded-md text-sm font-semibold ${okCls}">${escape(okLabel)}</button>
-        </div>
-      </div>`;
-    const done = (v: boolean) => { overlay.remove(); document.removeEventListener("keydown", onKey); resolve(v); };
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") done(false); };
-    overlay.addEventListener("click", (e) => { if (e.target === overlay) done(false); });
-    overlay.querySelector('[data-mc="ok"]')?.addEventListener("click", () => done(true));
-    overlay.querySelector('[data-mc="cancel"]')?.addEventListener("click", () => done(false));
-    document.addEventListener("keydown", onKey);
-    document.body.appendChild(overlay);
-    overlay.querySelector<HTMLButtonElement>('[data-mc="ok"]')?.focus();
   });
 }
 
@@ -353,7 +327,7 @@ function renderInto(root: HTMLElement, data: ConfigResponse, reload: () => void,
   const regenBtn = root.querySelector<HTMLButtonElement>("#cfg-regen");
   const regenMsg = root.querySelector<HTMLElement>("#cfg-regen-msg");
   regenBtn?.addEventListener("click", async () => {
-    if (!confirm(pick(`${agent.display_name}의 ⭐핵심룰(멈춤장치·통신·conti)을 현재 템플릿으로 재적용할까요?\n정체·능력 등 커스텀은 보존됩니다. (백업 자동)`, `Re-apply ${agent.display_name}'s ⭐core rules (stop-guard · comms · conti) from the current template?\nCustomizations like identity & capabilities are preserved. (auto backup)`))) return;
+    if (!await showConfirm(pick(`${agent.display_name}의 ⭐핵심룰(멈춤장치·통신·conti)을 현재 템플릿으로 재적용할까요?\n정체·능력 등 커스텀은 보존됩니다. (백업 자동)`, `Re-apply ${agent.display_name}'s ⭐core rules (stop-guard · comms · conti) from the current template?\nCustomizations like identity & capabilities are preserved. (auto backup)`))) return;
     const _busy = setBtnBusy(regenBtn, pick("⏳ 적용 중…", "⏳ Applying…"));
     if (regenMsg) { regenMsg.textContent = pick("재적용 중…", "Re-applying…"); regenMsg.className = "text-[11px] text-slate-400"; }
     try {
@@ -378,7 +352,7 @@ function renderInto(root: HTMLElement, data: ConfigResponse, reload: () => void,
   const restartBtn = root.querySelector<HTMLButtonElement>("#cfg-restart");
   restartBtn?.addEventListener("click", async () => {
     const gwNote = GATEWAY_RESTART_NOTE[agent.runtime];
-    if (!confirm(pick(`${agent.display_name} 런타임을 재시작할까요? (새 페르소나/상태 로드${gwNote ? `.${gwNote.ko}` : ""})`, `Restart the ${agent.display_name} runtime? (loads new persona/state${gwNote ? `.${gwNote.en}` : ""})`))) return;
+    if (!await showConfirm(pick(`${agent.display_name} 런타임을 재시작할까요? (새 페르소나/상태 로드${gwNote ? `.${gwNote.ko}` : ""})`, `Restart the ${agent.display_name} runtime? (loads new persona/state${gwNote ? `.${gwNote.en}` : ""})`))) return;
     const _busy = setBtnBusy(restartBtn, pick("⏳ 재시작 중…", "⏳ Restarting…"));
     if (regenMsg) { regenMsg.textContent = pick(`${agent.display_name} 재시작 중…`, `Restarting ${agent.display_name}…`); regenMsg.className = "text-[11px] text-slate-400"; }
     try {
@@ -394,7 +368,7 @@ function renderInto(root: HTMLElement, data: ConfigResponse, reload: () => void,
   // 🧹 완전 재시작 — 세션 컨텍스트(기억) 완전 비움 + 콜드 스타트(--fresh). 되돌릴 수 없는 작업이라 명시 경고.
   const restartFreshBtn = root.querySelector<HTMLButtonElement>("#cfg-restart-fresh");
   restartFreshBtn?.addEventListener("click", async () => {
-    if (!confirm(pick(`${agent.display_name}을(를) 완전 재시작할까요?\n\n⚠ 이 팀원의 대화 컨텍스트(그동안의 기억)가 완전히 비워지고, 새 CLAUDE.md로 콜드 스타트합니다.\n진행 중이던 작업 맥락이 사라집니다. 되돌릴 수 없습니다.`, `Fully restart ${agent.display_name}?\n\n⚠ This member's conversation context (all memory so far) will be completely wiped, and it will cold-start with the new CLAUDE.md.\nThe context of any in-progress work is lost. This cannot be undone.`))) return;
+    if (!await showConfirm({ message: pick(`${agent.display_name}을(를) 완전 재시작할까요?\n\n⚠ 이 팀원의 대화 컨텍스트(그동안의 기억)가 완전히 비워지고, 새 CLAUDE.md로 콜드 스타트합니다.\n진행 중이던 작업 맥락이 사라집니다. 되돌릴 수 없습니다.`, `Fully restart ${agent.display_name}?\n\n⚠ This member's conversation context (all memory so far) will be completely wiped, and it will cold-start with the new CLAUDE.md.\nThe context of any in-progress work is lost. This cannot be undone.`), danger: true })) return;
     const _busy = setBtnBusy(restartFreshBtn, pick("⏳ 완전 재시작 중…", "⏳ Full restarting…"));
     if (regenMsg) { regenMsg.textContent = pick(`${agent.display_name} 완전 재시작 중… (컨텍스트 비움)`, `Fully restarting ${agent.display_name}… (wiping context)`); regenMsg.className = "text-[11px] text-slate-400"; }
     try {
@@ -411,7 +385,7 @@ function renderInto(root: HTMLElement, data: ConfigResponse, reload: () => void,
   const onoffBtn = root.querySelector<HTMLButtonElement>("#cfg-onoff");
   onoffBtn?.addEventListener("click", async () => {
     const want = data.off === true; // off면 기동(true), on이면 정지(false)
-    if (!confirm(pick(`${agent.display_name}을(를) ${want ? "기동" : "정지"}할까요?`, `${want ? "Start" : "Stop"} ${agent.display_name}?`))) return;
+    if (!await showConfirm({ message: pick(`${agent.display_name}을(를) ${want ? "기동" : "정지"}할까요?`, `${want ? "Start" : "Stop"} ${agent.display_name}?`), danger: !want })) return;
     onoffBtn.disabled = true;
     if (regenMsg) { regenMsg.textContent = pick(`${agent.display_name} ${want ? "기동" : "정지"} 중…`, `${want ? "Starting" : "Stopping"} ${agent.display_name}…`); regenMsg.className = "text-[11px] text-slate-400"; }
     try {
@@ -488,9 +462,9 @@ function renderInto(root: HTMLElement, data: ConfigResponse, reload: () => void,
     const token = tokenInput?.value.trim() ?? "";
     if (!token) { setTokenMsg("text-txt-red", pick("토큰을 입력하세요.", "Enter a token.")); return; }
     // 엉뚱한 팀원에게 적용 방지 — 팀원명 크게 노출한 확인창(GD 2026-07-01).
-    if (!(await confirmModal(pick(
+    if (!(await showConfirm({ messageHtml: pick(
       `<b class="text-base text-slate-100">${escape(agent.display_name)}</b> 의 봇 토큰을 바꾸시겠습니까?<div class="text-[12px] text-slate-500 mt-1">이 팀원의 봇을 새 토큰으로 다시 연결합니다.</div>`,
-      `Change <b class="text-base text-slate-100">${escape(agent.display_name)}</b>'s bot token?<div class="text-[12px] text-slate-500 mt-1">Reconnects this member's bot with the new token.</div>`)))) { if (tokenInput) tokenInput.value = ""; return; }
+      `Change <b class="text-base text-slate-100">${escape(agent.display_name)}</b>'s bot token?<div class="text-[12px] text-slate-500 mt-1">Reconnects this member's bot with the new token.</div>`) }))) { if (tokenInput) tokenInput.value = ""; return; }
     if (tokenBtn) tokenBtn.disabled = true;
     setTokenMsg("text-slate-400", pick("검증 중…", "Verifying…"));
     try {
@@ -541,10 +515,10 @@ function renderInto(root: HTMLElement, data: ConfigResponse, reload: () => void,
     const confirmName = swapConfirm?.value.trim() ?? "";
     if (!target || confirmName !== agent.display_name) return;
     // 파괴적 작업(런타임 정지→재기동) — 팀원명 크게 노출한 확인창(offboard/토큰변경과 동일 패턴, GD 2026-07-01 관례).
-    if (!(await confirmModal(pick(
+    if (!(await showConfirm({ messageHtml: pick(
       `<b class="text-base text-slate-100">${escape(agent.display_name)}</b> 의 런타임을 <b class="text-txt-amber">${escape(runtimeLabel(agent.runtime))} → ${escape(runtimeLabel(target))}</b> 로 교체할까요?<div class="text-[12px] text-slate-500 mt-1">런타임을 정지했다 재기동합니다. 진행 중 작업이 있으면 중단될 수 있습니다. 메모리는 보존됩니다.</div>`,
       `Swap <b class="text-base text-slate-100">${escape(agent.display_name)}</b>'s runtime from <b class="text-txt-amber">${escape(runtimeLabel(agent.runtime))} → ${escape(runtimeLabel(target))}</b>?<div class="text-[12px] text-slate-500 mt-1">This stops and restarts the runtime. In-progress work may be interrupted. Memory is preserved.</div>`),
-      { danger: true, okLabel: pick("교체", "Swap") }))) return;
+      danger: true, okLabel: pick("교체", "Swap") }))) return;
     const _busy = setBtnBusy(swapBtn, pick("⏳ 교체 중…", "⏳ Swapping…"));
     if (swapMsg) { swapMsg.textContent = pick("런타임 교체 중… (정지→레지스트리 갱신→재기동)", "Swapping runtime… (stop → registry update → restart)"); swapMsg.className = "text-[12px] mt-2 leading-snug text-slate-400"; }
     renderSwapSteps(undefined);
@@ -599,9 +573,9 @@ function renderInto(root: HTMLElement, data: ConfigResponse, reload: () => void,
   });
   offBtn?.addEventListener("click", async () => {
     // 이름-타이핑 가드에 더해 명시적 확인창 — 엉뚱한 팀원 퇴사 방지, 팀원명 크게(GD 2026-07-01).
-    if (!(await confirmModal(pick(
+    if (!(await showConfirm({ messageHtml: pick(
       `정말 <b class="text-base text-slate-100">${escape(agent.display_name)}</b> 을(를) 퇴사시키겠습니까?<div class="text-[12px] text-slate-500 mt-1">팀원 목록에서 지우고, 지금까지 등록·진행한 내용을 정리합니다.</div>`,
-      `Really offboard <b class="text-base text-slate-100">${escape(agent.display_name)}</b>?<div class="text-[12px] text-slate-500 mt-1">Removes them from the team and clears what was set up so far.</div>`), { danger: true, okLabel: pick("퇴사", "Offboard") }))) return;
+      `Really offboard <b class="text-base text-slate-100">${escape(agent.display_name)}</b>?<div class="text-[12px] text-slate-500 mt-1">Removes them from the team and clears what was set up so far.</div>`), danger: true, okLabel: pick("퇴사", "Offboard") }))) return;
     offBtn.disabled = true;
     if (offMsg) {
       // openclaw는 게이트웨이 정리(bootout+프로필 제거)로 퇴사가 더 오래 걸림 → 눈에 띄게 안내(GD 2026-07-02).

--- a/src/web/components/AgentSlack.ts
+++ b/src/web/components/AgentSlack.ts
@@ -9,6 +9,7 @@ import { apiBase } from "../ws";
 import { setBtnBusy } from "./Settings";
 import { renderIcon } from "../icons";
 import { pick } from "../i18n";
+import { showAlert, showConfirm } from "./dialogs";
 
 const inputCls = "w-full bg-surface-0 border border-surface-3 rounded-lg text-sm text-slate-200 px-3 py-2.5 outline-none focus:border-accent-green/40 placeholder:text-slate-600";
 const labelCls = "block text-[13px] font-medium text-slate-300 mb-1.5";
@@ -267,14 +268,14 @@ export function renderAgentSlack(host: HTMLElement, agentId: string, _displayNam
 
     const revokeBtn = host.querySelector<HTMLButtonElement>("#sl-revoke");
     revokeBtn?.addEventListener("click", async () => {
-      if (!confirm(pick(`${agentId}의 Slack 연동을 해제할까요?\n저장된 봇 토큰이 삭제됩니다(신원도 함께 정리). 되돌리려면 재연동 필요.`, `Disconnect ${agentId}'s Slack integration?\nThe saved bot token will be deleted (identity cleared too). Reconnecting is needed to undo this.`))) return;
+      if (!await showConfirm({ message: pick(`${agentId}의 Slack 연동을 해제할까요?\n저장된 봇 토큰이 삭제됩니다(신원도 함께 정리). 되돌리려면 재연동 필요.`, `Disconnect ${agentId}'s Slack integration?\nThe saved bot token will be deleted (identity cleared too). Reconnecting is needed to undo this.`), danger: true })) return;
       const done = setBtnBusy(revokeBtn, pick("⏳ 해제 중…", "⏳ Disconnecting…"));
       try {
         const r = await fetch(`${apiBase()}/api/members/${encodeURIComponent(agentId)}/slack/revoke`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({}) });
         const j = await r.json().catch(() => ({}));
         if (!r.ok || !j.ok) throw new Error(j.error || `HTTP ${r.status}`);
         me = await fetchStatus(); info = null; open = false; render();
-      } catch (e) { alert(pick("해제 실패: ", "Disconnect failed: ") + (e as Error).message); done(); }
+      } catch (e) { await showAlert(pick("해제 실패: ", "Disconnect failed: ") + (e as Error).message); done(); }
     });
 
     const saveBtn = host.querySelector<HTMLButtonElement>("#sl-save");

--- a/src/web/components/Reports.ts
+++ b/src/web/components/Reports.ts
@@ -11,6 +11,7 @@
 
 import { pick } from "../i18n";
 import { parseSqliteDate } from "../lib/datetime";
+import { showAlert, showConfirm } from "./dialogs";
 
 const REPORTS_BASE = "/reports";
 const DEFAULT_CAT = "보고서";
@@ -430,7 +431,7 @@ function renderList(): void {
         await setReportImportant(id, next);
         await reloadList();
       } catch (err) {
-        alert(pick(`중요 표시 변경 실패: ${(err as Error).message}`, `Failed to update important mark: ${(err as Error).message}`));
+        await showAlert(pick(`중요 표시 변경 실패: ${(err as Error).message}`, `Failed to update important mark: ${(err as Error).message}`));
         el.disabled = false;
       }
     });
@@ -441,13 +442,13 @@ function renderList(): void {
       e.stopPropagation();
       const id = el.dataset.id || "";
       const title = el.dataset.title || id;
-      if (!id || !confirm(pick(`보고서 "${title}"을(를) 목록에서 삭제할까요?\n\n첨부 파일은 디스크에 남고, 대시보드 등록 정보만 삭제됩니다.`, `Delete report "${title}" from the list?\n\nThe attached files stay on disk; only the dashboard registration is removed.`))) return;
+      if (!id || !await showConfirm({ message: pick(`보고서 "${title}"을(를) 목록에서 삭제할까요?\n\n첨부 파일은 디스크에 남고, 대시보드 등록 정보만 삭제됩니다.`, `Delete report "${title}" from the list?\n\nThe attached files stay on disk; only the dashboard registration is removed.`), danger: true })) return;
       el.disabled = true;
       try {
         await deleteReport(id);
         await reloadList();
       } catch (err) {
-        alert(pick(`삭제 실패: ${(err as Error).message}`, `Delete failed: ${(err as Error).message}`));
+        await showAlert(pick(`삭제 실패: ${(err as Error).message}`, `Delete failed: ${(err as Error).message}`));
         el.disabled = false;
       }
     });
@@ -548,20 +549,20 @@ async function renderDetail(): Promise<void> {
       await loadReportsPage(true);
       void renderDetail();
     } catch (err) {
-      alert(pick(`중요 표시 변경 실패: ${(err as Error).message}`, `Failed to update important mark: ${(err as Error).message}`));
+      await showAlert(pick(`중요 표시 변경 실패: ${(err as Error).message}`, `Failed to update important mark: ${(err as Error).message}`));
       btn.disabled = false;
     }
   });
   _root.querySelector<HTMLButtonElement>("#reports-delete-detail")?.addEventListener("click", async () => {
     const btn = _root?.querySelector<HTMLButtonElement>("#reports-delete-detail");
-    if (!confirm(pick(`보고서 "${meta.title}"을(를) 목록에서 삭제할까요?\n\n첨부 파일은 디스크에 남고, 대시보드 등록 정보만 삭제됩니다.`, `Delete report "${meta.title}" from the list?\n\nThe attached files stay on disk; only the dashboard registration is removed.`))) return;
+    if (!await showConfirm({ message: pick(`보고서 "${meta.title}"을(를) 목록에서 삭제할까요?\n\n첨부 파일은 디스크에 남고, 대시보드 등록 정보만 삭제됩니다.`, `Delete report "${meta.title}" from the list?\n\nThe attached files stay on disk; only the dashboard registration is removed.`), danger: true })) return;
     if (btn) btn.disabled = true;
     try {
       await deleteReport(id);
       _view = "list";
       await reloadList();
     } catch (err) {
-      alert(pick(`삭제 실패: ${(err as Error).message}`, `Delete failed: ${(err as Error).message}`));
+      await showAlert(pick(`삭제 실패: ${(err as Error).message}`, `Delete failed: ${(err as Error).message}`));
       if (btn) btn.disabled = false;
     }
   });

--- a/src/web/components/Settings.ts
+++ b/src/web/components/Settings.ts
@@ -7,6 +7,7 @@ import { pick } from "../i18n";
 import { renderIcon, agentIconName } from "../icons";
 import { renderAgentIcon } from "../agentColors";
 import { FALLBACK_RUNTIME_OPTIONS, fetchRuntimeOptions, runtimeLabel as optionRuntimeLabel, runtimeSetupHref, type RuntimeOption } from "./runtimeOptions";
+import { showAlert, showConfirm } from "./dialogs";
 
 // 시간 걸리는 버튼: 클릭 즉시 "⏳ …중" + 흐려짐 + 다시 못 눌림(중복 클릭 방지). restore() 로 복구.
 export function setBtnBusy(btn: HTMLButtonElement, busyText: string): () => void {
@@ -924,7 +925,7 @@ function wire(): void {
   const regenAll = _root.querySelector<HTMLButtonElement>("#regen-all");
   const regenAllMsg = _root.querySelector<HTMLElement>("#regen-all-msg");
   regenAll?.addEventListener("click", async () => {
-    if (!confirm(pick("모든 팀원의 ⭐핵심룰을 현재 템플릿(멈춤장치·통신·conti)으로 재적용할까요?\n각자 정체·능력은 보존되고 백업이 남습니다. 적용된 규칙은 각 팀원 다음 세션부터 적용됩니다.\n적용 후 6시간 동안 되돌리기 버튼으로 되돌릴 수 있습니다.", "Reapply every member's ⭐core rules with the current template (stop guards·comms·conti)?\nEach member's identity·capabilities are preserved and a backup is kept. The applied rules take effect from each member's next session.\nYou can undo it with the Undo button for 6 hours after applying."))) return;
+    if (!await showConfirm(pick("모든 팀원의 ⭐핵심룰을 현재 템플릿(멈춤장치·통신·conti)으로 재적용할까요?\n각자 정체·능력은 보존되고 백업이 남습니다. 적용된 규칙은 각 팀원 다음 세션부터 적용됩니다.\n적용 후 6시간 동안 되돌리기 버튼으로 되돌릴 수 있습니다.", "Reapply every member's ⭐core rules with the current template (stop guards·comms·conti)?\nEach member's identity·capabilities are preserved and a backup is kept. The applied rules take effect from each member's next session.\nYou can undo it with the Undo button for 6 hours after applying."))) return;
     const _busy = setBtnBusy(regenAll, `⏳ ${pick("적용 중…", "Applying…")}`);
     if (regenAllMsg) { regenAllMsg.textContent = pick("전체 재적용 중…", "Reapplying to all…"); regenAllMsg.className = "text-[11px] text-slate-400 flex-1 leading-snug"; }
     try {
@@ -971,7 +972,7 @@ function wire(): void {
     _rollbackTimer = setInterval(tick, 30000);
   }
   rollbackBtn?.addEventListener("click", async () => {
-    if (!confirm(pick("직전 전체 핵심룰 재적용(가장 최근 1회분)을 되돌릴까요?\n각 팀원 페르소나가 재적용 직전 .bak 백업으로 복원됩니다.", "Undo the last reapply-all of core rules (the most recent batch)?\nEach member's persona is restored from the .bak backup taken just before reapplying."))) return;
+    if (!await showConfirm(pick("직전 전체 핵심룰 재적용(가장 최근 1회분)을 되돌릴까요?\n각 팀원 페르소나가 재적용 직전 .bak 백업으로 복원됩니다.", "Undo the last reapply-all of core rules (the most recent batch)?\nEach member's persona is restored from the .bak backup taken just before reapplying."))) return;
     // setBtnBusy는 버튼 child(#regen-rollback-label span)를 textContent로 날려 카운트다운이 깨짐(Devon P2).
     // disabled + label 텍스트만 바꿔 span을 보존 → 실패/재시도 경로에서도 tick()이 계속 라벨 갱신.
     rollbackBtn.disabled = true;
@@ -998,7 +999,7 @@ function wire(): void {
   // 🔄 전체 재시작 — 빌·정지팀원 제외 전원 재시작(빌 맨 마지막).
   const restartAll = _root.querySelector<HTMLButtonElement>("#restart-all");
   restartAll?.addEventListener("click", async () => {
-    if (!confirm(pick("정지 팀원 제외 전원을 재시작할까요?\n새 페르소나/상태를 로드합니다. openclaw 게이트웨이는 ~1분 깜빡, 복구 코디네이터는 맨 마지막(이 대화 ~15s 깜빡 후 복귀).", "Restart everyone except stopped members?\nThey reload fresh persona/state. The openclaw gateway blinks ~1 min; the recovery coordinator is last (this chat blinks ~15s, then returns)."))) return;
+    if (!await showConfirm(pick("정지 팀원 제외 전원을 재시작할까요?\n새 페르소나/상태를 로드합니다. openclaw 게이트웨이는 ~1분 깜빡, 복구 코디네이터는 맨 마지막(이 대화 ~15s 깜빡 후 복귀).", "Restart everyone except stopped members?\nThey reload fresh persona/state. The openclaw gateway blinks ~1 min; the recovery coordinator is last (this chat blinks ~15s, then returns)."))) return;
     const _busy = setBtnBusy(restartAll, `⏳ ${pick("재시작 중…", "Restarting…")}`);
     if (regenAllMsg) { regenAllMsg.textContent = pick("전체 재시작 중…", "Restarting all…"); regenAllMsg.className = "text-[11px] text-slate-400 flex-1 leading-snug"; }
     try {
@@ -1017,7 +1018,7 @@ function wire(): void {
   // 🔴 전체 정지 (비상) — 빌 제외 전원 정지. 더블컨펌(강한 경고).
   const stopAll = _root.querySelector<HTMLButtonElement>("#stop-all");
   stopAll?.addEventListener("click", async () => {
-    if (!confirm(pick("🔴 비상 정지\n\n복구 코디네이터를 제외한 모든 팀원을 즉시 정지합니다.\n폭주·이상 상황의 서킷브레이커입니다. 정말 전원 정지할까요?\n\n(다시 켜려면 각 팀원 🟢 기동 또는 /onoff)", "🔴 Emergency stop\n\nImmediately stops every member except the recovery coordinator.\nThis is the circuit breaker for runaway/abnormal situations. Really stop everyone?\n\n(To turn them back on, use each member's 🟢 Start or /onoff)"))) return;
+    if (!await showConfirm({ message: pick("🔴 비상 정지\n\n복구 코디네이터를 제외한 모든 팀원을 즉시 정지합니다.\n폭주·이상 상황의 서킷브레이커입니다. 정말 전원 정지할까요?\n\n(다시 켜려면 각 팀원 🟢 기동 또는 /onoff)", "🔴 Emergency stop\n\nImmediately stops every member except the recovery coordinator.\nThis is the circuit breaker for runaway/abnormal situations. Really stop everyone?\n\n(To turn them back on, use each member's 🟢 Start or /onoff)"), danger: true })) return;
     const _busy = setBtnBusy(stopAll, `⏳ ${pick("정지 중…", "Stopping…")}`);
     if (regenAllMsg) { regenAllMsg.textContent = `🔴 ${pick("비상 정지 중…", "Emergency stopping…")}`; regenAllMsg.className = "text-[11px] text-txt-red flex-1 leading-snug"; }
     try {
@@ -1272,7 +1273,7 @@ function wireOtZone(): void {
   _root.querySelector<HTMLButtonElement>("#ot-cancel")?.addEventListener("click", async () => {
     if (!_ot) return;
     const name = _ot.member.display_name;
-    if (!confirm(`${name} ${pick("영입을 취소할까요?\n\n지금까지 등록·진행한 것을 지우고, 자동으로 만들어진 빈 작업 폴더를 정리합니다.\n(직접 손댄 파일은 그대로 둡니다)", "onboarding — cancel it?\n\nClears what was registered and set up so far, and removes the empty auto-created work folder.\n(files you touched are kept)")}`)) return;
+    if (!await showConfirm({ message: `${name} ${pick("영입을 취소할까요?\n\n지금까지 등록·진행한 것을 지우고, 자동으로 만들어진 빈 작업 폴더를 정리합니다.\n(직접 손댄 파일은 그대로 둡니다)", "onboarding — cancel it?\n\nClears what was registered and set up so far, and removes the empty auto-created work folder.\n(files you touched are kept)")}`, danger: true })) return;
     const btn = _root!.querySelector<HTMLButtonElement>("#ot-cancel")!;
     btn.disabled = true; btn.textContent = pick("취소 중…", "Cancelling…");
     try {
@@ -1282,7 +1283,7 @@ function wireOtZone(): void {
       stopOtPolling(); resetOtVerify(); _ot = null; _activating = false; _activateMsg = ""; _pairing = false; _pairMsg = ""; _prechecking = false; _precheckMsg = ""; render();
     } catch (e) {
       btn.disabled = false; btn.textContent = `✕ ${pick("영입 취소 — 지금까지 등록한 것 지움", "Cancel onboarding — clear what was set up")}`;
-      alert(pick("취소 실패: ", "Cancel failed: ") + (e as Error).message);
+      await showAlert(pick("취소 실패: ", "Cancel failed: ") + (e as Error).message);
     }
   });
   // 합류 패키지(OT 번들) 보기

--- a/src/web/components/ThreadView.ts
+++ b/src/web/components/ThreadView.ts
@@ -6,6 +6,7 @@ import { enUS } from "date-fns/locale/en-US";
 import { agentIconName, renderIcon } from "../icons";
 import { pick, getLocale } from "../i18n";
 import { parseSqliteDate } from "../lib/datetime";
+import { showAlert } from "./dialogs";
 
 function safeRelative(s: string | null): string {
   const d = parseSqliteDate(s);
@@ -91,7 +92,7 @@ export function renderThreadView(root: HTMLElement): void {
           source: "user",
         });
         if (!result.ok) {
-          alert(pick(`전송 실패: ${result.error}`, `Send failed: ${result.error}`));
+          await showAlert(pick(`전송 실패: ${result.error}`, `Send failed: ${result.error}`));
           input.value = body;
         }
       });

--- a/src/web/components/dialogs.ts
+++ b/src/web/components/dialogs.ts
@@ -1,0 +1,77 @@
+import { pick } from "../i18n";
+
+function escape(s: unknown): string {
+  return String(s == null ? "" : s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+interface DialogOptions {
+  title?: string;
+  message?: string;
+  messageHtml?: string;
+  okLabel?: string;
+  cancelLabel?: string;
+  danger?: boolean;
+}
+
+function dialogShell(opts: DialogOptions, mode: "alert" | "confirm"): Promise<boolean> {
+  return new Promise((resolve) => {
+    const overlay = document.createElement("div");
+    overlay.className = "fixed inset-0 z-[100] flex items-start justify-center overflow-y-auto bg-black/55 px-4 py-6 backdrop-blur-sm sm:items-center";
+    const okCls = opts.danger
+      ? "border-status-blocked/40 bg-status-blocked/85 text-white hover:bg-status-blocked"
+      : "border-accent-green/40 bg-accent-green/85 text-white hover:bg-accent-green";
+    const title = opts.title ?? (mode === "confirm" ? pick("확인", "Confirm") : pick("알림", "Notice"));
+    const okLabel = opts.okLabel ?? (mode === "confirm" ? pick("확인", "Confirm") : pick("닫기", "Close"));
+    const cancelLabel = opts.cancelLabel ?? pick("취소", "Cancel");
+    const message = opts.messageHtml ?? escape(opts.message ?? "");
+
+    overlay.innerHTML = `
+      <div class="w-full max-w-md rounded-md border border-surface-3 bg-surface-1 p-4 shadow-2xl" role="dialog" aria-modal="true" aria-labelledby="app-dialog-title">
+        <div class="flex items-start justify-between gap-3">
+          <div class="min-w-0">
+            <h3 id="app-dialog-title" class="text-base font-semibold text-slate-100">${escape(title)}</h3>
+            <div class="mt-2 whitespace-pre-line break-words text-sm leading-6 text-slate-300">${message}</div>
+          </div>
+          <button type="button" data-dialog-cancel class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-surface-3 bg-surface-2 text-slate-400 hover:text-slate-100" aria-label="${pick("닫기", "Close")}">
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" aria-hidden="true"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </button>
+        </div>
+        <div class="mt-5 flex justify-end gap-2">
+          ${mode === "confirm" ? `<button type="button" data-dialog-cancel class="rounded-md border border-surface-3 bg-surface-2 px-3 py-2 text-xs font-semibold text-slate-300 hover:text-slate-100">${escape(cancelLabel)}</button>` : ""}
+          <button type="button" data-dialog-ok class="rounded-md border px-3 py-2 text-xs font-semibold ${okCls}">${escape(okLabel)}</button>
+        </div>
+      </div>`;
+
+    let settled = false;
+    const done = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      overlay.remove();
+      document.removeEventListener("keydown", onKey);
+      resolve(value);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") done(false);
+      if (mode === "alert" && e.key === "Enter") done(true);
+    };
+    overlay.addEventListener("click", (e) => { if (e.target === overlay) done(false); });
+    overlay.querySelectorAll("[data-dialog-cancel]").forEach((el) => el.addEventListener("click", () => done(false)));
+    overlay.querySelector("[data-dialog-ok]")?.addEventListener("click", () => done(true));
+    document.addEventListener("keydown", onKey);
+    document.body.appendChild(overlay);
+    overlay.querySelector<HTMLButtonElement>("[data-dialog-ok]")?.focus();
+  });
+}
+
+export function showConfirm(opts: DialogOptions | string): Promise<boolean> {
+  return dialogShell(typeof opts === "string" ? { message: opts } : opts, "confirm");
+}
+
+export async function showAlert(opts: DialogOptions | string): Promise<void> {
+  await dialogShell(typeof opts === "string" ? { message: opts } : opts, "alert");
+}

--- a/src/web/reports.html
+++ b/src/web/reports.html
@@ -159,6 +159,17 @@ a{color:inherit;text-decoration:none}
 .md th,.md td{border:1px solid var(--border);padding:7px 11px;text-align:left}
 .md th{background:var(--bg-soft);color:var(--head);font-weight:600}
 
+.dialogOverlay{position:fixed;inset:0;z-index:100;display:flex;align-items:center;justify-content:center;
+  overflow-y:auto;background:rgba(0,0,0,.55);padding:24px 16px;backdrop-filter:blur(6px)}
+.dialogBox{width:100%;max-width:420px;background:var(--card);border:1px solid var(--border);
+  border-radius:10px;box-shadow:0 24px 80px rgba(0,0,0,.45);padding:18px}
+.dialogTitle{font-size:16px;font-weight:700;color:var(--head);margin-bottom:8px}
+.dialogMsg{white-space:pre-line;word-break:break-word;font-size:14px;line-height:1.65;color:var(--text)}
+.dialogActions{display:flex;justify-content:flex-end;gap:8px;margin-top:18px}
+.dialogBtn{font-size:13px;font-weight:700;padding:8px 14px;border-radius:8px;border:1px solid var(--green-soft);
+  color:#04140a;background:var(--green);cursor:pointer}
+.dialogBtn:hover{background:var(--green-bright)}
+
 @media(max-width:520px){
   .row{padding:14px 15px}
   .dl{margin-left:0;width:100%;justify-content:center}
@@ -231,6 +242,24 @@ function fileUrl(id,type){ return BASE + "/file/" + encodeURIComponent(id) + "/"
 function fetchFile(id,type){
   if(usingMock){ var k=id+"/"+type; return Promise.resolve(MOCK.files[k] != null ? MOCK.files[k] : "(목업에 "+k+" 없음)"); }
   return fetch(fileUrl(id,type)).then(function(r){ if(!r.ok) throw new Error("HTTP "+r.status); return r.text(); });
+}
+function showNotice(message){
+  return new Promise(function(resolve){
+    var overlay = document.createElement("div");
+    overlay.className = "dialogOverlay";
+    overlay.innerHTML = '<div class="dialogBox" role="dialog" aria-modal="true" aria-labelledby="notice-title">'
+      + '<div class="dialogTitle" id="notice-title">알림</div>'
+      + '<div class="dialogMsg">'+esc(message)+'</div>'
+      + '<div class="dialogActions"><button type="button" class="dialogBtn" data-ok>닫기</button></div>'
+      + '</div>';
+    var done = function(){ overlay.remove(); document.removeEventListener("keydown", onKey); resolve(); };
+    var onKey = function(e){ if(e.key==="Escape" || e.key==="Enter") done(); };
+    overlay.addEventListener("click", function(e){ if(e.target===overlay) done(); });
+    overlay.querySelector("[data-ok]").addEventListener("click", done);
+    document.addEventListener("keydown", onKey);
+    document.body.appendChild(overlay);
+    overlay.querySelector("[data-ok]").focus();
+  });
 }
 
 // ── 유틸 ──────────────────────────────────────────────────────────
@@ -398,7 +427,7 @@ function renderDetail(id){
       var viewer = document.getElementById("viewer");
       [].forEach.call(document.querySelectorAll(".tab"), function(el){ el.classList.toggle("active", el.getAttribute("data-type")===type); });
       var dl = document.getElementById("dl");
-      if(dl){ if(usingMock){ dl.removeAttribute("href"); dl.onclick=function(){ alert("목업 모드 — 실제 다운로드는 API 연결 후."); }; }
+      if(dl){ if(usingMock){ dl.removeAttribute("href"); dl.onclick=function(e){ e.preventDefault(); showNotice("목업 모드 — 실제 다운로드는 API 연결 후."); }; }
               else { dl.href=fileUrl(id,type); dl.setAttribute("download",""); dl.onclick=null; } }
       viewer.innerHTML = '<div class="md" style="color:#64748b">불러오는 중…</div>';
       if(type==="html"){


### PR DESCRIPTION
## Summary
- Add shared in-page dialog helpers for alert/confirm flows
- Replace src/web native alert/confirm usages in Reports, Settings, AgentConfig, AgentSlack, ThreadView, and standalone reports.html
- Preserve existing action flow and messages while avoiding WKWebView-native dialogs

## Verification
- bun run typecheck
- bun run build
- bun test src/web/components/inboxAudit.dom.test.ts src/web/components/settingsPairing.test.ts src/web/components/runtimeOptions.test.ts
- CAPTURE_GROUP_FILE=/tmp/b3rys-team-os-test-capture-group-id-empty bun test src/server/routes/broadcastToGroup.test.ts

## Notes
- rg found 0 remaining src/web alert/confirm/prompt calls.
- Full bun test currently hits an existing env/file isolation issue in broadcastToGroup when run with the local var/capture-group-id.txt and parallel test env mutation; the targeted suite passes with CAPTURE_GROUP_FILE isolated.