### PR TITLE
docs(comm-flow): Korean translation + mermaid parse fix

### DIFF
--- a/docs/COMMUNICATION_FLOW.md
+++ b/docs/COMMUNICATION_FLOW.md
@@ -1,23 +1,25 @@
-# b3rys Communication Flow
+# b3rys 통신 흐름 (Communication Flow)
 
-> Status: active reference
-> Scope: Telegram/Slack, runtimes, router, team bus, DB, and reply paths
+> 상태: 활성 레퍼런스
+> 범위: Telegram/Slack · 런타임 · 라우터 · 팀버스 · DB · 답장 경로
 
-This document explains how team communication moves through the system. It replaces the narrower "routing flow" framing: routing is only one part of the full communication flow.
+이 문서는 팀 통신이 시스템을 어떻게 흐르는지 설명한다. "라우팅 흐름"이라는 좁은 틀을 대체한다 — 라우팅은 전체 통신 흐름의 한 부분일 뿐이다.
 
-## High-Level Architecture
+> 📖 실제 코드·템플릿·수치까지 상세히 보려면 [`TEAM_COMMUNICATION.md`](TEAM_COMMUNICATION.md) (팀버스·주입문 형식·무한루프 방지·리스타트 주입). 이 문서는 아키텍처 흐름도 중심.
+
+## 상위 아키텍처
 
 ```mermaid
 flowchart LR
-  Telegram[Telegram<br/>group + DM] <--> Capture[Capture / Adapter<br/>Telegram bot]
-  Slack[Slack<br/>relay/poll] <--> Capture
-  Capture --> Router[Router<br/>who should respond?]
-  Router --> Bus[Team Bus<br/>inbox + recipients]
-  Bus <--> DB[(SQLite team.db)]
-  Bus --> Claude[Claude Channel runtimes<br/>Bill/Steve/Demis/Dbak]
-  Bus --> OpenClaw["OpenClaw runtimes<br/>Codex/Brief/Devon/Lui (+Forin personal-scope)"]
-  Bus --> Hermes[Hermes runtime]
-  Claude --> Reply[Reply mirror<br/>Telegram/Slack/team bus]
+  Telegram["Telegram<br/>그룹 + DM"] <--> Capture["캡처 / 어댑터<br/>Telegram 봇"]
+  Slack["Slack<br/>릴레이/폴링"] <--> Capture
+  Capture --> Router["라우터<br/>누가 답할까?"]
+  Router --> Bus["팀버스<br/>inbox + 수신자"]
+  Bus <--> DB[("SQLite team.db")]
+  Bus --> Claude["Claude Channel 런타임<br/>Bill/Steve/Demis/Dbak"]
+  Bus --> OpenClaw["OpenClaw 런타임<br/>Codex/Brief/Devon/Lui"]
+  Bus --> Hermes["Hermes 런타임"]
+  Claude --> Reply["답장 미러<br/>Telegram/Slack/팀버스"]
   OpenClaw --> Reply
   Hermes --> Reply
   Reply --> Telegram
@@ -25,48 +27,48 @@ flowchart LR
   Reply --> DB
 ```
 
-The short version:
+한 줄 요약:
 
-- External channels are Telegram and Slack.
-- `team-collab` captures messages, stores them, routes them, and tracks delivery.
-- The router decides who should respond.
-- The team bus records the message and recipient state.
-- Each runtime is woken through its own path.
-- Replies return to the visible channel when appropriate and are also stored in the DB.
+- 외부 채널은 Telegram과 Slack이다.
+- `team-collab`가 메시지를 캡처·저장·라우팅하고 배달 상태를 추적한다.
+- 라우터가 누가 답할지 결정한다.
+- 팀버스가 메시지와 수신자 상태를 기록한다.
+- 각 런타임은 자기 경로로 깨워진다.
+- 답장은 적절할 때 보이는 채널로 돌아가고, DB에도 저장된다.
 
