### PR TITLE
fix(hermes): base 프로필 이름을 설정값으로 분리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,8 @@ B3OS_SCHEDULER_DRY_RUN=0
 #   ★본인 전용 장비(personal machine)에서 b3os를 쓰는 경우, 대시보드 접근=본인 인가로 보고 1로 설정하세요.★
 #   공용/노출 서버라면 절대 1로 두지 마세요(엣지 인증 앞단 필수). = b3os는 개인 장비 전제.
 APPROVAL_EXECUTION_ENABLED=
+# 공유 Hermes 인증 원본 프로필. 공개 기본값은 b3os; 기존 설치는 실제 base 프로필명으로 지정.
+HERMES_BASE_PROFILE=b3os
 
 # ─── Slack 연동 (선택) ───────────────
 # 공개 base URL — Slack 재설치 마법사가 Event Subscriptions URL·재설치 링크를 이 도메인으로 만든다.

--- a/docs/COMMUNICATION_FLOW.md
+++ b/docs/COMMUNICATION_FLOW.md
@@ -68,7 +68,7 @@ flowchart TB
   subgraph Runtimes["에이전트 런타임"]
     Claude["Claude Channel<br/>tmux 세션 + poller"]
     OpenClaw["OpenClaw 게이트웨이<br/>:18789 세션 wake"]
-    Hermes["Hermes 게이트웨이/프로필<br/>b3ryshermes"]
+    Hermes["Hermes 게이트웨이/프로필<br/>HERMES_BASE_PROFILE"]
   end
 
   TG --> Capture

--- a/install.sh
+++ b/install.sh
@@ -121,6 +121,25 @@ fi
 grep -q '^B3OS_SCHEDULER_ENABLED=' .env 2>/dev/null || printf 'B3OS_SCHEDULER_ENABLED=true\n' >> .env
 grep -q '^B3OS_SCHEDULER_DRY_RUN=' .env 2>/dev/null || printf 'B3OS_SCHEDULER_DRY_RUN=0\n' >> .env
 
+# 기존 설치 마이그레이션: 예전 .env에는 base 프로필 키가 없다. 이 상태로 새 중립 기본값을
+# 적용하면 실제 공유 auth 원본이 삭제 가드에서 빠지므로, 기존 auth 심링크 구조에서 보수적으로 추론해 backfill한다.
+if ! grep -q '^HERMES_BASE_PROFILE=' .env 2>/dev/null; then
+  _detector="$ROOT/src/server/runtimes/hermes/detect-base-profile.sh"
+  _detected_base=""
+  _detect_status=0
+  _detected_base="$(bash "$_detector" "$HOME/.hermes/profiles")" || _detect_status=$?
+  if [ "$_detect_status" -eq 0 ] && [ -n "$_detected_base" ]; then
+    printf 'HERMES_BASE_PROFILE=%s\n' "$_detected_base" >> .env
+    say "✅ 기존 Hermes base 프로필 감지·보존 설정 완료: $_detected_base"
+  elif [ "$_detect_status" -eq 0 ]; then
+    printf 'HERMES_BASE_PROFILE=b3os\n' >> .env
+  else
+    warn "❌ Hermes auth 원본 프로필을 하나로 판별할 수 없어 안전을 위해 설치를 중단합니다."
+    warn "   .env에 HERMES_BASE_PROFILE=<공유 auth 원본 프로필명>을 지정한 뒤 다시 실행하세요."
+    exit 1
+  fi
+fi
+
 # ── 4b) 팀원 활성화 허용 스위치 (APPROVAL_EXECUTION_ENABLED) ──────
 # 본인 전용 장비에서만 팀원(봇) 활성화를 허용. 대화형으로 물어보고 .env 에 자동 설정
 # (예전엔 사용자가 .env 를 수동 편집해야 했음 → 프롬프트로 자동화).

--- a/install.sh
+++ b/install.sh
@@ -100,6 +100,32 @@ if [ -f "$SKILL_SRC/SKILL.md" ]; then
 fi
 
 # ── 4) .env 준비 ─────────────────────────────────────────────────
+# .env 생성보다 먼저 기존 Hermes 공유 auth 원본을 판별한다. 먼저 example을 복사하면 그 안의
+# 중립 기본값이 "명시 설정"처럼 보여 기존 설치 마이그레이션이 영구히 건너뛰어진다.
+read_hermes_base_env() {
+  [ -f "$1" ] || return 0
+  { grep -E '^[[:space:]]*(export[[:space:]]+)?HERMES_BASE_PROFILE[[:space:]]*=' "$1" 2>/dev/null || true; } \
+    | tail -1 \
+    | sed -E -e 's/^[[:space:]]*(export[[:space:]]+)?HERMES_BASE_PROFILE[[:space:]]*=[[:space:]]*//' \
+      -e 's/[[:space:]]+#.*$//' -e 's/^["'\''][[:space:]]*//' -e 's/[[:space:]]*["'\'']$//' -e 's/[[:space:]]*$//'
+}
+
+_existing_base="$(read_hermes_base_env .env)"
+_selected_base=""
+if printf '%s' "$_existing_base" | grep -Eq '^[A-Za-z0-9_-]+$'; then
+  _selected_base="$_existing_base"
+else
+  _detector="$ROOT/src/server/runtimes/hermes/detect-base-profile.sh"
+  _detect_status=0
+  _selected_base="$(bash "$_detector" "$HOME/.hermes/profiles")" || _detect_status=$?
+  if [ "$_detect_status" -ne 0 ]; then
+    warn "❌ Hermes auth 원본 프로필을 하나로 판별할 수 없어 안전을 위해 설치를 중단합니다."
+    warn "   기존 .env에 HERMES_BASE_PROFILE=<공유 auth 원본 프로필명>을 지정한 뒤 다시 실행하세요."
+    exit 1
+  fi
+  _selected_base="${_selected_base:-b3os}"
+fi
+
 if [ ! -f .env ]; then
   cp .env.example .env
   say "✅ .env 생성 (.env.example 복사) — 기본값으로 대시보드는 바로 동작."
@@ -107,6 +133,12 @@ if [ ! -f .env ]; then
 else
   say "✅ .env 이미 있음 — 유지."
 fi
+
+# 새 값을 확정한 뒤에만 기존 표기(export/공백/따옴표 포함)를 제거하고 원자적으로 교체한다.
+awk '!/^[[:space:]]*(export[[:space:]]+)?HERMES_BASE_PROFILE[[:space:]]*=/' .env > .env.tmp
+printf 'HERMES_BASE_PROFILE=%s\n' "$_selected_base" >> .env.tmp
+mv .env.tmp .env
+say "✅ Hermes base 프로필 보존 설정: $_selected_base"
 
 # ── 4a) B3RYS_HOME 데이터 루트 ────────────────────────────────────
 # 팀원 워크스페이스는 $B3RYS_HOME/members/<id> 에 생성된다. 미설정 시 ~/Development/<id> 로
@@ -120,32 +152,6 @@ fi
 # explicit operator values; only append missing keys.
 grep -q '^B3OS_SCHEDULER_ENABLED=' .env 2>/dev/null || printf 'B3OS_SCHEDULER_ENABLED=true\n' >> .env
 grep -q '^B3OS_SCHEDULER_DRY_RUN=' .env 2>/dev/null || printf 'B3OS_SCHEDULER_DRY_RUN=0\n' >> .env
-
-# 기존 설치 마이그레이션: 예전 .env에는 base 프로필 키가 없다. 이 상태로 새 중립 기본값을
-# 적용하면 실제 공유 auth 원본이 삭제 가드에서 빠지므로, 기존 auth 심링크 구조에서 보수적으로 추론해 backfill한다.
-if ! grep -qE '^HERMES_BASE_PROFILE=[[:space:]]*[A-Za-z0-9_-]+[[:space:]]*(#.*)?$' .env 2>/dev/null; then
-  # 빈 값/잘못된 기존 줄은 중복 키를 남기지 않고 원자적으로 제거한 뒤 안전한 값만 기록한다.
-  grep -v '^HERMES_BASE_PROFILE=' .env > .env.tmp 2>/dev/null || true
-  mv .env.tmp .env
-  _detector="$ROOT/src/server/runtimes/hermes/detect-base-profile.sh"
-  _detected_base=""
-  _detect_status=0
-  _detected_base="$(bash "$_detector" "$HOME/.hermes/profiles")" || _detect_status=$?
-  if [ "$_detect_status" -eq 0 ] && [ -n "$_detected_base" ]; then
-    printf 'HERMES_BASE_PROFILE=%s\n' "$_detected_base" >> .env
-    say "✅ 기존 Hermes base 프로필 감지·보존 설정 완료: $_detected_base"
-  elif [ "$_detect_status" -eq 0 ]; then
-    printf 'HERMES_BASE_PROFILE=b3os\n' >> .env
-  elif ! grep -Eq '"runtime"[[:space:]]*:[[:space:]]*"hermes_agent"' "$ROOT/agents.json" 2>/dev/null; then
-    # Hermes를 쓰지 않는 설치에서 사용자 개인 auth 프로필이 여러 개라는 이유만으로 전체 설치를 막지 않는다.
-    printf 'HERMES_BASE_PROFILE=b3os\n' >> .env
-    warn "⚠ Hermes auth 원본이 여러 개지만 등록된 Hermes 팀원이 없어 중립 기본값 b3os를 사용합니다."
-  else
-    warn "❌ Hermes auth 원본 프로필을 하나로 판별할 수 없어 안전을 위해 설치를 중단합니다."
-    warn "   .env에 HERMES_BASE_PROFILE=<공유 auth 원본 프로필명>을 지정한 뒤 다시 실행하세요."
-    exit 1
-  fi
-fi
 
 # ── 4b) 팀원 활성화 허용 스위치 (APPROVAL_EXECUTION_ENABLED) ──────
 # 본인 전용 장비에서만 팀원(봇) 활성화를 허용. 대화형으로 물어보고 .env 에 자동 설정

--- a/install.sh
+++ b/install.sh
@@ -118,7 +118,28 @@ if [ -n "${_requested_base// }" ]; then
     warn "❌ HERMES_BASE_PROFILE은 안전한 프로필 slug여야 합니다: 영문/숫자/_/-"
     exit 1
   fi
-  _selected_base="$_requested_base"
+  # 명시 override는 자동 탐지 실패의 탈출구이므로 문자열만 믿지 않는다. 실제 비심링크 auth 원본과
+  # 대소문자 없이 일치하는 디렉터리가 정확히 하나 있어야 한다.
+  _requested_match=""
+  for _profile_dir in "$HOME"/.hermes/profiles/*; do
+    [ -d "$_profile_dir" ] || continue
+    _profile_name="$(basename "$_profile_dir")"
+    if [ "$(printf '%s' "$_profile_name" | tr '[:upper:]' '[:lower:]')" = "$(printf '%s' "$_requested_base" | tr '[:upper:]' '[:lower:]')" ] \
+      && [ -f "$_profile_dir/auth.json" ] && [ ! -L "$_profile_dir/auth.json" ]; then
+      [ -z "$_requested_match" ] || { warn "❌ HERMES_BASE_PROFILE과 대소문자 없이 일치하는 auth 원본이 둘 이상입니다."; exit 1; }
+      _requested_match="$_profile_name"
+    fi
+  done
+  if [ -z "$_requested_match" ]; then
+    warn "❌ 명시한 Hermes base '$_requested_base'가 실제 비심링크 auth 원본 프로필이 아닙니다."
+    warn "   후보(auth.json 원본 보유):"
+    for _profile_dir in "$HOME"/.hermes/profiles/*; do
+      [ -d "$_profile_dir" ] && [ -f "$_profile_dir/auth.json" ] && [ ! -L "$_profile_dir/auth.json" ] \
+        && warn "     - $(basename "$_profile_dir")"
+    done
+    exit 1
+  fi
+  _selected_base="$_requested_match"
 elif printf '%s' "$_existing_base" | grep -Eq '^[A-Za-z0-9_-]+$'; then
   _selected_base="$_existing_base"
 else
@@ -127,6 +148,11 @@ else
   _selected_base="$(bash "$_detector" "$HOME/.hermes/profiles")" || _detect_status=$?
   if [ "$_detect_status" -ne 0 ]; then
     warn "❌ Hermes auth 원본 프로필을 하나로 판별할 수 없어 안전을 위해 설치를 중단합니다."
+    warn "   후보(auth.json 원본 보유):"
+    for _profile_dir in "$HOME"/.hermes/profiles/*; do
+      [ -d "$_profile_dir" ] && [ -f "$_profile_dir/auth.json" ] && [ ! -L "$_profile_dir/auth.json" ] \
+        && warn "     - $(basename "$_profile_dir")"
+    done
     warn "   HERMES_BASE_PROFILE=<공유 auth 원본 프로필명> bash install.sh 로 명시 지정해 다시 실행하세요."
     exit 1
   fi

--- a/install.sh
+++ b/install.sh
@@ -110,9 +110,16 @@ read_hermes_base_env() {
       -e 's/[[:space:]]+#.*$//' -e 's/^["'\''][[:space:]]*//' -e 's/[[:space:]]*["'\'']$//' -e 's/[[:space:]]*$//'
 }
 
+_requested_base="${HERMES_BASE_PROFILE:-}"
 _existing_base="$(read_hermes_base_env .env)"
 _selected_base=""
-if printf '%s' "$_existing_base" | grep -Eq '^[A-Za-z0-9_-]+$'; then
+if [ -n "${_requested_base// }" ]; then
+  if ! printf '%s' "$_requested_base" | grep -Eq '^[A-Za-z0-9_-]+$'; then
+    warn "❌ HERMES_BASE_PROFILE은 안전한 프로필 slug여야 합니다: 영문/숫자/_/-"
+    exit 1
+  fi
+  _selected_base="$_requested_base"
+elif printf '%s' "$_existing_base" | grep -Eq '^[A-Za-z0-9_-]+$'; then
   _selected_base="$_existing_base"
 else
   _detector="$ROOT/src/server/runtimes/hermes/detect-base-profile.sh"
@@ -120,7 +127,7 @@ else
   _selected_base="$(bash "$_detector" "$HOME/.hermes/profiles")" || _detect_status=$?
   if [ "$_detect_status" -ne 0 ]; then
     warn "❌ Hermes auth 원본 프로필을 하나로 판별할 수 없어 안전을 위해 설치를 중단합니다."
-    warn "   기존 .env에 HERMES_BASE_PROFILE=<공유 auth 원본 프로필명>을 지정한 뒤 다시 실행하세요."
+    warn "   HERMES_BASE_PROFILE=<공유 auth 원본 프로필명> bash install.sh 로 명시 지정해 다시 실행하세요."
     exit 1
   fi
   _selected_base="${_selected_base:-b3os}"
@@ -128,6 +135,7 @@ fi
 
 if [ ! -f .env ]; then
   cp .env.example .env
+  chmod 600 .env
   say "✅ .env 생성 (.env.example 복사) — 기본값으로 대시보드는 바로 동작."
   say "  텔레그램 봇·팀장 chat_id·그룹 연결은 ★대시보드 Settings★에서 안내에 따라 넣으면 됩니다(수동 .env 편집 불필요). 봇 토큰은 BotFather에서 사람이 발급."
 else
@@ -137,7 +145,10 @@ fi
 # 새 값을 확정한 뒤에만 기존 표기(export/공백/따옴표 포함)를 제거하고 원자적으로 교체한다.
 _env_mode=""
 if command -v stat >/dev/null 2>&1; then
-  _env_mode="$(stat -f '%Lp' .env 2>/dev/null || stat -c '%a' .env 2>/dev/null || true)"
+  case "$(uname -s)" in
+    Darwin|FreeBSD) _env_mode="$(stat -f '%Lp' .env 2>/dev/null || true)" ;;
+    *) _env_mode="$(stat -c '%a' .env 2>/dev/null || true)" ;;
+  esac
 fi
 awk '!/^[[:space:]]*(export[[:space:]]+)?HERMES_BASE_PROFILE[[:space:]]*=/' .env > .env.tmp
 printf 'HERMES_BASE_PROFILE=%s\n' "$_selected_base" >> .env.tmp
@@ -169,8 +180,14 @@ if ! grep -q '^APPROVAL_EXECUTION_ENABLED=1' .env 2>/dev/null; then
   fi
   case "$ans" in
     y|Y)
+      _approval_env_mode=""
+      case "$(uname -s)" in
+        Darwin|FreeBSD) _approval_env_mode="$(stat -f '%Lp' .env 2>/dev/null || true)" ;;
+        *) _approval_env_mode="$(stat -c '%a' .env 2>/dev/null || true)" ;;
+      esac
       grep -v '^APPROVAL_EXECUTION_ENABLED=' .env > .env.tmp 2>/dev/null || true
       mv .env.tmp .env
+      [ -z "$_approval_env_mode" ] || chmod "$_approval_env_mode" .env
       printf 'APPROVAL_EXECUTION_ENABLED=1\n' >> .env
       say "✅ 팀원 활성화 허용됨 (APPROVAL_EXECUTION_ENABLED=1)."
       ;;

--- a/install.sh
+++ b/install.sh
@@ -123,7 +123,10 @@ grep -q '^B3OS_SCHEDULER_DRY_RUN=' .env 2>/dev/null || printf 'B3OS_SCHEDULER_DR
 
 # 기존 설치 마이그레이션: 예전 .env에는 base 프로필 키가 없다. 이 상태로 새 중립 기본값을
 # 적용하면 실제 공유 auth 원본이 삭제 가드에서 빠지므로, 기존 auth 심링크 구조에서 보수적으로 추론해 backfill한다.
-if ! grep -q '^HERMES_BASE_PROFILE=' .env 2>/dev/null; then
+if ! grep -qE '^HERMES_BASE_PROFILE=[[:space:]]*[A-Za-z0-9_-]+[[:space:]]*(#.*)?$' .env 2>/dev/null; then
+  # 빈 값/잘못된 기존 줄은 중복 키를 남기지 않고 원자적으로 제거한 뒤 안전한 값만 기록한다.
+  grep -v '^HERMES_BASE_PROFILE=' .env > .env.tmp 2>/dev/null || true
+  mv .env.tmp .env
   _detector="$ROOT/src/server/runtimes/hermes/detect-base-profile.sh"
   _detected_base=""
   _detect_status=0
@@ -133,6 +136,10 @@ if ! grep -q '^HERMES_BASE_PROFILE=' .env 2>/dev/null; then
     say "✅ 기존 Hermes base 프로필 감지·보존 설정 완료: $_detected_base"
   elif [ "$_detect_status" -eq 0 ]; then
     printf 'HERMES_BASE_PROFILE=b3os\n' >> .env
