### PR TITLE
fix(clean-install): 새 설치 첫 경험에서 정상 상태를 결함으로 표시하지 않는다

### DIFF
--- a/src/server/lib/acceptanceCheck.ts
+++ b/src/server/lib/acceptanceCheck.ts
@@ -99,6 +99,34 @@ function loadAgents(registryPath: string): AgentRecord[] {
   }
 }
 
+/** ★'로드 성공, 0건' 과 '로드 실패' 를 반드시 구분한다★ — loadAgents 의 catch→[] 를 그대로 '팀원 0명'
+ *  으로 쓰면 손상된 agents.json(파싱 오류·권한 오류·배열 아님)에서 인수체크가 "새 설치입니다, 이상
+ *  없습니다" 라고 ★적극적 거짓 주장★ 을 한다(Bill 적대검증 2026-07-25: team.db 에 팀원 12명이 살아있는데
+ *  ok=true). 로드 실패는 fail 로 노출하고, freshInstall 신호에서도 제외한다.
+ *  파일 없음(ENOENT)은 loadRegistry 가 정상적으로 [] 를 주므로 실패가 아니다 — 공개 clone 첫 부팅. */
+interface RegistryLoad {
+  ok: boolean;
+  agents: AgentRecord[];
+  error?: string;
+}
+function loadAgentsChecked(registryPath: string): RegistryLoad {
+  try {
+    return { ok: true, agents: loadRegistry(registryPath) };
+  } catch (e: any) {
+    // 메시지에 경로/토큰이 섞일 수 있으므로 원인 코드·유형만 남긴다(값 노출 금지).
+    const code = e?.code ? String(e.code) : e instanceof SyntaxError ? "parse_error" : "load_error";
+    return { ok: false, agents: [], error: code };
+  }
+}
+
+function dbAgentCount(db: Database): number {
+  try {
+    return (db.query("SELECT COUNT(*) AS n FROM agent").get() as { n: number } | null)?.n ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
 function blockerCategory(line: string, internalIdRe: RegExp | null): string {
   if (SECRET_RE.test(line)) return "secret";
   if (ABSOLUTE_PATH_RE.test(line)) return "absolute-path";
@@ -106,11 +134,41 @@ function blockerCategory(line: string, internalIdRe: RegExp | null): string {
   return "blocker";
 }
 
-function settingsStep(db: Database, freshInstall: boolean): AcceptanceStep {
+function settingsStep(db: Database, registry: RegistryLoad, dbAgents: number): AcceptanceStep {
   const items: AcceptanceItem[] = [];
   const teamName = getSetting(db, "team_name");
   const ownerName = getSetting(db, "owner_name");
   const systemOp = captureConfigStatus(db);
+
+  // ★freshInstall = 레지스트리 ★로드 성공★ + 레지스트리 0건 + team.db 로스터 0명★.
+  //   세 조건을 모두 요구하는 이유(Bill 적대검증):
+  //     · 로드 실패(파싱·권한·배열아님)를 0명으로 세면 손상된 라이브에서 "새 설치입니다" 라고 거짓말한다.
+  //     · 파일만 사라진 경우는 loadRegistry 가 정상적으로 [] 를 주지만, team.db 에 팀원이 남아 있으면
+  //       그건 새 설치가 아니라 ★레지스트리 유실★ 이다(대시보드는 DB 기준으로 팀원을 계속 보여준다).
+  const freshInstall = registry.ok && registry.agents.length === 0 && dbAgents === 0;
+
+  // ★agents.json 로드 자체를 먼저 노출한다★ — 손상·권한 오류는 조용히 넘기지 않고 fail.
+  if (!registry.ok) {
+    items.push(
+      item(
+        "fail",
+        "agents.json 로드",
+        `실패(${registry.error ?? "load_error"}) — 로스터를 읽지 못했다(team.db 로스터 ${dbAgents}명)`,
+        "agents.json 의 JSON 형식·파일 권한을 확인하세요. 서버는 마지막으로 읽은 로스터로 계속 동작하며, 다음 sync 때 team.db 기준 자동복구를 시도합니다.",
+      ),
+    );
+  } else if (registry.agents.length === 0 && dbAgents > 0) {
+    items.push(
+      item(
+        "fail",
+        "agents.json 로드",
+        `레지스트리 0명인데 team.db 로스터 ${dbAgents}명 — 레지스트리 유실 의심(새 설치 아님)`,
+        "agents.json 을 복구하세요(서버는 다음 registry sync 에서 team.db/백업 기준 자동복구를 시도합니다).",
+      ),
+    );
+  } else {
+    items.push(item("pass", "agents.json 로드", `성공 — 팀원 ${registry.agents.length}명`));
+  }
 
   // ★새 설치(팀원 0명)의 '팀 이름 미설정'은 결함이 아니라 정상 출발점★ — 방금 install.sh 를 돌린
   //   사람은 당연히 팀 이름을 안 정했다. 이걸 fail 로 찍으면 첫 인수체크가 빨간불로 떠서 "설치가
@@ -411,9 +469,10 @@ function claudeLauncherChecks(deps: AcceptanceDeps): AcceptanceItem[] {
 export function runAcceptanceCheck(deps: AcceptanceDeps, member: string | null): AcceptanceResult {
   const rootDir = deps.rootDir ?? dirname(dirname(deps.teamOsPath));
   const membersRoot = deps.membersRoot ?? defaultMembersRoot();
-  const agents = loadAgents(deps.registryPath);
+  const registry = loadAgentsChecked(deps.registryPath);
+  const agents = registry.agents;
   const sections = [
-    settingsStep(deps.db, agents.length === 0),
+    settingsStep(deps.db, registry, dbAgentCount(deps.db)),
     coreRulesStep(deps.teamOsPath),
     onboardingStep(member, agents, membersRoot),
     portabilityStep(rootDir, membersRoot, member, buildInternalIdRe(deps.db)),

--- a/src/server/lib/acceptanceCheck.ts
+++ b/src/server/lib/acceptanceCheck.ts
@@ -106,13 +106,28 @@ function blockerCategory(line: string, internalIdRe: RegExp | null): string {
   return "blocker";
 }
 
-function settingsStep(db: Database): AcceptanceStep {
+function settingsStep(db: Database, freshInstall: boolean): AcceptanceStep {
   const items: AcceptanceItem[] = [];
   const teamName = getSetting(db, "team_name");
   const ownerName = getSetting(db, "owner_name");
   const systemOp = captureConfigStatus(db);
 
-  items.push(teamName ? item("pass", "팀 이름", teamName) : item("fail", "팀 이름", "미설정"));
+  // ★새 설치(팀원 0명)의 '팀 이름 미설정'은 결함이 아니라 정상 출발점★ — 방금 install.sh 를 돌린
+  //   사람은 당연히 팀 이름을 안 정했다. 이걸 fail 로 찍으면 첫 인수체크가 빨간불로 떠서 "설치가
+  //   잘못됐나"로 읽힌다(2026-07-25 공개 클린설치 리허설). → 초기 상태는 info + 다음 할 일 안내로,
+  //   팀이 구성된 뒤(팀원 1명 이상)에도 비어 있으면 그건 진짜 누락이라 fail 유지.
+  items.push(
+    teamName
+      ? item("pass", "팀 이름", teamName)
+      : freshInstall
+        ? item(
+            "info",
+            "팀 이름",
+            "미설정 — 새 설치의 정상 상태(팀원 0명)",
+            "다음 할 일: Settings 에서 팀 이름을 정하고 첫 팀원을 영입하세요.",
+          )
+        : item("fail", "팀 이름", "미설정"),
+  );
   items.push(ownerName ? item("pass", "팀장 이름", ownerName) : item("info", "팀장 이름", "미설정({{OWNER}} 유지)"));
   // ★capture 봇·라우터는 그룹(팀방) 협업 전용 = 선택★ — 1:1 DM 영입엔 불필요하다.
   //   fail 로 두면 정상적인 1:1 영입도 무조건 "검증 실패"로 떠서 사용자가 막힌 걸로 오해한다
@@ -398,7 +413,7 @@ export function runAcceptanceCheck(deps: AcceptanceDeps, member: string | null):
   const membersRoot = deps.membersRoot ?? defaultMembersRoot();
   const agents = loadAgents(deps.registryPath);
   const sections = [
-    settingsStep(deps.db),
+    settingsStep(deps.db, agents.length === 0),
     coreRulesStep(deps.teamOsPath),
     onboardingStep(member, agents, membersRoot),
     portabilityStep(rootDir, membersRoot, member, buildInternalIdRe(deps.db)),

--- a/src/server/lib/registry.test.ts
+++ b/src/server/lib/registry.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { openDb, migrate } from "../db/migrate";
 import { listAgents } from "../db/queries";
 import { detectExplicitTargets } from "./teamRouter";
@@ -201,6 +201,55 @@ describe("loadRegistry", () => {
       expect(syncRegistry(db, registryPath)).toEqual([]);
       expect(listAgents(db)).toEqual([]);
     } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // ── 클린 설치 첫 기동: 팀원 0명은 정상 초기 상태라 경고를 찍지 않는다 (2026-07-25 공개 리허설) ──
+  test("syncRegistry 는 팀원 0명(새 설치)에 coordinator 경고를 찍지 않는다", () => {
+    const dir = mkdtempSync(join(tmpdir(), "team-registry-fresh-install-"));
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    const log = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const registryPath = join(dir, "agents.json");
+      const db = openDb(join(dir, "team.db"));
+      migrate(db);
+      writeFileSync(registryPath, "[]\n");
+
+      expect(syncRegistry(db, registryPath, dir)).toEqual([]);
+      expect(warn.mock.calls.flat().join("\n")).not.toContain("coordinator capability");
+      // 경고 대신 안내 문구 1줄.
+      expect(log.mock.calls.flat().join("\n")).toContain("첫 팀원을 영입하면 coordinator");
+      // 오타·누락 audit 도 남기지 않는다(0명은 오류가 아니다).
+      const audits = db.prepare(`SELECT COUNT(*) AS n FROM audit_event WHERE action = 'fallback_no_coordinator'`)
+        .get() as { n: number };
+      expect(audits.n).toBe(0);
+    } finally {
+      warn.mockRestore();
+      log.mockRestore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("syncRegistry 는 팀원이 있는데 coordinator 가 없으면 계속 경고한다(진짜 누락)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "team-registry-no-coordinator-"));
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const registryPath = join(dir, "agents.json");
+      const db = openDb(join(dir, "team.db"));
+      migrate(db);
+      writeFileSync(registryPath, JSON.stringify([{
+        id: "bill", display_name: "Bill", role: "Infra", runtime: "claude_channel",
+        status_provider: "claude_tmux", workspace_path: "/tmp/bill", persona_file: "/tmp/bill/CLAUDE.md",
+      }]));
+
+      expect(syncRegistry(db, registryPath, dir).map((a) => a.id)).toEqual(["bill"]);
+      expect(warn.mock.calls.flat().join("\n")).toContain("coordinator capability");
+      const audits = db.prepare(`SELECT COUNT(*) AS n FROM audit_event WHERE action = 'fallback_no_coordinator'`)
+        .get() as { n: number };
+      expect(audits.n).toBe(1);
+    } finally {
+      warn.mockRestore();
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/src/server/lib/registry.ts
+++ b/src/server/lib/registry.ts
@@ -113,8 +113,13 @@ export function syncRegistry(db: Database, registryPath: string, repoRoot?: stri
   deleteAgentsNotIn(db, agents.map((a) => a.id));
   appendAudit(db, "system", "registry_synced", null, { count: agents.length });
   // load-time coordinator 검증 — 정확히 1명이 아니면 경고 + audit(공개 사용자 agents.json 오타/누락 가시화).
+  // ★단, 팀원 0명(새 설치)은 오타·누락이 아니라 정상 초기 상태★ — 그런데도 경고를 찍으면 새 사용자가
+  //   보는 첫 기동 로그 맨 첫 줄이 경고라 "설치가 깨졌나"로 읽힌다(2026-07-25 공개 클린설치 리허설).
+  //   → 0명은 안내 문구로 낮추고, agents 가 있는데 coordinator 가 0/2+ 인 진짜 오류만 경고 + audit.
   const cc = validateCoordinators(agents);
-  if (!cc.ok) {
+  if (!cc.ok && agents.length === 0) {
+    console.log("[registry] 팀원 0명 — 첫 팀원을 영입하면 coordinator 가 자동 지정됩니다.");
+  } else if (!cc.ok) {
     const reason = cc.issue === "none" ? "fallback_no_coordinator" : "multiple_coordinators";
     console.warn(
       `[registry] coordinator capability ${cc.count}개(${cc.coordinatorIds.join(", ") || "없음"}) — 정확히 1명이어야 함(${reason}).`,

--- a/src/server/routes/acceptance.test.ts
+++ b/src/server/routes/acceptance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, beforeEach } from "bun:test";
 import { Database } from "bun:sqlite";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { migrate } from "../db/migrate";
@@ -127,6 +127,16 @@ function setupFreshInstall() {
     teamOsSnapshot: () => ({ scheduled: [] }),
   });
   return { app, db, dir, root, membersRoot };
+}
+
+/** team.db 로스터에 팀원 N명을 심는다 — '레지스트리는 0/손상인데 DB엔 팀원이 있다'(=유실·손상) 재현용. */
+function insertDbAgents(db: Database, ids: string[]) {
+  for (const id of ids) {
+    db.prepare(
+      `INSERT INTO agent (id, display_name, role, runtime, status_provider, workspace_path, persona_file)
+       VALUES (?, ?, 'dev', 'openclaw', 'openclaw_gateway', ?, ?)`,
+    ).run(id, id, `/tmp/${id}`, `/tmp/${id}/SOUL.md`);
+  }
 }
 
 function insertScheduledJob(db: Database, id: string, status: "failed" | "cancelled", enabled: 0 | 1) {
@@ -404,19 +414,72 @@ describe("acceptance-check routes", () => {
   });
 
   // ── 클린 설치 첫 경험: 정상 초기 상태를 fail 로 찍지 않는다 (2026-07-25 공개 리허설) ──
+  const settingsCheck = (body: any, label: string) =>
+    body.sections.find((section: any) => section.key === "settings").checks.find((c: any) => c.label === label);
+
   test("클린 설치(팀원 0명)는 fail 0 — '팀 이름 미설정'은 info + 다음 할 일 안내", async () => {
     const { app, dir } = setupFreshInstall();
     try {
       const body = (await (await app.request("/acceptance-check")).json()) as any;
       expect(body.summary.fail).toBe(0);
       expect(body.ok).toBe(true);
-      const settings = body.sections.find((section: any) => section.key === "settings");
-      expect(settings.checks[0]).toEqual({
+      expect(settingsCheck(body, "팀 이름")).toEqual({
         label: "팀 이름",
         status: "info",
         detail: "미설정 — 새 설치의 정상 상태(팀원 0명)",
         fix: "다음 할 일: Settings 에서 팀 이름을 정하고 첫 팀원을 영입하세요.",
       });
+      expect(settingsCheck(body, "agents.json 로드")).toEqual({
+        label: "agents.json 로드",
+        status: "pass",
+        detail: "성공 — 팀원 0명",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // ── ★major A(Bill 적대검증 2026-07-25)★ 레지스트리 로드 실패를 '팀원 0명 = 새 설치' 로 삼키면
+  //    손상된 라이브에서 인수체크가 "새 설치입니다, 이상 없습니다" 라고 적극적 거짓 주장을 한다.
+  //    → 로드 실패는 fail 로 노출하고 freshInstall 신호에서 제외한다. 네 가지 손상 유형 전부 고정. ──
+  const corruptions: Array<{ name: string; corrupt: (registryPath: string) => void }> = [
+    { name: "JSON 잘림", corrupt: (p) => writeFileSync(p, '[{"id":"bill",', "utf-8") },
+    { name: "배열 아닌 객체", corrupt: (p) => writeFileSync(p, '{"id":"bill"}', "utf-8") },
+    { name: "권한 없음(chmod 000)", corrupt: (p) => chmodSync(p, 0o000) },
+  ];
+  for (const { name, corrupt } of corruptions) {
+    test(`손상된 agents.json(${name}) → '새 설치' 라고 하지 않는다 (로드 fail + 팀 이름 fail)`, async () => {
+      const { app, db, dir, root } = setupFreshInstall();
+      try {
+        insertDbAgents(db, ["bill", "codex", "steve"]); // team.db 로스터는 살아있다(대시보드는 3명을 보여준다)
+        corrupt(join(root, "agents.json"));
+
+        const body = (await (await app.request("/acceptance-check")).json()) as any;
+        expect(body.ok).toBe(false);
+        const load = settingsCheck(body, "agents.json 로드");
+        expect(load.status).toBe("fail");
+        expect(load.detail).toContain("team.db 로스터 3명");
+        // 팀 이름은 '새 설치의 정상 상태' 로 둘 수 없다 — 새 설치가 아니다.
+        expect(settingsCheck(body, "팀 이름")).toEqual({ label: "팀 이름", status: "fail", detail: "미설정" });
+      } finally {
+        try { chmodSync(join(root, "agents.json"), 0o644); } catch { /* 이미 정상 */ }
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  }
+
+  test("agents.json 파일만 사라졌는데 team.db 에 팀원이 있으면 유실 의심 fail — '새 설치' 아님", async () => {
+    const { app, db, dir, root } = setupFreshInstall();
+    try {
+      insertDbAgents(db, ["bill", "codex"]);
+      rmSync(join(root, "agents.json"));
+
+      const body = (await (await app.request("/acceptance-check")).json()) as any;
+      expect(body.ok).toBe(false);
+      const load = settingsCheck(body, "agents.json 로드");
+      expect(load.status).toBe("fail");
+      expect(load.detail).toContain("레지스트리 유실 의심");
+      expect(settingsCheck(body, "팀 이름").status).toBe("fail");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/server/routes/acceptance.test.ts
+++ b/src/server/routes/acceptance.test.ts
@@ -99,6 +99,36 @@ Tasks 칸반 사용.
   return { app, db, dir, root, membersRoot, novaWs };
 }
 
+/** 방금 install.sh 를 돌린 새 사용자 상태 — 팀원 0명 · 설정 전무(팀 이름·팀장·capture·라우터 미설정). */
+function setupFreshInstall() {
+  const db = new Database(":memory:");
+  migrate(db);
+  const dir = mkdtempSync(join(tmpdir(), "acceptance-fresh-"));
+  const root = join(dir, "repo");
+  const membersRoot = join(dir, "members");
+  const rulesDir = join(root, "rules");
+  mkdirSync(rulesDir, { recursive: true });
+  const teamOsPath = join(rulesDir, "TEAM-OS.md");
+  const registryPath = join(root, "agents.json");
+  writeFileSync(
+    teamOsPath,
+    "# TEAM-OS\n\nowner 판정은 @멘션 우선.\n\nBWF 정의.\n\nTasks 칸반 사용.\n",
+    "utf-8",
+  );
+  writeFileSync(registryPath, "[]\n", "utf-8");
+
+  const app = createAcceptanceRoutes({
+    db,
+    registryPath,
+    teamOsPath,
+    rootDir: root,
+    membersRoot,
+    // 새 설치엔 launchd 등록이 없다(수동 실행).
+    teamOsSnapshot: () => ({ scheduled: [] }),
+  });
+  return { app, db, dir, root, membersRoot };
+}
+
 function insertScheduledJob(db: Database, id: string, status: "failed" | "cancelled", enabled: 0 | 1) {
   db.prepare(
     `INSERT INTO scheduled_job
@@ -368,6 +398,38 @@ describe("acceptance-check routes", () => {
         status: "info",
         detail: "인자 없음 - OT 단계 스킵",
       });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // ── 클린 설치 첫 경험: 정상 초기 상태를 fail 로 찍지 않는다 (2026-07-25 공개 리허설) ──
+  test("클린 설치(팀원 0명)는 fail 0 — '팀 이름 미설정'은 info + 다음 할 일 안내", async () => {
+    const { app, dir } = setupFreshInstall();
+    try {
+      const body = (await (await app.request("/acceptance-check")).json()) as any;
+      expect(body.summary.fail).toBe(0);
+      expect(body.ok).toBe(true);
+      const settings = body.sections.find((section: any) => section.key === "settings");
+      expect(settings.checks[0]).toEqual({
+        label: "팀 이름",
+        status: "info",
+        detail: "미설정 — 새 설치의 정상 상태(팀원 0명)",
+        fix: "다음 할 일: Settings 에서 팀 이름을 정하고 첫 팀원을 영입하세요.",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("팀이 구성된 뒤(팀원 존재) 팀 이름이 비면 그건 진짜 누락 — fail 유지", async () => {
+    const { app, db, dir } = setup();
+    try {
+      db.query("DELETE FROM setting WHERE key = 'team_name'").run();
+      const body = (await (await app.request("/acceptance-check")).json()) as any;
+      const settings = body.sections.find((section: any) => section.key === "settings");
+      expect(settings.checks).toContainEqual({ label: "팀 이름", status: "fail", detail: "미설정" });
+      expect(body.ok).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/server/workers/dmSyncWorker.test.ts
+++ b/src/server/workers/dmSyncWorker.test.ts
@@ -6,7 +6,7 @@
 //      그래서 설정값(owner_chat_id)을 읽고, 없으면 ★캡처를 아예 하지 않는다★(무동작이 오동작보다 낫다).
 //   ② DM 적재는 팀원 세션 기록을 읽는 기능이라 ★끌 수 있어야★ 한다(dm_capture=off).
 //      끄면 적재만 멈추고 버스·위임·발신은 그대로여야 한다 — dm_message 는 크리티컬이 아니다.
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -124,6 +124,18 @@ describe("dmSyncWorker 게이트", () => {
     const ws = workspaceWithOneDm(OWNER);
     const db = freshDb({ owner_chat_id: OWNER });
     expect(syncDmOnce(db, member(ws)).inserted).toBe(1);
+  });
+
+  // ── 클린 설치 첫 기동: 팀원 0명이면 캡처 대상이 없으니 경고도 찍지 않는다 (2026-07-25 공개 리허설) ──
+  test("팀원 0명(새 설치) → 조용히 0건, owner 미설정 경고 없음", () => {
+    const db = freshDb({}); // owner_chat_id 미설정 = 방금 설치한 상태
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(syncDmOnce(db, []).inserted).toBe(0);
+      expect(warn.mock.calls.flat().join("\n")).not.toContain("팀장 chat_id");
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   test("한 멤버 파서 실패를 격리하고 health+audit에 남긴다", () => {

--- a/src/server/workers/dmSyncWorker.test.ts
+++ b/src/server/workers/dmSyncWorker.test.ts
@@ -127,12 +127,31 @@ describe("dmSyncWorker 게이트", () => {
   });
 
   // ── 클린 설치 첫 기동: 팀원 0명이면 캡처 대상이 없으니 경고도 찍지 않는다 (2026-07-25 공개 리허설) ──
-  test("팀원 0명(새 설치) → 조용히 0건, owner 미설정 경고 없음", () => {
-    const db = freshDb({}); // owner_chat_id 미설정 = 방금 설치한 상태
+  //
+  // ★이 테스트가 공허해지지 않게 하는 두 장치★ (Bill 적대검증 2026-07-25 반영):
+  //   ① owner resolver 를 주입한다 — 기본 resolver 는 설정이 없으면 resolveOwnerDmId() 로 ★실행 머신의
+  //      실제 ~/.claude 페어링 파일★ 을 읽는다. 그래서 주입 없이 freshDb({}) 만 쓰면 owner 가 truthy 로
+  //      나와 '경고 분기'를 아예 타지 않고, 수정을 되돌려도 테스트가 통과한다(= 회귀 방지 가치 0).
+  //   ② warnedNoOwner(모듈 전역 1회권 플래그)를 먼저 리셋하고, ★양성 대조군★ 을 같은 테스트에 둔다.
+  //      플래그가 이미 서 있으면 어떤 코드든 경고를 안 찍으므로, 그 상태의 '경고 없음'은 증거가 아니다.
+  test("팀원 0명(새 설치) → 조용히 0건, owner 미설정 경고 없음 (양성 대조군 포함)", () => {
+    const db = freshDb({});
+    const stubParsers = { claude_channel: () => [] }; // 파일시스템 접근 없는 파서
+    const oneMember: DmSyncMember[] = [{ id: "bill", runtime: "claude_channel", workspacePath: "/tmp/none" }];
+
+    // ① owner 를 찾은 tick 을 1회 흘려 warnedNoOwner=false 로 리셋(경고 1회권 재충전).
+    syncDmOnce(db, oneMember, stubParsers, () => OWNER);
+
     const warn = spyOn(console, "warn").mockImplementation(() => {});
     try {
-      expect(syncDmOnce(db, []).inserted).toBe(0);
+      // ② 팀원 0명 + owner 없음 → 경고 없어야 한다(early return 을 되돌리면 여기서 경고가 찍혀 실패).
+      expect(syncDmOnce(db, [], stubParsers, () => "").inserted).toBe(0);
       expect(warn.mock.calls.flat().join("\n")).not.toContain("팀장 chat_id");
+
+      // ③ ★양성 대조군★ — 같은 조건에서 멤버만 1명이면 경고가 실제로 찍힌다.
+      //    이게 통과해야 위 ②의 '경고 없음'이 "분기를 탔지만 안 찍었다"는 증거가 된다.
+      syncDmOnce(db, oneMember, stubParsers, () => "");
+      expect(warn.mock.calls.flat().join("\n")).toContain("팀장 chat_id");
     } finally {
       warn.mockRestore();
     }

--- a/src/server/workers/dmSyncWorker.ts
+++ b/src/server/workers/dmSyncWorker.ts
@@ -138,6 +138,10 @@ export function syncDmOnce(
   let scanned = 0;
   const byMember: Record<string, number> = {};
   if (!dmCaptureEnabled(db)) return { inserted, scanned, byMember }; // 설정에서 껐음
+  // ★팀원 0명(새 설치)이면 캡처할 DM 자체가 없다★ — 아래 owner 미설정 경고까지 가면 새 사용자가
+  //   보는 첫 기동 로그에 경고가 찍혀 "설치가 깨졌나"로 읽힌다(2026-07-25 공개 클린설치 리허설).
+  //   members 가 비면 owner 가 있어도 루프가 아무 일도 안 하므로 조용히 빠지는 게 동작상 동일하다.
+  if (members.length === 0) return { inserted, scanned, byMember };
   const owner = ownerChatId(db);
   if (!owner) {
     if (!warnedNoOwner) {

--- a/src/server/workers/dmSyncWorker.ts
+++ b/src/server/workers/dmSyncWorker.ts
@@ -133,6 +133,10 @@ export function syncDmOnce(
   db: Database,
   members: DmSyncMember[],
   parsers: Record<string, (m: DmSyncMember, ownerChatId: string) => DmMessageInput[]> = PARSERS,
+  // ★테스트 주입점★ — 기본 resolver 는 설정 미설정 시 resolveOwnerDmId() 로 ★실 파일시스템★
+  //   (~/.claude/channels/*/access.json)을 읽는다. 주입 없이 "owner 없음" 분기를 테스트하면 실행 머신의
+  //   실제 페어링 파일 때문에 owner 가 truthy 로 나와 분기를 아예 타지 않는다(= 공허한 테스트).
+  resolveOwner: (db: Database) => string = ownerChatId,
 ): DmSyncResult {
   let inserted = 0;
   let scanned = 0;
@@ -140,9 +144,11 @@ export function syncDmOnce(
   if (!dmCaptureEnabled(db)) return { inserted, scanned, byMember }; // 설정에서 껐음
   // ★팀원 0명(새 설치)이면 캡처할 DM 자체가 없다★ — 아래 owner 미설정 경고까지 가면 새 사용자가
   //   보는 첫 기동 로그에 경고가 찍혀 "설치가 깨졌나"로 읽힌다(2026-07-25 공개 클린설치 리허설).
-  //   members 가 비면 owner 가 있어도 루프가 아무 일도 안 하므로 조용히 빠지는 게 동작상 동일하다.
+  //   ★데이터 경로는 동일★(members 가 비면 owner 가 있어도 루프가 아무 일도 안 한다). 단 완전히
+  //   동일하진 않다 — 아래 warnedNoOwner 리셋(모듈 전역 플래그)을 건너뛰므로, owner 를 다시 찾은 tick 이
+  //   멤버 0명이면 경고 1회권이 재충전되지 않는다(경고가 덜 나올 뿐, 적재 결과는 불변). Bill 지적 반영.
   if (members.length === 0) return { inserted, scanned, byMember };
-  const owner = ownerChatId(db);
+  const owner = resolveOwner(db);
   if (!owner) {
     if (!warnedNoOwner) {
       warnedNoOwner = true;


### PR DESCRIPTION
Bill 요청(thread pub-clean-0725) — 공개 repo fresh clone → 격리 HOME `install.sh` → 첫 기동 리허설에서 '새 사용자 첫 경험'이 잘못 보이는 문제.

## 무엇을 고쳤나

셋 다 같은 패턴 — **팀원 0명(정상 초기 상태)을 오류로 표시**했다.

| # | 증상 | 수정 |
|---|---|---|
| 1 | acceptance `sections[0].checks[0]` = `팀 이름 / fail / 미설정` → 첫 인수테스트가 빨간불 | 팀원 0명이면 `info` + `fix`(다음 할 일) 안내. 팀원 1명 이상인데 비면 `fail` 유지 |
| 2 | 첫 기동 로그 맨 첫 줄이 `[registry] coordinator capability 0개(없음) … (fallback_no_coordinator)` | 팀원 0명이면 안내 문구 1줄로. agents 가 있는데 coordinator 0/2+ 인 진짜 오타·누락만 경고 + audit 유지 |
| 3 | (추가 발견) 첫 기동 로그의 `[registry]` 다음 경고 `[dm_sync] 팀장 chat_id 를 찾지 못해…` | 팀원 0명이면 조용히 skip. `members` 가 비면 owner 가 있어도 루프가 아무 일도 안 하므로 동작 동일 |

3번은 Bill 이 지목한 2건에는 없었지만 **완료기준 ② "클린 첫 기동 로그에 경고 없음"** 을 만족시키려면 같이 고쳐야 했다(같은 클래스). 리뷰에서 범위 밖이면 빼도 된다.

> 결함1 위치는 요청서의 `routes/acceptance.ts` 가 아니라 실제 판정 로직이 있는 `lib/acceptanceCheck.ts` (`settingsStep`).

## 검증

- **① 클린 설치 acceptance fail=0** — fresh clone(이 브랜치) + 격리 HOME + `install.sh` + 기동 실측: `ok=true`, `{pass:7, fail:0, info:12}`, `checks[0]` = `팀 이름 / info / 미설정 — 새 설치의 정상 상태(팀원 0명)` + 다음 할 일 안내
- **② 클린 첫 기동 로그 경고 0줄** — 실측 로그 첫 줄이 `[registry] 팀원 0명 — 첫 팀원을 영입하면 coordinator 가 자동 지정됩니다.` 로 바뀌고, 경고 라인 0
- **③ 기존 팀 무회귀** — 라이브 `team.db` 복사본 + 라이브 `agents.json` 에 대해 main 코드 / 이 브랜치 코드로 acceptance 를 각각 실행해 **결과 완전 동일**(`pass 15 / fail 0`, check 목록 diff 없음). 라이브 서버 실 응답 baseline 도 `pass 15 / fail 0`
  - 비교 시 `cwd`(.env 로딩)와 `TEAM_COLLAB_ROOT` 를 동일하게 고정해야 한다 — `REPO_ROOT` 가 `import.meta.dir` 기반이라 worktree 에서 그냥 돌리면 `런처 정본 일치` 가 위치 아티팩트로 fail 로 뜬다
- **테스트** — `bun test src/server src/web`: 1560 pass / 6 fail, 사전 실패 6건과 **동일**(baseline 1556 pass / 동일 6 fail) = 회귀 없음. 신규 회귀테스트 5건 추가
- **타입** — `tsc --noEmit` 통과

## 검증 안 한 범위

- 맥스튜디오 실기 클린테스트(Bill 담당)
- 라이브 서버 재시작 후 실 응답(재시작은 조율 필요 — 코드 경로는 위 ③ 로 확인)
- 대시보드 UI 렌더(acceptance JSON 만 검증)

## 롤백

`git revert b6298df` — 소스 3파일 + 테스트 3파일뿐이고 스키마·설정 변경 없음.