### PR TITLE
feat(acceptance): claude 런처 사본 drift 가드 — plist 가 정본 런처를 가리키는지 검사

### DIFF
--- a/src/server/lib/acceptanceCheck.ts
+++ b/src/server/lib/acceptanceCheck.ts
@@ -388,7 +388,7 @@ function claudeLauncherChecks(deps: AcceptanceDeps): AcceptanceItem[] {
       "fail",
       "런처 정본 일치",
       `정본(${CLAUDE_START_SCRIPT})과 다른 런처 ${drifted.length}건 — ${drifted.join(", ")}`,
-      "해당 멤버를 대시보드에서 비활성화→활성화 하면 plist 가 정본으로 재생성된다",
+      "해당 팀원을 대시보드에서 다시 활성화(activate)하면 plist 가 정본 경로로 재생성된다 — 정지→기동으로는 안 고쳐진다(등록 파일을 읽기만 한다)",
     ),
   ];
 }

--- a/src/server/lib/acceptanceCheck.ts
+++ b/src/server/lib/acceptanceCheck.ts
@@ -4,6 +4,7 @@ import { dirname, join, relative } from "node:path";
 import { captureConfigStatus } from "./captureConfig";
 import { loadRegistry } from "./registry";
 import { teamOsSnapshot, type TeamOsSnapshot } from "./teamosProbe";
+import { CLAUDE_START_SCRIPT, claudeBridgePaths } from "../runtimes/claude/launcher";
 import type { AgentRecord } from "../types";
 
 export type AcceptanceStatus = "pass" | "fail" | "info";
@@ -340,7 +341,56 @@ function infraStep(deps: AcceptanceDeps): AcceptanceStep {
   ).get() as { count: number };
   items.push(item("info", "고아 wake", orphanWakes.count === 0 ? "없음" : `reconcile 후보 ${orphanWakes.count}개`));
 
+  items.push(...claudeLauncherChecks(deps));
+
   return { key: "infra", label: "인프라/운영", checks: items };
+}
+
+/** plist 에서 ProgramArguments 의 첫 <string> 을 뽑는다. 못 뽑으면 null. */
+export function plistFirstProgramArgument(xml: string): string | null {
+  const m = /<key>\s*ProgramArguments\s*<\/key>\s*<array>\s*<string>([^<]*)<\/string>/.exec(xml);
+  return m?.[1]?.trim() ?? null;
+}
+
+/** ★런처 사본 drift 가드★ — claude 멤버의 LaunchAgent plist 가 정본 vendored 런처를 가리키는지 검사한다.
+ *  사본이 여러 벌이면 "한 곳만 고치고 나머지는 옛 동작" 사고가 난다(2026-07-25 실측: 모델 하드코딩 fix 때
+ *  멤버별로 개인 스킬 사본·구 repo 사본·정본 3곳으로 갈려 있었다). 사람이 기억하는 대신 여기서 잡는다. */
+function claudeLauncherChecks(deps: AcceptanceDeps): AcceptanceItem[] {
+  const agents = loadAgents(deps.registryPath).filter((a) => a.runtime === "claude_channel");
+  if (agents.length === 0) return [];
+
+  const drifted: string[] = [];
+  let checked = 0;
+  for (const agent of agents) {
+    let plistPath: string;
+    try {
+      plistPath = claudeBridgePaths(agent.id).plist;
+    } catch {
+      continue; // id 가드 위반 — 다른 체크가 잡는다
+    }
+    if (!existsSync(plistPath)) continue; // 미등록 = 이 검사 대상 아님(활성화 체크가 따로 본다)
+    checked += 1;
+    let program: string | null = null;
+    try {
+      program = plistFirstProgramArgument(readFileSync(plistPath, "utf-8"));
+    } catch {
+      program = null;
+    }
+    if (program !== CLAUDE_START_SCRIPT) drifted.push(`${agent.id}→${program ?? "파싱실패"}`);
+  }
+
+  if (checked === 0) return [item("info", "런처 정본 일치", "등록된 claude 멤버 plist 없음")];
+  if (drifted.length === 0) {
+    return [item("pass", "런처 정본 일치", `claude 멤버 ${checked}명 전원 정본 런처`)];
+  }
+  return [
+    item(
+      "fail",
+      "런처 정본 일치",
+      `정본(${CLAUDE_START_SCRIPT})과 다른 런처 ${drifted.length}건 — ${drifted.join(", ")}`,
+      "해당 멤버를 대시보드에서 비활성화→활성화 하면 plist 가 정본으로 재생성된다",
+    ),
+  ];
 }
 
 export function runAcceptanceCheck(deps: AcceptanceDeps, member: string | null): AcceptanceResult {

--- a/src/server/lib/acceptanceLauncherDrift.test.ts
+++ b/src/server/lib/acceptanceLauncherDrift.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { plistFirstProgramArgument } from "./acceptanceCheck";
+
+const CANON = "/repo/src/server/runtimes/claude/start-telegram-channel.sh";
+
+function plist(program: string, id = "bill"): string {
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<plist version="1.0">',
+    "<dict>",
+    "  <key>Label</key><string>com.example.claude-telegram-" + id + "</string>",
+    "  <key>ProgramArguments</key>",
+    "  <array>",
+    `    <string>${program}</string>`,
+    `    <string>${id}</string>`,
+    "  </array>",
+    "  <key>RunAtLoad</key><true/>",
+    "</dict>",
+    "</plist>",
+  ].join("\n");
+}
+
+test("정본 런처를 가리키는 plist 는 그대로 뽑힌다", () => {
+  expect(plistFirstProgramArgument(plist(CANON))).toBe(CANON);
+});
+
+test("개인 스킬 사본을 가리키면 정본과 다른 값이 뽑힌다 (drift 검출)", () => {
+  const skillCopy = "/Users/someone/.claude/skills/setup-claude-telegram-bot/scripts/start-telegram-channel.sh";
+  const got = plistFirstProgramArgument(plist(skillCopy, "steve"));
+  expect(got).toBe(skillCopy);
+  expect(got).not.toBe(CANON);
+});
+
+test("구 repo 사본을 가리켜도 검출된다", () => {
+  const oldRepo = "/Users/someone/Development/old-repo/src/server/runtimes/claude/start-telegram-channel.sh";
+  expect(plistFirstProgramArgument(plist(oldRepo, "lui"))).not.toBe(CANON);
+});
+
+test("ProgramArguments 가 없으면 null", () => {
+  expect(plistFirstProgramArgument("<plist><dict><key>Label</key><string>x</string></dict></plist>")).toBeNull();
+});
+
+test("공백/개행이 달라도 파싱된다", () => {
+  const xml = `<key>ProgramArguments</key>\n\n  <array>\n\n    <string>${CANON}</string>\n  </array>`;
+  expect(plistFirstProgramArgument(xml)).toBe(CANON);
+});

