### PR TITLE
fix(runtime): bash 3.2 compat for DISPLAY default (drop ${var^^})

### DIFF
--- a/src/server/runtimes/hermes/activate-hermes-agent.sh
+++ b/src/server/runtimes/hermes/activate-hermes-agent.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 export PATH="$HOME/.local/bin:$PATH"
 
 AGENT_ID="${AGENT_ID:?AGENT_ID 필요 (예: myagent)}"
-DISPLAY="${DISPLAY:-${AGENT_ID^^}}"
+DISPLAY="${DISPLAY:-$(echo "$AGENT_ID" | tr '[:lower:]' '[:upper:]')}"   # ${var^^}는 bash 4+ 전용 → macOS 기본 bash 3.2 호환 위해 tr 사용
 KO="${KO:-$AGENT_ID}"                     # 한글 멘션 별칭 (예: 별칭)
 DESC="${DESC:-b3rys 팀원 ($AGENT_ID)}"
 WS="${WS:-$HOME/Development/$AGENT_ID}"

--- a/src/server/runtimes/openclaw/activate-openclaw-agent.sh
+++ b/src/server/runtimes/openclaw/activate-openclaw-agent.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 AGENT_ID="${AGENT_ID:?AGENT_ID 필요 (예: myagent)}"
-DISPLAY="${DISPLAY:-${AGENT_ID^^}}"
+DISPLAY="${DISPLAY:-$(echo "$AGENT_ID" | tr '[:lower:]' '[:upper:]')}"   # ${var^^}는 bash 4+ 전용 → macOS 기본 bash 3.2 호환 위해 tr 사용
 WS="${WS:-$HOME/Development/$AGENT_ID}"
 MODEL="${MODEL:-openai/gpt-5.5}"      # 기본 모델(codex 런타임 라우팅). 공개 사용자는 자신의 provider/모델에 맞게 env MODEL 로 override.
 OC="$HOME/.openclaw"


### PR DESCRIPTION
hermes/openclaw activate 스크립트의 ${AGENT_ID^^}(bash 4+ 전용)가 macOS 기본 bash 3.2서 bad substitution → hermes 영입 항상 실패. tr로 교체(bash 3.2 호환). 전 .sh 스윕 결과 bash-4 문법은 이 2곳뿐. bash 3.2 재현+수정 테스트 통과. fresh-clone 온보딩 크리티컬.