### PR TITLE
feat: infra acceptance checks + OS tab deprecated filter

### DIFF
--- a/skills/b3os/references/system-jobs.md
+++ b/skills/b3os/references/system-jobs.md
@@ -5,6 +5,16 @@
 
 > 원칙: **새 시스템 잡(워커·스케줄 잡)을 추가하면 반드시 이 표에 한 줄 넣는다.** 그래야 "뭐가 도는지" 한곳에서 보인다.
 
+## 0) 운영 잡 실행 계층 — 3종
+
+| 종류 | 정본·실행 주체 | 적합한 용도 | Team OS 탭의 상태 해석 |
+|---|---|---|---|
+| **launchd** | `~/Library/LaunchAgents/*.plist` · macOS `launchd` | `team-collab(:7878)`·`caffeinate`·gateway처럼 재부팅/크래시 뒤에도 살아야 하는 상시 서비스, macOS 런타임 브리지 | `KeepAlive` 서비스만 현재 PID 기반 `running=true/false`. `StartInterval`·`StartCalendarInterval` 잡은 실행 사이에 꺼져 있는 것이 정상이므로 `running=null` |
+| **scheduled_job** | `team.db`의 `scheduled_job`/`scheduled_job_run` · b3os `schedulerWorker` | 팀 공용 durable(세션 종료 후에도 보존되는) cron·interval·one-shot, inbox wake, allowlist된 ops 스크립트 | `next_run_at`·`last_run_at` 표시. `enabled=1 AND status=failed`는 인수테스트 실패. `enabled=0 AND status=cancelled`는 은퇴 잡으로 집계하되 OS 탭 목록에서는 제외 |
+| **openclaw_cron** | `~/.openclaw/cron/jobs.json` · OpenClaw 런타임 | OpenClaw 에이전트에 종속된 런타임 자체 예약 작업 | 예약 정의를 관측용으로 표시하며 상주 프로세스가 아니므로 `running=null`. 팀 공용 잡은 가능하면 `scheduled_job` 사용 |
+
+선택 기준: **상시 프로세스는 launchd**, **팀 공용 예약·리마인드는 scheduled_job**, **OpenClaw 한 런타임에만 귀속되는 작업은 openclaw_cron**이다. 같은 작업을 둘 이상의 계층에 중복 등록하지 않는다.
+
 ## 1) 항상 켜짐 (부팅 시 무조건 시작)
 
 | 잡 | 하는 일 | 주기 | 상태 로그 |