+  elif ! grep -Eq '"runtime"[[:space:]]*:[[:space:]]*"hermes_agent"' "$ROOT/agents.json" 2>/dev/null; then
+    # Hermes를 쓰지 않는 설치에서 사용자 개인 auth 프로필이 여러 개라는 이유만으로 전체 설치를 막지 않는다.
+    printf 'HERMES_BASE_PROFILE=b3os\n' >> .env
+    warn "⚠ Hermes auth 원본이 여러 개지만 등록된 Hermes 팀원이 없어 중립 기본값 b3os를 사용합니다."
   else
     warn "❌ Hermes auth 원본 프로필을 하나로 판별할 수 없어 안전을 위해 설치를 중단합니다."
     warn "   .env에 HERMES_BASE_PROFILE=<공유 auth 원본 프로필명>을 지정한 뒤 다시 실행하세요."

--- a/install.sh
+++ b/install.sh
@@ -135,9 +135,14 @@ else
 fi
 
 # 새 값을 확정한 뒤에만 기존 표기(export/공백/따옴표 포함)를 제거하고 원자적으로 교체한다.
+_env_mode=""
+if command -v stat >/dev/null 2>&1; then
+  _env_mode="$(stat -f '%Lp' .env 2>/dev/null || stat -c '%a' .env 2>/dev/null || true)"
+fi
 awk '!/^[[:space:]]*(export[[:space:]]+)?HERMES_BASE_PROFILE[[:space:]]*=/' .env > .env.tmp
 printf 'HERMES_BASE_PROFILE=%s\n' "$_selected_base" >> .env.tmp
 mv .env.tmp .env
+[ -z "$_env_mode" ] || chmod "$_env_mode" .env
 say "✅ Hermes base 프로필 보존 설정: $_selected_base"
 
 # ── 4a) B3RYS_HOME 데이터 루트 ────────────────────────────────────

--- a/scripts/test-hermes-base-profile.sh
+++ b/scripts/test-hermes-base-profile.sh
@@ -42,13 +42,27 @@ chmod +x "$INSTALL_BIN/bun" "$INSTALL_BIN/uname"
 HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" bash "$INSTALL_ROOT/install.sh" >/dev/null
 grep -q '^HERMES_BASE_PROFILE=old-base$' "$INSTALL_ROOT/.env" || fail "existing .env was not backfilled"
 
-# A present-but-empty key is also migrated; unrelated ambiguous Hermes auth does not block non-Hermes installs.
+# A newly created .env also uses detection before .env.example's neutral default is copied.
+rm "$INSTALL_ROOT/.env"
+HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" bash "$INSTALL_ROOT/install.sh" >/dev/null
+grep -q '^HERMES_BASE_PROFILE=old-base$' "$INSTALL_ROOT/.env" || fail "new .env skipped existing base detection"
+
+# Ambiguous auth fails before changing an invalid/empty existing setting.
 rm "$INSTALL_HOME/.hermes/profiles/member/auth.json"
 touch "$INSTALL_HOME/.hermes/profiles/member/auth.json"
 printf 'TEAM_HTTP_PORT=7878\nHERMES_BASE_PROFILE=\n' > "$INSTALL_ROOT/.env"
+cp "$INSTALL_ROOT/.env" "$INSTALL_ROOT/.env.before"
+set +e
+HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" bash "$INSTALL_ROOT/install.sh" >/dev/null 2>&1
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "ambiguous install did not fail closed"
+cmp -s "$INSTALL_ROOT/.env.before" "$INSTALL_ROOT/.env" || fail "failed migration modified existing config"
+
+# Quoted/exported valid settings are preserved and normalized only after selection.
+printf 'TEAM_HTTP_PORT=7878\n  export HERMES_BASE_PROFILE=\"old-base\"\n' > "$INSTALL_ROOT/.env"
 HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" bash "$INSTALL_ROOT/install.sh" >/dev/null
-[ "$(grep -c '^HERMES_BASE_PROFILE=' "$INSTALL_ROOT/.env")" -eq 1 ] || fail "empty key migration left duplicate settings"
-grep -q '^HERMES_BASE_PROFILE=b3os$' "$INSTALL_ROOT/.env" || fail "non-Hermes ambiguous install did not use neutral default"
+grep -q '^HERMES_BASE_PROFILE=old-base$' "$INSTALL_ROOT/.env" || fail "quoted/exported valid setting was not preserved"
 
 # activate: configured base wins; when absent, another authenticated profile remains the fallback.
 ACT_HOME="$TMP/activate-home"
@@ -90,11 +104,13 @@ set -e
 # uninstall: .env-configured base survives while a non-base Hermes profile is removed.
 UN_ROOT="$TMP/uninstall-repo"
 UN_HOME="$TMP/uninstall-home"
-mkdir -p "$UN_ROOT" "$UN_HOME/.hermes/profiles/configured-base" "$UN_HOME/.hermes/profiles/worker" \
+mkdir -p "$UN_ROOT/src/server/runtimes/hermes" "$UN_HOME/.hermes/profiles/configured-base" "$UN_HOME/.hermes/profiles/worker" "$UN_HOME/.hermes/profiles/configured-base-2" \
   "$UN_HOME/.hermes/credentials" "$UN_HOME/Library/LaunchAgents"
 cp "$ROOT/uninstall.sh" "$UN_ROOT/uninstall.sh"
-printf 'HERMES_BASE_PROFILE=configured-base # preserved base\n' > "$UN_ROOT/.env"
-printf '[{"id":"base","runtime":"hermes_agent","hermes_profile":"configured-base"},{"id":"worker","runtime":"hermes_agent","hermes_profile":"worker"}]\n' > "$UN_ROOT/agents.json"
+cp "$ROOT/src/server/runtimes/hermes/detect-base-profile.sh" "$UN_ROOT/src/server/runtimes/hermes/detect-base-profile.sh"
+printf 'HERMES_BASE_PROFILE=CONFIGURED-BASE # case-insensitive APFS guard\n' > "$UN_ROOT/.env"
+printf '[{"id":"base","runtime":"hermes_agent","hermes_profile":"configured-base"},{"id":"worker","runtime":"hermes_agent","hermes_profile":"worker"},{"id":"similar","runtime":"hermes_agent","hermes_profile":"configured-base-2"}]\n' > "$UN_ROOT/agents.json"
+touch "$UN_HOME/.hermes/profiles/configured-base/auth.json"
 touch "$UN_HOME/.hermes/credentials/base-token.txt" "$UN_HOME/.hermes/credentials/worker-token.txt"
 touch "$UN_HOME/Library/LaunchAgents/ai.hermes.gateway-configured-base.plist"
 touch "$UN_HOME/Library/LaunchAgents/ai.hermes.gateway-worker.plist"
@@ -107,11 +123,24 @@ HOME="$UN_HOME" USER="b3os-test" bash "$UN_ROOT/uninstall.sh" --yes --keep-data 
 [ ! -e "$UN_HOME/Library/LaunchAgents/ai.hermes.gateway-worker.plist" ] || fail "non-base plist was preserved"
 [ ! -e "$UN_HOME/.hermes/credentials/worker-token.txt" ] || fail "non-base credential was preserved"
 
+# Missing config on a retry still preserves the detected base; a similar name is not over-protected.
+rm "$UN_ROOT/.env"
+HOME="$UN_HOME" USER="b3os-test" bash "$UN_ROOT/uninstall.sh" --yes --keep-data >/dev/null
+[ -d "$UN_HOME/.hermes/profiles/configured-base" ] || fail "retry without .env deleted detected base"
+[ ! -e "$UN_HOME/.hermes/profiles/configured-base-2" ] || fail "similar non-base name was preserved"
+
 printf 'HERMES_BASE_PROFILE=../unsafe\n' > "$UN_ROOT/.env"
 set +e
 HOME="$UN_HOME" USER="b3os-test" bash "$UN_ROOT/uninstall.sh" --yes --keep-data >/dev/null 2>&1
 status=$?
 set -e
 [ "$status" -ne 0 ] || fail "uninstall accepted an unsafe base profile"
+
+# A full uninstall removes registry/config so a best-effort retry cannot replay stale members.
+printf 'HERMES_BASE_PROFILE=configured-base\n' > "$UN_ROOT/.env"
+HOME="$UN_HOME" USER="b3os-test" bash "$UN_ROOT/uninstall.sh" --yes >/dev/null
+[ ! -e "$UN_ROOT/.env" ] || fail "full uninstall preserved .env"
+[ ! -e "$UN_ROOT/agents.json" ] || fail "full uninstall preserved stale registry"
+[ -d "$UN_HOME/.hermes/profiles/configured-base" ] || fail "full uninstall deleted detected base"
 
 echo "PASS: Hermes base profile configuration"

--- a/scripts/test-hermes-base-profile.sh
+++ b/scripts/test-hermes-base-profile.sh
@@ -37,8 +37,9 @@ touch "$INSTALL_ROOT/skills/b3os/SKILL.md" "$INSTALL_HOME/.hermes/profiles/old-b
 ln -s "$INSTALL_HOME/.hermes/profiles/old-base/auth.json" "$INSTALL_HOME/.hermes/profiles/member/auth.json"
 printf 'TEAM_HTTP_PORT=7878\n' > "$INSTALL_ROOT/.env"
 printf '#!/usr/bin/env bash\n[ "${1:-}" = "--version" ] && echo test\nexit 0\n' > "$INSTALL_BIN/bun"
-printf '#!/usr/bin/env bash\necho Linux\n' > "$INSTALL_BIN/uname"
-chmod +x "$INSTALL_BIN/bun" "$INSTALL_BIN/uname"
+printf '#!/usr/bin/env bash\nexec /usr/bin/uname "$@"\n' > "$INSTALL_BIN/uname"
+printf '#!/usr/bin/env bash\n[ "${1:-}" = "-V" ] && echo "tmux test"\nexit 0\n' > "$INSTALL_BIN/tmux"
+chmod +x "$INSTALL_BIN/bun" "$INSTALL_BIN/uname" "$INSTALL_BIN/tmux"
 HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" bash "$INSTALL_ROOT/install.sh" >/dev/null
 grep -q '^HERMES_BASE_PROFILE=old-base$' "$INSTALL_ROOT/.env" || fail "existing .env was not backfilled"
 
@@ -71,6 +72,15 @@ cmp -s "$INSTALL_ROOT/.env.before" "$INSTALL_ROOT/.env" || fail "failed migratio
 HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" HERMES_BASE_PROFILE=old-base \
   bash "$INSTALL_ROOT/install.sh" >/dev/null
 grep -q '^HERMES_BASE_PROFILE=old-base$' "$INSTALL_ROOT/.env" || fail "explicit install override did not recover ambiguity"
+cp "$INSTALL_ROOT/.env" "$INSTALL_ROOT/.env.before-invalid"
+set +e
+invalid_install_out="$(HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" HERMES_BASE_PROFILE=doesnotexist \
+  bash "$INSTALL_ROOT/install.sh" 2>&1)"
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "install accepted nonexistent explicit base"
+grep -q 'old-base' <<< "$invalid_install_out" || fail "install did not show candidate base names"
+cmp -s "$INSTALL_ROOT/.env.before-invalid" "$INSTALL_ROOT/.env" || fail "invalid install override modified .env"
 
 # Quoted/exported valid settings are preserved and normalized only after selection.
 printf 'TEAM_HTTP_PORT=7878\n  export HERMES_BASE_PROFILE=\"old-base\"\n' > "$INSTALL_ROOT/.env"
@@ -160,6 +170,7 @@ cp "$ROOT/uninstall.sh" "$PARSE_ROOT/uninstall.sh"
 cp "$ROOT/src/server/runtimes/hermes/detect-base-profile.sh" "$PARSE_ROOT/src/server/runtimes/hermes/detect-base-profile.sh"
 printf '  export HERMES_BASE_PROFILE = "export-base" # comment\n' > "$PARSE_ROOT/.env"
 printf '[{"id":"base","runtime":"hermes_agent","hermes_profile":"export-base"},{"id":"worker","runtime":"hermes_agent","hermes_profile":"export-worker"}]\n' > "$PARSE_ROOT/agents.json"
+touch "$PARSE_HOME/.hermes/profiles/export-base/auth.json"
 HOME="$PARSE_HOME" USER="b3os-test" bash "$PARSE_ROOT/uninstall.sh" --yes --keep-data >/dev/null
 [ -d "$PARSE_HOME/.hermes/profiles/export-base" ] || fail "uninstall parser missed export/spaced/quoted base setting"
 [ ! -e "$PARSE_HOME/.hermes/profiles/export-worker" ] || fail "uninstall parser test did not remove worker"
@@ -212,6 +223,18 @@ done
   || fail "ambiguous uninstall deleted recovery data"
 [ -d "$AMB_HOME/.claude/channels/telegram-claude-member" ] \
   || fail "ambiguous preflight partially deleted a non-Hermes member"
+
+# A syntactically valid but nonexistent/member-symlink override must not disarm protection.
+for invalid_base in doesnotexist member-a; do
+  set +e
+  invalid_out="$(HOME="$AMB_HOME" USER="b3os-test" HERMES_BASE_PROFILE="$invalid_base" \
+    bash "$AMB_ROOT/uninstall.sh" --yes 2>&1)"
+  status=$?
+  set -e
+  [ "$status" -ne 0 ] || fail "uninstall accepted unverified explicit base: $invalid_base"
+  grep -q 'base-a' <<< "$invalid_out" || fail "uninstall did not show candidate base names"
+  [ -f "$AMB_HOME/.hermes/profiles/base-a/auth.json" ] || fail "invalid override deleted real shared auth source"
+done
 
 # The documented explicit setting is a real recovery path: it overrides ambiguous auto-detection.
 printf 'HERMES_BASE_PROFILE=base-a\n' > "$AMB_ROOT/.env"

--- a/scripts/test-hermes-base-profile.sh
+++ b/scripts/test-hermes-base-profile.sh
@@ -42,6 +42,12 @@ chmod +x "$INSTALL_BIN/bun" "$INSTALL_BIN/uname"
 HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" bash "$INSTALL_ROOT/install.sh" >/dev/null
 grep -q '^HERMES_BASE_PROFILE=old-base$' "$INSTALL_ROOT/.env" || fail "existing .env was not backfilled"
 
+# Atomic replacement must preserve restrictive permissions because .env contains bot tokens.
+chmod 600 "$INSTALL_ROOT/.env"
+HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" bash "$INSTALL_ROOT/install.sh" >/dev/null
+[ "$(stat -f '%Lp' "$INSTALL_ROOT/.env" 2>/dev/null || stat -c '%a' "$INSTALL_ROOT/.env")" = "600" ] \
+  || fail "install weakened .env permissions"
+
 # A newly created .env also uses detection before .env.example's neutral default is copied.
 rm "$INSTALL_ROOT/.env"
 HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" bash "$INSTALL_ROOT/install.sh" >/dev/null
@@ -123,6 +129,19 @@ HOME="$UN_HOME" USER="b3os-test" bash "$UN_ROOT/uninstall.sh" --yes --keep-data 
 [ ! -e "$UN_HOME/Library/LaunchAgents/ai.hermes.gateway-worker.plist" ] || fail "non-base plist was preserved"
 [ ! -e "$UN_HOME/.hermes/credentials/worker-token.txt" ] || fail "non-base credential was preserved"
 
+# uninstall uses the same permissive env syntax as install.
+PARSE_ROOT="$TMP/parser-uninstall-repo"
+PARSE_HOME="$TMP/parser-uninstall-home"
+mkdir -p "$PARSE_ROOT/src/server/runtimes/hermes" \
+  "$PARSE_HOME/.hermes/profiles/export-base" "$PARSE_HOME/.hermes/profiles/export-worker"
+cp "$ROOT/uninstall.sh" "$PARSE_ROOT/uninstall.sh"
+cp "$ROOT/src/server/runtimes/hermes/detect-base-profile.sh" "$PARSE_ROOT/src/server/runtimes/hermes/detect-base-profile.sh"
+printf '  export HERMES_BASE_PROFILE = "export-base" # comment\n' > "$PARSE_ROOT/.env"
+printf '[{"id":"base","runtime":"hermes_agent","hermes_profile":"export-base"},{"id":"worker","runtime":"hermes_agent","hermes_profile":"export-worker"}]\n' > "$PARSE_ROOT/agents.json"
+HOME="$PARSE_HOME" USER="b3os-test" bash "$PARSE_ROOT/uninstall.sh" --yes --keep-data >/dev/null
+[ -d "$PARSE_HOME/.hermes/profiles/export-base" ] || fail "uninstall parser missed export/spaced/quoted base setting"
+[ ! -e "$PARSE_HOME/.hermes/profiles/export-worker" ] || fail "uninstall parser test did not remove worker"
+
 # Missing config on a retry still preserves the detected base; a similar name is not over-protected.
 rm "$UN_ROOT/.env"
 HOME="$UN_HOME" USER="b3os-test" bash "$UN_ROOT/uninstall.sh" --yes --keep-data >/dev/null
@@ -142,5 +161,46 @@ HOME="$UN_HOME" USER="b3os-test" bash "$UN_ROOT/uninstall.sh" --yes >/dev/null
 [ ! -e "$UN_ROOT/.env" ] || fail "full uninstall preserved .env"
 [ ! -e "$UN_ROOT/agents.json" ] || fail "full uninstall preserved stale registry"
 [ -d "$UN_HOME/.hermes/profiles/configured-base" ] || fail "full uninstall deleted detected base"
