### PR TITLE
fix(hermes): 남의 hermes 프로필을 덮어쓰지 않도록 소유권 가드 추가

### DIFF
--- a/src/server/runtimes/hermes/activate-hermes-agent.sh
+++ b/src/server/runtimes/hermes/activate-hermes-agent.sh
@@ -65,8 +65,13 @@ say "■ 복제 원본 프로필: $SRC_PROFILE"
 say "■ 1) 프로필 생성 (clone-from $SRC_PROFILE)"
 # ★완전-프로필 판정 version-aware(BUG8b): v0.17.0=config.yaml · v0.18.0+=profile.yaml → 둘 중 하나라도 있으면 완전.
 #   config.yaml 만 보면 v0.18.0 정상 프로필을 half-state 로 오판해 rm-rf+재클론(불필요·위험)하던 갭. OWNER 2026-07-03.
+PROF_PREEXISTING=0
+B3OS_MARKER="$PROF_DIR/.b3os-managed"
 if [ -d "$PROF_DIR" ] && { [ -f "$PROF_DIR/config.yaml" ] || [ -f "$PROF_DIR/profile.yaml" ]; }; then
-  echo "  이미 존재(완전): $PROF_DIR — 건너뜀(덮어쓰기 안 함)"
+  # ★"덮어쓰기 안 함"은 '재클론 안 함'이라는 뜻일 뿐★ — 아래 2)토큰·3)멘션/cwd·3b)model 단계는
+  #   이 프로필에 그대로 적용된다. 그래서 소유권 판정이 필요하다(아래 가드).
+  echo "  이미 존재(완전): $PROF_DIR — 재클론 건너뜀"
+  PROF_PREEXISTING=1
 else
   # 불완전 프로필 잔재(config.yaml·profile.yaml 둘 다 없음 = 이전 퇴사가 덜 정리한 half-state) 감지 시 제거 후 재클론.
   #   안 그러면 clone 건너뛰어 설정 없는 채로 진행→게이트웨이 못 뜸(2026-07-01 실측). 슬러그 가드+고정 prefix로 안전.
@@ -75,6 +80,35 @@ else
     rm -rf "$PROF_DIR"
   fi
   hermes profile create "$AGENT_ID" --clone-from "$SRC_PROFILE" --description "$DESC"
+  # ★소유권 마커★ — 이 프로필은 b3os 가 만들었다는 표시. 다음 활성화 때 '사용자 것'과 구별하는 근거.
+  : > "$B3OS_MARKER" 2>/dev/null || true
+fi
+
+# ★소유권 가드 — 남의 hermes 프로필을 덮어쓰지 않는다★
+#   b3os 팀원 id 가 사용자가 이미 쓰던 hermes 프로필 이름과 겹치면, 아래 단계들이 그 프로필을
+#   그대로 개조한다: .env 의 TELEGRAM_BOT_TOKEN 을 b3os 봇 토큰으로 교체(=원래 봇이 죽는다),
+#   멘션 패턴·terminal.cwd 재작성, model 재작성. 경고도 없이 조용히 일어난다.
+#   → 기존 프로필인데 b3os 소유 근거가 없으면 중단한다. 근거는 아래 둘 중 하나:
+#     ① 마커(.b3os-managed)  ② b3os 가 만든 게이트웨이 plist(= 과거에 b3os 가 활성화한 적 있음)
+#   ②는 마커 도입 이전에 이미 운영 중이던 프로필을 막지 않기 위한 grace 경로다(마커를 채워 넣고 통과).
+#   ※ 토큰 파일(~/.hermes/credentials/<id>-token.txt)은 근거가 될 수 없다 — provision 이 activate
+#     이전에 항상 써두므로 첫 충돌에서도 존재한다.
+if [ "$PROF_PREEXISTING" = 1 ] && [ ! -f "$B3OS_MARKER" ]; then
+  if [ -f "$HOME/Library/LaunchAgents/ai.hermes.gateway-$AGENT_ID.plist" ]; then
+    echo "  ℹ b3os 게이트웨이 plist 존재 — 기존 b3os 프로필로 인정하고 마커 생성(마커 도입 이전 프로필)"
+    : > "$B3OS_MARKER" 2>/dev/null || true
+  elif [ "${B3OS_ADOPT_PROFILE:-0}" = 1 ]; then
+    echo "  ℹ B3OS_ADOPT_PROFILE=1 — 기존 프로필을 b3os 소유로 인수(마커 생성)"
+    : > "$B3OS_MARKER" 2>/dev/null || true
+  else
+    echo "❌ hermes 프로필 '$AGENT_ID' 이(가) 이미 있는데 b3os 가 만든 것이 아닙니다 — 덮어쓰지 않고 중단합니다."
+    echo "   그대로 진행하면 이 프로필의 봇 토큰이 b3os 봇으로 교체되어 ★원래 쓰시던 봇이 응답을 멈춥니다.★"
+    echo "   조치(둘 중 하나):"
+    echo "     · 팀원 id 를 다른 이름으로 바꿔 다시 영입   ← 권장"
+    echo "     · 이 프로필이 정말 b3os 용이면 인수: B3OS_ADOPT_PROFILE=1 로 재실행"
+    echo "   대상 경로: $PROF_DIR"
+    exit 1
+  fi
 fi
 # auth.json 심링크 — clone-from은 모델 provider 인증(auth.json)을 복제하지 않아 새 프로필이 '메시지는 받지만 응답 생성서 인증실패'로 떨어짐(2026-07-01 실측).
 #   공유 인증($SRC_PROFILE)에 심링크(복사 아님=토큰 로테이션 시 stale 만료 방지·항상 현재).