-## Detailed System View
+## 상세 시스템 뷰
 
 ```mermaid
 flowchart TB
-  subgraph Channels[External channels]
-    TG[Telegram<br/>group + DM]
-    SL[Slack<br/>relay/poll path]
+  subgraph Channels["외부 채널"]
+    TG["Telegram<br/>그룹 + DM"]
+    SL["Slack<br/>릴레이/폴링 경로"]
   end
 
-  subgraph Server[team-collab Bun process :7878]
-    API[Hono HTTP API<br/>/team/api/*]
-    Dashboard[Web dashboard<br/>Vite bundle]
-    Capture[telegramCapture worker<br/>captures team-room messages]
-    SlackPoll[slackPoll worker<br/>Slack history polling]
-    Router[teamRouter<br/>@mention/reply/sticky rules]
-    Inbox[routes/inbox<br/>team bus API]
-    Dispatcher[wakeDispatcher<br/>polls pending recipients every 1.5s]
-    Status[status/metrics probes<br/>runtime health]
-    Search[search routes<br/>GET search + explicit reindex]
+  subgraph Server["team-collab Bun 프로세스 :7878"]
+    API["Hono HTTP API<br/>/team/api/*"]
+    Dashboard["웹 대시보드<br/>Vite 번들"]
+    Capture["telegramCapture 워커<br/>팀방 메시지 캡처"]
+    SlackPoll["slackPoll 워커<br/>Slack 히스토리 폴링"]
+    Router["teamRouter<br/>@멘션/답장/sticky 규칙"]
+    Inbox["routes/inbox<br/>팀버스 API"]
+    Dispatcher["wakeDispatcher<br/>1.5초마다 대기 수신자 폴링"]
+    Status["status/metrics 프로브<br/>런타임 헬스"]
+    Search["search 라우트<br/>GET 검색 + 명시적 reindex"]
   end
 
-  subgraph Data[SQLite team.db via bun:sqlite]
-    Msg[(message / recipient)]
-    Audit[(audit_event)]
-    Agent[(agent / status / metrics)]
-    Task[(task)]
-    SearchTables[(team_search_chunk<br/>team_search_fts)]
+  subgraph Data["SQLite team.db (bun:sqlite)"]
+    Msg[("message / recipient")]
+    Audit[("audit_event")]
+    Agent[("agent / status / metrics")]
+    Task[("task")]
+    SearchTables[("team_search_chunk<br/>team_search_fts")]
   end
 
-  subgraph Runtimes[Agent runtimes]
-    Claude[Claude Channel<br/>tmux sessions + pollers]
-    OpenClaw[OpenClaw gateway<br/>:18789 session wake]
-    Hermes[Hermes gateway/profile<br/>b3ryshermes]
+  subgraph Runtimes["에이전트 런타임"]
+    Claude["Claude Channel<br/>tmux 세션 + poller"]
+    OpenClaw["OpenClaw 게이트웨이<br/>:18789 세션 wake"]
+    Hermes["Hermes 게이트웨이/프로필<br/>b3ryshermes"]
   end
 
   TG --> Capture
@@ -85,146 +87,146 @@ flowchart TB
   Search --> SearchTables
   Search --> Msg
   Dashboard --> API
-  Dashboard -. read-only polling<br/>3s bus/topology, 15s Team OS .-> API
+  Dashboard -. "읽기전용 폴링<br/>3초 bus/topology, 15초 Team OS" .-> API
   Claude --> Inbox
   OpenClaw --> Inbox
   Hermes --> Inbox
-  Claude -. visible reply .-> TG
-  OpenClaw -. visible reply .-> TG
-  Hermes -. visible reply .-> TG
+  Claude -. "보이는 답장" .-> TG
+  OpenClaw -. "보이는 답장" .-> TG
+  Hermes -. "보이는 답장" .-> TG
 ```
 
-Important timing:
+중요한 타이밍:
 