+
+# M9/M4: two distinct shared targets are ambiguous. No Hermes profile or recovery data may be deleted.
+AMB_ROOT="$TMP/ambiguous-uninstall-repo"
+AMB_HOME="$TMP/ambiguous-uninstall-home"
+mkdir -p "$AMB_ROOT/src/server/runtimes/hermes" \
+  "$AMB_HOME/.hermes/profiles/base-a" "$AMB_HOME/.hermes/profiles/base-b" \
+  "$AMB_HOME/.hermes/profiles/member-a" "$AMB_HOME/.hermes/profiles/member-b"
+cp "$ROOT/uninstall.sh" "$AMB_ROOT/uninstall.sh"
+cp "$ROOT/src/server/runtimes/hermes/detect-base-profile.sh" "$AMB_ROOT/src/server/runtimes/hermes/detect-base-profile.sh"
+touch "$AMB_HOME/.hermes/profiles/base-a/auth.json" "$AMB_HOME/.hermes/profiles/base-b/auth.json"
+ln -s "$AMB_HOME/.hermes/profiles/base-a/auth.json" "$AMB_HOME/.hermes/profiles/member-a/auth.json"
+ln -s "$AMB_HOME/.hermes/profiles/base-b/auth.json" "$AMB_HOME/.hermes/profiles/member-b/auth.json"
+printf 'HERMES_BASE_PROFILE=\n' > "$AMB_ROOT/.env"
+printf '[{"id":"member-a","runtime":"hermes_agent","hermes_profile":"member-a"},{"id":"member-b","runtime":"hermes_agent","hermes_profile":"member-b"}]\n' > "$AMB_ROOT/agents.json"
+touch "$AMB_ROOT/team.db"
+set +e
+amb_out="$(HOME="$AMB_HOME" USER="b3os-test" bash "$AMB_ROOT/uninstall.sh" --yes 2>&1)"
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "ambiguous uninstall reported success"
+grep -q '미완료' <<< "$amb_out" || fail "ambiguous uninstall did not clearly report incomplete cleanup"
+for p in base-a base-b member-a member-b; do
+  [ -e "$AMB_HOME/.hermes/profiles/$p" ] || fail "ambiguous uninstall deleted profile $p"
+done
+[ -f "$AMB_ROOT/.env" ] && [ -f "$AMB_ROOT/agents.json" ] && [ -f "$AMB_ROOT/team.db" ] \
+  || fail "ambiguous uninstall deleted recovery data"
+
+# M7: with one resolvable shared target, activation must prefer it over an alphabetically earlier auth profile.
+RES_HOME="$TMP/resolved-activate-home"
+mkdir -p "$RES_HOME/.local/bin" "$RES_HOME/.hermes/credentials" \
+  "$RES_HOME/.hermes/profiles/aaa" "$RES_HOME/.hermes/profiles/real-base" "$RES_HOME/.hermes/profiles/existing-member"
+touch "$RES_HOME/.hermes/profiles/aaa/auth.json" "$RES_HOME/.hermes/profiles/real-base/auth.json"
+ln -s "$RES_HOME/.hermes/profiles/real-base/auth.json" "$RES_HOME/.hermes/profiles/existing-member/auth.json"
+printf 'test-token\n' > "$RES_HOME/.hermes/credentials/new-member-token.txt"
+printf '#!/usr/bin/env bash\nexit 42\n' > "$RES_HOME/.local/bin/hermes"
+chmod +x "$RES_HOME/.local/bin/hermes"
+set +e
+resolved_out="$(HOME="$RES_HOME" HERMES_BASE_PROFILE=missing AGENT_ID=new-member \
+  bash "$ROOT/src/server/runtimes/hermes/activate-hermes-agent.sh" 2>&1)"
+set -e
+grep -q '복제 원본 프로필: real-base' <<< "$resolved_out" || fail "activate did not prefer detected shared base"
 
 echo "PASS: Hermes base profile configuration"

--- a/scripts/test-hermes-base-profile.sh
+++ b/scripts/test-hermes-base-profile.sh
@@ -52,6 +52,8 @@ HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" bash "$INSTALL_ROOT/insta
 rm "$INSTALL_ROOT/.env"
 HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" bash "$INSTALL_ROOT/install.sh" >/dev/null
 grep -q '^HERMES_BASE_PROFILE=old-base$' "$INSTALL_ROOT/.env" || fail "new .env skipped existing base detection"
+[ "$(stat -f '%Lp' "$INSTALL_ROOT/.env" 2>/dev/null || stat -c '%a' "$INSTALL_ROOT/.env")" = "600" ] \
+  || fail "new .env was not created with restrictive permissions"
 
 # Ambiguous auth fails before changing an invalid/empty existing setting.
 rm "$INSTALL_HOME/.hermes/profiles/member/auth.json"
@@ -65,10 +67,30 @@ set -e
 [ "$status" -ne 0 ] || fail "ambiguous install did not fail closed"
 cmp -s "$INSTALL_ROOT/.env.before" "$INSTALL_ROOT/.env" || fail "failed migration modified existing config"
 
+# The documented environment override is a real escape hatch even while auto-detection is ambiguous.
+HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" HERMES_BASE_PROFILE=old-base \
+  bash "$INSTALL_ROOT/install.sh" >/dev/null
+grep -q '^HERMES_BASE_PROFILE=old-base$' "$INSTALL_ROOT/.env" || fail "explicit install override did not recover ambiguity"
+
 # Quoted/exported valid settings are preserved and normalized only after selection.
 printf 'TEAM_HTTP_PORT=7878\n  export HERMES_BASE_PROFILE=\"old-base\"\n' > "$INSTALL_ROOT/.env"
 HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" bash "$INSTALL_ROOT/install.sh" >/dev/null
 grep -q '^HERMES_BASE_PROFILE=old-base$' "$INSTALL_ROOT/.env" || fail "quoted/exported valid setting was not preserved"
+
+# The interactive approval rewrite is a second atomic replacement and must also retain mode 600.
+if command -v expect >/dev/null 2>&1; then
+  chmod 600 "$INSTALL_ROOT/.env"
+  HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" INSTALL_SCRIPT="$INSTALL_ROOT/install.sh" \
+    expect <<'EOF' >/dev/null
+set timeout 20
+spawn bash $env(INSTALL_SCRIPT)
+expect "허용할까요?"
+send "y\r"
+expect eof
+EOF
+  [ "$(stat -f '%Lp' "$INSTALL_ROOT/.env")" = "600" ] || fail "approval prompt weakened .env permissions"
+  grep -q '^APPROVAL_EXECUTION_ENABLED=1$' "$INSTALL_ROOT/.env" || fail "approval tty fixture did not take y branch"
+fi
 
 # activate: configured base wins; when absent, another authenticated profile remains the fallback.
 ACT_HOME="$TMP/activate-home"
@@ -167,14 +189,15 @@ AMB_ROOT="$TMP/ambiguous-uninstall-repo"
 AMB_HOME="$TMP/ambiguous-uninstall-home"
 mkdir -p "$AMB_ROOT/src/server/runtimes/hermes" \
   "$AMB_HOME/.hermes/profiles/base-a" "$AMB_HOME/.hermes/profiles/base-b" \
-  "$AMB_HOME/.hermes/profiles/member-a" "$AMB_HOME/.hermes/profiles/member-b"
+  "$AMB_HOME/.hermes/profiles/member-a" "$AMB_HOME/.hermes/profiles/member-b" \
+  "$AMB_HOME/.claude/channels/telegram-claude-member"
 cp "$ROOT/uninstall.sh" "$AMB_ROOT/uninstall.sh"
 cp "$ROOT/src/server/runtimes/hermes/detect-base-profile.sh" "$AMB_ROOT/src/server/runtimes/hermes/detect-base-profile.sh"
 touch "$AMB_HOME/.hermes/profiles/base-a/auth.json" "$AMB_HOME/.hermes/profiles/base-b/auth.json"
 ln -s "$AMB_HOME/.hermes/profiles/base-a/auth.json" "$AMB_HOME/.hermes/profiles/member-a/auth.json"
 ln -s "$AMB_HOME/.hermes/profiles/base-b/auth.json" "$AMB_HOME/.hermes/profiles/member-b/auth.json"
 printf 'HERMES_BASE_PROFILE=\n' > "$AMB_ROOT/.env"
-printf '[{"id":"member-a","runtime":"hermes_agent","hermes_profile":"member-a"},{"id":"member-b","runtime":"hermes_agent","hermes_profile":"member-b"}]\n' > "$AMB_ROOT/agents.json"
+printf '[{"id":"claude-member","runtime":"claude_channel"},{"id":"member-a","runtime":"hermes_agent","hermes_profile":"member-a"},{"id":"member-b","runtime":"hermes_agent","hermes_profile":"member-b"}]\n' > "$AMB_ROOT/agents.json"
 touch "$AMB_ROOT/team.db"
 set +e
 amb_out="$(HOME="$AMB_HOME" USER="b3os-test" bash "$AMB_ROOT/uninstall.sh" --yes 2>&1)"
@@ -187,6 +210,46 @@ for p in base-a base-b member-a member-b; do
 done
 [ -f "$AMB_ROOT/.env" ] && [ -f "$AMB_ROOT/agents.json" ] && [ -f "$AMB_ROOT/team.db" ] \
   || fail "ambiguous uninstall deleted recovery data"
+[ -d "$AMB_HOME/.claude/channels/telegram-claude-member" ] \
+  || fail "ambiguous preflight partially deleted a non-Hermes member"
+
+# The documented explicit setting is a real recovery path: it overrides ambiguous auto-detection.
+printf 'HERMES_BASE_PROFILE=base-a\n' > "$AMB_ROOT/.env"
+HOME="$AMB_HOME" USER="b3os-test" bash "$AMB_ROOT/uninstall.sh" --yes >/dev/null
+[ ! -e "$AMB_ROOT/.env" ] && [ ! -e "$AMB_ROOT/agents.json" ] \
+  || fail "explicit base setting did not recover ambiguous uninstall"
+
+# A keep-data run may remove member symlinks; the preserved explicit setting must still let full retry finish.
+KEEP_ROOT="$TMP/keep-uninstall-repo"
+KEEP_HOME="$TMP/keep-uninstall-home"
+mkdir -p "$KEEP_ROOT/src/server/runtimes/hermes" \
+  "$KEEP_HOME/.hermes/profiles/real-base" "$KEEP_HOME/.hermes/profiles/probe" \
+  "$KEEP_HOME/.hermes/profiles/member-a" "$KEEP_HOME/.hermes/profiles/member-b"
+cp "$ROOT/uninstall.sh" "$KEEP_ROOT/uninstall.sh"
+cp "$ROOT/src/server/runtimes/hermes/detect-base-profile.sh" "$KEEP_ROOT/src/server/runtimes/hermes/detect-base-profile.sh"
+touch "$KEEP_HOME/.hermes/profiles/real-base/auth.json" "$KEEP_HOME/.hermes/profiles/probe/auth.json"
+ln -s "$KEEP_HOME/.hermes/profiles/real-base/auth.json" "$KEEP_HOME/.hermes/profiles/member-a/auth.json"
+ln -s "$KEEP_HOME/.hermes/profiles/real-base/auth.json" "$KEEP_HOME/.hermes/profiles/member-b/auth.json"
+printf 'HERMES_BASE_PROFILE=real-base\n' > "$KEEP_ROOT/.env"
+printf '[{"id":"member-a","runtime":"hermes_agent","hermes_profile":"member-a"},{"id":"member-b","runtime":"hermes_agent","hermes_profile":"member-b"}]\n' > "$KEEP_ROOT/agents.json"
+HOME="$KEEP_HOME" USER="b3os-test" bash "$KEEP_ROOT/uninstall.sh" --yes --keep-data >/dev/null
+[ ! -e "$KEEP_HOME/.hermes/profiles/member-a" ] && [ -f "$KEEP_ROOT/.env" ] \
+  || fail "keep-data fixture did not preserve config while offboarding member"
+HOME="$KEEP_HOME" USER="b3os-test" bash "$KEEP_ROOT/uninstall.sh" --yes >/dev/null
+[ ! -e "$KEEP_ROOT/.env" ] && [ ! -e "$KEEP_ROOT/agents.json" ] \
+  || fail "full uninstall deadlocked after keep-data"
+
+# M2: config/registry/FS case drift must preserve the configured base even without detector help.
+CASE_ROOT="$TMP/case-uninstall-repo"
+CASE_HOME="$TMP/case-uninstall-home"
+mkdir -p "$CASE_ROOT/src/server/runtimes/hermes" "$CASE_HOME/.hermes/profiles/MyBase"
+cp "$ROOT/uninstall.sh" "$CASE_ROOT/uninstall.sh"
+cp "$ROOT/src/server/runtimes/hermes/detect-base-profile.sh" "$CASE_ROOT/src/server/runtimes/hermes/detect-base-profile.sh"
+printf 'HERMES_BASE_PROFILE=mybase\n' > "$CASE_ROOT/.env"
+printf '[{"id":"base","runtime":"hermes_agent","hermes_profile":"MYBASE"}]\n' > "$CASE_ROOT/agents.json"
+touch "$CASE_HOME/.hermes/profiles/MyBase/auth.json"
+HOME="$CASE_HOME" USER="b3os-test" bash "$CASE_ROOT/uninstall.sh" --yes --keep-data >/dev/null
+[ -f "$CASE_HOME/.hermes/profiles/MyBase/auth.json" ] || fail "case drift deleted configured base"
 
 # M7: with one resolvable shared target, activation must prefer it over an alphabetically earlier auth profile.
 RES_HOME="$TMP/resolved-activate-home"

--- a/scripts/test-hermes-base-profile.sh
+++ b/scripts/test-hermes-base-profile.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/b3os-hermes-base-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# activate: configured base wins; when absent, another authenticated profile remains the fallback.
+ACT_HOME="$TMP/activate-home"
+mkdir -p "$ACT_HOME/.local/bin" "$ACT_HOME/.hermes/credentials" \
+  "$ACT_HOME/.hermes/profiles/configured-base" "$ACT_HOME/.hermes/profiles/fallback"
+touch "$ACT_HOME/.hermes/profiles/configured-base/auth.json" "$ACT_HOME/.hermes/profiles/fallback/auth.json"
+printf 'test-token\n' > "$ACT_HOME/.hermes/credentials/new-agent-token.txt"
+printf '#!/usr/bin/env bash\nexit 42\n' > "$ACT_HOME/.local/bin/hermes"
+chmod +x "$ACT_HOME/.local/bin/hermes"
+
+set +e
+out="$(HOME="$ACT_HOME" HERMES_BASE_PROFILE=configured-base AGENT_ID=new-agent \
+  bash "$ROOT/src/server/runtimes/hermes/activate-hermes-agent.sh" 2>&1)"
+set -e
+grep -q "복제 원본 프로필: configured-base" <<< "$out" || fail "configured base was not selected"
+
+rm "$ACT_HOME/.hermes/profiles/configured-base/auth.json"
+set +e
+out="$(HOME="$ACT_HOME" HERMES_BASE_PROFILE=missing-base AGENT_ID=new-agent \
+  bash "$ROOT/src/server/runtimes/hermes/activate-hermes-agent.sh" 2>&1)"
+set -e
+grep -q "복제 원본 프로필: fallback" <<< "$out" || fail "authenticated-profile fallback did not run"
+
+# Invalid names fail closed before any activation or uninstall cleanup.
+set +e
+HOME="$ACT_HOME" HERMES_BASE_PROFILE='../unsafe' AGENT_ID=new-agent \
+  bash "$ROOT/src/server/runtimes/hermes/activate-hermes-agent.sh" >/dev/null 2>&1
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "activate accepted an unsafe base profile"
+
+# uninstall: .env-configured base survives while a non-base Hermes profile is removed.
+UN_ROOT="$TMP/uninstall-repo"
+UN_HOME="$TMP/uninstall-home"
+mkdir -p "$UN_ROOT" "$UN_HOME/.hermes/profiles/configured-base" "$UN_HOME/.hermes/profiles/worker" \
+  "$UN_HOME/.hermes/credentials" "$UN_HOME/Library/LaunchAgents"
+cp "$ROOT/uninstall.sh" "$UN_ROOT/uninstall.sh"
+printf 'HERMES_BASE_PROFILE=configured-base\n' > "$UN_ROOT/.env"
+printf '[{"id":"base","runtime":"hermes_agent","hermes_profile":"configured-base"},{"id":"worker","runtime":"hermes_agent","hermes_profile":"worker"}]\n' > "$UN_ROOT/agents.json"
+touch "$UN_HOME/.hermes/credentials/base-token.txt" "$UN_HOME/.hermes/credentials/worker-token.txt"
+touch "$UN_HOME/Library/LaunchAgents/ai.hermes.gateway-configured-base.plist"
+touch "$UN_HOME/Library/LaunchAgents/ai.hermes.gateway-worker.plist"
+
+HOME="$UN_HOME" USER="b3os-test" bash "$UN_ROOT/uninstall.sh" --yes --keep-data >/dev/null
+[ -d "$UN_HOME/.hermes/profiles/configured-base" ] || fail "configured base profile was deleted"
+[ -f "$UN_HOME/Library/LaunchAgents/ai.hermes.gateway-configured-base.plist" ] || fail "configured base plist was deleted"
+[ -f "$UN_HOME/.hermes/credentials/base-token.txt" ] || fail "configured base credential was deleted"
+[ ! -e "$UN_HOME/.hermes/profiles/worker" ] || fail "non-base profile was preserved"
+[ ! -e "$UN_HOME/Library/LaunchAgents/ai.hermes.gateway-worker.plist" ] || fail "non-base plist was preserved"
+[ ! -e "$UN_HOME/.hermes/credentials/worker-token.txt" ] || fail "non-base credential was preserved"
+
+printf 'HERMES_BASE_PROFILE=../unsafe\n' > "$UN_ROOT/.env"
+set +e
+HOME="$UN_HOME" USER="b3os-test" bash "$UN_ROOT/uninstall.sh" --yes --keep-data >/dev/null 2>&1
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "uninstall accepted an unsafe base profile"
+
+echo "PASS: Hermes base profile configuration"

--- a/scripts/test-hermes-base-profile.sh
+++ b/scripts/test-hermes-base-profile.sh
@@ -7,6 +7,41 @@ trap 'rm -rf "$TMP"' EXIT
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
+# install migration detector: cloned auth symlinks identify the old shared source without a branded literal.
+DETECT_ROOT="$TMP/detect/profiles"
+mkdir -p "$DETECT_ROOT/old-base" "$DETECT_ROOT/member-a" "$DETECT_ROOT/member-b"
+touch "$DETECT_ROOT/old-base/auth.json"
+ln -s "$DETECT_ROOT/old-base/auth.json" "$DETECT_ROOT/member-a/auth.json"
+ln -s "$DETECT_ROOT/old-base/auth.json" "$DETECT_ROOT/member-b/auth.json"
+detected="$(bash "$ROOT/src/server/runtimes/hermes/detect-base-profile.sh" "$DETECT_ROOT")"
+[ "$detected" = "old-base" ] || fail "existing-install base detection failed"
+
+rm "$DETECT_ROOT/member-a/auth.json" "$DETECT_ROOT/member-b/auth.json"
+touch "$DETECT_ROOT/member-a/auth.json"
+set +e
+bash "$ROOT/src/server/runtimes/hermes/detect-base-profile.sh" "$DETECT_ROOT" >/dev/null 2>&1
+status=$?
+set -e
+[ "$status" -eq 2 ] || fail "ambiguous existing auth profiles did not fail closed"
+
+# install.sh backfills an existing .env from the detected shared auth source.
+INSTALL_ROOT="$TMP/install-repo"
+INSTALL_HOME="$TMP/install-home"
+INSTALL_BIN="$TMP/install-bin"
+mkdir -p "$INSTALL_ROOT/src/server/runtimes/hermes" "$INSTALL_ROOT/skills/b3os" "$INSTALL_HOME/.hermes/profiles/old-base" \
+  "$INSTALL_HOME/.hermes/profiles/member" "$INSTALL_BIN"
+cp "$ROOT/install.sh" "$INSTALL_ROOT/install.sh"
+cp "$ROOT/.env.example" "$INSTALL_ROOT/.env.example"
+cp "$ROOT/src/server/runtimes/hermes/detect-base-profile.sh" "$INSTALL_ROOT/src/server/runtimes/hermes/detect-base-profile.sh"
+touch "$INSTALL_ROOT/skills/b3os/SKILL.md" "$INSTALL_HOME/.hermes/profiles/old-base/auth.json"
+ln -s "$INSTALL_HOME/.hermes/profiles/old-base/auth.json" "$INSTALL_HOME/.hermes/profiles/member/auth.json"
+printf 'TEAM_HTTP_PORT=7878\n' > "$INSTALL_ROOT/.env"
+printf '#!/usr/bin/env bash\n[ "${1:-}" = "--version" ] && echo test\nexit 0\n' > "$INSTALL_BIN/bun"
+printf '#!/usr/bin/env bash\necho Linux\n' > "$INSTALL_BIN/uname"
+chmod +x "$INSTALL_BIN/bun" "$INSTALL_BIN/uname"
+HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" bash "$INSTALL_ROOT/install.sh" >/dev/null
+grep -q '^HERMES_BASE_PROFILE=old-base$' "$INSTALL_ROOT/.env" || fail "existing .env was not backfilled"
+
 # activate: configured base wins; when absent, another authenticated profile remains the fallback.
 ACT_HOME="$TMP/activate-home"
 mkdir -p "$ACT_HOME/.local/bin" "$ACT_HOME/.hermes/credentials" \
