### PR TITLE
test(acceptance): 로드실패↔유실의심 구분 테스트 고정 + 로스터 조회 실패 삼킴 제거

### DIFF
--- a/src/server/lib/acceptanceCheck.ts
+++ b/src/server/lib/acceptanceCheck.ts
@@ -119,11 +119,15 @@ function loadAgentsChecked(registryPath: string): RegistryLoad {
   }
 }
 
-function dbAgentCount(db: Database): number {
+/** team.db 로스터 인원. ★조회 실패는 null — 0 으로 삼키지 않는다★.
+ *  0 은 freshInstall 신호의 한 축이라, 실패를 0 으로 반환하면 방금 고친 major A 와 똑같은
+ *  '실패를 정상 초기상태로 오판' 패턴이 여기서 되살아난다(Bill 후속지적 2026-07-25 minor 2).
+ *  null = "모른다" → freshInstall 은 성립하지 않고, 로드 체크가 fail 로 노출한다. */
+function dbAgentCount(db: Database): number | null {
   try {
-    return (db.query("SELECT COUNT(*) AS n FROM agent").get() as { n: number } | null)?.n ?? 0;
+    return (db.query("SELECT COUNT(*) AS n FROM agent").get() as { n: number } | null)?.n ?? null;
   } catch {
-    return 0;
+    return null;
   }
 }
 
@@ -134,7 +138,7 @@ function blockerCategory(line: string, internalIdRe: RegExp | null): string {
   return "blocker";
 }
 
-function settingsStep(db: Database, registry: RegistryLoad, dbAgents: number): AcceptanceStep {
+function settingsStep(db: Database, registry: RegistryLoad, dbAgents: number | null): AcceptanceStep {
   const items: AcceptanceItem[] = [];
   const teamName = getSetting(db, "team_name");
   const ownerName = getSetting(db, "owner_name");
@@ -145,7 +149,10 @@ function settingsStep(db: Database, registry: RegistryLoad, dbAgents: number): A
   //     · 로드 실패(파싱·권한·배열아님)를 0명으로 세면 손상된 라이브에서 "새 설치입니다" 라고 거짓말한다.
   //     · 파일만 사라진 경우는 loadRegistry 가 정상적으로 [] 를 주지만, team.db 에 팀원이 남아 있으면
   //       그건 새 설치가 아니라 ★레지스트리 유실★ 이다(대시보드는 DB 기준으로 팀원을 계속 보여준다).
+  //     · team.db 로스터 조회 자체가 실패하면(dbAgents === null) "0명" 이 아니라 "모른다" 다 —
+  //       모르는 상태를 새 설치로 단정하지 않는다(Bill 후속지적 minor 2, 같은 삼킴 패턴).
   const freshInstall = registry.ok && registry.agents.length === 0 && dbAgents === 0;
+  const dbRoster = dbAgents === null ? "조회 실패" : `${dbAgents}명`;
 
   // ★agents.json 로드 자체를 먼저 노출한다★ — 손상·권한 오류는 조용히 넘기지 않고 fail.
   if (!registry.ok) {
@@ -153,8 +160,17 @@ function settingsStep(db: Database, registry: RegistryLoad, dbAgents: number): A
       item(
         "fail",
         "agents.json 로드",
-        `실패(${registry.error ?? "load_error"}) — 로스터를 읽지 못했다(team.db 로스터 ${dbAgents}명)`,
+        `실패(${registry.error ?? "load_error"}) — 로스터를 읽지 못했다(team.db 로스터 ${dbRoster})`,
         "agents.json 의 JSON 형식·파일 권한을 확인하세요. 서버는 마지막으로 읽은 로스터로 계속 동작하며, 다음 sync 때 team.db 기준 자동복구를 시도합니다.",
+      ),
+    );
+  } else if (dbAgents === null) {
+    items.push(
+      item(
+        "fail",
+        "agents.json 로드",
+        "team.db 로스터 조회 실패 — 새 설치 여부를 판정할 수 없다(agents.json 자체는 로드됨)",
+        "team.db 파일 권한·스키마(agent 테이블)를 확인하세요.",
       ),
     );
   } else if (registry.agents.length === 0 && dbAgents > 0) {

--- a/src/server/routes/acceptance.test.ts
+++ b/src/server/routes/acceptance.test.ts
@@ -442,13 +442,17 @@ describe("acceptance-check routes", () => {
   // ── ★major A(Bill 적대검증 2026-07-25)★ 레지스트리 로드 실패를 '팀원 0명 = 새 설치' 로 삼키면
   //    손상된 라이브에서 인수체크가 "새 설치입니다, 이상 없습니다" 라고 적극적 거짓 주장을 한다.
   //    → 로드 실패는 fail 로 노출하고 freshInstall 신호에서 제외한다. 네 가지 손상 유형 전부 고정. ──
-  const corruptions: Array<{ name: string; corrupt: (registryPath: string) => void }> = [
-    { name: "JSON 잘림", corrupt: (p) => writeFileSync(p, '[{"id":"bill",', "utf-8") },
-    { name: "배열 아닌 객체", corrupt: (p) => writeFileSync(p, '{"id":"bill"}', "utf-8") },
-    { name: "권한 없음(chmod 000)", corrupt: (p) => chmodSync(p, 0o000) },
+  //
+  // ★assert 는 반드시 '원인 코드' 까지 본다★ — 'team.db 로스터 N명' 같은 ★두 분기 공통 문자열★ 만
+  //   보면 loadAgentsChecked 를 옛 catch→[] 로 되돌리는 mutation 이 안 잡힌다(로드실패 fail 대신
+  //   '유실 의심' fail 로 떨어져 문자열이 그대로 맞기 때문). Bill 후속지적 M2.
+  const corruptions: Array<{ name: string; cause: string; corrupt: (registryPath: string) => void }> = [
+    { name: "JSON 잘림", cause: "parse_error", corrupt: (p) => writeFileSync(p, '[{"id":"bill",', "utf-8") },
+    { name: "배열 아닌 객체", cause: "load_error", corrupt: (p) => writeFileSync(p, '{"id":"bill"}', "utf-8") },
+    { name: "권한 없음(chmod 000)", cause: "EACCES", corrupt: (p) => chmodSync(p, 0o000) },
   ];
-  for (const { name, corrupt } of corruptions) {
-    test(`손상된 agents.json(${name}) → '새 설치' 라고 하지 않는다 (로드 fail + 팀 이름 fail)`, async () => {
+  for (const { name, cause, corrupt } of corruptions) {
+    test(`손상된 agents.json(${name}) → 로드 fail(${cause}) + 팀 이름 fail — '새 설치' 라고 하지 않는다`, async () => {
       const { app, db, dir, root } = setupFreshInstall();
       try {
         insertDbAgents(db, ["bill", "codex", "steve"]); // team.db 로스터는 살아있다(대시보드는 3명을 보여준다)
@@ -458,6 +462,8 @@ describe("acceptance-check routes", () => {
         expect(body.ok).toBe(false);
         const load = settingsCheck(body, "agents.json 로드");
         expect(load.status).toBe("fail");
+        // ★원인 코드★ — '로드 실패' 와 '유실 의심' 을 구분하는 유일한 신호.
+        expect(load.detail).toContain(`실패(${cause})`);
         expect(load.detail).toContain("team.db 로스터 3명");
         // 팀 이름은 '새 설치의 정상 상태' 로 둘 수 없다 — 새 설치가 아니다.
         expect(settingsCheck(body, "팀 이름")).toEqual({ label: "팀 이름", status: "fail", detail: "미설정" });
@@ -466,7 +472,43 @@ describe("acceptance-check routes", () => {
         rmSync(dir, { recursive: true, force: true });
       }
     });
+
+    // ★DB 로스터가 0명이어도 손상은 여전히 fail★ — dbAgents 가드는 '로스터>0' 만 덮으므로,
+    //   이 케이스가 없으면 로드실패를 삼키는 mutation 이 ok=true·fail=0 으로 부활한다(Bill M2 실측).
+    test(`손상된 agents.json(${name}) + team.db 로스터 0명 → 여전히 로드 fail (거짓 '새 설치' 부활 방지)`, async () => {
+      const { app, dir, root } = setupFreshInstall();
+      try {
+        corrupt(join(root, "agents.json"));
+
+        const body = (await (await app.request("/acceptance-check")).json()) as any;
+        expect(body.ok).toBe(false);
+        const load = settingsCheck(body, "agents.json 로드");
+        expect(load.status).toBe("fail");
+        expect(load.detail).toContain(`실패(${cause})`);
+        // 로드가 실패했으면 '팀원 0명' 을 근거로 새 설치라고 단정할 수 없다.
+        expect(settingsCheck(body, "팀 이름").status).toBe("fail");
+      } finally {
+        try { chmodSync(join(root, "agents.json"), 0o644); } catch { /* 이미 정상 */ }
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
   }
+
+  test("team.db 로스터 조회 실패는 '팀원 0명' 이 아니다 — 새 설치로 단정하지 않고 fail", async () => {
+    const { app, db, dir } = setupFreshInstall();
+    try {
+      db.query("DROP TABLE agent").run(); // 로스터 조회가 throw 하는 상태(권한·스키마 손상 대용)
+
+      const body = (await (await app.request("/acceptance-check")).json()) as any;
+      expect(body.ok).toBe(false);
+      const load = settingsCheck(body, "agents.json 로드");
+      expect(load.status).toBe("fail");
+      expect(load.detail).toContain("team.db 로스터 조회 실패");
+      expect(settingsCheck(body, "팀 이름").status).toBe("fail");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 
   test("agents.json 파일만 사라졌는데 team.db 에 팀원이 있으면 유실 의심 fail — '새 설치' 아님", async () => {
     const { app, db, dir, root } = setupFreshInstall();


### PR DESCRIPTION
Bill 후속지적(PR#47 머지 후 minor 2건) 반영.

## M2 — 테스트 구멍

`loadAgentsChecked` 를 옛 `catch → []` 로 되돌리는 mutation 이 **1576개 중 단 1건도 잡지 못했다.**

원인: 손상 케이스 assert 가 `team.db 로스터 3명` 이라는 **로드실패·유실의심 두 분기의 공통 문자열**만 봤다. 게다가 `손상 + DB 로스터 0명` 조합에서는 그 mutation 이 `ok=true · fail=0` 으로 major A 의 거짓 "새 설치" 주장을 그대로 부활시킨다(`dbAgents` 가드는 로스터 > 0 만 덮기 때문).

- assert 에 원인 코드 추가 — `parse_error` / `load_error` / `EACCES`
- `손상 + team.db 로스터 0명 → 여전히 로드 fail` 케이스 3건 추가
- **mutation 되돌림 → 6건 fail** (이전 0건)

## minor 2 — 같은 삼킴 패턴 잔존

`dbAgentCount()` 가 `catch` 에서 `0` 을 반환했다. `0` 은 `freshInstall` 신호의 한 축이라 **조회 실패가 "새 설치"로 오판된다** — 방금 고친 major A 와 정확히 같은 패턴.

- `null`("모른다") 반환. `freshInstall` 은 `dbAgents === 0` 만 인정하므로 자동으로 성립하지 않는다
- 로드 체크가 `team.db 로스터 조회 실패 — 새 설치 여부를 판정할 수 없다` fail 로 노출
- 회귀테스트 1건(`agent` 테이블 드롭). **mutation 되돌림 → 1건 fail**

## 검증

- `bun test src/server src/web`: 1569 pass / 5 skip / 6 fail — 사전 실패 6건과 동일(회귀 0)
- `tsc --noEmit` 통과
- 두 mutation 모두 되돌림 실측으로 테스트가 잡는 것 확인

## 검증 안 한 범위

라이브 재시작 후 실응답 · 대시보드 UI 렌더(체크 개수는 불변 — 라벨·detail 문구만 조건부로 달라진다).

## 롤백

`git revert` 1커밋. 스키마·설정 변경 없음.