-- `wakeDispatcher` checks the bus every **1.5 seconds** for pending delivery work. This is the internal delivery loop, not a user-facing refresh.
-- The dashboard uses read-only polling for views: Bus Flow/Topology roughly every **3 seconds**, Team OS roughly every **15 seconds**.
-- Retries and backoff are stored in SQLite leases, so the dispatcher does not spin in a tight retry loop.
+- `wakeDispatcher`는 **1.5초**마다 팀버스의 대기 배달 작업을 확인한다. 이건 내부 배달 루프지 사용자용 새로고침이 아니다.
+- 대시보드는 뷰마다 읽기전용 폴링을 쓴다: Bus Flow/Topology 약 **3초**, Team OS 약 **15초**.
+- 재시도·backoff는 SQLite 리스에 저장돼, 디스패처가 촘촘한 재시도 루프로 돌지 않는다.
 
-Process boundary:
+프로세스 경계:
 
-- `team-collab` is one Bun service exposing the dashboard and APIs.
-- SQLite `team.db` is the durable store. There is no separate message queue server in V0.
-- Claude agents are reached through tmux injection and their own Telegram polling bridge.
-- OpenClaw agents are reached through the OpenClaw gateway/session path.
-- Hermes is reached through its Hermes profile/gateway path.
+- `team-collab`는 대시보드와 API를 노출하는 하나의 Bun 서비스다.
+- SQLite `team.db`가 durable(영속) 저장소다. V0엔 별도 메시지 큐 서버가 없다.
+- Claude 에이전트는 tmux 주입과 자기 Telegram 폴링 브리지로 도달한다.
+- OpenClaw 에이전트는 OpenClaw 게이트웨이/세션 경로로 도달한다.
+- Hermes는 자기 Hermes 프로필/게이트웨이 경로로 도달한다.
 
-## Components
+## 구성요소
 
-| Component | What it means | Current implementation |
+| 구성요소 | 뜻 | 현재 구현 |
 | --- | --- | --- |
-| Telegram | GD/team visible chat and direct messages | Capture bot + per-agent bot/plugin paths |
-| Slack | Optional team channel relay | Slack routes/workers in `team-collab` |
-| Capture / Adapter | Turns external messages into internal records | `telegramCapture.ts`, `slackPoll.ts`, `routes/slack.ts` |
-| Router | Chooses responder(s) from message text and context | `teamRouter.ts`, `routes/router.ts` |
-| Team Bus | Internal inbox/outbox and delivery state machine | `routes/inbox.ts`, `inboxQueries.ts`, `wakeDispatcher.ts` polling every 1.5s |
-| DB | Durable state for messages, recipients, tasks, search | SQLite `team.db` via `bun:sqlite` |
-| Claude Channel runtimes | Interactive Claude Code sessions | tmux + Telegram polling bridge |
-| OpenClaw runtimes | OpenClaw/Codex-style agent sessions | OpenClaw gateway/session wake |
-| Hermes runtime | Hermes-specific bridge | `hermesBridge.ts` |
+| Telegram | GD·팀이 보는 채팅과 DM | 캡처 봇 + 에이전트별 봇/플러그인 경로 |
+| Slack | 선택적 팀 채널 릴레이 | `team-collab`의 Slack 라우트/워커 |
+| 캡처 / 어댑터 | 외부 메시지를 내부 레코드로 변환 | `telegramCapture.ts`, `slackPoll.ts`, `routes/slack.ts` |
+| 라우터 | 메시지 텍스트·맥락으로 답할 사람 선택 | `teamRouter.ts`, `routes/router.ts` |
+| 팀버스 | 내부 inbox/outbox + 배달 상태기계 | `routes/inbox.ts`, `inboxQueries.ts`, `wakeDispatcher.ts`(1.5초 폴링) |
+| DB | 메시지·수신자·작업·검색의 durable 상태 | SQLite `team.db` (`bun:sqlite`) |
+| Claude Channel 런타임 | 인터랙티브 Claude Code 세션 | tmux + Telegram 폴링 브리지 |
+| OpenClaw 런타임 | OpenClaw/Codex형 에이전트 세션 | OpenClaw 게이트웨이/세션 wake |
+| Hermes 런타임 | Hermes 전용 브리지 | `hermesBridge.ts` |
 