@@ -50,7 +85,7 @@ UN_HOME="$TMP/uninstall-home"
 mkdir -p "$UN_ROOT" "$UN_HOME/.hermes/profiles/configured-base" "$UN_HOME/.hermes/profiles/worker" \
   "$UN_HOME/.hermes/credentials" "$UN_HOME/Library/LaunchAgents"
 cp "$ROOT/uninstall.sh" "$UN_ROOT/uninstall.sh"
-printf 'HERMES_BASE_PROFILE=configured-base\n' > "$UN_ROOT/.env"
+printf 'HERMES_BASE_PROFILE=configured-base # preserved base\n' > "$UN_ROOT/.env"
 printf '[{"id":"base","runtime":"hermes_agent","hermes_profile":"configured-base"},{"id":"worker","runtime":"hermes_agent","hermes_profile":"worker"}]\n' > "$UN_ROOT/agents.json"
 touch "$UN_HOME/.hermes/credentials/base-token.txt" "$UN_HOME/.hermes/credentials/worker-token.txt"
 touch "$UN_HOME/Library/LaunchAgents/ai.hermes.gateway-configured-base.plist"

--- a/scripts/test-hermes-base-profile.sh
+++ b/scripts/test-hermes-base-profile.sh
@@ -42,6 +42,14 @@ chmod +x "$INSTALL_BIN/bun" "$INSTALL_BIN/uname"
 HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" bash "$INSTALL_ROOT/install.sh" >/dev/null
 grep -q '^HERMES_BASE_PROFILE=old-base$' "$INSTALL_ROOT/.env" || fail "existing .env was not backfilled"
 
+# A present-but-empty key is also migrated; unrelated ambiguous Hermes auth does not block non-Hermes installs.
+rm "$INSTALL_HOME/.hermes/profiles/member/auth.json"
+touch "$INSTALL_HOME/.hermes/profiles/member/auth.json"
+printf 'TEAM_HTTP_PORT=7878\nHERMES_BASE_PROFILE=\n' > "$INSTALL_ROOT/.env"
+HOME="$INSTALL_HOME" PATH="$INSTALL_BIN:/usr/bin:/bin" bash "$INSTALL_ROOT/install.sh" >/dev/null
+[ "$(grep -c '^HERMES_BASE_PROFILE=' "$INSTALL_ROOT/.env")" -eq 1 ] || fail "empty key migration left duplicate settings"
+grep -q '^HERMES_BASE_PROFILE=b3os$' "$INSTALL_ROOT/.env" || fail "non-Hermes ambiguous install did not use neutral default"
+
 # activate: configured base wins; when absent, another authenticated profile remains the fallback.
 ACT_HOME="$TMP/activate-home"
 mkdir -p "$ACT_HOME/.local/bin" "$ACT_HOME/.hermes/credentials" \

--- a/scripts/test-hermes-base-profile.sh
+++ b/scripts/test-hermes-base-profile.sh
@@ -37,6 +37,13 @@ status=$?
 set -e
 [ "$status" -ne 0 ] || fail "activate accepted an unsafe base profile"
 
+# The server must also fail closed before destructive TypeScript cleanup paths can run.
+set +e
+HERMES_BASE_PROFILE='../unsafe' bun -e "await import('$ROOT/src/server/lib/paths.ts')" >/dev/null 2>&1
+status=$?
+set -e
+[ "$status" -ne 0 ] || fail "server config accepted an unsafe base profile"
+
 # uninstall: .env-configured base survives while a non-base Hermes profile is removed.
 UN_ROOT="$TMP/uninstall-repo"
 UN_HOME="$TMP/uninstall-home"

--- a/skills/b3os/SKILL.md
+++ b/skills/b3os/SKILL.md
@@ -426,7 +426,7 @@ b3os는 팀 스킬 인덱스(`docs/B3OS_SKILLS.md`)에 등록된 **팀 스킬**�
 
 - **claude 팀원 여러 명** — 한 머신의 Claude 로그인 **하나를 공유**한다(각자 봇 토큰만 다름). telegram 플러그인은 user-scope 1회면 끝.
 - **openclaw 팀원** — 공유 게이트웨이. 새 에이전트마다 페어링(pair-approve) 필요.
-- **hermes 팀원** — 프로필별 게이트웨이. base 프로필(`b3ryshermes`)은 auth 소스라 퇴사/삭제 대상이 아님.
+- **hermes 팀원** — 프로필별 게이트웨이. base 프로필(`HERMES_BASE_PROFILE`, 기본 `b3os`)은 auth 소스라 퇴사/삭제 대상이 아님.
 
 > 다만 **추가 영입도 첫 팀원이 이어받는 게 이상적**이다(§7 handoff). 이 스킬은 "첫 팀원까지"가 기본 임무이고,
 > [8]은 사용자가 스킬에게 계속 맡기고 싶을 때의 편의 경로다.
@@ -538,7 +538,7 @@ cd "$B3OS" && bash uninstall.sh          # 확인 프롬프트 → 팀원 전원
 #   bash uninstall.sh --keep-data        # 오프보드+정지만, team.db/.env/데이터 보존
 ```
 마지막에 스크립트가 안내하는 `rm -rf "$B3OS"` 로 repo 폴더까지 지우면 끝.
-(uninstall.sh는 base hermes 프로필 `b3ryshermes`는 보존하고, 알려진 경로만 안전하게 지운다.)
+(uninstall.sh는 설정된 base hermes 프로필(`HERMES_BASE_PROFILE`, 기본 `b3os`)을 보존하고, 알려진 경로만 안전하게 지운다.)
 
 ## 참고 파일
 

--- a/skills/b3os/references/b3os-ops-primer.md
+++ b/skills/b3os/references/b3os-ops-primer.md
@@ -74,7 +74,7 @@ curl -s -X POST http://localhost:7878/team/api/members/<id>/swap-runtime \
 
 1. **검증(read-only)** — 대상 존재·no-op(같은 런타임)·공개 런타임(`claude_channel`/`openclaw`/
    `hermes_agent`) 우선. 오타·미지원 문자열은 여기서 즉시 400 `invalid_runtime`)·base hermes 프로필
-   (`b3ryshermes`) 가드·`APPROVAL_EXECUTION_ENABLED`(활성화 스위치) 확인. **여기서 막히면 아무것도 안 바뀐다**
+   (`HERMES_BASE_PROFILE`, 기본 `b3os`) 가드·`APPROVAL_EXECUTION_ENABLED`(활성화 스위치) 확인. **여기서 막히면 아무것도 안 바뀐다**
    (가장 안전한 실패).
 2. **preflight** — `checkRuntimeAuth(target_runtime)`. 미설치/미인증이면 여기서 중단 — 구 런타임은 아직
    살아 있어 다운타임 0. `error/code="preflight_blocked"`, `detail`에 조치법(fixHint)이 그대로 온다.
@@ -107,7 +107,7 @@ curl -s -X POST http://localhost:7878/team/api/members/<id>/swap-runtime \
   워크스페이스 밖에 있고 Claude 런타임에서만 주입된다. `claude_channel`에서 다른 런타임으로 바꾸면 파일은
   디스크에 남지만 다음 세션에 주입되지 않는다 — 교체 전 경고. 역방향(→`claude_channel`)으로 복귀하면 같은
   워크스페이스 경로 기준으로 다시 주입될 수 있다.
-- **base hermes 프로필(`b3ryshermes`)은 교체 대상 아님** — 모든 hermes 멤버의 공유 auth 소스라 어느 방향이든
+- **base hermes 프로필(`HERMES_BASE_PROFILE`, 기본 `b3os`)은 교체 대상 아님** — 모든 hermes 멤버의 공유 auth 소스라 어느 방향이든
   거부된다(`code:"base_hermes_guard"`).
 - **`APPROVAL_EXECUTION_ENABLED`가 꺼져 있으면 아예 시작 안 함** — `code:"execution_off"`. 팀장 인가(터미널
   y/n 또는 `/approve`) 후에만 켜져 있다.
@@ -122,7 +122,7 @@ curl -s -X POST http://localhost:7878/team/api/members/<id>/swap-runtime \
 curl -s -X DELETE http://localhost:7878/team/api/members/<id> \
   -H 'content-type: application/json' -d '{"confirm_name":"Alex"}'
 ```
-- 마지막 1명은 못 지운다(`cannot_remove_last_member`). base hermes 프로필(`b3ryshermes`)은 퇴사 대상 아님(auth 소스).
+- 마지막 1명은 못 지운다(`cannot_remove_last_member`). 설정된 base hermes 프로필은 퇴사 대상 아님(auth 소스).
 - 퇴사 = 봇·tmux/게이트웨이·슬랙 완전 disconnect + workspace는 삭제가 아니라 `.archived/<id>-<ts>`로 보관.
 - **UI**: Settings ▸ 팀원 목록에서 퇴사(이름 정확 입력 확인).
 
@@ -161,7 +161,7 @@ UI: Settings ▸ 시스템 OP 라우터 토글. 영구 고정은 `.env` `ROUTER_
 cd "$HOME/b3rys-team-os" && bash uninstall.sh     # 팀원 전원 오프보드 → 서버 정지 → 데이터 삭제
 #   --yes(확인 생략) · --keep-data(오프보드+정지만, team.db/.env 보존)
 ```
-스크립트가 안내하는 `rm -rf` 로 repo 폴더까지 지우면 끝. base hermes 프로필(`b3ryshermes`)은 보존된다.
+스크립트가 안내하는 `rm -rf` 로 repo 폴더까지 지우면 끝. 설정된 base hermes 프로필은 보존된다.
 
 ## 8. 어디까지가 사람(팀장) 몫인가
 

--- a/skills/b3os/references/recruit.md
+++ b/skills/b3os/references/recruit.md
@@ -198,4 +198,4 @@ curl -s -X POST http://localhost:$PORT/team/api/ot/<ot_id>/activate
 | `hermes_agent` | 고급 | Hermes 프로필 게이트웨이 | DM 페어링 게이트(팀장은 activate가 allowlist 자동시드→코드 불필요) | hermes CLI + base 프로필·python3 |
 
 > **추가 영입 시 런타임별 구독 재사용** — claude 팀원 여러 명 = 한 머신의 Claude 로그인 하나 공유(봇 토큰만 다름).
-> openclaw = 공유 게이트웨이(에이전트마다 pair-approve). hermes = 프로필별(base 프로필 b3ryshermes는 auth 소스라 퇴사 대상 아님).
+> openclaw = 공유 게이트웨이(에이전트마다 pair-approve). hermes = 프로필별(`HERMES_BASE_PROFILE`, 기본 `b3os`는 auth 소스라 퇴사 대상 아님).

--- a/src/server/lib/activation.test.ts
+++ b/src/server/lib/activation.test.ts
@@ -22,6 +22,7 @@ import {
   activateMember, teardownRuntime, swapRuntime, RUNTIMES, STATUS_BY_RUNTIME,
   type ActivateResult, type SwapDeps,
 } from "./activation";
+import { HERMES_BASE_PROFILE } from "./paths";
 
 /** tmp HOME을 만들고, present=true면 ~/.claude/channels/telegram-<id>/bot.pid 를 미리 쓴다(실 HOME 미접촉). */
 function tmpHome(id: string, present: boolean): string {
@@ -161,7 +162,7 @@ describe("activation: hermes gateway 헬스게이트 (waitForHermesGateway)", ()
           "✗ Gateway service is not loaded",
           "  Service definition exists locally but launchd has not loaded it.",
           "Other profiles:",
-          "  ✓ b3ryshermes      — PID 12325",
+          "  ✓ legacy-base     — PID 12325",
         ].join("\n"),
       }),
     });
@@ -178,7 +179,7 @@ describe("activation: hermes gateway 헬스게이트 (waitForHermesGateway)", ()
           "✓ Service definition matches the current Hermes install",
           "✓ Gateway is supervised by launchd (PID 43335)",
           "Other profiles:",
-          "  ✓ b3ryshermes      — PID 12325",
+          "  ✓ legacy-base     — PID 12325",
           "  ✓ mes              — PID 44736",
         ].join("\n"),
       }),
@@ -267,9 +268,9 @@ describe("activation: teardownRuntime (Phase1 offboard 4-branch 추출)", () => 
     expect(calls.some((c) => c.startsWith("removePathWithRetries:") && c.includes("/profiles/mes"))).toBe(true);
   });
 