### PR DESCRIPTION
> base = `main` 입니다. #42·#43 과 **다른 구간**(프로필 생성부)을 건드려 충돌하지 않습니다. 독립적으로 머지 가능합니다.

## 문제

b3os 팀원 id 가 사용자가 **이미 쓰던 hermes 프로필 이름과 겹치면**, 활성화가 그 프로필을 그대로 개조합니다.

프로필 생성 분기는 이렇게 출력합니다:

```
이미 존재(완전): ~/.hermes/profiles/herm — 건너뜀(덮어쓰기 안 함)
```

그런데 이건 **재클론을 안 한다는 뜻일 뿐**이고, 그 뒤 단계는 조건 없이 실행됩니다:

| 단계 | 하는 일 | 영향 |
|---|---|---|
| 2) | `.env` 의 `TELEGRAM_BOT_TOKEN` → b3os 봇 토큰으로 교체 | 🔴 **원래 쓰던 봇이 응답을 멈춤** |
| 3) | 멘션 패턴 · `terminal.cwd` 재작성 | 설정 손실 |
| 3b) | `model` 재작성 (#39 에서 추가) | 설정 손실 |

경고가 없고, 오히려 `"덮어쓰기 안 함"` 메시지가 안심시킵니다. 토큰 교체는 **백업도 없습니다** (#42 가 넣은 `.bak` 은 model 쓰기 경로에만 있습니다).

## 수정 — 소유권 마커 + 가드

b3os 가 프로필을 만들 때 `$PROF_DIR/.b3os-managed` 마커를 남기고, 기존 프로필인데 소유 근거가 없으면 **편집 전에 중단**합니다.

**소유 근거 (둘 중 하나면 통과)**
1. 마커 `.b3os-managed`
2. b3os 가 만든 게이트웨이 plist `ai.hermes.gateway-<id>.plist` — 과거에 b3os 가 이 프로필을 활성화한 증거입니다. **마커 도입 이전부터 운영 중이던 프로필이 막히지 않도록 하는 grace 경로**로, 마커를 채워 넣고 통과시킵니다.

**탈출구**: `B3OS_ADOPT_PROFILE=1` 로 재실행하면 기존 프로필을 b3os 소유로 인수합니다.

> ※ 토큰 파일(`~/.hermes/credentials/<id>-token.txt`)은 근거로 쓸 수 없습니다 — provision 이 activate 이전에 항상 써두므로 **첫 충돌에서도 존재**합니다(소스 확인).

차단 시 안내:
```
❌ hermes 프로필 'herm' 이(가) 이미 있는데 b3os 가 만든 것이 아닙니다 — 덮어쓰지 않고 중단합니다.
   그대로 진행하면 이 프로필의 봇 토큰이 b3os 봇으로 교체되어 ★원래 쓰시던 봇이 응답을 멈춥니다.★
   조치(둘 중 하나):
     · 팀원 id 를 다른 이름으로 바꿔 다시 영입   ← 권장
     · 이 프로필이 정말 b3os 용이면 인수: B3OS_ADOPT_PROFILE=1 로 재실행
```

## 검증 (가드 블록 독립 실행, 5경로)

| # | 상황 | 결과 |
|---|---|---|
| ① | 신규 생성 | 통과 |
| ② | 기존 + 마커 O | 통과 (멱등) |
| ③ | 기존 + 마커 X + plist O | 마커 백필 후 통과 — **기존 사용자 무영향** |
| ④ | 기존 + 마커 X + plist X | **중단 (exit 1)** + 조치 안내 |
| ⑤ | ④ + `B3OS_ADOPT_PROFILE=1` | 인수 후 통과 |

`bash -n` 통과.

## 범위

이 PR 은 **'차단'까지만** 합니다. 영입 단계에서 기존 hermes 프로필과의 id 충돌을 미리 검사해 사용자에게 다른 id 를 권하는 UX 는 서버(recruit) 쪽 변경이라 별도로 다루는 게 맞다고 봅니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)