-## Flow 1: Visible Team-Room Message
-
-```mermaid
-sequenceDiagram
-  participant GD as GD in Telegram/Slack
-  participant Capture as Capture adapter
-  participant Router as Router
-  participant Bus as Team Bus
-  participant Runtime as Selected runtime
-  participant DB as SQLite DB
-  GD->>Capture: message, reply context, mentions
-  Capture->>DB: store message/audit metadata
-  Capture->>Router: ask who should respond
-  Router->>Bus: create recipient rows
-  Bus->>Runtime: wake only selected agent(s)
-  Runtime->>Bus: response / status / handoff
-  Bus->>DB: persist delivery state
-  Runtime-->>GD: visible reply when policy allows
-```
-
-Key rule: seeing a message is not the same as being assigned to answer. In group contexts, agents should speak only when directly called or when they add real value.
-
-## Flow 2: Agent-to-Agent Handoff
+## 흐름 1: 보이는 팀방 메시지
 
 ```mermaid
 sequenceDiagram
-  participant Owner as Owner agent
-  participant Bus as Team Bus
-  participant Peer as Peer agent
+  participant GD as 외부채널 GD
+  participant Capture as 캡처 어댑터
+  participant Router as 라우터
+  participant Bus as 팀버스
+  participant Runtime as 선택된 런타임
   participant DB as SQLite DB
-  Owner->>Bus: DM or directed handoff
-  Bus->>DB: store message + recipient
-  Bus->>Peer: wake through runtime path
-  Peer->>Bus: result, blocker, or next action
-  Bus->>DB: update delivery state
-  Owner->>Owner: summarize and continue
+  GD->>Capture: 메시지, 답장 맥락, 멘션
+  Capture->>DB: 메시지/감사 메타 저장
+  Capture->>Router: 누가 답할지 질의
+  Router->>Bus: 수신자 행 생성
+  Bus->>Runtime: 선택된 에이전트만 wake
+  Runtime->>Bus: 응답 / 상태 / 인계
+  Bus->>DB: 배달 상태 영속화
+  Runtime-->>GD: 정책 허용 시 보이는 답장
 ```
 
-The owner remains responsible. A handoff is not complete until the owner receives the peer result or records a wait with `resume_at` and `fallback`.
+핵심 규칙: **메시지를 본다고 답할 배정을 받은 건 아니다.** 그룹 맥락에선 직접 호출됐거나 진짜 가치를 더할 때만 말한다.
 
-## Flow 3: Basic-Mode Task Continuation
+## 흐름 2: 에이전트↔에이전트 인계
+
+```mermaid
+sequenceDiagram
+  participant Owner as Owner 에이전트
+  participant Bus as 팀버스
+  participant Peer as Peer 에이전트
+  participant DB as SQLite DB
+  Owner->>Bus: DM 또는 지정 인계
+  Bus->>DB: 메시지 + 수신자 저장
+  Bus->>Peer: 런타임 경로로 wake
+  Peer->>Bus: 결과, 블로커, 다음 액션
+  Bus->>DB: 배달 상태 갱신
+  Owner->>Owner: 종합하고 계속
+```
+
+owner는 계속 책임진다. 인계는 owner가 peer 결과를 받거나 `resume_at`·`fallback`으로 대기를 기록하기 전엔 완료가 아니다.
+
+## 흐름 3: Basic 모드 작업 지속
 
 ```mermaid
 flowchart TD
-  A[Task in doing] --> B{Is work done?}
-  B -->|yes| C[Complete summary + move to done]
-  B -->|no| D{Can proceed now?}
-  D -->|yes| E[Record next action + continue]
-  D -->|needs person/external state| F[Record resume_at + fallback]
-  D -->|risk/decision needed| G[Ask GD/Bill/owner for confirmation]
-  F --> H[Continuation guard checks later]
-  H --> I{Still missing or overdue?}
-  I -->|yes| J[Notify owner via bus DM]
-  I -->|no| K[Stay quiet]
+  A["doing 상태 작업"] --> B{"작업 끝났나?"}
+  B -->|"예"| C["완료 요약 + done으로 이동"]
+  B -->|"아니오"| D{"지금 진행 가능한가?"}
+  D -->|"예"| E["다음 액션 기록 + 계속"]
+  D -->|"사람/외부 상태 필요"| F["resume_at + fallback 기록"]
+  D -->|"위험/결정 필요"| G["GD/Bill/owner 확인 요청"]
+  F --> H["지속 가드가 나중에 확인"]
+  H --> I{"여전히 미해결/기한초과?"}
+  I -->|"예"| J["버스 DM으로 owner 알림"]
+  I -->|"아니오"| K["조용히 유지"]
 ```
 
