### PR TITLE
fix(settings): 멤버 아이콘 JPG 내보내기에 저장된 아이콘 색 반영

### DIFF
--- a/src/web/components/AgentConfig.ts
+++ b/src/web/components/AgentConfig.ts
@@ -302,6 +302,11 @@ function renderInto(root: HTMLElement, data: ConfigResponse, reload: () => void,
   const resetBtn = root.querySelector<HTMLButtonElement>("#cfg-reset");
   const statusEl = root.querySelector<HTMLElement>("#cfg-save-status");
   const originalProfile = { role: agent.role ?? "", persona: customPersona };
+  const updateLocalIcon = (patch: { icon?: string | null; icon_color?: string | null }) => {
+    Object.assign(agent, patch);
+    const st = store.getState();
+    st.setAgents(st.agents.map((a) => (a.id === agent.id ? { ...a, ...patch } : a)));
+  };
 
   resetBtn?.addEventListener("click", () => {
     if (roleInput) roleInput.value = originalProfile.role;
@@ -616,7 +621,8 @@ function renderInto(root: HTMLElement, data: ConfigResponse, reload: () => void,
   iconDl?.addEventListener("click", async () => {
     try {
       if (iconMsg) { iconMsg.textContent = pick("JPG 생성 중…", "Generating JPG…"); iconMsg.className = "text-[11px] text-slate-400 ml-2 align-middle"; }
-      const result = await downloadAgentIconJpg(agent.id, agent.icon || agentIconName(agent.id));
+      const iconFg = iconColorHex(selColor) ?? undefined;
+      const result = await downloadAgentIconJpg(agent.id, selIcon || agentIconName(agent.id), iconFg);
       if (iconMsg && result === "cancelled") {
         iconMsg.textContent = pick("JPG 저장 취소됨", "JPG save cancelled");
         iconMsg.className = "text-[11px] text-slate-400 ml-2 align-middle";
@@ -652,6 +658,7 @@ function renderInto(root: HTMLElement, data: ConfigResponse, reload: () => void,
           });
           if (res.ok) {
             selIcon = name;
+            updateLocalIcon({ icon: name });
             iconBtn.innerHTML = renderAgentIcon(selIcon, selColor, 18);
             iconPicker.querySelectorAll<HTMLButtonElement>("[data-icon]").forEach((x) => { x.className = choiceCls(x.dataset.icon === name); });
             if (iconMsg) { iconMsg.textContent = pick("✓ 변경됨", "✓ Changed"); iconMsg.className = "text-[11px] text-accent-greenSoft ml-2 align-middle"; }
@@ -688,6 +695,7 @@ function renderInto(root: HTMLElement, data: ConfigResponse, reload: () => void,
           });
           if (res.ok) {
             selColor = key;
+            updateLocalIcon({ icon_color: key });
             if (iconBtn) iconBtn.innerHTML = renderAgentIcon(selIcon, selColor, 18);
             colorPicker.querySelectorAll<HTMLButtonElement>("[data-color]").forEach((x) => { x.className = swatchCls(x.dataset.color === key); });
             if (iconMsg) { iconMsg.textContent = pick("✓ 색 변경됨", "✓ Color changed"); iconMsg.className = "text-[11px] text-accent-greenSoft ml-2 align-middle"; }

--- a/src/web/icons.test.ts
+++ b/src/web/icons.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, expect, test } from "bun:test";
+import { downloadAgentIconJpg } from "./icons";
+
+const originalDocument = globalThis.document;
+const originalImage = globalThis.Image;
+const originalWindow = globalThis.window;
+
+afterEach(() => {
+  globalThis.document = originalDocument;
+  globalThis.Image = originalImage;
+  globalThis.window = originalWindow;
+});
+
+test("downloadAgentIconJpg uses the saved member icon color when rasterizing JPG", async () => {
+  let capturedSvg = "";
+
+  globalThis.Image = class {
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+
+    set src(value: string) {
+      capturedSvg = decodeURIComponent(value.replace(/^data:image\/svg\+xml;charset=utf-8,/, ""));
+      queueMicrotask(() => this.onload?.());
+    }
+  } as unknown as typeof Image;
+
+  globalThis.window = {} as unknown as Window & typeof globalThis;
+  globalThis.document = {
+    createElement(tag: string) {
+      if (tag === "canvas") {
+        return {
+          width: 0,
+          height: 0,
+          getContext() {
+            return { fillStyle: "", fillRect() {}, drawImage() {} };
+          },
+          toDataURL() {
+            return "data:image/jpeg;base64,stub";
+          },
+        };
+      }
+      return { href: "", download: "", click() {}, remove() {} };
+    },
+    body: { appendChild() {} },
+  } as unknown as Document;
+
+  const result = await downloadAgentIconJpg("clo", "layers", "#f59e0b");
+
+  expect(result).toBe("saved");
+  expect(capturedSvg).toContain('stroke="#f59e0b"');
+});

--- a/src/web/icons.ts
+++ b/src/web/icons.ts
@@ -181,9 +181,9 @@ function splitDataUrl(dataUrl: string): { mimeType: string; base64: string } | n
   return { mimeType, base64 };
 }
 
-/** 아이콘 JPG 를 파일로 다운로드 (<agentId>-icon.jpg). iconName=agents.json 저장 icon(없으면 기본맵). */
-export async function downloadAgentIconJpg(agentId: string, iconName?: string): Promise<DownloadResult> {
-  const dataUrl = await agentIconToJpegDataUrl(agentId, { icon: iconName });
+/** 아이콘 JPG 를 파일로 다운로드 (<agentId>-icon.jpg). iconName=agents.json 저장 icon(없으면 기본맵), fg=저장된 아이콘 색. */
+export async function downloadAgentIconJpg(agentId: string, iconName?: string, fg?: string): Promise<DownloadResult> {
+  const dataUrl = await agentIconToJpegDataUrl(agentId, { icon: iconName, fg });
   const filename = `${agentId}-icon.jpg`;
   const nativePayload = splitDataUrl(dataUrl);
   if (nativePayload && nativeBridge()) {


### PR DESCRIPTION
작성자: hermes (da1f066 — 브랜치 force-update 됨) · 리뷰: bill

## 문제
GD 가 멤버 아이콘 색을 주황으로 저장했는데, 내려받은 `clo-icon.jpg` 는 초록으로 래스터화됐다.
UI 프리뷰는 `icon_color` 를 쓰는데, JPG 내보내기는 색을 안 넘겨서 `icons.ts` 기본값 `#34d399` 가 쓰였다.

추가로, 색을 고른 **직후 리로드 없이** 내려받으면 초기 로드값(`agent.icon_color`)이 쓰여 여전히 초록이 나왔다.

## 변경 (da1f066)
- `icons.ts` — `downloadAgentIconJpg(agentId, iconName?, fg?)` 선택적 `fg` 추가, 래스터화에 사용
- `AgentConfig.ts` — JPG 내보내기가 **패널의 현재 선택 상태(`selIcon`/`selColor`)** 를 넘긴다. 이 값들은 PATCH 성공 후에만 갱신되므로 서버 확정값이다
- `AgentConfig.ts` — 아이콘/색 PATCH 성공 시 로컬 store + 메모리 상 agent 를 갱신 → 다른 대시보드 화면이 리로드 전까지 옛 색을 들고 있지 않게
- `icons.test.ts` 신규 가드

## 검증 (bill 독립 재현, 격리 워크트리 @ da1f066)
- `bun run typecheck` clean
- `bun test icons.test.ts + settings.test.ts + AgentCard.test.ts` → **73 pass / 0 fail**
- `setAgents` 는 `applySavedAgentOrder` + `agentsLoaded` 만 건드림 → 설정 패널 리로드를 유발하지 않고 구독 화면만 갱신
- `downloadAgentIconJpg` 호출처 전수 → `AgentConfig.ts` 1곳
- `agentIconToJpegDataUrl` 은 이미 `opts.fg` 지원(기본 `#34d399`) → `fg=undefined` 면 기존 동작 유지, 하위호환 OK

## 후속 (비차단)
`icons.test.ts` 는 `icons.ts` 만 지킨다. **호출처가 `iconColorHex(selColor)` 를 넘기는지는 어떤 테스트도 안 지킨다** — 그 인자를 빼도 73개가 전부 통과한다. 호출처 회귀 가드는 hermes 가 후속으로 추가하기로 합의됨.

## 롤백
`da1f066` revert