### PR TITLE
feat(scripts): minimal public auto-heal core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,12 @@ archiving/
 # 버전관리는 은퇴하는 private repo(내부 유지)가 계속 tracked 로 보존 → 유실 없음. 공개엔 명시 allowlist 만 싣는다.
 # (기본=제외 + `!` allowlist. 새 공개용 스크립트/문서는 여기 `!` 로 추가.)
 /scripts/*
+!/scripts/auto-heal-core.sh
+!/scripts/auto-heal-core-harness.sh
 !/scripts/task-review-ping.ts
 !/scripts/task-review-summary.ts
 /docs/*
+!/docs/AUTO_HEAL_CORE.md
 !/docs/SLACK_SETUP.md
 !/docs/remote-access.md
 !/docs/BUILD_MODES.md

--- a/docs/AUTO_HEAL_CORE.md
+++ b/docs/AUTO_HEAL_CORE.md
@@ -1,0 +1,79 @@
+# Auto-heal core
+
+`scripts/auto-heal-core.sh` is a small, opt-in recovery loop for:
+
+- a configured tmux bot whose session is positively absent;
+- a configured bot poller whose PID file contains a valid PID that is positively dead;
+- a configured launchd gateway that is unregistered, stopped (`-`), or has a positively dead PID;
+- Claude's `How is Claude doing this session` survey, dismissed with the literal `0` key while preserving the prompt input line.
+
+The core is safe-fail: missing tools, failed inventories, malformed or missing PID
+files, duplicate matches, permission ambiguity, and verification failures are
+reported as `NOOP` or `FAILED`. They never trigger a fallback restart or extra
+keystroke.
+
+## Configuration
+
+Create a pipe-delimited file. Blank lines and lines beginning with `#` are
+ignored.
+
+```text
+bot|worker|claude-worker|/path/to/worker.pid|on|/path/to/team-os.sh|up|worker
+gateway|openclaw|ai.openclaw.gateway|-|on|/path/to/team-os.sh|up|openclaw
+bot|paused-worker|claude-paused|/path/to/paused.pid|off|/path/to/team-os.sh|up|paused-worker
+```
+
+Fields are:
+
+1. `bot` or `gateway`;
+2. a display name;
+3. the exact tmux session or launchd label;
+4. the poller PID file (`-` for gateways);
+5. `on` or `off`;
+6. an executable recovery program followed by zero or more argv fields.
+
+The file is parsed as data and is never sourced or evaluated. Do not use `|` or
+newlines inside fields. Only configured records are inspected; an `off` record
+is skipped.
+
+Run once:
+
+```bash
+scripts/auto-heal-core.sh --config /path/to/auto-heal.conf
+```
+
+Preview possible actions without restarting services or sending keys:
+
+```bash
+scripts/auto-heal-core.sh --config /path/to/auto-heal.conf --dry-run
+```
+
+Use a scheduler only after testing the exact configuration and recovery
+programs. This repository does not install a scheduler or modify an existing
+local monitor.
+
+## Recovery boundary
+
+The script does not probe application health. A live PID is never restarted,
+even if the application looks stuck. A missing poller PID file is also not
+proof of death and results in `NOOP`.
+
+Recovery is attempted once. A non-zero recovery result is reported without
+force-clean, escalation, retry, alert delivery, database cleanup, or any other
+fallback.
+
+For the Claude survey, the script sends exactly one literal `0`, then verifies
+that the survey disappeared and the `❯` input line is byte-for-byte unchanged.
+If verification fails, it reports the failure and sends no restore or retry
+keys.
+
+## Harness
+
+The harness replaces `tmux`, `launchctl`, `kill`, `ps`, and the recovery program
+with local mocks. It covers positive death, live state, missing/ambiguous state,
+configured-off targets, survey preservation, and the invariant that uncertain
+state invokes recovery zero times.
+
+```bash
+scripts/auto-heal-core-harness.sh
+```

--- a/scripts/auto-heal-core-harness.sh
+++ b/scripts/auto-heal-core-harness.sh
@@ -113,9 +113,13 @@ run_dry_case() {
 pid_alive="$TMP/pid-alive"
 pid_dead="$TMP/pid-dead"
 pid_ambiguous="$TMP/pid-ambiguous"
+pid_malformed="$TMP/pid-malformed"
+pid_multiline="$TMP/pid-multiline"
 printf '111\n' > "$pid_alive"
 printf '222\n' > "$pid_dead"
 printf '333\n' > "$pid_ambiguous"
+printf 'not-a-pid\n' > "$pid_malformed"
+printf '222\n223\n' > "$pid_multiline"
 
 config="$TMP/config"
 
@@ -129,11 +133,25 @@ assert_calls 1
 MOCK_SESSIONS=alive run_dry_case "$config" >/dev/null
 assert_calls 0
 
+MOCK_TMUX_FAIL=1 run_case "$config" >/dev/null
+assert_calls 0
+
+AUTO_HEAL_TMUX_BIN="$TMP/no-such-tmux" run_case "$config" >/dev/null
+assert_calls 0
+
 printf 'bot|dead-poller|alive|%s|on|%s/recover|poller-dead\n' "$pid_dead" "$MOCK" > "$config"
 MOCK_SESSIONS=alive run_case "$config" >/dev/null
 assert_calls 1
 
 printf 'bot|missing-pid|alive|%s/no-file|on|%s/recover|must-not-run\n' "$TMP" "$MOCK" > "$config"
+MOCK_SESSIONS=alive run_case "$config" >/dev/null
+assert_calls 0
+
+printf 'bot|malformed-pid|alive|%s|on|%s/recover|must-not-run\n' "$pid_malformed" "$MOCK" > "$config"
+MOCK_SESSIONS=alive run_case "$config" >/dev/null
+assert_calls 0
+
+printf 'bot|multiline-pid|alive|%s|on|%s/recover|must-not-run\n' "$pid_multiline" "$MOCK" > "$config"
 MOCK_SESSIONS=alive run_case "$config" >/dev/null
 assert_calls 0
 
@@ -153,6 +171,10 @@ printf 'gateway|dead|configured.label|-|on|%s/recover|gateway-dead\n' "$MOCK" > 
 MOCK_LAUNCHD_LIST=$'222\t0\tconfigured.label' run_case "$config" >/dev/null
 assert_calls 1
 
+printf 'gateway|stopped|configured.label|-|on|%s/recover|gateway-stopped\n' "$MOCK" > "$config"
+MOCK_LAUNCHD_LIST=$'-\t0\tconfigured.label' run_case "$config" >/dev/null
+assert_calls 1
+
 printf 'gateway|alive|configured.label|-|on|%s/recover|must-not-run\n' "$MOCK" > "$config"
 MOCK_LAUNCHD_LIST=$'111\t0\tconfigured.label' run_case "$config" >/dev/null
 assert_calls 0
@@ -163,6 +185,14 @@ assert_calls 0
 
 printf 'gateway|unknown|configured.label|-|on|%s/recover|must-not-run\n' "$MOCK" > "$config"
 MOCK_LAUNCHCTL_FAIL=1 run_case "$config" >/dev/null
+assert_calls 0
+
+cat > "$config" <<EOF
+bot|too-few|fields
+bot||alive|$pid_alive|on|$MOCK/recover|must-not-run
+bot|bad-mode|alive|$pid_alive|maybe|$MOCK/recover|must-not-run
+EOF
+MOCK_SESSIONS=alive run_case "$config" >/dev/null
 assert_calls 0
 
 printf 'bot|survey|alive|%s|on|%s/recover|must-not-run\n' "$pid_alive" "$MOCK" > "$config"

--- a/scripts/auto-heal-core-harness.sh
+++ b/scripts/auto-heal-core-harness.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+CORE="$ROOT/scripts/auto-heal-core.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+MOCK="$TMP/mock"
+mkdir -p "$MOCK"
+CALLS="$TMP/calls"
+: > "$CALLS"
+
+cat > "$MOCK/recover" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$AUTO_HEAL_TEST_CALLS"
+EOF
+
+cat > "$MOCK/kill" <<'EOF'
+#!/usr/bin/env bash
+case "${2:-}" in
+  111) exit 0 ;;
+  *) exit 1 ;;
+esac
+EOF
+
+cat > "$MOCK/ps" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *111*) echo " 111"; exit 0 ;;
+  *333*) echo " 333"; exit 0 ;;
+  *) exit 1 ;;
+esac
+EOF
+
+cat > "$MOCK/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+cat > "$MOCK/tmux" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  list-sessions)
+    if [ "${MOCK_TMUX_NO_SERVER:-0}" = 1 ]; then
+      echo "no server running on /tmp/tmux-test/default" >&2
+      exit 1
+    fi
+    [ "${MOCK_TMUX_FAIL:-0}" = 1 ] && exit 2
+    printf '%s\n' "${MOCK_SESSIONS:-alive}"
+    ;;
+  capture-pane)
+    count_file="${AUTO_HEAL_TEST_TMP}/capture-count"
+    count=$(cat "$count_file" 2>/dev/null || echo 0)
+    count=$((count + 1))
+    echo "$count" > "$count_file"
+    if [ "$count" -eq 1 ]; then
+      printf '%s\n' "${MOCK_PANE_BEFORE:-normal}"
+    else
+      printf '%s\n' "${MOCK_PANE_AFTER:-normal}"
+    fi
+    ;;
+  send-keys)
+    echo "send-keys:${*:2}" >> "$AUTO_HEAL_TEST_CALLS"
+    ;;
+  *) exit 2 ;;
+esac
+EOF
+
+cat > "$MOCK/launchctl" <<'EOF'
+#!/usr/bin/env bash
+[ "${MOCK_LAUNCHCTL_FAIL:-0}" = 1 ] && exit 2
+printf '%s\n' "${MOCK_LAUNCHD_LIST:-}"
+EOF
+
+chmod +x "$MOCK"/*
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_calls() {
+  local expected=$1
+  local actual
+  actual=$(grep -vc '^send-keys:' "$CALLS" || true)
+  [ "$actual" -eq "$expected" ] || fail "expected $expected recovery calls, got $actual: $(cat "$CALLS")"
+}
+
+run_case() {
+  : > "$CALLS"
+  rm -f "$TMP/capture-count"
+  PATH="$MOCK:/usr/bin:/bin" \
+    AUTO_HEAL_KILL_BIN="$MOCK/kill" \
+    AUTO_HEAL_PS_BIN="$MOCK/ps" \
+    AUTO_HEAL_TEST_CALLS="$CALLS" \
+    AUTO_HEAL_TEST_TMP="$TMP" \
+    AUTO_HEAL_SURVEY_WAIT_SECONDS=0 \
+    "$CORE" --config "$1"
+}
+
+run_dry_case() {
+  : > "$CALLS"
+  rm -f "$TMP/capture-count"
+  PATH="$MOCK:/usr/bin:/bin" \
+    AUTO_HEAL_KILL_BIN="$MOCK/kill" \
+    AUTO_HEAL_PS_BIN="$MOCK/ps" \
+    AUTO_HEAL_TEST_CALLS="$CALLS" \
+    AUTO_HEAL_TEST_TMP="$TMP" \
+    AUTO_HEAL_SURVEY_WAIT_SECONDS=0 \
+    "$CORE" --config "$1" --dry-run
+}
+
+pid_alive="$TMP/pid-alive"
+pid_dead="$TMP/pid-dead"
+pid_ambiguous="$TMP/pid-ambiguous"
+printf '111\n' > "$pid_alive"
+printf '222\n' > "$pid_dead"
+printf '333\n' > "$pid_ambiguous"
+
+config="$TMP/config"
+
+printf 'bot|missing-tmux|gone|%s|on|%s/recover|bot-down\n' "$pid_alive" "$MOCK" > "$config"
+MOCK_SESSIONS=alive run_case "$config" >/dev/null
+assert_calls 1
+
+MOCK_TMUX_NO_SERVER=1 run_case "$config" >/dev/null
+assert_calls 1
+
+MOCK_SESSIONS=alive run_dry_case "$config" >/dev/null
+assert_calls 0
+
+printf 'bot|dead-poller|alive|%s|on|%s/recover|poller-dead\n' "$pid_dead" "$MOCK" > "$config"
+MOCK_SESSIONS=alive run_case "$config" >/dev/null
+assert_calls 1
+
+printf 'bot|missing-pid|alive|%s/no-file|on|%s/recover|must-not-run\n' "$TMP" "$MOCK" > "$config"
+MOCK_SESSIONS=alive run_case "$config" >/dev/null
+assert_calls 0
+
+printf 'bot|ambiguous-pid|alive|%s|on|%s/recover|must-not-run\n' "$pid_ambiguous" "$MOCK" > "$config"
+MOCK_SESSIONS=alive run_case "$config" >/dev/null
+assert_calls 0
+
+printf 'bot|disabled|gone|%s|off|%s/recover|must-not-run\n' "$pid_dead" "$MOCK" > "$config"
+MOCK_SESSIONS=alive run_case "$config" >/dev/null
+assert_calls 0
+
+printf 'gateway|unregistered|configured.label|-|on|%s/recover|gateway-up\n' "$MOCK" > "$config"
+MOCK_LAUNCHD_LIST="" run_case "$config" >/dev/null
+assert_calls 1
+
+printf 'gateway|dead|configured.label|-|on|%s/recover|gateway-dead\n' "$MOCK" > "$config"
+MOCK_LAUNCHD_LIST=$'222\t0\tconfigured.label' run_case "$config" >/dev/null
+assert_calls 1
+
+printf 'gateway|alive|configured.label|-|on|%s/recover|must-not-run\n' "$MOCK" > "$config"
+MOCK_LAUNCHD_LIST=$'111\t0\tconfigured.label' run_case "$config" >/dev/null
+assert_calls 0
+
+printf 'gateway|ambiguous|configured.label|-|on|%s/recover|must-not-run\n' "$MOCK" > "$config"
+MOCK_LAUNCHD_LIST=$'111\t0\tconfigured.label\n222\t0\tconfigured.label' run_case "$config" >/dev/null
+assert_calls 0
+
+printf 'gateway|unknown|configured.label|-|on|%s/recover|must-not-run\n' "$MOCK" > "$config"
+MOCK_LAUNCHCTL_FAIL=1 run_case "$config" >/dev/null
+assert_calls 0
+
+printf 'bot|survey|alive|%s|on|%s/recover|must-not-run\n' "$pid_alive" "$MOCK" > "$config"
+MOCK_SESSIONS=alive \
+MOCK_PANE_BEFORE=$'How is Claude doing this session\n❯ preserved input' \
+MOCK_PANE_AFTER=$'normal\n❯ preserved input' \
+run_case "$config" >/dev/null
+assert_calls 0
+grep -q '^send-keys:.* 0$' "$CALLS" || fail "survey did not send literal 0"
+
+MOCK_SESSIONS=alive \
+MOCK_PANE_BEFORE=$'How is Claude doing this session\n❯ preserved input' \
+MOCK_PANE_AFTER=$'normal\n❯ changed input' \
+run_case "$config" > "$TMP/survey-failed.out"
+assert_calls 0
+[ "$(grep -c '^send-keys:' "$CALLS")" -eq 1 ] || fail "survey failure sent additional keys"
+grep -q 'no restore attempted' "$TMP/survey-failed.out" || fail "survey failure was not reported"
+
+echo "PASS auto-heal core harness"

--- a/scripts/auto-heal-core.sh
+++ b/scripts/auto-heal-core.sh
@@ -19,6 +19,7 @@ EOF
 
 CONFIG=""
 DRY_RUN=0
+TMUX_BIN=${AUTO_HEAL_TMUX_BIN:-tmux}
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --config)
@@ -75,8 +76,8 @@ run_recovery() {
 
 capture_sessions() {
   local out status
-  command -v tmux >/dev/null 2>&1 || return 1
-  out=$(tmux list-sessions -F '#S' 2>&1)
+  command -v "$TMUX_BIN" >/dev/null 2>&1 || return 1
+  out=$("$TMUX_BIN" list-sessions -F '#S' 2>&1)
   status=$?
   if [ "$status" -eq 0 ]; then
     printf '%s\n' "$out"
@@ -109,11 +110,9 @@ pid_state() {
   ps_out=$("$ps_bin" -p "$pid" -o pid= 2>/dev/null)
   case "$?" in
     0)
-      if printf '%s\n' "$ps_out" | awk -v wanted="$pid" '$1 == wanted { found=1 } END { exit !found }'; then
-        echo ambiguous
-      else
-        echo ambiguous
-      fi
+      # Whether ps reports this PID or an unexpected row, a successful query
+      # contradicts kill's failure and therefore cannot prove death.
+      echo ambiguous
       ;;
     1)
       [ -z "$ps_out" ] && echo dead || echo ambiguous
@@ -136,12 +135,12 @@ dismiss_survey() {
     log "DRY-RUN [bot:$name] would dismiss Claude survey with literal 0"
     return 0
   fi
-  if ! tmux send-keys -l -t "$session" -- 0 2>/dev/null; then
+  if ! "$TMUX_BIN" send-keys -l -t "$session" -- 0 2>/dev/null; then
     log "FAILED [bot:$name] survey dismiss key was not sent; no retry attempted"
     return 0
   fi
   sleep "${AUTO_HEAL_SURVEY_WAIT_SECONDS:-1}"
-  after=$(tmux capture-pane -p -t "$session" 2>/dev/null) || {
+  after=$("$TMUX_BIN" capture-pane -p -t "$session" 2>/dev/null) || {
     log "FAILED [bot:$name] survey verification capture failed; no further input sent"
     return 0
   }
@@ -243,7 +242,7 @@ while IFS= read -r raw || [ -n "$raw" ]; do
         fi
       fi
 
-      pane=$(tmux capture-pane -p -t "$target" 2>/dev/null) || {
+      pane=$("$TMUX_BIN" capture-pane -p -t "$target" 2>/dev/null) || {
         log "NOOP [bot:$name] pane capture failed"
         continue
       }

--- a/scripts/auto-heal-core.sh
+++ b/scripts/auto-heal-core.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# Minimal, config-gated auto-heal for positively dead tmux bots/gateways and
+# Claude's session survey. Ambiguous observations always result in no action.
+
+set -uo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: auto-heal-core.sh --config FILE [--dry-run]
+
+Config (one pipe-delimited record per line):
+  bot|NAME|TMUX_SESSION|PID_FILE|on|RECOVERY_PROGRAM|ARG...
+  gateway|NAME|LAUNCHD_LABEL|-|on|RECOVERY_PROGRAM|ARG...
+
+Set field 5 to "off" to skip a configured target. Recovery programs are
+executed directly as argv; config lines are never evaluated as shell code.
+EOF
+}
+
+CONFIG=""
+DRY_RUN=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --config)
+      [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+      CONFIG=$2
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'ERROR unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+[ -n "$CONFIG" ] && [ -r "$CONFIG" ] || {
+  echo "ERROR --config must name a readable file" >&2
+  exit 2
+}
+
+log() {
+  printf '%s\n' "$*"
+}
+
+valid_atom() {
+  [ -n "$1" ] && [[ "$1" != *"|"* ]] && [[ "$1" != *$'\n'* ]]
+}
+
+run_recovery() {
+  local kind=$1 name=$2
+  shift 2
+  if [ "$#" -lt 1 ] || [ ! -x "$1" ]; then
+    log "NOOP [$kind:$name] recovery program is missing or not executable"
+    return 0
+  fi
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN [$kind:$name] would run recovery"
+    return 0
+  fi
+  if "$@"; then
+    log "HEALED [$kind:$name] recovery completed"
+  else
+    log "FAILED [$kind:$name] recovery returned non-zero; no fallback attempted"
+  fi
+}
+
+capture_sessions() {
+  local out status
+  command -v tmux >/dev/null 2>&1 || return 1
+  out=$(tmux list-sessions -F '#S' 2>&1)
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    printf '%s\n' "$out"
+    return 0
+  fi
+  # tmux uses exit 1 when there is no server. Its explicit diagnostic makes
+  # the empty inventory positive evidence; all other failures stay unknown.
+  if [ "$status" -eq 1 ] && printf '%s\n' "$out" |
+    grep -Eqi 'no server running|failed to connect to server'; then
+    return 0
+  fi
+  return 1
+}
+
+session_count() {
+  printf '%s\n' "$SESSION_LIST" | awk -v wanted="$1" '$0 == wanted { count++ } END { print count + 0 }'
+}
+
+pid_state() {
+  # Prints alive, dead, or ambiguous. A failed kill alone is not proof of death:
+  # ps must also positively report that the numeric PID does not exist.
+  local pid=$1 ps_out
+  local kill_bin=${AUTO_HEAL_KILL_BIN:-kill}
+  local ps_bin=${AUTO_HEAL_PS_BIN:-ps}
+  if "$kill_bin" -0 "$pid" 2>/dev/null; then
+    echo alive
+    return
+  fi
+  command -v "$ps_bin" >/dev/null 2>&1 || { echo ambiguous; return; }
+  ps_out=$("$ps_bin" -p "$pid" -o pid= 2>/dev/null)
+  case "$?" in
+    0)
+      if printf '%s\n' "$ps_out" | awk -v wanted="$pid" '$1 == wanted { found=1 } END { exit !found }'; then
+        echo ambiguous
+      else
+        echo ambiguous
+      fi
+      ;;
+    1)
+      [ -z "$ps_out" ] && echo dead || echo ambiguous
+      ;;
+    *)
+      echo ambiguous
+      ;;
+  esac
+}
+
+prompt_input() {
+  printf '%s\n' "$1" | sed -n -E 's/^❯[[:space:]]*//p' | tail -1
+}
+
+dismiss_survey() {
+  local name=$1 session=$2 pane=$3 before after
+  printf '%s\n' "$pane" | grep -Fqi "How is Claude doing this session" || return 0
+  before=$(prompt_input "$pane")
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN [bot:$name] would dismiss Claude survey with literal 0"
+    return 0
+  fi
+  if ! tmux send-keys -l -t "$session" -- 0 2>/dev/null; then
+    log "FAILED [bot:$name] survey dismiss key was not sent; no retry attempted"
+    return 0
+  fi
+  sleep "${AUTO_HEAL_SURVEY_WAIT_SECONDS:-1}"
+  after=$(tmux capture-pane -p -t "$session" 2>/dev/null) || {
+    log "FAILED [bot:$name] survey verification capture failed; no further input sent"
+    return 0
+  }
+  if printf '%s\n' "$after" | grep -Fqi "How is Claude doing this session"; then
+    log "FAILED [bot:$name] survey remains visible; no further input sent"
+    return 0
+  fi
+  if [ "$(prompt_input "$after")" != "$before" ]; then
+    log "FAILED [bot:$name] input line changed after survey dismiss; no restore attempted"
+    return 0
+  fi
+  log "HEALED [bot:$name] Claude survey dismissed; input line preserved"
+}
+
+SESSION_LIST=""
+SESSIONS_KNOWN=0
+if SESSION_LIST=$(capture_sessions); then
+  SESSIONS_KNOWN=1
+else
+  log "NOOP [tmux] session inventory unavailable; bot recovery and survey handling disabled"
+fi
+
+LAUNCHD_LIST=""
+LAUNCHD_KNOWN=0
+if command -v launchctl >/dev/null 2>&1 && LAUNCHD_LIST=$(launchctl list 2>/dev/null); then
+  LAUNCHD_KNOWN=1
+else
+  log "NOOP [launchd] service inventory unavailable; gateway recovery disabled"
+fi
+
+line_no=0
+while IFS= read -r raw || [ -n "$raw" ]; do
+  line_no=$((line_no + 1))
+  case "$raw" in
+    ""|\#*) continue ;;
+  esac
+  IFS='|' read -r -a fields <<< "$raw"
+  if [ "${#fields[@]}" -lt 6 ]; then
+    log "NOOP [config:$line_no] expected at least 6 fields"
+    continue
+  fi
+  kind=${fields[0]}
+  name=${fields[1]}
+  target=${fields[2]}
+  pid_file=${fields[3]}
+  mode=${fields[4]}
+  recovery=("${fields[@]:5}")
+
+  if ! valid_atom "$name" || ! valid_atom "$target"; then
+    log "NOOP [config:$line_no] empty or invalid name/target"
+    continue
+  fi
+  case "$mode" in
+    off)
+      log "SKIP [$kind:$name] configured off"
+      continue
+      ;;
+    on) ;;
+    *)
+      log "NOOP [$kind:$name] mode must be on or off"
+      continue
+      ;;
+  esac
+
+  case "$kind" in
+    bot)
+      if [ "$SESSIONS_KNOWN" -ne 1 ]; then
+        log "NOOP [bot:$name] tmux state is unknown"
+        continue
+      fi
+      count=$(session_count "$target")
+      if [ "$count" -eq 0 ]; then
+        run_recovery bot "$name" "${recovery[@]}"
+        continue
+      elif [ "$count" -ne 1 ]; then
+        log "NOOP [bot:$name] tmux session match is ambiguous"
+        continue
+      fi
+
+      if [ ! -e "$pid_file" ]; then
+        log "NOOP [bot:$name] poller PID file is missing"
+      elif [ ! -r "$pid_file" ]; then
+        log "NOOP [bot:$name] poller PID file is unreadable"
+      else
+        pid=$(sed -n '1p' "$pid_file" 2>/dev/null)
+        if ! [[ "$pid" =~ ^[1-9][0-9]*$ ]] || [ "$(wc -l < "$pid_file" 2>/dev/null)" -gt 1 ]; then
+          log "NOOP [bot:$name] poller PID is malformed"
+        else
+          state=$(pid_state "$pid")
+          case "$state" in
+            dead)
+              run_recovery bot "$name" "${recovery[@]}"
+              continue
+              ;;
+            ambiguous)
+              log "NOOP [bot:$name] poller PID state is ambiguous"
+              ;;
+          esac
+        fi
+      fi
+
+      pane=$(tmux capture-pane -p -t "$target" 2>/dev/null) || {
+        log "NOOP [bot:$name] pane capture failed"
+        continue
+      }
+      dismiss_survey "$name" "$target" "$pane"
+      ;;
+    gateway)
+      if [ "$LAUNCHD_KNOWN" -ne 1 ]; then
+        log "NOOP [gateway:$name] launchd state is unknown"
+        continue
+      fi
+      matches=$(printf '%s\n' "$LAUNCHD_LIST" | awk -v label="$target" '$3 == label { print $1 }')
+      match_count=$(printf '%s\n' "$matches" | awk 'NF { count++ } END { print count + 0 }')
+      if [ "$match_count" -eq 0 ]; then
+        run_recovery gateway "$name" "${recovery[@]}"
+      elif [ "$match_count" -ne 1 ]; then
+        log "NOOP [gateway:$name] launchd label match is ambiguous"
+      else
+        pid=$(printf '%s\n' "$matches" | head -1)
+        if [ "$pid" = "-" ]; then
+          run_recovery gateway "$name" "${recovery[@]}"
+        elif ! [[ "$pid" =~ ^[1-9][0-9]*$ ]]; then
+          log "NOOP [gateway:$name] launchd PID is malformed"
+        else
+          state=$(pid_state "$pid")
+          case "$state" in
+            dead) run_recovery gateway "$name" "${recovery[@]}" ;;
+            ambiguous) log "NOOP [gateway:$name] launchd PID state is ambiguous" ;;
+          esac
+        fi
+      fi
+      ;;
+    *)
+      log "NOOP [config:$line_no] unknown kind"
+      ;;
+  esac
+done < "$CONFIG"


### PR DESCRIPTION
공개 유저용 최소 auto-heal 코어. config-gated, positive-death-only, safe-fail(불확실=no-op). 봇 tmux 미존재/폴러 positive death, gateway 미등록/정지 → recovery 1회(fallback 없음). Claude 설문 literal '0' dismiss + 입력줄보존 검증(실패=보고만). 검증: 하네스 적대 안전검증기 CONFIRMED-SAFE + Steve 소스리뷰 CONFIRMED-SAFE + mock 하네스 PASS(uncertain=recovery 0 실카운트, safe-fail 5케이스 회귀가드 포함). .gitignore allowlist로 공개.