### PR TITLE
fix(openclaw): ownerAllowFrom 정본 경로(commands.ownerAllowFrom) 인식

### DIFF
--- a/src/server/lib/runtimeEssentials.test.ts
+++ b/src/server/lib/runtimeEssentials.test.ts
@@ -130,6 +130,38 @@ describe("runtime essentials strategy registry", () => {
     expect(r.missing).toContain("allowFrom:openclaw ownerAllowFrom");
   });
 
+  test("openclaw accepts canonical commands.ownerAllowFrom (openclaw 2026.7.x)", async () => {
+    const { home, repo } = tmpRoot();
+    const id = "lui";
+    const tokenFile = join(home, ".openclaw/credentials", `telegram-${id}-token.txt`);
+    write(tokenFile, "123:abc\n");
+    // 실제 openclaw 2026.7.x 가 쓰는 배치 — channels.telegram 에는 accounts/groups 만 있고
+    // 소유자 allowlist 는 commands.ownerAllowFrom 에 저장된다.
+    write(join(home, ".openclaw/openclaw.json"), JSON.stringify({
+      channels: { telegram: { accounts: { [id]: { enabled: true, tokenFile } } } },
+      commands: { ownerAllowFrom: ["telegram:7066867819"] },
+    }));
+    const registry = createRuntimeEssentialsRegistry({ home, repoRoot: repo });
+    const r = await checkEssentialSettings({ id, runtime: "openclaw" } as any, registry);
+    expect(r.ok).toBe(true);
+    expect(r.missing).toEqual([]);
+  });
+
+  test("openclaw fails when both ownerAllowFrom locations are empty", async () => {
+    const { home, repo } = tmpRoot();
+    const id = "lui";
+    const tokenFile = join(home, ".openclaw/credentials", `telegram-${id}-token.txt`);
+    write(tokenFile, "123:abc\n");
+    write(join(home, ".openclaw/openclaw.json"), JSON.stringify({
+      channels: { telegram: { ownerAllowFrom: [], accounts: { [id]: { enabled: true, tokenFile } } } },
+      commands: { ownerAllowFrom: [] },
+    }));
+    const registry = createRuntimeEssentialsRegistry({ home, repoRoot: repo });
+    const r = await checkEssentialSettings({ id, runtime: "openclaw" } as any, registry);
+    expect(r.ok).toBe(false);
+    expect(r.missing).toContain("allowFrom:openclaw ownerAllowFrom");
+  });
+
   test("hermes checks profile env, auth, and LaunchAgent", async () => {
     const { home, repo } = tmpRoot();
     const id = "mes";

--- a/src/server/lib/runtimeEssentials.ts
+++ b/src/server/lib/runtimeEssentials.ts
@@ -96,6 +96,15 @@ function openclawConfig(home: string, deps: Required<Pick<RuntimeEssentialDeps, 
   return parsed && typeof parsed === "object" ? parsed : null;
 }
 
+// openclaw 소유자 allowlist 는 버전에 따라 위치가 다르다 — 정본(2026.7.x)은 `commands.ownerAllowFrom`,
+// 구 스키마는 `channels.telegram.ownerAllowFrom`. 둘 중 ★값이 있는 쪽★을 채택한다(빈 배열은 미설정으로 취급).
+function openclawOwnerAllowFrom(cfg: any): unknown[] | null {
+  for (const candidate of [cfg?.channels?.telegram?.ownerAllowFrom, cfg?.commands?.ownerAllowFrom]) {
+    if (Array.isArray(candidate) && candidate.length > 0) return candidate;
+  }
+  return null;
+}
+
 function openclawAccountTokenFile(account: string, home: string, deps: Required<Pick<RuntimeEssentialDeps, "exists" | "readText">>): string | null {
   const cfg = openclawConfig(home, deps);
   const raw = cfg?.channels?.telegram?.accounts?.[account]?.tokenFile;
@@ -183,8 +192,8 @@ export function createRuntimeEssentialsRegistry(deps: RuntimeEssentialDeps = {})
       const accountCfg = cfg?.channels?.telegram?.accounts?.[account];
       if (!accountCfg && !nativeCodexFallback) missing.push("channel:openclaw telegram account");
       if (accountCfg && accountCfg.enabled !== true) missing.push("channel:openclaw account disabled");
-      const ownerAllowFrom = cfg?.channels?.telegram?.ownerAllowFrom;
-      if ((!Array.isArray(ownerAllowFrom) || ownerAllowFrom.length === 0) && !nativeCodexFallback) {
+      const ownerAllowFrom = openclawOwnerAllowFrom(cfg);
+      if (!ownerAllowFrom && !nativeCodexFallback) {
         missing.push("allowFrom:openclaw ownerAllowFrom");
       }
       return result(missing, true);


### PR DESCRIPTION
## 문제

openclaw 팀원이 페어링(`pair-approve`)을 정상 완료하고 **텔레그램에서 실제로 응답하는데도**, activate 가 계속 실패합니다:

```
essentials — 필수설정 누락: allowFrom:openclaw ownerAllowFrom (자동복구 가능)
→ activate ok:false → OT bundle 이 pending 에서 멈춤
```

영향:
- OT `bundle` 이 완료되지 않아 **팀지식 주입이 끝나지 않음** (`join` 은 done 인데 `bundle` 만 pending)
- health 모니터가 해당 팀원을 계속 `essentials missing` 으로 경고

## 원인

`runtimeEssentials.ts` 의 openclaw 검사가 `channels.telegram.ownerAllowFrom` 만 보는데,
openclaw 2026.7.x 는 소유자 allowlist 를 **`commands.ownerAllowFrom`** 에 저장합니다.

재현 환경 `openclaw 2026.7.1-2 (0790d9f)` 의 실제 `~/.openclaw/openclaw.json`:

```
channels.telegram 하위 키 : ['accounts', 'groups']      ← ownerAllowFrom 없음
commands.ownerAllowFrom    : ['telegram:7066867819']    ← 여기에 있음
```

openclaw 번들(`dist/`)을 grep 해봐도 `channels.telegram.ownerAllowFrom` 을 읽는 코드는 없고,
자체 스키마 설명문이 일관되게 `commands.ownerAllowFrom` 을 정본으로 가리킵니다:

> `If you leave this unset, OpenClaw falls back to commands.ownerAllowFrom when possible.`

## 수정

두 위치 중 **값이 있는 쪽**을 채택합니다. 구 스키마(`channels.telegram.ownerAllowFrom`)를 먼저 보므로
기존 동작은 그대로이고, 빈 배열은 기존과 동일하게 미설정으로 취급합니다.

## 테스트

- 신규 2건: 정본 경로(`commands.ownerAllowFrom`) 인식 / 양쪽 모두 빈 경우 실패
- `bun run typecheck` 통과
- `runtimeEssentials.test.ts` 13/13 통과
- 전체 `bun test`: 1587 pass / 8 fail — 이 8건은 **이 변경 이전에도 동일하게 실패**하는 기존 실패입니다
  (EXAONE 로컬 모델 의존 4건, Telegram `getMe` 네트워크 의존 3건, teamContextPolicy 1건).
  변경을 stash 한 기준선에서 1585 pass / 동일한 8 fail 을 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)