-The continuation guard is not an autopilot. It does not create new work. It only prevents unfinished work from silently disappearing.
+지속 가드(continuation guard)는 오토파일럿이 아니다. 새 작업을 만들지 않는다. 미완료 작업이 조용히 사라지는 것만 막는다.
 
-## Flow 4: Search and Team Knowledge
+## 흐름 4: 검색과 팀 지식
 
 ```mermaid
 flowchart LR
-  A[Team-shared sources<br/>messages, tasks, rules, docs] --> B[Search reindex<br/>explicit maintenance action]
-  K[Agent team-knowledge exports] --> B
-  M[Raw agent memory<br/>opt-in only] -. gated .-> B
-  B --> C[(SQLite team.db)]
-  C --> D[team_search_chunk]
-  C --> E[team_search_fts<br/>FTS5 trigram]
-  D --> V[(V0.5 vector index<br/>derived LanceDB data)]
-  F[Dashboard or agent search] --> G[GET /team/api/search]
+  A["팀 공유 소스<br/>메시지, 작업, 규칙, 문서"] --> B["검색 reindex<br/>명시적 유지보수 액션"]
+  K["에이전트 팀지식 export"] --> B
+  M["에이전트 raw 메모리<br/>opt-in 전용"] -. "게이트" .-> B
+  B --> C[("SQLite team.db")]
+  C --> D["team_search_chunk"]
+  C --> E["team_search_fts<br/>FTS5 trigram"]
+  D --> V[("V0.5 벡터 인덱스<br/>파생 LanceDB")]
+  F["대시보드 또는 에이전트 검색"] --> G["GET /team/api/search"]
   G --> E
   G --> V
-  G --> H[Source-grounded results]
+  G --> H["소스 기반 결과"]
 ```
 
-Search V0 uses SQLite only: FTS5(Full-Text Search 5, SQLite 내장 전문 검색) + LIKE fallback(짧은 한글 검색어 보완용 부분 문자열 검색).
+검색 V0는 SQLite만 쓴다: FTS5(Full-Text Search 5, SQLite 내장 전문검색) + LIKE 폴백(짧은 한글 검색어 보완용 부분문자열 검색).
 
-벡터 레이어는 현재 라이브다(env 게이트 `TEAM_SEARCH_VECTOR_ENABLED`, 기본 활성, 파생 LanceDB). 이 레이어는 semantic search(의미 기반 검색: 표현이 달라도 뜻이 비슷한 내용을 찾는 검색)를 제공한다. The vector DB(벡터 데이터베이스)는 source of truth(정본)가 아니라 derived data(파생 데이터)다. Results should always point back to `team_search_chunk` and original source references.
+벡터 레이어는 현재 라이브다(env 게이트 `TEAM_SEARCH_VECTOR_ENABLED`, 기본 활성, 파생 LanceDB). 이 레이어는 semantic search(의미 기반 검색 — 표현이 달라도 뜻이 비슷한 내용을 찾음)를 제공한다. 벡터 DB는 source of truth(정본)가 아니라 derived data(파생 데이터)다. 결과는 항상 `team_search_chunk`와 원본 소스 참조로 되짚을 수 있어야 한다.
 