-  test("hermes_agent(base b3ryshermes) → setAgentEnabled 호출 안 함(공유 auth 소스 보존)", async () => {
+  test("설정된 base hermes → setAgentEnabled 호출 안 함(공유 auth 소스 보존)", async () => {
     const calls: string[] = [];
-    const r = await teardownRuntime("mes", "hermes_agent", { hermes_profile: "b3ryshermes" }, {
+    const r = await teardownRuntime("mes", "hermes_agent", { hermes_profile: HERMES_BASE_PROFILE }, {
       sleepMs: 0,
       setAgentEnabled: async () => { calls.push("setAgentEnabled"); return { ok: true, detail: "" }; },
       existsSync: () => true,
@@ -524,10 +525,10 @@ describe("activation: swapRuntime", () => {
     }
   });
 
-  test("base hermes(b3ryshermes) 스왑 시도 → teardown 호출 전 거부(code=base_hermes_guard)", async () => {
-    const { registryPath, db } = setupSwapFixture({ id: "b3ryshermes", runtime: "hermes_agent", status_provider: "hermes_gateway", hermes_profile: "b3ryshermes" });
+  test("설정된 base hermes 스왑 시도 → teardown 호출 전 거부(code=base_hermes_guard)", async () => {
+    const { registryPath, db } = setupSwapFixture({ id: HERMES_BASE_PROFILE, runtime: "hermes_agent", status_provider: "hermes_gateway", hermes_profile: HERMES_BASE_PROFILE });
     let teardownCalls = 0;
-    const result = await swapRuntime(db, { id: "b3ryshermes", targetRuntime: "codex", registryPath }, {
+    const result = await swapRuntime(db, { id: HERMES_BASE_PROFILE, targetRuntime: "codex", registryPath }, {
       checkRuntimeAuth: authOk, activateMember: activateOk,
       teardownRuntime: async () => { teardownCalls++; return { ok: true, detail: "" }; },
     });

--- a/src/server/lib/activation.test.ts
+++ b/src/server/lib/activation.test.ts
@@ -537,6 +537,27 @@ describe("activation: swapRuntime", () => {
     expect(teardownCalls).toBe(0);
   });
 
+  test("base 이름의 비-Hermes 멤버를 Hermes로 스왑 → base 프로필 점유 전 거부", async () => {
+    const { registryPath, db } = setupSwapFixture({
+      id: HERMES_BASE_PROFILE,
+      runtime: "claude_channel",
+      status_provider: "tmux",
+    });
+    let teardownCalls = 0;
+    const result = await swapRuntime(db, {
+      id: HERMES_BASE_PROFILE,
+      targetRuntime: "hermes_agent",
+      registryPath,
+    }, {
+      checkRuntimeAuth: authOk,
+      activateMember: activateOk,
+      teardownRuntime: async () => { teardownCalls++; return { ok: true, detail: "" }; },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("base_hermes_guard");
+    expect(teardownCalls).toBe(0);
+  });
+
   test("STEP5(activateMember) 실패 → 레지스트리·persona 원복 + old runtime self-heal 시도", async () => {
     const { registryPath, wsDir, db } = setupSwapFixture();
     const ORIGINAL_PERSONA = "# Nova\n\n원본 SOUL.md 커스텀 내용.\n";

--- a/src/server/lib/activation.ts
+++ b/src/server/lib/activation.ts
@@ -15,7 +15,7 @@ import { existsSync, mkdirSync, writeFileSync, chmodSync, readFileSync, renameSy
 import { dirname } from "node:path";
 import { memberPaths, MEMBERS_ROOT, personaTargetsForRuntime, assertNotLiveMemberFsUnderTest } from "./personaTemplates";
 import { writeMemberPersona, savePersonaFile } from "./writeMemberPersona";
-import { MANUALS_DIR } from "./paths";
+import { HERMES_BASE_PROFILE, MANUALS_DIR } from "./paths";
 import { appendAuditFile } from "./auditFile";
 import { codexBridgePaths, placeCodexToken, writeCodexBridgeFiles, removeCodexBridgeFiles, resolveOwnerDmId } from "../runtimes/codex/launcher";
 import { placeClaudeToken, writeClaudeBridgeFiles, seedClaudeTrust, seedClaudeAccess, killClaudeTmux, reconnectClaudeTelegram, claudeBridgePaths, installReplyGuardHook, installOutboundHook, installProgressHook, uninstallOutboundHook, uninstallReplyGuardHook, uninstallRecoveryHook, removeClaudeBridgeFiles } from "../runtimes/claude/launcher";
@@ -130,11 +130,11 @@ export async function teardownRuntime(
     return { ok: true, detail: "claude_channel teardown 완료(best-effort)" };
   }
   // hermes_agent teardown: 게이트웨이 stop + 프로필별 LaunchAgent plist + credential 토큰 + 프로필 dir 정리.
-  //   ★CRITICAL 가드: base 프로필(b3ryshermes)은 모든 hermes 멤버의 auth.json 심링크 소스+clone 원본이라
+  //   ★CRITICAL 가드: 설정된 base 프로필은 모든 hermes 멤버의 auth.json 심링크 소스+clone 원본이라
   //   절대 정지/삭제하지 않는다(공유 인프라 보존, 멤버 레지스트리/per-id 토큰만 정리) — offboard 원본 로직 그대로.
   if (runtime === "hermes_agent") {
     const prof = agent?.hermes_profile ?? id;
-    const isBaseHermesProfile = prof === "b3ryshermes";
+    const isBaseHermesProfile = prof === HERMES_BASE_PROFILE;
     try { if (!isBaseHermesProfile) await doSetAgentEnabled(id, "hermes_agent", false); } catch { /* best-effort */ }
     await new Promise((r) => setTimeout(r, opts.sleepMs ?? 1500)); // 게이트웨이 bootout 후 프로필 dir 해제 대기(레이스 방지)
     if (/^[a-z0-9_-]+$/i.test(prof) && !isBaseHermesProfile) {
@@ -266,7 +266,7 @@ function runtimeScript(id: string, runtime: string): { script: string; tokenFile
     return {
       script: `${MANUALS_DIR}/hermes/activate-hermes-agent.sh`,
       tokenFile: `${HOME}/.hermes/credentials/${id}-token.txt`,
-      env: { AGENT_ID: id, WS: ws, ...(ownerDm ? { OWNER_CHAT_ID: ownerDm } : {}) },
+      env: { AGENT_ID: id, WS: ws, HERMES_BASE_PROFILE, ...(ownerDm ? { OWNER_CHAT_ID: ownerDm } : {}) },
     };
   }
   return null; // claude_channel 은 별도 런타임 활성화 없음(CLAUDE.md + tmux/LaunchAgent)
@@ -868,15 +868,14 @@ export async function swapRuntime(db: Database, input: SwapInput, deps: SwapDeps
     return { ok: false, steps, error: `허용되지 않는 런타임: ${targetRuntime}`, code: "invalid_runtime" };
   }
 
-  // STEP0(e) — base hermes 프로필(b3ryshermes) 가드. 모든 hermes 멤버의 공유 auth 소스라 교체 대상이
+  // STEP0(e) — 설정된 base hermes 프로필 가드. 모든 hermes 멤버의 공유 auth 소스라 교체 대상이
   //   아니다(offboard 가드와 동일 조건 재사용: target.runtime==="hermes_agent" && (hermes_profile??id)
-  //   === "b3ryshermes"). swap 특유 추가: id 자체가 b3ryshermes면 방향 무관 거부(STEP3에서 hermes_profile
-  //   이 id로 세팅되므로 "b3ryshermes로 교체해 들어가는" 경우도 이 한 줄로 커버됨).
-  const isBaseHermesTarget = target.runtime === "hermes_agent" && ((target.hermes_profile ?? id) === "b3ryshermes");
-  if (isBaseHermesTarget || id === "b3ryshermes") {
+  //   === HERMES_BASE_PROFILE). swap 특유 추가: id 자체가 base 이름이면 방향 무관 거부한다.
+  const isBaseHermesTarget = target.runtime === "hermes_agent" && ((target.hermes_profile ?? id) === HERMES_BASE_PROFILE);
+  if (isBaseHermesTarget || id === HERMES_BASE_PROFILE) {
     return {
       ok: false, steps,
-      error: "b3ryshermes는 모든 hermes 멤버가 공유하는 base 프로필(auth 소스)입니다. 런타임 교체 대상이 아닙니다.",
+      error: `${HERMES_BASE_PROFILE}는 모든 hermes 멤버가 공유하는 base 프로필(auth 소스)입니다. 런타임 교체 대상이 아닙니다.`,
       code: "base_hermes_guard",
     };
   }

--- a/src/server/lib/activation.ts
+++ b/src/server/lib/activation.ts
@@ -16,7 +16,7 @@ import { dirname } from "node:path";
 import { memberPaths, MEMBERS_ROOT, personaTargetsForRuntime, assertNotLiveMemberFsUnderTest } from "./personaTemplates";
 import { writeMemberPersona, savePersonaFile } from "./writeMemberPersona";
 import { HERMES_BASE_PROFILE, MANUALS_DIR } from "./paths";
-import { isHermesProfileProtected } from "./hermesBaseProfile";
+import { isHermesMemberProtected, isHermesProfileProtected } from "./hermesBaseProfile";
 import { appendAuditFile } from "./auditFile";
 import { codexBridgePaths, placeCodexToken, writeCodexBridgeFiles, removeCodexBridgeFiles, resolveOwnerDmId } from "../runtimes/codex/launcher";
 import { placeClaudeToken, writeClaudeBridgeFiles, seedClaudeTrust, seedClaudeAccess, killClaudeTmux, reconnectClaudeTelegram, claudeBridgePaths, installReplyGuardHook, installOutboundHook, installProgressHook, uninstallOutboundHook, uninstallReplyGuardHook, uninstallRecoveryHook, removeClaudeBridgeFiles } from "../runtimes/claude/launcher";
@@ -869,11 +869,11 @@ export async function swapRuntime(db: Database, input: SwapInput, deps: SwapDeps
     return { ok: false, steps, error: `허용되지 않는 런타임: ${targetRuntime}`, code: "invalid_runtime" };
   }
 
-  // STEP0(e) — 설정된 base hermes 프로필 가드. 모든 hermes 멤버의 공유 auth 소스라 교체 대상이
-  //   아니다(offboard 가드와 동일 조건 재사용: target.runtime==="hermes_agent" && (hermes_profile??id)
-  //   === HERMES_BASE_PROFILE). swap 특유 추가: id 자체가 base 이름이면 방향 무관 거부한다.
-  const isBaseHermesTarget = target.runtime === "hermes_agent" && isHermesProfileProtected(target.hermes_profile ?? id);
-  if (isBaseHermesTarget || isHermesProfileProtected(id)) {
+  // STEP0(e) — 현재 런타임이 Hermes인 대상에만 프로필 보호 판정을 적용한다. 탐지가 모호할 때
+  //   모든 Hermes 프로필을 fail-closed로 보호하되, Claude/Codex/OpenClaw 멤버 id까지 Hermes
+  //   프로필로 오인해 모든 런타임 교체를 막아서는 안 된다.
+  const isBaseHermesTarget = isHermesMemberProtected(target.runtime, target.hermes_profile ?? id);
+  if (isBaseHermesTarget) {
     return {
       ok: false, steps,
       error: `${HERMES_BASE_PROFILE}는 모든 hermes 멤버가 공유하는 base 프로필(auth 소스)입니다. 런타임 교체 대상이 아닙니다.`,

--- a/src/server/lib/activation.ts
+++ b/src/server/lib/activation.ts
@@ -873,7 +873,9 @@ export async function swapRuntime(db: Database, input: SwapInput, deps: SwapDeps
   //   모든 Hermes 프로필을 fail-closed로 보호하되, Claude/Codex/OpenClaw 멤버 id까지 Hermes
   //   프로필로 오인해 모든 런타임 교체를 막아서는 안 된다.
   const isBaseHermesTarget = isHermesMemberProtected(target.runtime, target.hermes_profile ?? id);
-  if (isBaseHermesTarget) {
+  const wouldClaimConfiguredBase =
+    targetRuntime === "hermes_agent" && id.toLowerCase() === HERMES_BASE_PROFILE.toLowerCase();
+  if (isBaseHermesTarget || wouldClaimConfiguredBase) {
     return {
       ok: false, steps,
       error: `${HERMES_BASE_PROFILE}는 모든 hermes 멤버가 공유하는 base 프로필(auth 소스)입니다. 런타임 교체 대상이 아닙니다.`,

--- a/src/server/lib/activation.ts
+++ b/src/server/lib/activation.ts
@@ -16,6 +16,7 @@ import { dirname } from "node:path";
 import { memberPaths, MEMBERS_ROOT, personaTargetsForRuntime, assertNotLiveMemberFsUnderTest } from "./personaTemplates";
 import { writeMemberPersona, savePersonaFile } from "./writeMemberPersona";
 import { HERMES_BASE_PROFILE, MANUALS_DIR } from "./paths";
+import { isHermesProfileProtected } from "./hermesBaseProfile";
 import { appendAuditFile } from "./auditFile";
 import { codexBridgePaths, placeCodexToken, writeCodexBridgeFiles, removeCodexBridgeFiles, resolveOwnerDmId } from "../runtimes/codex/launcher";
 import { placeClaudeToken, writeClaudeBridgeFiles, seedClaudeTrust, seedClaudeAccess, killClaudeTmux, reconnectClaudeTelegram, claudeBridgePaths, installReplyGuardHook, installOutboundHook, installProgressHook, uninstallOutboundHook, uninstallReplyGuardHook, uninstallRecoveryHook, removeClaudeBridgeFiles } from "../runtimes/claude/launcher";
@@ -134,7 +135,7 @@ export async function teardownRuntime(
   //   절대 정지/삭제하지 않는다(공유 인프라 보존, 멤버 레지스트리/per-id 토큰만 정리) — offboard 원본 로직 그대로.
   if (runtime === "hermes_agent") {
     const prof = agent?.hermes_profile ?? id;
-    const isBaseHermesProfile = prof === HERMES_BASE_PROFILE;
+    const isBaseHermesProfile = isHermesProfileProtected(prof);
     try { if (!isBaseHermesProfile) await doSetAgentEnabled(id, "hermes_agent", false); } catch { /* best-effort */ }
     await new Promise((r) => setTimeout(r, opts.sleepMs ?? 1500)); // 게이트웨이 bootout 후 프로필 dir 해제 대기(레이스 방지)
     if (/^[a-z0-9_-]+$/i.test(prof) && !isBaseHermesProfile) {
@@ -871,8 +872,8 @@ export async function swapRuntime(db: Database, input: SwapInput, deps: SwapDeps
   // STEP0(e) — 설정된 base hermes 프로필 가드. 모든 hermes 멤버의 공유 auth 소스라 교체 대상이
   //   아니다(offboard 가드와 동일 조건 재사용: target.runtime==="hermes_agent" && (hermes_profile??id)
   //   === HERMES_BASE_PROFILE). swap 특유 추가: id 자체가 base 이름이면 방향 무관 거부한다.
-  const isBaseHermesTarget = target.runtime === "hermes_agent" && ((target.hermes_profile ?? id) === HERMES_BASE_PROFILE);
-  if (isBaseHermesTarget || id === HERMES_BASE_PROFILE) {
+  const isBaseHermesTarget = target.runtime === "hermes_agent" && isHermesProfileProtected(target.hermes_profile ?? id);
+  if (isBaseHermesTarget || isHermesProfileProtected(id)) {
     return {
       ok: false, steps,
       error: `${HERMES_BASE_PROFILE}는 모든 hermes 멤버가 공유하는 base 프로필(auth 소스)입니다. 런타임 교체 대상이 아닙니다.`,

--- a/src/server/lib/agentControl.ts
+++ b/src/server/lib/agentControl.ts
@@ -102,7 +102,7 @@ async function setClaude(id: string, enabled: boolean): Promise<ControlResult> {
 
 /** hermes 에이전트: 프로필 게이트웨이 stop/start. */
 async function setHermes(id: string, enabled: boolean): Promise<ControlResult> {
-  // 프로필 = agent.hermes_profile ?? id (restartAgent와 동일) — HERMES_PROFILE=id 하드코딩이면 프로필≠id(기존 hermes=b3ryshermes)일 때 on/off가 엉뚱한 프로필을 건드림(Codex 크로스리뷰 지적). GD 2026-07-01.
+  // 프로필 = agent.hermes_profile ?? id (restartAgent와 동일) — HERMES_PROFILE=id 하드코딩이면 프로필≠id일 때 on/off가 엉뚱한 프로필을 건드린다.
   const agent = ambientAgents().find((a) => a.id === id);
   const profile = agent?.hermes_profile ?? id;
   if (enabled) {
@@ -158,7 +158,6 @@ export async function setAgentEnabled(agentId: string, runtime: string, enabled:
 // ── 재시작 (페르소나 reload·복구) ──────────────────────────────────────────
 //   정지(off)와 다름: off 는 끄는 것, 재시작은 켜둔 채 다시 띄워 최신 페르소나/상태 로드.
 //   런타임별: claude=restart-agent.sh --resume(컨텍스트 유지+새 CLAUDE.md) / openclaw·hermes=게이트웨이 in-place kickstart.
-const HERMES_LABEL = "ai.hermes.gateway-b3ryshermes";
 const OPENCLAW_LABEL = "ai.openclaw.gateway";
 
 /** 팀원 1명 재시작. off 상태는 거부(기동은 🟢). bill 도 가능 — claude_channel 이라 --resume(컨텍스트 유지)이고,
@@ -203,7 +202,7 @@ export async function restartAgent(agentId: string, runtime: string, fresh = fal
       return { ok: r.code === 0, detail: r.code === 0 ? `openclaw 게이트웨이 재시작(${agentId} 등 새 IDENTITY/AGENTS 로드 · 다른 openclaw 1~2분 깜빡 · 정지된 forin 은 그대로 off)` : `재시작 실패: ${r.out.slice(-150)}` };
     }
     if (runtime === "hermes_agent") {
-      // 프로필별 게이트웨이 타겟(기존 hermes=b3ryshermes, 신규 영입=id) — HERMES_LABEL 하드코딩이면 신규 hermes 재시작 불가였음(하네스). GD 2026-07-01.
+      // 프로필별 게이트웨이 타겟(profile≠id인 기존 멤버 포함).
       const agent = ambientAgents().find((a) => a.id === agentId);
       const label = agent?.gateway_service ?? `ai.hermes.gateway-${agent?.hermes_profile ?? agentId}`;
       const r = await run(["launchctl", "kickstart", "-k", `gui/${uid}/${label}`]);

--- a/src/server/lib/hermesBaseProfile.test.ts
+++ b/src/server/lib/hermesBaseProfile.test.ts
@@ -7,13 +7,13 @@ import { hermesProtectedProfiles, isHermesMemberProtected } from "./hermesBasePr
 describe("Hermes base profile defense-in-depth", () => {
   test("공유 auth 심링크 원본을 설정과 독립적으로 탐지하고 대소문자 없이 보호", () => {
     const root = mkdtempSync(join(tmpdir(), "hermes-base-"));
-    mkdirSync(join(root, "zzbase"));
+    mkdirSync(join(root, "MyBase"));
     mkdirSync(join(root, "member"));
-    writeFileSync(join(root, "zzbase", "auth.json"), "{}");
-    symlinkSync(join(root, "zzbase", "auth.json"), join(root, "member", "auth.json"));
+    writeFileSync(join(root, "MyBase", "auth.json"), "{}");
+    symlinkSync(join(root, "MyBase", "auth.json"), join(root, "member", "auth.json"));
     const state = hermesProtectedProfiles(root);
     expect(state.ambiguous).toBe(false);
-    expect(state.names.has("zzbase")).toBe(true);
+    expect(state.names.has("mybase")).toBe(true);
   });
 
   test("공유 원본이 모호하면 destructive 경로가 전체 보호하도록 ambiguous", () => {

--- a/src/server/lib/hermesBaseProfile.test.ts
+++ b/src/server/lib/hermesBaseProfile.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { hermesProtectedProfiles } from "./hermesBaseProfile";
+import { hermesProtectedProfiles, isHermesMemberProtected } from "./hermesBaseProfile";
 
 describe("Hermes base profile defense-in-depth", () => {
   test("공유 auth 심링크 원본을 설정과 독립적으로 탐지하고 대소문자 없이 보호", () => {
@@ -23,5 +23,8 @@ describe("Hermes base profile defense-in-depth", () => {
       writeFileSync(join(root, profile, "auth.json"), "{}");
     }
     expect(hermesProtectedProfiles(root).ambiguous).toBe(true);
+    expect(isHermesMemberProtected("hermes_agent", "some-member", root)).toBe(true);
+    expect(isHermesMemberProtected("claude_channel", "some-member", root)).toBe(false);
+    expect(isHermesMemberProtected("codex", "some-member", root)).toBe(false);
   });
 });

--- a/src/server/lib/hermesBaseProfile.test.ts
+++ b/src/server/lib/hermesBaseProfile.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { hermesProtectedProfiles } from "./hermesBaseProfile";
+
+describe("Hermes base profile defense-in-depth", () => {
+  test("공유 auth 심링크 원본을 설정과 독립적으로 탐지하고 대소문자 없이 보호", () => {
+    const root = mkdtempSync(join(tmpdir(), "hermes-base-"));
+    mkdirSync(join(root, "zzbase"));
+    mkdirSync(join(root, "member"));
+    writeFileSync(join(root, "zzbase", "auth.json"), "{}");
+    symlinkSync(join(root, "zzbase", "auth.json"), join(root, "member", "auth.json"));
+    const state = hermesProtectedProfiles(root);
+    expect(state.ambiguous).toBe(false);
+    expect(state.names.has("zzbase")).toBe(true);
+  });
+
+  test("공유 원본이 모호하면 destructive 경로가 전체 보호하도록 ambiguous", () => {
+    const root = mkdtempSync(join(tmpdir(), "hermes-base-"));
+    for (const profile of ["one", "two"]) {
+      mkdirSync(join(root, profile));
+      writeFileSync(join(root, profile, "auth.json"), "{}");
+    }
+    expect(hermesProtectedProfiles(root).ambiguous).toBe(true);
+  });
+});

--- a/src/server/lib/hermesBaseProfile.ts
+++ b/src/server/lib/hermesBaseProfile.ts
@@ -1,0 +1,46 @@
+import { lstatSync, readlinkSync, readdirSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { HERMES_BASE_PROFILE, HERMES_ROOT } from "./paths";
+
+const slug = /^[A-Za-z0-9_-]+$/;
+const fold = (value: string): string => value.toLowerCase();
+
+/** 설정과 실제 auth 심링크 구조를 함께 사용한다. 모호하면 모든 Hermes 프로필을 보호해 삭제를 fail-closed한다. */
+export function hermesProtectedProfiles(root = `${HERMES_ROOT}/profiles`): { names: Set<string>; ambiguous: boolean } {
+  const names = new Set<string>([fold(HERMES_BASE_PROFILE)]);
+  const authProfiles: string[] = [];
+  const sharedTargets: string[] = [];
+  let entries: string[] = [];
+  try { entries = readdirSync(root); } catch { return { names, ambiguous: false }; }
+
+  for (const profile of entries) {
+    if (!slug.test(profile)) continue;
+    const auth = join(root, profile, "auth.json");
+    try {
+      const stat = lstatSync(auth);
+      authProfiles.push(profile);
+      if (!stat.isSymbolicLink()) continue;
+      const raw = readlinkSync(auth);
+      const target = isAbsolute(raw) ? raw : resolve(dirname(auth), raw);
+      const targetRoot = resolve(root) + "/";
+      if (!target.startsWith(targetRoot) || !target.endsWith("/auth.json")) continue;
+      const targetProfile = target.slice(targetRoot.length, -"/auth.json".length);
+      if (slug.test(targetProfile) && !targetProfile.includes("/")) sharedTargets.push(targetProfile);
+    } catch { /* auth 없음/깨진 링크 */ }
+  }
+
+  const uniqueTargets = [...new Set(sharedTargets.map(fold))];
+  if (uniqueTargets.length === 1) names.add(uniqueTargets[0]!);
+  else if (uniqueTargets.length > 1) return { names, ambiguous: true };
+  else {
+    const uniqueAuth = [...new Set(authProfiles.map(fold))];
+    if (uniqueAuth.length === 1) names.add(uniqueAuth[0]!);
+    else if (uniqueAuth.length > 1) return { names, ambiguous: true };
+  }
+  return { names, ambiguous: false };
+}
+
+export function isHermesProfileProtected(profile: string): boolean {
+  const state = hermesProtectedProfiles();
+  return state.ambiguous || state.names.has(fold(profile));
+}

--- a/src/server/lib/hermesBaseProfile.ts
+++ b/src/server/lib/hermesBaseProfile.ts
@@ -40,7 +40,12 @@ export function hermesProtectedProfiles(root = `${HERMES_ROOT}/profiles`): { nam
   return { names, ambiguous: false };
 }
 
-export function isHermesProfileProtected(profile: string): boolean {
-  const state = hermesProtectedProfiles();
+export function isHermesProfileProtected(profile: string, root?: string): boolean {
+  const state = hermesProtectedProfiles(root);
   return state.ambiguous || state.names.has(fold(profile));
+}
+
+/** 모호성 fail-closed는 Hermes 런타임에만 적용한다. 다른 런타임의 멤버 id는 프로필 판정 대상이 아니다. */
+export function isHermesMemberProtected(runtime: string, profile: string, root?: string): boolean {
+  return runtime === "hermes_agent" && isHermesProfileProtected(profile, root);
 }

--- a/src/server/lib/paths.ts
+++ b/src/server/lib/paths.ts
@@ -23,6 +23,9 @@ export const LOCAL_BIN = `${HOME}/.local/bin`;
 /** hermes 런타임 홈(~/.hermes) — 프로필 .env / credentials 위치. */
 export const HERMES_ROOT = `${HOME}/.hermes`;
 
+/** 공유 Hermes 인증 원본 프로필. 공개 기본값은 중립적인 b3os이며 운영 환경에서 env로 재정의한다. */
+export const HERMES_BASE_PROFILE = process.env.HERMES_BASE_PROFILE?.trim() || "b3os";
+
 /** openclaw 런타임 홈(~/.openclaw) — openclaw.env / credentials 위치. */
 export const OPENCLAW_ROOT = `${HOME}/.openclaw`;
 

--- a/src/server/lib/paths.ts
+++ b/src/server/lib/paths.ts
@@ -23,8 +23,13 @@ export const LOCAL_BIN = `${HOME}/.local/bin`;
 /** hermes 런타임 홈(~/.hermes) — 프로필 .env / credentials 위치. */
 export const HERMES_ROOT = `${HOME}/.hermes`;
 
-/** 공유 Hermes 인증 원본 프로필. 공개 기본값은 중립적인 b3os이며 운영 환경에서 env로 재정의한다. */
-export const HERMES_BASE_PROFILE = process.env.HERMES_BASE_PROFILE?.trim() || "b3os";
+/** 공유 Hermes 인증 원본 프로필. 공개 기본값은 중립적인 b3os이며 운영 환경에서 env로 재정의한다.
+ *  삭제 가드의 기준이므로 잘못된 값은 기본값으로 조용히 폴백하지 않고 서버 시작 단계에서 fail-closed한다. */
+const configuredHermesBaseProfile = process.env.HERMES_BASE_PROFILE?.trim();
+if (configuredHermesBaseProfile && !/^[A-Za-z0-9_-]+$/.test(configuredHermesBaseProfile)) {
+  throw new Error("HERMES_BASE_PROFILE must be a safe profile slug (letters, numbers, underscore, hyphen)");
+}
+export const HERMES_BASE_PROFILE = configuredHermesBaseProfile || "b3os";
 
 /** openclaw 런타임 홈(~/.openclaw) — openclaw.env / credentials 위치. */
 export const OPENCLAW_ROOT = `${HOME}/.openclaw`;

--- a/src/server/lib/rotateToken.ts
+++ b/src/server/lib/rotateToken.ts
@@ -111,7 +111,7 @@ export function resolveTokenStore(runtime: string, id: string, agent: AgentRecor
     return plainFileStore(file, `⚠ openclaw는 게이트웨이를 공유해서, 재시작 시 openclaw 팀원 전체가 1~2분 함께 재시작됩니다.${existsSync(file) ? "" : " (토큰파일이 없어 새로 생성합니다.)"}`);
   }
   if (runtime === "hermes_agent") {
-    // hermes = 격리(그 팀원 프로필만). 프로필 = agent.hermes_profile ?? id (기존 hermes=b3ryshermes, 신규=id). 다중설정 .env에서 TELEGRAM_BOT_TOKEN 키 라인만 교체.
+    // hermes = 격리(그 팀원 프로필만). 프로필 = agent.hermes_profile ?? id. 다중설정 .env에서 TELEGRAM_BOT_TOKEN 키 라인만 교체.
     const profile = agent.hermes_profile ?? id;
     if (!/^[a-z0-9_-]+$/i.test(profile)) return { unsupported: `hermes 프로필 형식이 올바르지 않아요 — 변경 미지원(기존 유지).` };
     return envFileStore(`${HOME}/.hermes/profiles/${profile}/.env`, "TELEGRAM_BOT_TOKEN");

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -53,6 +53,7 @@ import { hasCapability } from "../lib/capabilities";
 import { getNormalApprovers } from "../lib/approvals";
 import { hasSlackTokenFile, loadAgentCreds, saveAgentCreds, removeAgentCreds, slackTokensDir, postMessage } from "../lib/slack";
 import { renderAndRepoint, TEAM_OS_TEMPLATE_PATH, LIVE_TEAM_OS_PATH } from "../lib/teamOsRender";
+import { HERMES_BASE_PROFILE } from "../lib/paths";
 import { latestCaptureNonBotSender, listDiscoveredGroups } from "../lib/telegramLeadDetection";
 import { activeOfficialMemberCount, isTeamOfficialMember, MAX_OFFICIAL_TEAM_MEMBERS } from "../lib/agentMembership";
 import { writeRegistrySafely, type RegistryWriteOptions } from "../lib/registrySafety";
@@ -661,10 +662,10 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     if (typeof body.confirm_name !== "string" || body.confirm_name.trim() !== target.display_name)
       return c.json({ error: "confirm_name_mismatch", hint: `정확히 "${target.display_name}" 입력 필요` }, 400);
     if (list.length <= 1) return c.json({ error: "cannot_remove_last_member" }, 400);
-    // ★base hermes 프로필(b3ryshermes) 멤버 퇴사 차단 — 모든 hermes 멤버의 공유 auth.json 소스+clone 원본이라 정상 퇴사 대상이 아님(하네스 재검증 LOW-MED: 삭제 시 런타임 전멸, gateway만 정지해도 auth refresh 위험). 아래 프로필-dir 가드는 defense-in-depth. GD 2026-07-02.
-    if (target.runtime === "hermes_agent" && ((target as any).hermes_profile ?? id) === "b3ryshermes")
-      return c.json({ error: "cannot_offboard_base_hermes_profile", hint: "b3ryshermes는 모든 hermes 멤버가 공유하는 base 프로필(auth 소스)입니다. 이 멤버는 퇴사 대상이 아닙니다 — 필요 시 인프라 재구성으로 별도 처리하세요." }, 400);
-    // ⚠ 레지스트리 제거(writeAgents)는 런타임 cleanup 이후로 미룬다 — setAgentEnabled→setHermes가 ambientAgents()로 프로필을 조회하는데, 먼저 지우면 profile≠id(기존 hermes=b3ryshermes)일 때 오프로필을 stop함(Codex 크로스리뷰 #4). GD 2026-07-01.
+    // ★설정된 base hermes 프로필 멤버 퇴사 차단 — 공유 auth 소스+clone 원본 보존.
+    if (target.runtime === "hermes_agent" && ((target as any).hermes_profile ?? id) === HERMES_BASE_PROFILE)
+      return c.json({ error: "cannot_offboard_base_hermes_profile", hint: `${HERMES_BASE_PROFILE}는 모든 hermes 멤버가 공유하는 base 프로필(auth 소스)입니다. 이 멤버는 퇴사 대상이 아닙니다 — 필요 시 인프라 재구성으로 별도 처리하세요.` }, 400);
+    // ⚠ 레지스트리 제거(writeAgents)는 런타임 cleanup 이후로 미룬다 — setAgentEnabled→setHermes가 ambientAgents()로 프로필을 조회하므로 먼저 지우면 profile≠id일 때 오프로필을 stop한다.
     // 4-branch 런타임 teardown(codex/claude_channel/hermes_agent/openclaw) = teardownRuntime()로 추출(activation.ts,
     // Phase1 리팩터) — swap-runtime(신규 엔드포인트)과 이 함수를 공유한다. 동작은 원본과 동일(각 분기·가드·retry 그대로).
     await teardownRuntime(id, target.runtime, target, { skip: skipRuntimeCleanup });
@@ -1497,7 +1498,7 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
         try { const af = `${HHc}/.openclaw/credentials/telegram-${member_id}-allowFrom.json`; if (existsSync(af)) rmSync(af); } catch { /* best-effort */ }
         try { const ad = `${HHc}/.openclaw/agents/${member_id}`; if (existsSync(ad)) rmSync(ad, { recursive: true }); } catch { /* best-effort */ }
       }
-      if (runtime === "hermes_agent" && hermes_profile !== "b3ryshermes") { // ★base 프로필 보존(공유 auth 소스)
+      if (runtime === "hermes_agent" && hermes_profile !== HERMES_BASE_PROFILE) { // ★base 프로필 보존(공유 auth 소스)
         const prof = hermes_profile;
         try { await setAgentEnabled(member_id, "hermes_agent", false).catch(() => {}); } catch { /* best-effort */ }
         if (/^[a-z0-9_-]+$/i.test(prof)) { try { const hp = `${HHc}/Library/LaunchAgents/ai.hermes.gateway-${prof}.plist`; if (existsSync(hp)) rmSync(hp); } catch { /* best-effort */ } }

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -54,6 +54,7 @@ import { getNormalApprovers } from "../lib/approvals";
 import { hasSlackTokenFile, loadAgentCreds, saveAgentCreds, removeAgentCreds, slackTokensDir, postMessage } from "../lib/slack";
 import { renderAndRepoint, TEAM_OS_TEMPLATE_PATH, LIVE_TEAM_OS_PATH } from "../lib/teamOsRender";
 import { HERMES_BASE_PROFILE } from "../lib/paths";
+import { isHermesProfileProtected } from "../lib/hermesBaseProfile";
 import { latestCaptureNonBotSender, listDiscoveredGroups } from "../lib/telegramLeadDetection";
 import { activeOfficialMemberCount, isTeamOfficialMember, MAX_OFFICIAL_TEAM_MEMBERS } from "../lib/agentMembership";
 import { writeRegistrySafely, type RegistryWriteOptions } from "../lib/registrySafety";
@@ -663,7 +664,7 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
       return c.json({ error: "confirm_name_mismatch", hint: `정확히 "${target.display_name}" 입력 필요` }, 400);
     if (list.length <= 1) return c.json({ error: "cannot_remove_last_member" }, 400);
     // ★설정된 base hermes 프로필 멤버 퇴사 차단 — 공유 auth 소스+clone 원본 보존.
-    if (target.runtime === "hermes_agent" && ((target as any).hermes_profile ?? id) === HERMES_BASE_PROFILE)
+    if (target.runtime === "hermes_agent" && isHermesProfileProtected((target as any).hermes_profile ?? id))
       return c.json({ error: "cannot_offboard_base_hermes_profile", hint: `${HERMES_BASE_PROFILE}는 모든 hermes 멤버가 공유하는 base 프로필(auth 소스)입니다. 이 멤버는 퇴사 대상이 아닙니다 — 필요 시 인프라 재구성으로 별도 처리하세요.` }, 400);
     // ⚠ 레지스트리 제거(writeAgents)는 런타임 cleanup 이후로 미룬다 — setAgentEnabled→setHermes가 ambientAgents()로 프로필을 조회하므로 먼저 지우면 profile≠id일 때 오프로필을 stop한다.
     // 4-branch 런타임 teardown(codex/claude_channel/hermes_agent/openclaw) = teardownRuntime()로 추출(activation.ts,
@@ -1498,7 +1499,7 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
         try { const af = `${HHc}/.openclaw/credentials/telegram-${member_id}-allowFrom.json`; if (existsSync(af)) rmSync(af); } catch { /* best-effort */ }
         try { const ad = `${HHc}/.openclaw/agents/${member_id}`; if (existsSync(ad)) rmSync(ad, { recursive: true }); } catch { /* best-effort */ }
       }
-      if (runtime === "hermes_agent" && hermes_profile !== HERMES_BASE_PROFILE) { // ★base 프로필 보존(공유 auth 소스)
+      if (runtime === "hermes_agent" && !isHermesProfileProtected(hermes_profile)) { // ★base 프로필 보존(공유 auth 소스)
         const prof = hermes_profile;
         try { await setAgentEnabled(member_id, "hermes_agent", false).catch(() => {}); } catch { /* best-effort */ }
         if (/^[a-z0-9_-]+$/i.test(prof)) { try { const hp = `${HHc}/Library/LaunchAgents/ai.hermes.gateway-${prof}.plist`; if (existsSync(hp)) rmSync(hp); } catch { /* best-effort */ } }

--- a/src/server/runtimes/hermes/activate-hermes-agent.sh
+++ b/src/server/runtimes/hermes/activate-hermes-agent.sh
@@ -49,7 +49,7 @@ fi
 #   그 글로벌 auth 로 base 프로필을 자동 시드해 clone 원본으로 삼는다(preflight 가 인정한 것을 activate 도 인정).
 if [ -z "${SRC_PROFILE:-}" ] && [ -f "$HOME/.hermes/auth.json" ]; then
   BASE_PROFILE="$HERMES_BASE_PROFILE"
-  [ "$BASE_PROFILE" = "$AGENT_ID" ] && BASE_PROFILE="b3os-base"   # 타겟명과 충돌 방지(희박)
+  while [ "$BASE_PROFILE" = "$AGENT_ID" ]; do BASE_PROFILE="${BASE_PROFILE}-base"; done
   say "■ 인증 프로필 없음 + 글로벌 auth 존재 → base 프로필 '$BASE_PROFILE' 자동 시드(글로벌 ~/.hermes/auth.json)"
   if [ ! -d "$HOME/.hermes/profiles/$BASE_PROFILE" ]; then
     # --clone: 활성(default) 프로필의 config/.env/SOUL/skills 복사 → 게이트웨이가 뜰 설정 확보.

--- a/src/server/runtimes/hermes/activate-hermes-agent.sh
+++ b/src/server/runtimes/hermes/activate-hermes-agent.sh
@@ -18,18 +18,21 @@ DESC="${DESC:-b3rys 팀원 ($AGENT_ID)}"
 WS="${WS:-$HOME/Development/$AGENT_ID}"
 TOKEN_FILE="${TOKEN_FILE:-$HOME/.hermes/credentials/$AGENT_ID-token.txt}"
 PROF_DIR="$HOME/.hermes/profiles/$AGENT_ID"
+HERMES_BASE_PROFILE="${HERMES_BASE_PROFILE:-b3os}"
 say(){ printf "\033[32m%s\033[0m\n" "$1"; }
 
+[ -n "$HERMES_BASE_PROFILE" ] && [[ "$HERMES_BASE_PROFILE" =~ ^[a-zA-Z0-9_-]+$ ]] \
+  || { echo "❌ HERMES_BASE_PROFILE은 안전한 프로필 slug여야 합니다: 영문/숫자/_/-"; exit 1; }
 [ -s "$TOKEN_FILE" ] || { echo "❌ 봇 토큰 없음: $TOKEN_FILE (BotFather 토큰 먼저 저장)"; exit 1; }
 
 # 복제 원본(SRC_PROFILE) 결정 — activation.ts 는 SRC_PROFILE 를 주입하지 않으므로(AGENT_ID+WS 뿐),
-#   env 명시가 없으면 auth 보유 프로필을 동적 탐지한다. 특정 이름(b3ryshermes) 하드요구를 없애 →
+#   env 명시가 없으면 설정된 base 프로필을 먼저 보고, 이어 auth 보유 프로필을 동적 탐지한다.
 #   공개 사용자가 자기 이름 프로필(예: myhermes)만 인증돼 있어도 영입 가능(openclaw 스크립트의 동적 auth-소스 탐지와 동일 패턴).
-#   우선순위: ① env SRC_PROFILE 명시 → ② b3ryshermes(라이브 base, 있으면 먼저) → ③ auth.json 보유하는 첫 프로필(타겟 제외).
+#   우선순위: ① env SRC_PROFILE 명시 → ② HERMES_BASE_PROFILE(있으면 먼저) → ③ auth.json 보유하는 첫 프로필(타겟 제외).
 #   auth.json = 응답 생성 인증(공유 원본). 없으면 '메시지는 받지만 응답 못 하는' 死봇이 되므로 이를 가진 프로필만 원본으로 인정.
 if [ -z "${SRC_PROFILE:-}" ]; then
   SRC_PROFILE=""
-  for cand in "$HOME/.hermes/profiles/b3ryshermes" "$HOME"/.hermes/profiles/*; do
+  for cand in "$HOME/.hermes/profiles/$HERMES_BASE_PROFILE" "$HOME"/.hermes/profiles/*; do
     [ -d "$cand" ] || continue
     pname="$(basename "$cand")"
     [ "$pname" = "$AGENT_ID" ] && continue        # 타겟 자신은 원본이 될 수 없음
@@ -45,7 +48,7 @@ fi
 #   공개 hermes 사용자가 정상 인증하고도 전원 막히던 원인. 프로필이 없고 글로벌 auth 만 있으면,
 #   그 글로벌 auth 로 base 프로필을 자동 시드해 clone 원본으로 삼는다(preflight 가 인정한 것을 activate 도 인정).
 if [ -z "${SRC_PROFILE:-}" ] && [ -f "$HOME/.hermes/auth.json" ]; then
-  BASE_PROFILE="b3ryshermes"
+  BASE_PROFILE="$HERMES_BASE_PROFILE"
   [ "$BASE_PROFILE" = "$AGENT_ID" ] && BASE_PROFILE="b3os-base"   # 타겟명과 충돌 방지(희박)
   say "■ 인증 프로필 없음 + 글로벌 auth 존재 → base 프로필 '$BASE_PROFILE' 자동 시드(글로벌 ~/.hermes/auth.json)"
   if [ ! -d "$HOME/.hermes/profiles/$BASE_PROFILE" ]; then
@@ -75,7 +78,7 @@ if [ -d "$PROF_DIR" ] && { [ -f "$PROF_DIR/config.yaml" ] || [ -f "$PROF_DIR/pro
 else
   # 불완전 프로필 잔재(config.yaml·profile.yaml 둘 다 없음 = 이전 퇴사가 덜 정리한 half-state) 감지 시 제거 후 재클론.
   #   안 그러면 clone 건너뛰어 설정 없는 채로 진행→게이트웨이 못 뜸(2026-07-01 실측). 슬러그 가드+고정 prefix로 안전.
-  if [ -d "$PROF_DIR" ] && [[ "$AGENT_ID" =~ ^[a-z0-9_-]+$ ]] && [ "$AGENT_ID" != "b3ryshermes" ] && [ "$AGENT_ID" != "$SRC_PROFILE" ]; then
+  if [ -d "$PROF_DIR" ] && [[ "$AGENT_ID" =~ ^[a-z0-9_-]+$ ]] && [ "$AGENT_ID" != "$HERMES_BASE_PROFILE" ] && [ "$AGENT_ID" != "$SRC_PROFILE" ]; then
     echo "  ⚠ 불완전 프로필 잔재($PROF_DIR, config.yaml·profile.yaml 둘 다 없음) — 제거 후 재클론"
     rm -rf "$PROF_DIR"
   fi
@@ -469,14 +472,14 @@ export OWNER_CHAT_ID
 if [ -n "$OWNER_CHAT_ID" ]; then say "  팀장 chat_id 확보 — 게이트웨이 allowlist 에 시드(페어링 게이트 통과)"; else echo "  ⚠ owner_chat_id 미확보 — 게이트웨이 allowlist 시드 skip(팀장이 봇에 수동 pairing 필요)"; fi
 # durability(2026-07-01): seed 프로필($SRC_PROFILE) plist 템플릿에서 프로필명만 치환해 프로필별 LaunchAgent 생성+bootstrap.
 #   unmanaged `hermes gateway start`는 재부팅·크래시 시 사라져 restart/auto-heal 대상 밖 → LaunchAgent(RunAtLoad/KeepAlive)로 관리.
-#   템플릿은 seed 프로필의 plist 사용(라이브=b3ryshermes); 없으면 아래 unmanaged 폴백.
+#   템플릿은 seed 프로필의 plist 사용; 없으면 아래 unmanaged 폴백.
 HTMPL="$HOME/Library/LaunchAgents/ai.hermes.gateway-$SRC_PROFILE.plist"
 HPLIST="$HOME/Library/LaunchAgents/ai.hermes.gateway-$AGENT_ID.plist"
 GENERIC_PLIST="$HOME/Library/LaunchAgents/ai.hermes.gateway.plist"
 mkdir -p "$HOME/.hermes/profiles/$AGENT_ID/logs"
 # ★seed 전용 plist 폴백(자동시드 base 대응, OWNER 2026-07-19 맥북테스트)★ — 현대 hermes(v0.18+)의
 #   `hermes gateway install` 은 프로필별 plist 를 만들지 않고 generic ai.hermes.gateway.plist 하나만 만든다.
-#   그래서 자동시드된 base 프로필(b3ryshermes)엔 전용 plist(ai.hermes.gateway-b3ryshermes.plist)가 없어
+#   그래서 자동시드된 base 프로필엔 전용 plist가 없어
 #   아래 per-profile 복제가 unmanaged 폴백으로 빠지고, 그 폴백의 `hermes gateway start` 는 generic(=default
 #   프로필) 게이트웨이만 띄워 'herm 프로필 게이트웨이 안 뜸' 으로 실패했다(preflight/base 시드는 통과한 뒤 여기서 막힘).
 #   → seed 전용 plist 가 없으면 generic 을 복제 템플릿으로 삼는다(generic 도 없으면 install 로 만든 뒤).

--- a/src/server/runtimes/hermes/activate-hermes-agent.sh
+++ b/src/server/runtimes/hermes/activate-hermes-agent.sh
@@ -32,7 +32,10 @@ say(){ printf "\033[32m%s\033[0m\n" "$1"; }
 #   auth.json = 응답 생성 인증(공유 원본). 없으면 '메시지는 받지만 응답 못 하는' 死봇이 되므로 이를 가진 프로필만 원본으로 인정.
 if [ -z "${SRC_PROFILE:-}" ]; then
   SRC_PROFILE=""
-  for cand in "$HOME/.hermes/profiles/$HERMES_BASE_PROFILE" "$HOME"/.hermes/profiles/*; do
+  DETECTED_BASE=""
+  _detector="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/detect-base-profile.sh"
+  [ -f "$_detector" ] && DETECTED_BASE="$(bash "$_detector" "$HOME/.hermes/profiles" 2>/dev/null || true)"
+  for cand in ${DETECTED_BASE:+"$HOME/.hermes/profiles/$DETECTED_BASE"} "$HOME/.hermes/profiles/$HERMES_BASE_PROFILE" "$HOME"/.hermes/profiles/*; do
     [ -d "$cand" ] || continue
     pname="$(basename "$cand")"
     [ "$pname" = "$AGENT_ID" ] && continue        # 타겟 자신은 원본이 될 수 없음

--- a/src/server/runtimes/hermes/detect-base-profile.sh
+++ b/src/server/runtimes/hermes/detect-base-profile.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# 기존 Hermes 설치에서 공유 auth 원본 프로필을 보수적으로 추론한다.
+# stdout: 확신 가능한 프로필명 1개. auth 프로필 없음은 빈 출력/0, 모호하면 2.
+set -euo pipefail
+
+PROFILES_ROOT="${1:-$HOME/.hermes/profiles}"
+[ -d "$PROFILES_ROOT" ] || exit 0
+
+shared_targets=""
+auth_profiles=""
+for auth in "$PROFILES_ROOT"/*/auth.json; do
+  [ -e "$auth" ] || [ -L "$auth" ] || continue
+  profile="$(basename "$(dirname "$auth")")"
+  [[ "$profile" =~ ^[A-Za-z0-9_-]+$ ]] || continue
+  auth_profiles="${auth_profiles}${auth_profiles:+
+}$profile"
+
+  # b3os clone은 auth.json을 base 프로필의 auth.json에 심링크한다.
+  if [ -L "$auth" ]; then
+    target="$(readlink "$auth" 2>/dev/null || true)"
+    case "$target" in
+      "$PROFILES_ROOT"/*/auth.json)
+        target_profile="$(basename "$(dirname "$target")")"
+        if [[ "$target_profile" =~ ^[A-Za-z0-9_-]+$ ]]; then
+          shared_targets="${shared_targets}${shared_targets:+
+}$target_profile"
+        fi
+        ;;
+    esac
+  fi
+done
+
+unique_lines() { printf '%s\n' "$1" | awk 'NF && !seen[$0]++'; }
+
+if [ -n "$shared_targets" ]; then
+  unique_targets="$(unique_lines "$shared_targets")"
+  [ "$(printf '%s\n' "$unique_targets" | awk 'NF{n++} END{print n+0}')" -eq 1 ] || exit 2
+  printf '%s\n' "$unique_targets"
+  exit 0
+fi
+
+unique_auth_profiles="$(unique_lines "$auth_profiles")"
+auth_count="$(printf '%s\n' "$unique_auth_profiles" | awk 'NF{n++} END{print n+0}')"
+case "$auth_count" in
+  0) exit 0 ;;
+  1) printf '%s\n' "$unique_auth_profiles" ;;
+  *) exit 2 ;;
+esac

--- a/src/server/workers/dmSyncWorker.test.ts
+++ b/src/server/workers/dmSyncWorker.test.ts
@@ -180,7 +180,7 @@ describe("런타임 저장소 경로 매핑", () => {
       id: "hermes",
       runtime: "hermes_agent",
       workspacePath: "/unused",
-      hermesProfile: "b3ryshermes",
+      hermesProfile: "legacy-base",
       hermesStateDbPath: hermesDb,
     }]);
 
@@ -216,7 +216,7 @@ describe("런타임 저장소 경로 매핑", () => {
       id: "hermes",
       runtime: "hermes_agent",
       workspacePath: "/unused",
-      hermesProfile: "b3ryshermes",
+      hermesProfile: "legacy-base",
       hermesStateDbPath: hermesDb,
     }]);
 

--- a/src/web/components/agentSetup/diagrams.ts
+++ b/src/web/components/agentSetup/diagrams.ts
@@ -602,7 +602,7 @@ export function detailedSystemDiagram(): string {
           pick("session wake(세션 깨우기) 경로 사용", "Uses the session wake path"),
         ], false, "bot")}
         ${component("Hermes runtime", pick("Hermes 전용 실행 경로", "Hermes-only execution path"), [
-          "<code>b3ryshermes</code> profile",
+          "<code>HERMES_BASE_PROFILE</code> (default: <code>b3os</code>)",
           "Hermes gateway/status provider",
           pick("전략/CSO 역할의 별도 bridge", "A separate bridge for the strategy/CSO role"),
         ], false, "cpu")}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -23,7 +23,7 @@ cd "$SELF"
 # 공유 Hermes 인증 원본 프로필. 환경변수 우선, 없으면 .env의 해당 키만 읽고, 공개 기본값 b3os.
 HERMES_BASE_PROFILE="${HERMES_BASE_PROFILE:-}"
 if [ -z "${HERMES_BASE_PROFILE// }" ] && [ -f "$SELF/.env" ]; then
-  HERMES_BASE_PROFILE="$(grep -E '^[[:space:]]*HERMES_BASE_PROFILE=' "$SELF/.env" 2>/dev/null | tail -1 | cut -d= -f2- | sed -e 's/^["'\'' ]*//' -e 's/["'\'' ]*$//')"
+  HERMES_BASE_PROFILE="$(grep -E '^[[:space:]]*HERMES_BASE_PROFILE=' "$SELF/.env" 2>/dev/null | tail -1 | cut -d= -f2- | sed -e 's/[[:space:]][[:space:]]*#.*$//' -e 's/^["'\'' ]*//' -e 's/["'\'' ]*$//')"
 fi
 HERMES_BASE_PROFILE="${HERMES_BASE_PROFILE:-b3os}"
 if ! printf '%s' "$HERMES_BASE_PROFILE" | grep -Eq '^[A-Za-z0-9_-]+$'; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -20,10 +20,19 @@ set -uo pipefail   # ★ -e 는 쓰지 않는다 — best-effort teardown 은 �
 SELF="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 cd "$SELF"
 
+# 공유 Hermes 인증 원본 프로필. install.sh와 같은 문법(export/공백/따옴표/인라인 주석)을 읽는다.
+read_hermes_base_env() {
+  [ -f "$1" ] || return 0
+  { grep -E '^[[:space:]]*(export[[:space:]]+)?HERMES_BASE_PROFILE[[:space:]]*=' "$1" 2>/dev/null || true; } \
+    | tail -1 \
+    | sed -E -e 's/^[[:space:]]*(export[[:space:]]+)?HERMES_BASE_PROFILE[[:space:]]*=[[:space:]]*//' \
+      -e 's/[[:space:]]+#.*$//' -e 's/^["'\''][[:space:]]*//' -e 's/[[:space:]]*["'\'']$//' -e 's/[[:space:]]*$//'
+}
+
 # 공유 Hermes 인증 원본 프로필. 환경변수 우선, 없으면 .env의 해당 키만 읽고, 공개 기본값 b3os.
 HERMES_BASE_PROFILE="${HERMES_BASE_PROFILE:-}"
 if [ -z "${HERMES_BASE_PROFILE// }" ] && [ -f "$SELF/.env" ]; then
-  HERMES_BASE_PROFILE="$(grep -E '^[[:space:]]*HERMES_BASE_PROFILE=' "$SELF/.env" 2>/dev/null | tail -1 | cut -d= -f2- | sed -e 's/[[:space:]][[:space:]]*#.*$//' -e 's/^["'\'' ]*//' -e 's/["'\'' ]*$//')"
+  HERMES_BASE_PROFILE="$(read_hermes_base_env "$SELF/.env")"
 fi
 HERMES_BASE_PROFILE="${HERMES_BASE_PROFILE:-b3os}"
 if ! printf '%s' "$HERMES_BASE_PROFILE" | grep -Eq '^[A-Za-z0-9_-]+$'; then
@@ -216,6 +225,7 @@ echo ""
 # 2) 팀원 전원 오프보드 (런타임별 FS/launchctl 정리, best-effort)
 # ══════════════════════════════════════════════════════════════════════
 hl "■ 1/4  팀원 오프보드"
+HERMES_TEARDOWN_SKIPPED=0
 
 # 서버가 떠 있으면 원래는 대시보드(Settings 탭)의 오프보드가 graceful path.
 # 여기선 teardown 이므로 직접 FS/launchctl 정리를 수행한다.
@@ -271,6 +281,7 @@ else
         hermes_agent)
           _prof="${prof:-$id}"
           if [ "$HERMES_DETECT_STATUS" -ne 0 ]; then
+            HERMES_TEARDOWN_SKIPPED=1
             warn "    ⛔ 공유 auth 원본 프로필 판별 불가 — Hermes teardown 전체 건너뜀(fail-closed)."
           elif is_base_profile "$_prof"; then
             # ★★ CRITICAL 가드 — base 프로필은 모든 hermes 멤버의 공유 auth.json 소스 + clone 원본.
@@ -329,6 +340,10 @@ echo ""
 if [ "$KEEP_DATA" = 1 ]; then
   hl "■ 3/4  데이터 삭제 — 건너뜀(--keep-data)"
   say "  team.db · .env · var/ · team-media · slack-tokens 보존."
+elif [ "$HERMES_TEARDOWN_SKIPPED" = 1 ]; then
+  hl "■ 3/4  데이터 삭제 — 안전 중단"
+  warn "  ⛔ Hermes teardown이 완료되지 않아 복구에 필요한 team.db · .env · agents.json 및 데이터를 모두 보존합니다."
+  warn "     .env의 HERMES_BASE_PROFILE을 실제 공유 auth 원본 프로필명으로 설정한 뒤 uninstall을 다시 실행하세요."
 else
   hl "■ 3/4  데이터 삭제"
   # repo 내부 + 알려진 sibling(team-media) 만 삭제. 그 외 경로는 절대 건드리지 않는다.
@@ -355,8 +370,13 @@ echo ""
 # ══════════════════════════════════════════════════════════════════════
 # 5) repo 폴더 삭제 안내 (실행 중 자기 폴더는 못 지움)
 # ══════════════════════════════════════════════════════════════════════
-hl "■ 4/4  완료"
-say "  런타임/서버/데이터 정리가 끝났습니다."
+if [ "$HERMES_TEARDOWN_SKIPPED" = 1 ]; then
+  hl "■ 4/4  미완료 — 조치 필요"
+  warn "  Hermes 런타임 정리가 안전 중단되었습니다. 데이터는 보존했으며 위 안내대로 설정을 복구한 뒤 재실행하세요."
+else
+  hl "■ 4/4  완료"
+  say "  런타임/서버/데이터 정리가 끝났습니다."
+fi
 echo ""
 
 # ★설치 스킬 심링크 해제 — repo(clone) 삭제 전에 풀어야 깨진 링크가 안 남는다★ (ames 반대리뷰).
@@ -377,6 +397,8 @@ if [ -L "$SKILL_DEST" ]; then
     say "    스킬을 다시 쓰려면: install-skill.sh 로 재설치 + /reload-skills."
   fi
 fi
+
+[ "$HERMES_TEARDOWN_SKIPPED" = 0 ] || exit 2
 
 warn "  이 스크립트는 실행 중인 자기 repo 폴더를 삭제할 수 없습니다. 마지막으로 아래를 실행하세요:"
 echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,13 +12,24 @@
 #   - best-effort teardown. 한 팀원/한 단계가 실패해도 전체를 멈추지 않는다(set -e 미사용).
 #   - $HOME 기준 상대경로만. 특정 사용자(/Users/xxx) 하드코딩 없음 — 어느 Mac 에서나 동작.
 #   - macOS 중심(launchctl). launchctl/tmux 가 없으면 해당 단계는 건너뛴다(크래시 없음).
-#   - ★ 안전: 확인 프롬프트 + base hermes 프로필(b3ryshermes) 보존 가드 + "알려진 경로만 삭제".
+#   - ★ 안전: 확인 프롬프트 + 설정된 base hermes 프로필 보존 가드 + "알려진 경로만 삭제".
 #     빈/루트일 수 있는 변수는 절대 rm -rf 하지 않는다.
 set -uo pipefail   # ★ -e 는 쓰지 않는다 — best-effort teardown 은 개별 실패를 넘어가야 한다.
 
 # ── 자기 위치 = repo 루트(BASH_SOURCE 기준, symlink 안전) ─────────────
 SELF="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 cd "$SELF"
+
+# 공유 Hermes 인증 원본 프로필. 환경변수 우선, 없으면 .env의 해당 키만 읽고, 공개 기본값 b3os.
+HERMES_BASE_PROFILE="${HERMES_BASE_PROFILE:-}"
+if [ -z "${HERMES_BASE_PROFILE// }" ] && [ -f "$SELF/.env" ]; then
+  HERMES_BASE_PROFILE="$(grep -E '^[[:space:]]*HERMES_BASE_PROFILE=' "$SELF/.env" 2>/dev/null | tail -1 | cut -d= -f2- | sed -e 's/^["'\'' ]*//' -e 's/["'\'' ]*$//')"
+fi
+HERMES_BASE_PROFILE="${HERMES_BASE_PROFILE:-b3os}"
+if ! printf '%s' "$HERMES_BASE_PROFILE" | grep -Eq '^[A-Za-z0-9_-]+$'; then
+  echo "❌ HERMES_BASE_PROFILE은 안전한 프로필 slug여야 합니다: 영문/숫자/_/-" >&2
+  exit 1
+fi
 
 # ── 출력 헬퍼(install.sh 톤: green=say / yellow=warn) ─────────────────
 say()  { printf "\033[32m%s\033[0m\n" "$1"; }  # green
@@ -159,7 +170,7 @@ echo "    • 팀원 전원 오프보드 — tmux 종료 · LaunchAgent 해제 �
 echo "        claude  → ~/.claude/channels/telegram-<id> · $PREFIX.claude-telegram-<id> plist"
 echo "        openclaw→ ~/.openclaw/agents/<id> · ~/.openclaw/credentials/telegram-<id>-token.txt(+allowFrom)"
 echo "        hermes  → ~/.hermes/profiles/<프로필> · ai.hermes.gateway-<프로필> plist · credential 토큰"
-echo "                  ★ base 프로필 'b3ryshermes' 는 절대 삭제하지 않음(공유 auth 소스)"
+echo "                  ★ base 프로필 '$HERMES_BASE_PROFILE' 는 절대 삭제하지 않음(공유 auth 소스)"
 echo "    • 서버 정지 + LaunchAgent 해제 ($PREFIX.team-collab · $PREFIX.team-os-boot)"
 if [ "$KEEP_DATA" = 1 ]; then
   warn "    • 데이터 삭제는 건너뜁니다 (--keep-data): team.db · .env · var/ · team-media · slack-tokens${B3RYS_HOME_VAL:+ · B3RYS_HOME} 보존"
@@ -240,15 +251,15 @@ else
           ;;
         hermes_agent)
           _prof="${prof:-$id}"
-          if [ "$_prof" = "b3ryshermes" ]; then
+          if [ "$_prof" = "$HERMES_BASE_PROFILE" ]; then
             # ★★ CRITICAL 가드 — base 프로필은 모든 hermes 멤버의 공유 auth.json 소스 + clone 원본.
             #   삭제하면 hermes 런타임 전멸(auth dangling). 프로필 dir·게이트웨이·plist 를 절대 건드리지 않는다.
-            warn "    ★ base hermes 프로필 'b3ryshermes' 보존 — 게이트웨이/프로필/plist 삭제하지 않음(공유 auth 소스)."
+            warn "    ★ base hermes 프로필 '$HERMES_BASE_PROFILE' 보존 — 게이트웨이/프로필/plist 삭제하지 않음(공유 auth 소스)."
           else
             launchd_stop "ai.hermes.gateway-$_prof"
             rmf  "$HOME/Library/LaunchAgents/ai.hermes.gateway-$_prof.plist"
             # 프로필 dir 은 슬러그 가드된 프로필명 + base 제외 확인 후에만 삭제.
-            if valid_id "$_prof" && [ "$_prof" != "b3ryshermes" ]; then
+            if valid_id "$_prof" && [ "$_prof" != "$HERMES_BASE_PROFILE" ]; then
               rmrf "$HOME/.hermes/profiles/$_prof"
             fi
             # per-id credential 토큰(멤버 봇 토큰) 정리 — 공유 auth 아님(라이브 코드와 동일, non-base 만).

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -43,6 +43,39 @@ if ! printf '%s' "$HERMES_BASE_PROFILE" | grep -Eq '^[A-Za-z0-9_-]+$'; then
   exit 1
 fi
 
+same_profile() {
+  [ "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" = "$(printf '%s' "${2:-}" | tr '[:upper:]' '[:lower:]')" ]
+}
+
+# 명시값은 자동 탐지 모호성의 탈출구다. 실제 비심링크 auth 원본과 일치할 때만 신뢰하고
+# 실제 디렉터리 표기로 정규화한다. 존재하지 않는 slug나 멤버 auth 심링크는 절대 삭제 근거가 아니다.
+if [ "$HERMES_BASE_EXPLICIT" = 1 ]; then
+  _explicit_match=""
+  _auth_origin_count=0
+  for _profile_dir in "$HOME"/.hermes/profiles/*; do
+    [ -d "$_profile_dir" ] || continue
+    _profile_name="$(basename "$_profile_dir")"
+    if [ -f "$_profile_dir/auth.json" ] && [ ! -L "$_profile_dir/auth.json" ]; then
+      _auth_origin_count=$((_auth_origin_count + 1))
+    fi
+    if same_profile "$_profile_name" "$HERMES_BASE_PROFILE" && [ -f "$_profile_dir/auth.json" ] \
+      && [ ! -L "$_profile_dir/auth.json" ]; then
+      [ -z "$_explicit_match" ] || { echo "❌ HERMES_BASE_PROFILE과 대소문자 없이 일치하는 auth 원본이 둘 이상입니다." >&2; exit 1; }
+      _explicit_match="$_profile_name"
+    fi
+  done
+  if [ -z "$_explicit_match" ] && [ "$_auth_origin_count" -gt 0 ]; then
+    echo "❌ 명시한 Hermes base '$HERMES_BASE_PROFILE'가 실제 비심링크 auth 원본 프로필이 아닙니다." >&2
+    echo "   후보(auth.json 원본 보유):" >&2
+    for _profile_dir in "$HOME"/.hermes/profiles/*; do
+      [ -d "$_profile_dir" ] && [ -f "$_profile_dir/auth.json" ] && [ ! -L "$_profile_dir/auth.json" ] \
+        && echo "     - $(basename "$_profile_dir")" >&2
+    done
+    exit 1
+  fi
+  [ -z "$_explicit_match" ] || HERMES_BASE_PROFILE="$_explicit_match"
+fi
+
 # 설정과 독립된 defense-in-depth: 다른 프로필 auth.json이 가리키는 실제 공유 원본도 항상 보존한다.
 # 탐지가 모호하면 어느 프로필도 안전하게 삭제할 수 없으므로 Hermes teardown 전체를 건너뛴다.
 HERMES_DETECTED_BASE=""
@@ -53,9 +86,6 @@ if [ -f "$_detector" ]; then
 else
   HERMES_DETECT_STATUS=2
 fi
-same_profile() {
-  [ "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" = "$(printf '%s' "${2:-}" | tr '[:upper:]' '[:lower:]')" ]
-}
 is_base_profile() {
   local p="${1:-}"
   same_profile "$p" "$HERMES_BASE_PROFILE" && return 0
@@ -201,7 +231,8 @@ echo "    • 팀원 전원 오프보드 — tmux 종료 · LaunchAgent 해제 �
 echo "        claude  → ~/.claude/channels/telegram-<id> · $PREFIX.claude-telegram-<id> plist"
 echo "        openclaw→ ~/.openclaw/agents/<id> · ~/.openclaw/credentials/telegram-<id>-token.txt(+allowFrom)"
 echo "        hermes  → ~/.hermes/profiles/<프로필> · ai.hermes.gateway-<프로필> plist · credential 토큰"
-echo "                  ★ base 프로필 '$HERMES_BASE_PROFILE' 는 절대 삭제하지 않음(공유 auth 소스)"
+_display_base="${HERMES_DETECTED_BASE:-$HERMES_BASE_PROFILE}"
+echo "                  ★ base 프로필 '$_display_base' 는 절대 삭제하지 않음(공유 auth 소스)"
 echo "    • 서버 정지 + LaunchAgent 해제 ($PREFIX.team-collab · $PREFIX.team-os-boot)"
 if [ "$KEEP_DATA" = 1 ]; then
   warn "    • 데이터 삭제는 건너뜁니다 (--keep-data): team.db · .env · var/ · team-media · slack-tokens${B3RYS_HOME_VAL:+ · B3RYS_HOME} 보존"
@@ -251,6 +282,11 @@ else
       && printf '%s\n' "$_members" | awk -F '\t' '$2=="hermes_agent"{found=1} END{exit !found}'; then
       HERMES_TEARDOWN_SKIPPED=1
       warn "  ⛔ 공유 auth 원본 프로필 판별 불가 — 어떤 팀원도 삭제하기 전에 전체 오프보드를 안전 중단합니다."
+      warn "     후보(auth.json 원본 보유):"
+      for _profile_dir in "$HOME"/.hermes/profiles/*; do
+        [ -d "$_profile_dir" ] && [ -f "$_profile_dir/auth.json" ] && [ ! -L "$_profile_dir/auth.json" ] \
+          && warn "       - $(basename "$_profile_dir")"
+      done
     else
       while IFS=$'\t' read -r id runtime prof; do
       [ -n "${id:-}" ] || continue

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -29,10 +29,13 @@ read_hermes_base_env() {
       -e 's/[[:space:]]+#.*$//' -e 's/^["'\''][[:space:]]*//' -e 's/[[:space:]]*["'\'']$//' -e 's/[[:space:]]*$//'
 }
 
-# 공유 Hermes 인증 원본 프로필. 환경변수 우선, 없으면 .env의 해당 키만 읽고, 공개 기본값 b3os.
+# 공유 Hermes 인증 원본 프로필. 환경변수/.env의 유효한 명시값은 탐지 모호 시 운영자의 탈출구다.
+HERMES_BASE_EXPLICIT=0
 HERMES_BASE_PROFILE="${HERMES_BASE_PROFILE:-}"
+if [ -n "${HERMES_BASE_PROFILE// }" ]; then HERMES_BASE_EXPLICIT=1; fi
 if [ -z "${HERMES_BASE_PROFILE// }" ] && [ -f "$SELF/.env" ]; then
   HERMES_BASE_PROFILE="$(read_hermes_base_env "$SELF/.env")"
+  if [ -n "${HERMES_BASE_PROFILE// }" ]; then HERMES_BASE_EXPLICIT=1; fi
 fi
 HERMES_BASE_PROFILE="${HERMES_BASE_PROFILE:-b3os}"
 if ! printf '%s' "$HERMES_BASE_PROFILE" | grep -Eq '^[A-Za-z0-9_-]+$'; then
@@ -241,7 +244,15 @@ else
     warn "  agents.json 을 읽을 JSON 도구(node/bun/python3/jq)가 없거나 비어 있음 — 팀원 오프보드 건너뜀."
     warn "  필요 시 런타임 디렉토리를 수동 정리하세요: ~/.claude/channels · ~/.openclaw/agents · ~/.hermes/profiles"
   else
-    while IFS=$'\t' read -r id runtime prof; do
+    # 파괴 작업 전 선검사: Hermes 멤버가 있는데 자동 탐지가 모호하고 명시 설정도 없으면
+    # Claude/OpenClaw을 포함해 아무 멤버도 먼저 지우지 않는다. 명시 설정은 안내된 복구 탈출구다.
+    if [ "$HERMES_DETECT_STATUS" -ne 0 ] \
+      && [ "$HERMES_BASE_EXPLICIT" -ne 1 ] \
+      && printf '%s\n' "$_members" | awk -F '\t' '$2=="hermes_agent"{found=1} END{exit !found}'; then
+      HERMES_TEARDOWN_SKIPPED=1
+      warn "  ⛔ 공유 auth 원본 프로필 판별 불가 — 어떤 팀원도 삭제하기 전에 전체 오프보드를 안전 중단합니다."
+    else
+      while IFS=$'\t' read -r id runtime prof; do
       [ -n "${id:-}" ] || continue
       if ! valid_id "$id"; then warn "  ⚠ 비정상 id 건너뜀: '$id'"; continue; fi
       echo ""
@@ -280,13 +291,10 @@ else
           ;;
         hermes_agent)
           _prof="${prof:-$id}"
-          if [ "$HERMES_DETECT_STATUS" -ne 0 ]; then
-            HERMES_TEARDOWN_SKIPPED=1
-            warn "    ⛔ 공유 auth 원본 프로필 판별 불가 — Hermes teardown 전체 건너뜀(fail-closed)."
-          elif is_base_profile "$_prof"; then
+          if is_base_profile "$_prof"; then
             # ★★ CRITICAL 가드 — base 프로필은 모든 hermes 멤버의 공유 auth.json 소스 + clone 원본.
             #   삭제하면 hermes 런타임 전멸(auth dangling). 프로필 dir·게이트웨이·plist 를 절대 건드리지 않는다.
-            warn "    ★ base hermes 프로필 '$HERMES_BASE_PROFILE' 보존 — 게이트웨이/프로필/plist 삭제하지 않음(공유 auth 소스)."
+            warn "    ★ base hermes 프로필 '$_prof' 보존 — 게이트웨이/프로필/plist 삭제하지 않음(공유 auth 소스)."
           else
             launchd_stop "ai.hermes.gateway-$_prof"
             rmf  "$HOME/Library/LaunchAgents/ai.hermes.gateway-$_prof.plist"
@@ -302,7 +310,8 @@ else
           warn "    (알 수 없는 runtime '$runtime' — 런타임 정리 스킵)"
           ;;
       esac
-    done <<< "$_members"
+      done <<< "$_members"
+    fi
   fi
 fi
 echo ""
@@ -312,7 +321,9 @@ echo ""
 # ══════════════════════════════════════════════════════════════════════
 hl "■ 2/4  서버 정지"
 _srv_plist="$HOME/Library/LaunchAgents/$PREFIX.team-collab.plist"
-if owned_by_other_install "$_srv_plist"; then
+if [ "$HERMES_TEARDOWN_SKIPPED" = 1 ]; then
+  warn "  ⛔ 오프보드 선검사 실패 — 서버/LaunchAgent도 변경하지 않습니다."
+elif owned_by_other_install "$_srv_plist"; then
   # ★ 서버 LaunchAgent 가 다른 설치본(라이브) 것 — team-os.sh down·bootout 모두 건너뛴다(라이브 서버 정지 방지).
   warn "  ⛔ 다른 설치본($SELF 아님) 소유 서버 LaunchAgent — 서버 정지/해제 건너뜀(라이브 서버 보호)."
   warn "    이 머신에 다른 team-collab 설치본이 실행 중입니다. 서버를 내리려면 그 설치본에서 uninstall 하세요."
@@ -326,7 +337,9 @@ else
 fi
 # 부팅 재기동 plist(있으면) — 동일 소유 가드.
 _boot_plist="$HOME/Library/LaunchAgents/$PREFIX.team-os-boot.plist"
-if owned_by_other_install "$_boot_plist"; then
+if [ "$HERMES_TEARDOWN_SKIPPED" = 1 ]; then
+  :
+elif owned_by_other_install "$_boot_plist"; then
   warn "  ⛔ 다른 설치본 소유 부팅 LaunchAgent — 건너뜀(라이브 보호): $PREFIX.team-os-boot"
 else
   launchd_stop "$PREFIX.team-os-boot"
@@ -343,7 +356,8 @@ if [ "$KEEP_DATA" = 1 ]; then
 elif [ "$HERMES_TEARDOWN_SKIPPED" = 1 ]; then
   hl "■ 3/4  데이터 삭제 — 안전 중단"
   warn "  ⛔ Hermes teardown이 완료되지 않아 복구에 필요한 team.db · .env · agents.json 및 데이터를 모두 보존합니다."
-  warn "     .env의 HERMES_BASE_PROFILE을 실제 공유 auth 원본 프로필명으로 설정한 뒤 uninstall을 다시 실행하세요."
+  warn "     .env의 HERMES_BASE_PROFILE을 실제 공유 auth 원본 프로필명으로 설정하거나"
+  warn "     HERMES_BASE_PROFILE=<프로필명> bash uninstall.sh --yes 로 명시한 뒤 다시 실행하세요."
 else
   hl "■ 3/4  데이터 삭제"
   # repo 내부 + 알려진 sibling(team-media) 만 삭제. 그 외 경로는 절대 건드리지 않는다.
@@ -382,7 +396,7 @@ echo ""
 # ★설치 스킬 심링크 해제 — repo(clone) 삭제 전에 풀어야 깨진 링크가 안 남는다★ (ames 반대리뷰).
 #   이 repo 를 가리키는 심링크일 때만 해제(다른 clone 을 가리키면 건드리지 않음).
 SKILL_DEST="$HOME/.claude/skills/b3os"
-if [ -L "$SKILL_DEST" ]; then
+if [ "$HERMES_TEARDOWN_SKIPPED" = 0 ] && [ -L "$SKILL_DEST" ]; then
   _mine=0
   # ① inode 비교(-ef): 경로 철자 차이(/var↔/private/var·심링크 부모·$HOME 심링크)에도 이 repo 를 정확히 식별.
   if [ "$SKILL_DEST" -ef "$SELF/skills/b3os" ]; then _mine=1; fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -31,6 +31,25 @@ if ! printf '%s' "$HERMES_BASE_PROFILE" | grep -Eq '^[A-Za-z0-9_-]+$'; then
   exit 1
 fi
 
+# 설정과 독립된 defense-in-depth: 다른 프로필 auth.json이 가리키는 실제 공유 원본도 항상 보존한다.
+# 탐지가 모호하면 어느 프로필도 안전하게 삭제할 수 없으므로 Hermes teardown 전체를 건너뛴다.
+HERMES_DETECTED_BASE=""
+HERMES_DETECT_STATUS=0
+_detector="$SELF/src/server/runtimes/hermes/detect-base-profile.sh"
+if [ -f "$_detector" ]; then
+  HERMES_DETECTED_BASE="$(bash "$_detector" "$HOME/.hermes/profiles")" || HERMES_DETECT_STATUS=$?
+else
+  HERMES_DETECT_STATUS=2
+fi
+same_profile() {
+  [ "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" = "$(printf '%s' "${2:-}" | tr '[:upper:]' '[:lower:]')" ]
+}
+is_base_profile() {
+  local p="${1:-}"
+  same_profile "$p" "$HERMES_BASE_PROFILE" && return 0
+  [ -n "$HERMES_DETECTED_BASE" ] && same_profile "$p" "$HERMES_DETECTED_BASE"
+}
+
 # ── 출력 헬퍼(install.sh 톤: green=say / yellow=warn) ─────────────────
 say()  { printf "\033[32m%s\033[0m\n" "$1"; }  # green
 warn() { printf "\033[33m%s\033[0m\n" "$1"; }  # yellow
@@ -251,7 +270,9 @@ else
           ;;
         hermes_agent)
           _prof="${prof:-$id}"
-          if [ "$_prof" = "$HERMES_BASE_PROFILE" ]; then
+          if [ "$HERMES_DETECT_STATUS" -ne 0 ]; then
+            warn "    ⛔ 공유 auth 원본 프로필 판별 불가 — Hermes teardown 전체 건너뜀(fail-closed)."
+          elif is_base_profile "$_prof"; then
             # ★★ CRITICAL 가드 — base 프로필은 모든 hermes 멤버의 공유 auth.json 소스 + clone 원본.
             #   삭제하면 hermes 런타임 전멸(auth dangling). 프로필 dir·게이트웨이·plist 를 절대 건드리지 않는다.
             warn "    ★ base hermes 프로필 '$HERMES_BASE_PROFILE' 보존 — 게이트웨이/프로필/plist 삭제하지 않음(공유 auth 소스)."
@@ -259,7 +280,7 @@ else
             launchd_stop "ai.hermes.gateway-$_prof"
             rmf  "$HOME/Library/LaunchAgents/ai.hermes.gateway-$_prof.plist"
             # 프로필 dir 은 슬러그 가드된 프로필명 + base 제외 확인 후에만 삭제.
-            if valid_id "$_prof" && [ "$_prof" != "$HERMES_BASE_PROFILE" ]; then
+            if valid_id "$_prof" && ! is_base_profile "$_prof"; then
               rmrf "$HOME/.hermes/profiles/$_prof"
             fi
             # per-id credential 토큰(멤버 봇 토큰) 정리 — 공유 auth 아님(라이브 코드와 동일, non-base 만).
@@ -315,6 +336,7 @@ else
   rmf  "$SELF/team.db-wal"
   rmf  "$SELF/team.db-shm"
   rmf  "$SELF/.env"
+  rmf  "$SELF/agents.json"
   rmrf "$SELF/var"
   rmrf "$SELF/slack-tokens"
   # TEAM_MEDIA_DIR 기본값 = <설치폴더>/../team-media (mediaStore.ts). sibling 만 삭제.


### PR DESCRIPTION
## 변경
- `HERMES_BASE_PROFILE` 단일 설정값을 추가하고 공개 기본값을 `b3os`로 변경
- 활성화, 퇴사, 런타임 교체, 영입 취소, uninstall 보존 가드가 같은 설정을 사용
- 기존 브랜드 프로필명 하드코딩을 코드·테스트·문서에서 제거
- 실제 설치 환경은 `.env` override로 기존 프로필을 유지

## 안전 검증
- 격리 shell harness: 설정 base 우선 선택, 동적 auth 프로필 폴백, uninstall base profile/plist/credential 보존, non-base 삭제, invalid slug fail-closed
- `bun run typecheck`
- `bun run build`
- `HERMES_BASE_PROFILE=configured-base bun test src/server/lib/activation.test.ts --test-name-pattern "설정된 base hermes"` (2 pass)
- `rg b3ryshermes` 0건

## 참고
전체 관련 테스트 63개 중 62개가 통과했고, 기존 `codex→claude TEAM-OS.md 심링크 생성` 테스트 1건은 이 변경과 무관하게 실패합니다.