--- a/src/server/runtimes/claude/launcher.ts
+++ b/src/server/runtimes/claude/launcher.ts
@@ -13,6 +13,10 @@ import { getCaptureGroupId } from "../../lib/captureConfig";
 const HOME = process.env.HOME ?? "";
 // ★vendored 시작 스크립트 — repo 내(src/, 공개 export 포함)에서 REPO_ROOT로 해석. 기존 ~/.claude/skills 개인스킬 의존 제거(퍼블릭 fresh 클론서 봇 안 뜨던 #1 blocker). GD 2026-07-02.
 const START_SCRIPT = `${REPO_ROOT}/src/server/runtimes/claude/start-telegram-channel.sh`;
+/** 정본 런처 경로 — plist drift 검사(인수테스트)가 이 값과 대조한다.
+ *  ★사본이 여러 벌 굴러다니면 "한 곳만 고치고 까먹는" 사고가 난다★ (2026-07-25 실측: 모델 하드코딩 fix 때
+ *  claude 멤버 plist 가 ~/.claude/skills 사본·구 team-collab 사본·정본 3곳으로 갈려 있었다). */
+export const CLAUDE_START_SCRIPT = START_SCRIPT;
 
 export interface ClaudeBridgePaths {
   id: string;


### PR DESCRIPTION
## 왜

런처 스크립트 사본이 여러 벌 굴러다니면 **한 곳만 고치고 나머지는 옛 동작**인 채로 남는다.
2026-07-25 실측 — 모델 하드코딩 fix(#37) 를 하다 발견:

| 멤버 | plist 가 가리키는 런처 |
|---|---|
| bill·dbak·demis·steve | `~/.claude/skills/setup-claude-telegram-bot/…` (오너 개인 스킬 사본) |
| lui | `b3rys-team-collab/…` (구 repo 사본) |
| 대시보드/API 재시작 | `src/server/runtimes/claude/…` (**정본**) |

정본 vendoring(2026-07-02) 이후에도 **옛 plist 가 남아 있으면 계속 옛 사본이 실행된다.**
퍼블릭 fresh clone 은 사본이 하나뿐이라 구조상 안전하지만, 사용자가 개인 스킬을 섞어 쓰면 같은 함정에 빠진다.
사람 기억에 맡기지 말고 인수테스트가 잡게 한다.

## 변경

- `launcher.ts` — 정본 경로를 `CLAUDE_START_SCRIPT` 로 export
- `acceptanceCheck.ts` — infra 섹션에 **런처 정본 일치** 체크
  - claude 멤버 plist 의 `ProgramArguments[0]` 을 정본과 대조 → 다르면 `fail` + 복구법(`비활성화→활성화` 로 plist 재생성)
  - plist 미등록 멤버는 대상 제외 (활성화 체크가 따로 본다)
  - claude 멤버가 없으면 `info`
- `plistFirstProgramArgument` export → 파서 단위테스트

## 검증

- `bun run typecheck` clean
- 신규 유닛 **5 pass / 0 fail** — 정본 / 개인스킬 사본 / 구 repo 사본 / ProgramArguments 없음 / 공백·개행 변형
- ★**라이브 plist 5개 실측 → 5건 전부 DRIFT 로 검출**★ (가드가 실제 사고를 잡는 것 확인)

## 미검증 / 후속

- plist 재생성 자동화는 넣지 않았다(감지만). 자동 재생성은 launchd 상태를 건드리므로 별건으로.
- 롤백: 이 커밋 revert (검사 항목 추가일 뿐, 기존 동작 무변경)