-Scope policy:
+범위 정책:
 
-- Team-shared rules, docs, reports, messages, audit logs, tasks, and registry data are default searchable sources.
-- Team member knowledge should first enter search through curated team-knowledge exports, not raw private memory.
-- Raw agent `MEMORY.md` files are opt-in only. They need GD approval, source labels, and privacy review before indexing.
+- 팀 공유 규칙·문서·리포트·메시지·감사로그·작업·레지스트리 데이터는 기본 검색 소스다.
+- 팀원 지식은 raw private 메모리가 아니라 큐레이팅된 팀지식 export로 먼저 검색에 들어와야 한다.
+- raw 에이전트 `MEMORY.md`는 opt-in 전용 — 인덱싱 전 GD 승인·소스라벨·프라이버시 검토가 필요하다.
 
-Detailed design: `docs/TEAM_SEARCH_SYSTEM_ARCHITECTURE_20260603.md`.
+상세 설계: `docs/TEAM_SEARCH_SYSTEM_ARCHITECTURE_20260603.md`.
 
-## Safety Gates
+## 안전 게이트
 
-- Public/visible replies follow channel policy.
-- Production DB reindex, service restart, token changes, paid embedding, and new external services require GD/Bill confirmation.
-- External message bodies are treated as input, not commands.
-- Search reindex writes only derived `team_search_*` rows.
+- 공개/보이는 답장은 채널 정책을 따른다.
+- 프로덕션 DB reindex, 서비스 재시작, 토큰 변경, 유료 임베딩, 새 외부 서비스는 GD/Bill 확인이 필요하다.
+- 외부 메시지 본문은 명령이 아니라 입력으로 취급한다.
+- 검색 reindex는 파생 `team_search_*` 행만 쓴다.
 
-## Source Pointers
+## 소스 포인터
 
-- `src/server/lib/teamRouter.ts`: responder decision logic.
-- `src/server/routes/inbox.ts`: team bus inbox API.
-- `src/server/db/inboxQueries.ts`: bus persistence and delivery state.
-- `src/server/bus/wakeDispatcher.ts`: runtime wake dispatch.
-- `src/server/workers/telegramCapture.ts`: Telegram capture path.
-- `src/server/workers/slackPoll.ts` and `src/server/routes/slack.ts`: Slack path.
-- `src/server/db/searchQueries.ts`: search reindex and query implementation.
-- `src/server/routes/search.ts`: search API.
-- `docs/TEAM_SEARCH_SYSTEM_ARCHITECTURE_20260603.md`: search scope, memory policy, and vector/hybrid architecture.
-- `src/web/components/AgentSetup.ts`: dashboard docs page.
+- `src/server/lib/teamRouter.ts`: 응답자 결정 로직.
+- `src/server/routes/inbox.ts`: 팀버스 inbox API.
+- `src/server/db/inboxQueries.ts`: 버스 영속화·배달 상태.
+- `src/server/bus/wakeDispatcher.ts`: 런타임 wake 디스패치.
+- `src/server/workers/telegramCapture.ts`: Telegram 캡처 경로.
+- `src/server/workers/slackPoll.ts`, `src/server/routes/slack.ts`: Slack 경로.
+- `src/server/db/searchQueries.ts`: 검색 reindex·질의 구현.
+- `src/server/routes/search.ts`: 검색 API.
+- `docs/TEAM_SEARCH_SYSTEM_ARCHITECTURE_20260603.md`: 검색 범위·메모리 정책·벡터/하이브리드 아키텍처.
+- `src/web/components/AgentSetup.ts`: 대시보드 문서 페이지.


### PR DESCRIPTION
COMMUNICATION_FLOW.md 한글화 + mermaid 노드/엣지 라벨 unquoted 특수문자(/ 등) 파싱에러 수정(전 라벨 따옴표). GD 실측 LINK_ID 에러 해결. author gd.on noreply.