@@ -46,4 +56,6 @@
    ```
 3. **게이트는 env 로.** 위험하거나 실행부가 무거운 잡은 env 플래그로 켠다(예: scheduler 는 기본 OFF). 반대로 협업 필수 잡(wake dispatcher)은 기본 ON — 명시적 `=false` 로만 끈다.
 
-> 개선 후보(팀 리드 검토): 대시보드에 **"System Jobs" 패널**을 추가해 각 워커의 켜짐/주기/마지막 tick 을 한 화면에 노출하면, 로그를 grep 하지 않고도 "뭐가 도는지"를 볼 수 있다. (신규 엔드포인트 `GET /team/api/system/jobs` + 패널 — 승인 후 구현.)
+퍼블릭 인수테스트의 **인프라/운영** 섹션은 필수 KeepAlive 서비스 3종(`team-collab`·`caffeinate`·gateway), 활성 recurring 실패 잡, 1시간 넘은 `wake_dispatched` lease를 자동 점검한다. 고아 wake는 0개 pass, 1~10개 info, 10개 초과 fail이다.
+
+대시보드 **Team OS** 탭은 launchd·scheduled_job·openclaw_cron을 한 목록으로 합쳐 보여준다. 다만 서버 내부 워커의 마지막 tick은 아직 부팅 로그를 정본으로 확인한다.

--- a/src/server/lib/acceptanceCheck.ts
+++ b/src/server/lib/acceptanceCheck.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { captureConfigStatus } from "./captureConfig";
 import { loadRegistry } from "./registry";
+import { teamOsSnapshot, type TeamOsSnapshot } from "./teamosProbe";
 import type { AgentRecord } from "../types";
 
 export type AcceptanceStatus = "pass" | "fail" | "info";
@@ -15,7 +16,7 @@ export interface AcceptanceItem {
 }
 
 export interface AcceptanceStep {
-  key: "settings" | "rules" | "ot" | "portability";
+  key: "settings" | "rules" | "ot" | "portability" | "infra";
   label: string;
   checks: AcceptanceItem[];
 }
@@ -35,6 +36,7 @@ export interface AcceptanceDeps {
   teamOsPath: string;
   rootDir?: string;
   membersRoot?: string;
+  teamOsSnapshot?: (db: Database) => Pick<TeamOsSnapshot, "scheduled">;
 }
 
 // 누출/포터빌리티 탐지는 ★포맷 기반★(토큰 shape · 절대경로)만 쓴다. 특정 팀의 실값(chat_id·봇핸들·
@@ -267,6 +269,64 @@ function portabilityStep(
   return { key: "portability", label: "포터빌리티 / 누출", checks: items };
 }
 
+const INFRA_SERVICES = [
+  { name: "team-collab", required: true, matches: (label: string) => label.endsWith(".team-collab") },
+  { name: "caffeinate", required: false, matches: (label: string) => label.endsWith(".caffeinate") },
+  { name: "gateway", required: false, matches: (label: string) => label === "ai.openclaw.gateway" || label.endsWith(".gateway") },
+] as const;
+
+function infraStep(deps: AcceptanceDeps): AcceptanceStep {
+  const items: AcceptanceItem[] = [];
+  const scheduled = (deps.teamOsSnapshot?.(deps.db) ?? teamOsSnapshot(deps.db)).scheduled;
+  const services = scheduled.filter((job) => job.kind === "service");
+
+  for (const expected of INFRA_SERVICES) {
+    const service = services.find((job) => expected.matches(job.label));
+    const running = service?.running === true;
+    const detail = running
+      ? `${service.label} running`
+      : expected.required
+        ? service?.running === false
+          ? `${service.label} stopped`
+          : service
+            ? `${service.label} 상태 미확인`
+            : "미등록"
+        : "미설정 — 선택";
+    items.push(item(running ? "pass" : expected.required ? "fail" : "info", `${expected.required ? "필수" : "선택"} 서비스: ${expected.name}`, detail));
+  }
+
+  const failedJobs = deps.db.prepare(
+    `SELECT id, last_run_at
+       FROM scheduled_job
+      WHERE kind = 'recurring' AND status = 'failed' AND enabled = 1
+      ORDER BY id`,
+  ).all() as Array<{ id: string; last_run_at: string | null }>;
+  if (failedJobs.length === 0) {
+    items.push(item("pass", "예약 잡 실패", "0개"));
+  } else {
+    for (const job of failedJobs) {
+      items.push(item("fail", "예약 잡 실패", `${job.id} · last_run=${job.last_run_at ?? "-"}`));
+    }
+  }
+
+  const retired = deps.db.prepare(
+    `SELECT COUNT(*) AS count
+       FROM scheduled_job
+      WHERE enabled = 0 AND status = 'cancelled'`,
+  ).get() as { count: number };
+  items.push(item("info", "은퇴 잡", `은퇴 ${retired.count}개`));
+
+  const orphanWakes = deps.db.prepare(
+    `SELECT COUNT(*) AS count
+       FROM message_recipient
+      WHERE delivery_state = 'wake_dispatched'
+        AND lease_until < datetime('now', '-1 hour')`,
+  ).get() as { count: number };
+  items.push(item("info", "고아 wake", orphanWakes.count === 0 ? "없음" : `reconcile 후보 ${orphanWakes.count}개`));
+
+  return { key: "infra", label: "인프라/운영", checks: items };
+}
+
 export function runAcceptanceCheck(deps: AcceptanceDeps, member: string | null): AcceptanceResult {
   const rootDir = deps.rootDir ?? dirname(dirname(deps.teamOsPath));
   const membersRoot = deps.membersRoot ?? defaultMembersRoot();
@@ -276,6 +336,7 @@ export function runAcceptanceCheck(deps: AcceptanceDeps, member: string | null):
     coreRulesStep(deps.teamOsPath),
     onboardingStep(member, agents, membersRoot),
     portabilityStep(rootDir, membersRoot, member, buildInternalIdRe(deps.db)),
+    infraStep(deps),
   ];
   const summary = sections.flatMap((section) => section.checks).reduce<Record<AcceptanceStatus, number>>(
     (acc, entry) => {

--- a/src/server/lib/acceptanceCheck.ts
+++ b/src/server/lib/acceptanceCheck.ts
@@ -283,6 +283,22 @@ function infraStep(deps: AcceptanceDeps): AcceptanceStep {
   for (const expected of INFRA_SERVICES) {
     const service = services.find((job) => expected.matches(job.label));
     const running = service?.running === true;
+
+    // 이 인수체크를 응답하는 서버 자체가 team-collab 생존 증거다. launchd 는 리부팅 자동복구를
+    // 위한 선택 옵션이므로, 미등록(수동 실행)이나 stopped 스냅샷이 전체 인수체크를 red 로 만들면 안 된다.
+    if (expected.name === "team-collab") {
+      const status = running || !service ? "pass" : "info";
+      const detail = running
+        ? "running (launchd)"
+        : !service
+          ? "수동 실행 — launchd 상시서비스 미설치(리부팅 자동복구 없음)"
+          : service.running === false
+            ? "launchd 등록됨·stopped — 현재 서버는 수동 실행 중"
+            : "launchd 등록됨·상태 미확인 — 현재 서버는 수동 실행 중";
+      items.push(item(status, "필수 서비스: team-collab", detail));
+      continue;
+    }
+
     const detail = running
       ? `${service.label} running`
       : expected.required

--- a/src/server/lib/teamosProbe.test.ts
+++ b/src/server/lib/teamosProbe.test.ts
@@ -25,4 +25,21 @@ describe("teamOsSnapshot scheduled_job rows", () => {
     expect(row?.detail).toContain("next=07-21 09:30 KST");
     expect(row?.detail).toContain("last=07-21 08:15 KST");
   });
+
+  test("excludes disabled cancelled jobs retired from the OS tab", () => {
+    const db = new Database(":memory:");
+    migrate(db);
+    createCronJob(db, {
+      id: "retired-job",
+      title: "Retired job",
+      cron: "0 21 * * *",
+      timezone: "Asia/Seoul",
+      createdBy: "test",
+      payload: { type: "exec", execKey: "task-review-ping" },
+    });
+    db.prepare("UPDATE scheduled_job SET enabled = 0, status = 'cancelled' WHERE id = 'retired-job'").run();
+    __resetTeamOsSnapshotCacheForTest();
+
+    expect(teamOsSnapshot(db).scheduled.some((job) => job.label === "retired-job")).toBe(false);
+  });
 });

--- a/src/server/lib/teamosProbe.ts
+++ b/src/server/lib/teamosProbe.ts
@@ -240,7 +240,10 @@ function listScheduledJobs(db: Database): TeamOsScheduled[] {
   try {
     const rows = db.prepare(
       `SELECT id, title, schedule_expr, enabled, status, next_run_at, last_run_at
