### PR TITLE
fix(openclaw): default model -> gpt-5.6-sol (plain 5.6 errors)

### DIFF
--- a/src/server/runtimes/openclaw/activate-openclaw-agent.sh
+++ b/src/server/runtimes/openclaw/activate-openclaw-agent.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 AGENT_ID="${AGENT_ID:?AGENT_ID 필요 (예: myagent)}"
 DISPLAY="${DISPLAY:-$(echo "$AGENT_ID" | tr '[:lower:]' '[:upper:]')}"   # ${var^^}는 bash 4+ 전용 → macOS 기본 bash 3.2 호환 위해 tr 사용
 WS="${WS:-$HOME/Development/$AGENT_ID}"
-MODEL="${MODEL:-openai/gpt-5.6}"      # 기본 모델(codex 런타임 라우팅, text+image 1050k). 공개 사용자는 자신의 provider/모델에 맞게 env MODEL 로 override.
+MODEL="${MODEL:-openai/gpt-5.6-sol}"  # 기본 모델(openclaw 시스템 default·configured, text+image 1050k). ★plain gpt-5.6은 라우팅 에러 → sol 변형 사용★. 공개 사용자는 env MODEL 로 override.
 OC="$HOME/.openclaw"
 TOKEN_FILE="$OC/credentials/telegram-$AGENT_ID-token.txt"
 say(){ printf "\033[32m%s\033[0m\n" "$1"; }


### PR DESCRIPTION
plain gpt-5.6은 openclaw 라우팅 에러 → gpt-5.6-sol(시스템 default·configured)로 정정. GD 실측.