### PR TITLE
fix(reports): slow search debounce

### DIFF
--- a/src/web/reports.html
+++ b/src/web/reports.html
@@ -379,7 +379,7 @@ function renderList(q, cat){
     qel.addEventListener("compositionend", function(){ composing = false; scheduleSearch(qel.value); });
     function scheduleSearch(v){
       clearTimeout(qel._t);
-      qel._t=setTimeout(function(){ location.hash=hashFor(v, cat); },260);
+      qel._t=setTimeout(function(){ location.hash=hashFor(v, cat); },650);
     }
     qel.oninput=function(){ if(composing || this.isComposing) return; scheduleSearch(this.value); };
     if(q){ qel.focus(); qel.setSelectionRange(qel.value.length,qel.value.length); }


### PR DESCRIPTION
## Summary
- Increase Reports search debounce from 260ms to 650ms on top of b3rys-team-os main (43e2409 / PR#23 included).
- Scope is intentionally limited to src/web/reports.html only.

## Test Plan
- node --check /tmp/reports-inline-check.js
- git diff --check

## Notes
- If mobile input is still unstable, likely next fix is avoiding list re-render/input recreation by filtering rows in place.