-         FROM scheduled_job WHERE kind='recurring' ORDER BY id`,
+         FROM scheduled_job
+        WHERE kind='recurring'
+          AND NOT (enabled=0 AND status='cancelled')
+        ORDER BY id`,
     ).all() as Array<{
       id: string; title: string | null; schedule_expr: string | null;
       enabled: number; status: string | null; next_run_at: string | null; last_run_at: string | null;

--- a/src/server/routes/acceptance.test.ts
+++ b/src/server/routes/acceptance.test.ts
@@ -4,7 +4,14 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { migrate } from "../db/migrate";
+import type { TeamOsScheduled } from "../lib/teamosProbe";
 import { createAcceptanceRoutes } from "./acceptance";
+
+const healthyServices: TeamOsScheduled[] = [
+  { label: "com.test.team-collab", kind: "service", detail: "상시", description: "team-collab", source: "launchd", running: true, enabled: true },
+  { label: "com.test.caffeinate", kind: "service", detail: "상시", description: "caffeinate", source: "launchd", running: true, enabled: true },
+  { label: "ai.openclaw.gateway", kind: "service", detail: "상시", description: "gateway", source: "launchd", running: true, enabled: true },
+];
 
 function setSetting(db: Database, key: string, value: string) {
   db.query(
@@ -13,7 +20,7 @@ function setSetting(db: Database, key: string, value: string) {
   ).run(key, value);
 }
 
-function setup() {
+function setup(services: TeamOsScheduled[] = healthyServices) {
   const db = new Database(":memory:");
   migrate(db);
   const dir = mkdtempSync(join(tmpdir(), "acceptance-test-"));
@@ -81,8 +88,47 @@ Tasks 칸반 사용.
   setSetting(db, "owner_name", "Owner");
   setSetting(db, "router_enabled", "true");
 
-  const app = createAcceptanceRoutes({ db, registryPath, teamOsPath, rootDir: root, membersRoot });
+  const app = createAcceptanceRoutes({
+    db,
+    registryPath,
+    teamOsPath,
+    rootDir: root,
+    membersRoot,
+    teamOsSnapshot: () => ({ scheduled: services }),
+  });
   return { app, db, dir, root, membersRoot, novaWs };
+}
+
+function insertScheduledJob(db: Database, id: string, status: "failed" | "cancelled", enabled: 0 | 1) {
+  db.prepare(
+    `INSERT INTO scheduled_job
+       (id, kind, schedule_kind, status, enabled, title, created_by, timezone,
+        next_run_at, last_run_at, schedule_expr, payload_json)
+     VALUES (?, 'recurring', 'cron', ?, ?, ?, 'test', 'Asia/Seoul',
+             datetime('now', '+1 day'), '2026-07-23 12:34:00', '{}', '{}')`,
+  ).run(id, status, enabled, id);
+}
+
+function insertOrphanWakes(db: Database, count: number) {
+  db.prepare(
+    `INSERT INTO agent (id, display_name, role, runtime, status_provider, workspace_path, persona_file)
+     VALUES ('worker', 'Worker', 'dev', 'openclaw', 'openclaw_gateway', '/tmp/worker', '/tmp/worker/SOUL.md')`,
+  ).run();
+  db.prepare(
+    `INSERT INTO thread (id, title, kind, participants_json, opened_by)
+     VALUES ('infra-test', 'Infra test', 'dm', '[]', 'test')`,
+  ).run();
+  for (let i = 0; i < count; i += 1) {
+    const id = `orphan-${i}`;
+    db.prepare(
+      `INSERT INTO message (id, thread_id, from_agent_id, to_agent_id, type, body, source)
+       VALUES (?, 'infra-test', 'test', 'worker', 'dm', 'test', 'system')`,
+    ).run(id);
+    db.prepare(
+      `INSERT INTO message_recipient (message_id, agent_id, delivery_state, lease_until)
+       VALUES (?, 'worker', 'wake_dispatched', datetime('now', '-2 hours'))`,
+    ).run(id);
+  }
 }
 
 beforeEach(() => {
@@ -93,7 +139,7 @@ beforeEach(() => {
 });
 
 describe("acceptance-check routes", () => {
-  test("returns four staged checks for an onboarded member", async () => {
+  test("returns five staged checks including healthy infra for an onboarded member", async () => {
     const { app, dir } = setup();
     try {
       const res = await app.request("/members/nova/acceptance-check");
@@ -101,13 +147,91 @@ describe("acceptance-check routes", () => {
       const body = (await res.json()) as any;
       expect(body.ok).toBe(true);
       expect(body.member).toBe("nova");
-      expect(body.sections.map((section: any) => section.key)).toEqual(["settings", "rules", "ot", "portability"]);
+      expect(body.sections.map((section: any) => section.key)).toEqual(["settings", "rules", "ot", "portability", "infra"]);
       expect(body.sections.every((section: any) => Array.isArray(section.checks))).toBe(true);
       expect(body.sections.find((section: any) => section.key === "ot").checks).toContainEqual({
         label: "agents.json 등록",
         status: "pass",
         detail: "runtime=openclaw",
       });
+      const infra = body.sections.find((section: any) => section.key === "infra");
+      expect(infra.label).toBe("인프라/운영");
+      expect(
+        infra.checks
+          .filter((entry: any) => entry.label.endsWith("서비스: team-collab"))
+          .every((entry: any) => entry.status === "pass"),
+      ).toBe(true);
+      expect(infra.checks).toContainEqual({ label: "고아 wake", status: "info", detail: "없음" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("infra keeps stopped or missing optional services informational", async () => {
+    const optionalServices = healthyServices
+      .filter((service) => service.label !== "ai.openclaw.gateway")
+      .map((service) => service.label.endsWith("caffeinate") ? { ...service, running: false } : service);
+    const { app, dir } = setup(optionalServices);
+    try {
+      const body = (await (await app.request("/acceptance-check")).json()) as any;
+      const infra = body.sections.find((section: any) => section.key === "infra");
+      expect(infra.checks).toContainEqual({
+        label: "선택 서비스: caffeinate",
+        status: "info",
+        detail: "미설정 — 선택",
+      });
+      expect(infra.checks).toContainEqual({
+        label: "선택 서비스: gateway",
+        status: "info",
+        detail: "미설정 — 선택",
+      });
+      expect(body.ok).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("infra fails only for a stopped required service and enabled failed job", async () => {
+    const stoppedServices = healthyServices.map((service) =>
+      service.label.endsWith("team-collab") ? { ...service, running: false } : service,
+    );
+    const { app, db, dir } = setup(stoppedServices);
+    try {
+      insertScheduledJob(db, "broken-recurring", "failed", 1);
+      insertOrphanWakes(db, 11);
+
+      const body = (await (await app.request("/acceptance-check")).json()) as any;
+      const infra = body.sections.find((section: any) => section.key === "infra");
+      expect(infra.checks).toContainEqual(
+        expect.objectContaining({ label: "필수 서비스: team-collab", status: "fail" }),
+      );
+      expect(infra.checks).toContainEqual(
+        expect.objectContaining({
+          label: "예약 잡 실패",
+          status: "fail",
+          detail: expect.stringContaining("broken-recurring"),
+        }),
+      );
+      expect(infra.checks).toContainEqual(
+        { label: "고아 wake", status: "info", detail: "reconcile 후보 11개" },
+      );
+      expect(body.ok).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("infra reports retired jobs and a small orphan-wake backlog as info", async () => {
+    const { app, db, dir } = setup();
+    try {
+      insertScheduledJob(db, "retired-recurring", "cancelled", 0);
+      insertOrphanWakes(db, 3);
+
+      const body = (await (await app.request("/acceptance-check")).json()) as any;
+      const infra = body.sections.find((section: any) => section.key === "infra");
+      expect(infra.checks).toContainEqual({ label: "은퇴 잡", status: "info", detail: "은퇴 1개" });
+      expect(infra.checks).toContainEqual({ label: "고아 wake", status: "info", detail: "reconcile 후보 3개" });
+      expect(body.ok).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/server/routes/acceptance.test.ts
+++ b/src/server/routes/acceptance.test.ts
@@ -191,7 +191,24 @@ describe("acceptance-check routes", () => {
     }
   });
 
-  test("infra fails only for a stopped required service and enabled failed job", async () => {
+  test("infra treats a missing team-collab launchd service as a healthy manual server run", async () => {
+    const manuallyStartedServices = healthyServices.filter((service) => !service.label.endsWith("team-collab"));
+    const { app, dir } = setup(manuallyStartedServices);
+    try {
+      const body = (await (await app.request("/acceptance-check")).json()) as any;
+      const infra = body.sections.find((section: any) => section.key === "infra");
+      expect(infra.checks).toContainEqual({
+        label: "필수 서비스: team-collab",
+        status: "pass",
+        detail: "수동 실행 — launchd 상시서비스 미설치(리부팅 자동복구 없음)",
+      });
+      expect(body.ok).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("infra keeps a stopped team-collab launchd service informational while failed jobs fail", async () => {
     const stoppedServices = healthyServices.map((service) =>
       service.label.endsWith("team-collab") ? { ...service, running: false } : service,
     );
@@ -203,7 +220,11 @@ describe("acceptance-check routes", () => {
       const body = (await (await app.request("/acceptance-check")).json()) as any;
       const infra = body.sections.find((section: any) => section.key === "infra");
       expect(infra.checks).toContainEqual(
-        expect.objectContaining({ label: "필수 서비스: team-collab", status: "fail" }),
+        expect.objectContaining({
+          label: "필수 서비스: team-collab",
+          status: "info",
+          detail: "launchd 등록됨·stopped — 현재 서버는 수동 실행 중",
+        }),
       );
       expect(infra.checks).toContainEqual(
         expect.objectContaining({

--- a/src/server/routes/acceptance.ts
+++ b/src/server/routes/acceptance.ts
@@ -3,12 +3,10 @@ import type { Database } from "bun:sqlite";
 import { dirname } from "node:path";
 import { runAcceptanceCheck, type AcceptanceDeps } from "../lib/acceptanceCheck";
 
-export interface AcceptanceRouteDeps {
+export interface AcceptanceRouteDeps extends AcceptanceDeps {
   db: Database;
   registryPath: string;
   teamOsPath: string;
-  rootDir?: string;
-  membersRoot?: string;
 }
 
 function depsForCheck(deps: AcceptanceRouteDeps): AcceptanceDeps {
@@ -18,6 +16,7 @@ function depsForCheck(deps: AcceptanceRouteDeps): AcceptanceDeps {
     teamOsPath: deps.teamOsPath,
     rootDir: deps.rootDir ?? dirname(dirname(deps.teamOsPath)),
     membersRoot: deps.membersRoot,
+    teamOsSnapshot: deps.teamOsSnapshot,
   };
 }
 


### PR DESCRIPTION
퍼블릭 인수테스트에 infra 섹션 추가(필수 team-collab running·failed recurring 잡·은퇴 잡·고아 wake) + OS탭 은퇴잡(cancelled+disabled) 제외 + system-jobs.md 3계층 현행화. calibration: caffeinate/gateway는 선택(info), team-collab만 required(fail), orphan wake는 terminal-OK라 info. 검증 14 pass·typecheck PASS. GD 4체크 자동화.