### PR TITLE
fix(team-op): hide completed tasks from /board

### DIFF
--- a/src/server/workers/telegramCapture.test.ts
+++ b/src/server/workers/telegramCapture.test.ts
@@ -310,22 +310,14 @@ function dbWithTasks(): Database {
 }
 
 describe("slash command formatters (fmt*)", () => {
-  test("fmtBoard groups by lane with counts + owner", () => {
+  test("fmtBoard lists active lanes with counts + owner and excludes done", () => {
     const out = fmtBoard(dbWithTasks());
     expect(out).toContain("📋 칸반 작업 보드");
     expect(out).toContain("📝 계획 (1)");
     expect(out).toContain("🔧 실행 중 (1)");
-    expect(out).toContain("✅ 완료 (1)");
     expect(out).toContain("실행 작업B — @bill");
-  });
-  test("fmtBoard caps done list at 5 with overflow note", () => {
-    const db = new Database(":memory:");
-    migrate(db);
-    const ins = db.prepare(`INSERT INTO task (id, title, lane, owner, sort_order) VALUES (?, ?, 'done', NULL, ?)`);
-    for (let i = 0; i < 7; i++) ins.run(`d${i}`, `done${i}`, i);
-    const out = fmtBoard(db);
-    expect(out).toContain("✅ 완료 (7)");
-    expect(out).toContain("…외 2건");
+    expect(out).not.toContain("✅ 완료");
+    expect(out).not.toContain("완료 작업C");
   });
   test("fmtReview lists doing; empty message when none", () => {
     expect(fmtReview(dbWithTasks())).toContain("실행 작업B — @bill");

--- a/src/server/workers/telegramCapture.ts
+++ b/src/server/workers/telegramCapture.ts
@@ -326,13 +326,11 @@ export function fmtBoard(db: Database): string {
   const locale = getLocale(db);
   const rows = allTasks(db);
   const out = [pick(locale, "📋 칸반 작업 보드", "📋 Kanban task board")];
-  const labels: Array<[string, string]> = [["plan", pick(locale, "📝 계획", "📝 Plan")], ["doing", pick(locale, "🔧 실행 중", "🔧 Doing")], ["done", pick(locale, "✅ 완료", "✅ Done")]];
+  const labels: Array<[string, string]> = [["plan", pick(locale, "📝 계획", "📝 Plan")], ["doing", pick(locale, "🔧 실행 중", "🔧 Doing")]];
   for (const [k, label] of labels) {
     const items = byLane(rows, k);
     out.push(`\n${label} (${items.length})`);
-    const show = k === "done" ? items.slice(-5) : items;
-    for (const t of show) out.push(taskLine(t));
-    if (k === "done" && items.length > 5) out.push(pick(locale, `  …외 ${items.length - 5}건`, `  …and ${items.length - 5} more`));
+    for (const t of items) out.push(taskLine(t));
     if (!items.length) out.push("  —");
   }
   return out.join("\n");


### PR DESCRIPTION
Team Op /board fmtBoard가 plan/doing만 출력, done 목록·건수 제거(GD 승인). 테스트 24/24, typecheck 통과. author gd.on noreply.