### PR TITLE
fix(recruit): 첫 claude 멤버 페어링 대기를 '실패'로 표시하지 않는다 + setup_incomplete 필드 hint

### DIFF
--- a/src/server/lib/activation.test.ts
+++ b/src/server/lib/activation.test.ts
@@ -20,7 +20,7 @@ import { buildPersona, buildAgentsMd } from "./personaTemplates";
 import {
   waitForClaudePoller, waitForCodexPoller, waitForHermesGateway,
   activateMember, teardownRuntime, swapRuntime, RUNTIMES, STATUS_BY_RUNTIME,
-  classifyEssentials,
+  classifyEssentials, CLAUDE_ESSENTIAL_TOLERANCE,
   type ActivateResult, type SwapDeps,
 } from "./activation";
 
@@ -722,5 +722,62 @@ describe("classifyEssentials — 페어링 대기 관용 경계", () => {
     );
     expect(v.ok).toBe(false);
     expect(v.pendingPairing).toBe(false);
+  });
+});
+
+// ── ★M5a 갭 차단★: 판정부만 고정하면 '그 함수를 어떤 옵션으로 부르는가' 는 무방비다 ──
+//
+// Bill 교차검증(2026-07-25): claude 호출부에서 tolerateWhenPairing 옵션 하나만 지우면
+//   essentials 가 하드실패로 돌아가 '필수설정 누락 — 재활성화/설정 복구 필요' 라는 ★이 PR 이 고친
+//   원래 버그가 그대로 부활★ 하는데도 1631개 테스트가 전부 통과했다. 순수함수(classifyEssentials)는
+//   잘 고정돼 있었지만 호출부 opts 는 인라인 리터럴이라 어떤 테스트도 보지 않았기 때문이다.
+//
+// 그래서 호출부 opts 를 공유 상수(CLAUDE_ESSENTIAL_TOLERANCE)로 빼고 ★그 상수를 통과시켜★ 검증한다.
+// 라우트 레벨로는 못 잡는다 — 라우트 테스트는 activateMember 를 주입 모킹해서 activation.ts 를 안 태운다.
+describe("CLAUDE_ESSENTIAL_TOLERANCE — claude 활성화 호출부의 관용 정책", () => {
+  const PAIRING_WAITING = {
+    ok: false,
+    missing: ["allowFrom:claude access.json"],
+    canAutoFix: true,
+    pendingPairing: true,
+  };
+
+  test("★호출부 옵션으로 페어링 대기가 관용된다★ (옵션이 빠지면 원래 버그가 부활한다)", () => {
+    const v = classifyEssentials(PAIRING_WAITING, CLAUDE_ESSENTIAL_TOLERANCE);
+    expect(v.ok).toBe(true);              // 실패로 떨어지면 '재활성화 필요' 안내가 되살아난다
+    expect(v.pendingPairing).toBe(true);
+    expect(v.detail).toContain("DM 페어링 대기");
+  });
+
+  test("호출부 옵션은 poller 미기동도 관용한다(auto-reconnect 복구 대상)", () => {
+    const v = classifyEssentials(
+      { ok: false, missing: ["poller:claude bot.pid"], canAutoFix: true },
+      CLAUDE_ESSENTIAL_TOLERANCE,
+    );
+    expect(v.ok).toBe(true);
+    expect(v.pendingPairing).toBe(false);
+  });
+
+  test("호출부 옵션이라도 토큰·채널 누락은 관용하지 않는다", () => {
+    for (const missing of ["token:claude .env TELEGRAM_BOT_TOKEN", "channel:claude LaunchAgent plist"]) {
+      const v = classifyEssentials(
+        { ...PAIRING_WAITING, missing: [missing, "allowFrom:claude access.json"] },
+        CLAUDE_ESSENTIAL_TOLERANCE,
+      );
+      expect(v.ok).toBe(false);
+      expect(v.pendingPairing).toBe(false);
+    }
+  });
+
+  // 위 세 건은 '상수의 내용' 을 고정한다. 이 건은 ★claude 분기가 실제로 그 상수를 쓰는지★ 를 고정한다 —
+  // 상수를 놔둔 채 호출부만 인라인 리터럴로 되돌리는 변형까지 막는 소스 레벨 가드.
+  test("claude 분기가 인라인 리터럴이 아니라 이 상수를 넘긴다(정적 가드)", () => {
+    const src = readFileSync(new URL("./activation.ts", import.meta.url), "utf-8");
+    const claudeCall = src.match(/pushEssentialStep\(steps, \{ id, runtime \}, ([^)]*)\)/g) ?? [];
+    // claude 분기 = 옵션을 넘기는 유일한 호출부. 그 인자가 반드시 공유 상수여야 한다.
+    const withOpts = claudeCall.filter((c) => !c.endsWith("{ id, runtime })"));
+    expect(withOpts.length).toBe(1);
+    expect(withOpts[0]).toContain("CLAUDE_ESSENTIAL_TOLERANCE");
+    expect(withOpts[0]).not.toContain("tolerateWhenPairing:"); // 인라인 리터럴 회귀 금지
   });
 });

--- a/src/server/lib/activation.test.ts
+++ b/src/server/lib/activation.test.ts
@@ -20,6 +20,7 @@ import { buildPersona, buildAgentsMd } from "./personaTemplates";
 import {
   waitForClaudePoller, waitForCodexPoller, waitForHermesGateway,
   activateMember, teardownRuntime, swapRuntime, RUNTIMES, STATUS_BY_RUNTIME,
+  classifyEssentials,
   type ActivateResult, type SwapDeps,
 } from "./activation";
 
@@ -638,5 +639,88 @@ describe("activation: swap 후 persona 정합성의 근거 — buildPersona/buil
       expect(out).toContain("## ⭐ Core Rules");
       expect(out).not.toContain("## Communication note (Claude runtime)");
     }
+  });
+});
+
+// ── ★첫 claude 멤버 활성화는 '실패' 가 아니라 '거의 완료 — 마지막 한 단계'★ (2026-07-25 맥스튜디오 실기) ──
+//
+// 실기 증상: 첫 claude 멤버(lisa)가 봇 정상 기동·토큰 OK·poller OK 인데도
+//   'error: claude 필수설정 누락 — 재활성화/설정 복구 필요' + OT '활성화 실패 — 재시도 필요' 로 떴다.
+//   실제 남은 일은 팀장이 그 봇에게 DM 을 한 번 보내는 것뿐이라 ★재시도로는 절대 안 풀린다★
+//   (DM 한 통 보내니 재시도 없이 통과, 두 번째 멤버는 첫 멤버 것을 시드받아 DM 없이 통과).
+//
+// activateMember 전체는 tmux·launchd 를 건드려 유닛에서 못 돌리므로, 판정부(classifyEssentials)를
+// 순수 함수로 분리해 규칙을 고정한다. ★관용은 페어링 대기일 때, allowFrom 에만★ 적용돼야 한다.
+describe("classifyEssentials — 페어링 대기 관용 경계", () => {
+  const CLAUDE_OPTS = { tolerate: ["poller:"], tolerateWhenPairing: ["allowFrom:"] };
+
+  test("전부 정상 → ok, 페어링 대기 아님", () => {
+    const v = classifyEssentials({ ok: true, missing: [], canAutoFix: false }, CLAUDE_OPTS);
+    expect(v).toEqual({ ok: true, pendingPairing: false, detail: "필수설정 확인(토큰·allowFrom·채널·poller)" });
+  });
+
+  test("★allowFrom 만 누락 + 페어링 대기 → 실패 아님(대기)★ + 안내에 DM 문구", () => {
+    const v = classifyEssentials(
+      { ok: false, missing: ["allowFrom:claude access.json"], canAutoFix: true, pendingPairing: true },
+      CLAUDE_OPTS,
+    );
+    expect(v.ok).toBe(true);
+    expect(v.pendingPairing).toBe(true);
+    expect(v.detail).toContain("DM 페어링 대기");
+  });
+
+  test("allowFrom 누락이지만 페어링 대기 아님(access.json 부재·손상) → 종전대로 하드실패", () => {
+    const v = classifyEssentials(
+      { ok: false, missing: ["allowFrom:claude access.json"], canAutoFix: true },
+      CLAUDE_OPTS,
+    );
+    expect(v.ok).toBe(false);
+    expect(v.pendingPairing).toBe(false);
+    expect(v.detail).toContain("필수설정 누락");
+  });
+
+  test("★페어링 대기라도 토큰·채널이 같이 빠졌으면 실패★ (관용이 진짜 누락을 덮지 않는다)", () => {
+    const v = classifyEssentials(
+      {
+        ok: false,
+        missing: ["token:claude .env TELEGRAM_BOT_TOKEN", "allowFrom:claude access.json"],
+        canAutoFix: true,
+        pendingPairing: true,
+      },
+      CLAUDE_OPTS,
+    );
+    expect(v.ok).toBe(false);
+    expect(v.pendingPairing).toBe(false);
+    expect(v.detail).toContain("token:claude");
+    expect(v.detail).not.toContain("allowFrom:claude"); // 관용된 항목은 누락 목록에서 빠진다
+  });
+
+  test("poller 만 누락(페어링 무관) → 기존 degraded 동작 그대로, 페어링 문구 안 붙는다", () => {
+    const v = classifyEssentials(
+      { ok: false, missing: ["poller:claude bot.pid"], canAutoFix: true },
+      CLAUDE_OPTS,
+    );
+    expect(v.ok).toBe(true);
+    expect(v.pendingPairing).toBe(false);
+    expect(v.detail).toContain("needs_reconnect");
+  });
+
+  test("페어링 대기 + poller 도 미기동 → 대기로 보되 페어링 안내를 유지(둘 다 사람·자동복구 대상)", () => {
+    const v = classifyEssentials(
+      { ok: false, missing: ["allowFrom:claude access.json", "poller:claude bot.pid"], canAutoFix: true, pendingPairing: true },
+      CLAUDE_OPTS,
+    );
+    expect(v.ok).toBe(true);
+    expect(v.pendingPairing).toBe(true);
+    expect(v.detail).toContain("DM 페어링 대기");
+  });
+
+  test("codex 등 다른 런타임(tolerateWhenPairing 없음)은 allowFrom 누락을 관용하지 않는다", () => {
+    const v = classifyEssentials(
+      { ok: false, missing: ["allowFrom:codex CODEX_ALLOW_FROM seed"], canAutoFix: true, pendingPairing: true },
+      {},
+    );
+    expect(v.ok).toBe(false);
+    expect(v.pendingPairing).toBe(false);
   });
 });

--- a/src/server/lib/activation.ts
+++ b/src/server/lib/activation.ts
@@ -27,7 +27,7 @@ import { checkRuntimeAuth } from "./runtimeAuth";
 import { LIVE_TEAM_OS_PATH } from "./teamOsRender";
 import { linkHermesTeamSkill } from "./hermesSkills";
 import { resolveTokenStore } from "./rotateToken";
-import { checkEssentialSettings } from "./runtimeEssentials";
+import { checkEssentialSettings, type EssentialCheckResult } from "./runtimeEssentials";
 import { writeRegistrySafely } from "./registrySafety";
 
 const HOME = process.env.HOME ?? "";
@@ -181,6 +181,9 @@ export interface ActivateResult {
   code?: "member_limit";
   /** claude_channel: 세션·설정은 정상이나 telegram MCP poller 만 미기동(첫 부팅 핸드셰이크 실패) — recruit 는 degraded 완결, /mcp reconnect 로 poller 복구 필요. */
   needsReconnect?: boolean;
+  /** claude_channel 첫 멤버: 봇·토큰·채널 전부 정상이고 ★사람이 DM 1회★ 만 남은 상태.
+   *  실패가 아니라 '거의 완료 — 마지막 한 단계'다(2026-07-25 맥스튜디오 실기 클린테스트). */
+  needsPairing?: boolean;
 }
 
 function offMemberActivationLimitReached(agents: any[], id: string): boolean {
@@ -192,30 +195,59 @@ function offMemberActivationLimitReached(agents: any[], id: string): boolean {
 
 const COORDINATOR_CAPABILITY = "coordinator";
 
+export interface EssentialClassification {
+  ok: boolean;
+  pendingPairing: boolean;
+  detail: string;
+}
+
+/** essentials 결과를 ★실패 / degraded / 페어링 대기★ 로 분류한다(순수 — 파일시스템·프로세스 접근 없음).
+ *  pushEssentialStep 이 스텝을 push 하기 전에 쓰는 판정부를 분리한 것 = 활성화 전체를 돌리지 않고
+ *  분류 규칙만 테스트로 고정할 수 있다(활성화는 tmux·launchd 를 건드려 유닛에서 못 돌린다). */
+export function classifyEssentials(
+  essentials: EssentialCheckResult,
+  opts?: { tolerate?: string[]; tolerateWhenPairing?: string[] },
+): EssentialClassification {
+  const pendingPairing = essentials.pendingPairing === true;
+  const tolerate = [...(opts?.tolerate ?? []), ...(pendingPairing ? opts?.tolerateWhenPairing ?? [] : [])];
+  const hardMissing = essentials.missing.filter((m) => !tolerate.some((t) => m.startsWith(t)));
+  const degraded = !essentials.ok && hardMissing.length === 0;
+  const ok = essentials.ok || degraded;
+  // ★페어링 대기는 '관용된 누락이 allowFrom 뿐' 일 때만★ — 토큰·채널이 같이 빠졌으면 그건 진짜 실패다.
+  const pairingOnly = pendingPairing && degraded && essentials.missing.every((m) => m.startsWith("allowFrom:") || m.startsWith("poller:"));
+  const degradedDetail = pairingOnly
+    ? "필수설정 확인(토큰·채널) — DM 페어링 대기(첫 claude 멤버: 사람이 봇에게 DM 1회)"
+    : "필수설정 확인(토큰·allowFrom·채널) — poller 는 needs_reconnect(자동 복구 시도 중)";
+  return {
+    ok,
+    pendingPairing: pairingOnly,
+    detail: essentials.ok
+      ? "필수설정 확인(토큰·allowFrom·채널·poller)"
+      : degraded
+        ? degradedDetail
+        : `필수설정 누락: ${hardMissing.join(", ")}${essentials.canAutoFix ? " (자동복구 가능)" : ""}`,
+  };
+}
+
 async function pushEssentialStep(
   steps: ActivateResult["steps"],
   agent: { id: string; runtime: string; openclaw_agent_id?: string | null; hermes_profile?: string | null },
-  opts?: { tolerate?: string[] },
-): Promise<boolean> {
+  opts?: { tolerate?: string[]; tolerateWhenPairing?: string[] },
+): Promise<{ ok: boolean; pendingPairing: boolean }> {
   const essentials = await checkEssentialSettings(agent as any);
   // ★degraded tolerate(2026-07-25 하네스 §4 fix)★: poller(bot.pid) 미기동은 poller 스텝이 이미 needs_reconnect 로
   //   표면화하고 auto-reconnect 가 복구를 시도하므로, 그것만 빠졌으면 essentials 를 하드실패로 치지 않는다.
   //   그렇지 않으면 :620 이 recall·bus-wake·degraded 반환을 통째로 스킵해 746f6b3 의 degraded 완결이 무효가 된다.
   //   tolerate 에 없는 진짜 필수설정(token·allowFrom·채널)이 하나라도 빠지면 종전대로 하드실패.
-  const tolerate = opts?.tolerate ?? [];
-  const hardMissing = essentials.missing.filter((m) => !tolerate.some((t) => m.startsWith(t)));
-  const degraded = !essentials.ok && hardMissing.length === 0;
-  const stepOk = essentials.ok || degraded;
-  steps.push({
-    step: "essentials",
-    ok: stepOk,
-    detail: essentials.ok
-      ? "필수설정 확인(토큰·allowFrom·채널·poller)"
-      : degraded
-        ? "필수설정 확인(토큰·allowFrom·채널) — poller 는 needs_reconnect(자동 복구 시도 중)"
-        : `필수설정 누락: ${hardMissing.join(", ")}${essentials.canAutoFix ? " (자동복구 가능)" : ""}`,
-  });
-  return stepOk;
+  //
+  // ★tolerateWhenPairing(2026-07-25 맥스튜디오 실기)★: allowFrom 누락이 ★첫 claude 멤버의 설계상 pairing 대기★
+  //   (access.json 이 dmPolicy:"pairing" + allowFrom:[] 로 정상 시드된 상태)일 때만 추가로 관용한다.
+  //   그렇지 않으면 봇이 정상 기동했는데도 '활성화 실패 — 재시도 필요' 로 떠서, 사용자가 재시도해도 절대
+  //   해결되지 않는다(실제 해법은 재시도가 아니라 봇에게 DM 1회). access.json 부재·손상은 pendingPairing 이
+  //   false 라 종전대로 하드실패 — 진짜 누락을 관용하지 않는다.
+  const verdict = classifyEssentials(essentials, opts);
+  steps.push({ step: "essentials", ok: verdict.ok, detail: verdict.detail });
+  return { ok: verdict.ok, pendingPairing: verdict.pendingPairing };
 }
 
 /**
@@ -566,7 +598,7 @@ export async function activateMember(db: Database, input: ActivateInput): Promis
       const pollerOk = await waitForCodexPoller(id, pollerWaitMs);
       steps.push({ step: "poller", ok: pollerOk, detail: pollerOk ? "codex 브리지 poller 기동 확인(getUpdates ready marker)" : "codex 브리지 poller 미기동(ready marker 없음 — 봇이 메시지를 못 받음, 재활성화 필요)" });
       if (!pollerOk) return { ok: false, steps, error: "codex 브리지 poller 미기동 — 봇이 메시지를 받지 못합니다(재활성화하세요)" };
-      if (!await pushEssentialStep(steps, { id, runtime })) return { ok: false, steps, error: "codex 필수설정 누락 — 재활성화/설정 복구 필요" };
+      if (!(await pushEssentialStep(steps, { id, runtime })).ok) return { ok: false, steps, error: "codex 필수설정 누락 — 재활성화/설정 복구 필요" };
     } catch (e) {
       steps.push({ step: "runtime", ok: false, detail: (e as Error).message });
       return { ok: false, steps, error: "codex 브리지 셋업 오류" };
@@ -582,6 +614,7 @@ export async function activateMember(db: Database, input: ActivateInput): Promis
       steps.push({ step: "runtime", ok: false, detail: "실행 OFF(APPROVAL_EXECUTION_ENABLED≠1) — claude 봇 기동 건너뜀" });
       return { ok: false, steps, error: "런타임 활성화 권한 OFF(팀장 인가 필요)" };
     }
+    let pairingPending = false; // 첫 claude 멤버의 DM 페어링 대기 여부(essentials 에서 판정, 반환에 실어 라우트가 안내)
     try {
       placeClaudeToken(id, bot_token);   // ~/.claude/channels/telegram-<id>/.env (봇이 여기서 토큰 읽음)
       writeClaudeBridgeFiles(id);        // LaunchAgent plist 생성(setClaude bootstrap 대상)
@@ -642,7 +675,12 @@ export async function activateMember(db: Database, input: ActivateInput): Promis
       // ★early-return 제거 + degraded 완결(2026-07-25)★: poller 실패해도 essentials 를 tolerate(poller:) 로 통과시켜
       //   아래 recall·bus-wake·degraded 반환까지 진행한다(그렇지 않으면 :620 essentials 하드실패가 746f6b3 의 degraded 를 무효화).
       //   token·allowFrom·채널 등 진짜 필수설정이 빠지면 종전대로 하드실패.
-      if (!await pushEssentialStep(steps, { id, runtime }, { tolerate: ["poller:"] })) return { ok: false, steps, error: "claude 필수설정 누락 — 재활성화/설정 복구 필요" };
+      //   ★tolerateWhenPairing(2026-07-25 맥스튜디오 실기)★: 첫 claude 멤버는 allowFrom 을 복사해올 참조봇이
+      //   없어 access.json 이 pairing 대기로 시드된다 = 설계상 정상. 그걸 하드실패로 치면 봇이 살아 있는데도
+      //   '활성화 실패 — 재시도 필요' 로 떠서, 재시도로는 절대 안 풀린다(해법은 봇에게 DM 1회).
+      const essentialsResult = await pushEssentialStep(steps, { id, runtime }, { tolerate: ["poller:"], tolerateWhenPairing: ["allowFrom:"] });
+      if (!essentialsResult.ok) return { ok: false, steps, error: "claude 필수설정 누락 — 재활성화/설정 복구 필요" };
+      pairingPending = essentialsResult.pendingPairing;
       // recall 주입(GD 2026-07-05): 활성화=새 claude 세션(맥락 빔)이니 --fresh 재시작과 동일하게 직전 대화 digest 주입.
       //   런타임 스왑/영입이 곧 '첫 로딩'이라 여기가 GD가 원한 '첫 로딩 시 주입' 지점. fire-forget best-effort(세션 준비는 스크립트 sleep이 대기, 실패해도 활성화 정상).
       try { Bun.spawn(["bash", `${process.cwd()}/scripts/inject-recall.sh`, id], { stdout: "ignore", stderr: "ignore" }); } catch { /* best-effort */ }
@@ -656,7 +694,12 @@ export async function activateMember(db: Database, input: ActivateInput): Promis
     // ★degraded 완결(2026-07-25)★: poller 실패는 하드 실패로 치지 않는다(recruit 는 완결, poller 만 needs_reconnect).
     //   ok 는 poller 를 제외한 스텝들로 판정 → runtime·essentials·bus-wake 가 되면 라우트가 OT 를 완결한다. needsReconnect 로 poller 상태 노출.
     const pollerFailed = steps.some((s) => s.step === "poller" && !s.ok);
-    return { ok: steps.filter((s) => s.step !== "poller").every((s) => s.ok), steps, needsReconnect: pollerFailed };
+    return {
+      ok: steps.filter((s) => s.step !== "poller").every((s) => s.ok),
+      steps,
+      needsReconnect: pollerFailed,
+      needsPairing: pairingPending,
+    };
   }
   const rs = runtimeScript(id, runtime);
   if (rs) {
@@ -688,7 +731,7 @@ export async function activateMember(db: Database, input: ActivateInput): Promis
         steps.push({ step: "skills", ok: skill.linked, detail: skill.detail });
         if (!skill.linked) return { ok: false, steps, error: `팀 버스 스킬 링크 실패 — ${skill.detail} (스킬 없이는 팀원이 메시지를 보낼 수 없습니다)` };
       }
-      if (!await pushEssentialStep(steps, { id, runtime })) return { ok: false, steps, error: `${runtime} 필수설정 누락 — 재활성화/설정 복구 필요` };
+      if (!(await pushEssentialStep(steps, { id, runtime })).ok) return { ok: false, steps, error: `${runtime} 필수설정 누락 — 재활성화/설정 복구 필요` };
     } catch (e) {
       steps.push({ step: "runtime", ok: false, detail: (e as Error).message });
       return { ok: false, steps, error: "런타임 스크립트 실행 오류" };

--- a/src/server/lib/activation.ts
+++ b/src/server/lib/activation.ts
@@ -201,12 +201,30 @@ export interface EssentialClassification {
   detail: string;
 }
 
+export interface EssentialTolerance {
+  tolerate?: string[];
+  tolerateWhenPairing?: string[];
+}
+
+/** ★claude_channel 활성화의 관용 정책 — 호출부와 테스트의 단일 출처★.
+ *  인라인 리터럴로 두면 ★호출부에서 옵션 하나만 지워도 어떤 테스트도 안 깨지는★ 갭이 생긴다
+ *  (Bill 교차검증 2026-07-25 M5a: tolerateWhenPairing 만 제거하면 essentials 가 하드실패로 돌아가
+ *   '필수설정 누락 — 재활성화 필요' 라는 원래 버그가 부활하는데 1631 테스트가 전부 통과했다).
+ *  판정부(classifyEssentials)만 고정하는 걸로는 부족하다 — ★그 함수를 어떤 옵션으로 부르는지★ 가
+ *  이 PR 의 계약이므로, 옵션 자체를 여기 한 곳에 두고 테스트가 이 상수를 통과시켜 검증한다.
+ *    · tolerate         : poller 미기동은 auto-reconnect 가 복구를 시도하므로 하드실패로 치지 않는다.
+ *    · tolerateWhenPairing: 첫 claude 멤버의 설계상 DM 페어링 대기일 때만 allowFrom 누락을 관용한다. */
+export const CLAUDE_ESSENTIAL_TOLERANCE: EssentialTolerance = {
+  tolerate: ["poller:"],
+  tolerateWhenPairing: ["allowFrom:"],
+};
+
 /** essentials 결과를 ★실패 / degraded / 페어링 대기★ 로 분류한다(순수 — 파일시스템·프로세스 접근 없음).
  *  pushEssentialStep 이 스텝을 push 하기 전에 쓰는 판정부를 분리한 것 = 활성화 전체를 돌리지 않고
  *  분류 규칙만 테스트로 고정할 수 있다(활성화는 tmux·launchd 를 건드려 유닛에서 못 돌린다). */
 export function classifyEssentials(
   essentials: EssentialCheckResult,
-  opts?: { tolerate?: string[]; tolerateWhenPairing?: string[] },
+  opts?: EssentialTolerance,
 ): EssentialClassification {
   const pendingPairing = essentials.pendingPairing === true;
   const tolerate = [...(opts?.tolerate ?? []), ...(pendingPairing ? opts?.tolerateWhenPairing ?? [] : [])];
@@ -236,7 +254,7 @@ export function classifyEssentials(
 async function pushEssentialStep(
   steps: ActivateResult["steps"],
   agent: { id: string; runtime: string; openclaw_agent_id?: string | null; hermes_profile?: string | null },
-  opts?: { tolerate?: string[]; tolerateWhenPairing?: string[] },
+  opts?: EssentialTolerance,
 ): Promise<{ ok: boolean; pendingPairing: boolean }> {
   const essentials = await checkEssentialSettings(agent as any);
   // ★degraded tolerate(2026-07-25 하네스 §4 fix)★: poller(bot.pid) 미기동은 poller 스텝이 이미 needs_reconnect 로
@@ -682,7 +700,7 @@ export async function activateMember(db: Database, input: ActivateInput): Promis
       //   ★tolerateWhenPairing(2026-07-25 맥스튜디오 실기)★: 첫 claude 멤버는 allowFrom 을 복사해올 참조봇이
       //   없어 access.json 이 pairing 대기로 시드된다 = 설계상 정상. 그걸 하드실패로 치면 봇이 살아 있는데도
       //   '활성화 실패 — 재시도 필요' 로 떠서, 재시도로는 절대 안 풀린다(해법은 봇에게 DM 1회).
-      const essentialsResult = await pushEssentialStep(steps, { id, runtime }, { tolerate: ["poller:"], tolerateWhenPairing: ["allowFrom:"] });
+      const essentialsResult = await pushEssentialStep(steps, { id, runtime }, CLAUDE_ESSENTIAL_TOLERANCE);
       if (!essentialsResult.ok) return { ok: false, steps, error: "claude 필수설정 누락 — 재활성화/설정 복구 필요" };
       pairingPending = essentialsResult.pendingPairing;
       // recall 주입(GD 2026-07-05): 활성화=새 claude 세션(맥락 빔)이니 --fresh 재시작과 동일하게 직전 대화 digest 주입.

--- a/src/server/lib/activation.ts
+++ b/src/server/lib/activation.ts
@@ -213,8 +213,12 @@ export function classifyEssentials(
   const hardMissing = essentials.missing.filter((m) => !tolerate.some((t) => m.startsWith(t)));
   const degraded = !essentials.ok && hardMissing.length === 0;
   const ok = essentials.ok || degraded;
-  // ★페어링 대기는 '관용된 누락이 allowFrom 뿐' 일 때만★ — 토큰·채널이 같이 빠졌으면 그건 진짜 실패다.
-  const pairingOnly = pendingPairing && degraded && essentials.missing.every((m) => m.startsWith("allowFrom:") || m.startsWith("poller:"));
+  // ★페어링 대기 = 관용 후 남은 하드 누락이 0 일 때만★ — 토큰·채널이 같이 빠지면 degraded 가 false 라
+  //   그대로 실패로 떨어진다(경계는 degraded 가 지킨다).
+  //   초안엔 여기에 `missing.every(allowFrom|poller)` 절이 더 있었지만, degraded 가 이미 '하드 누락 0' 을
+  //   뜻해서 claude 호출부에선 항상 참인 ★도달 불가한 중복★ 이었다 — Bill 교차검증에서 그 절만 지워도
+  //   어떤 테스트도 안 깨진다는 게 드러나 제거했다(내가 그 절이 잡힌다고 보고한 건 부정확했다).
+  const pairingOnly = pendingPairing && degraded;
   const degradedDetail = pairingOnly
     ? "필수설정 확인(토큰·채널) — DM 페어링 대기(첫 claude 멤버: 사람이 봇에게 DM 1회)"
     : "필수설정 확인(토큰·allowFrom·채널) — poller 는 needs_reconnect(자동 복구 시도 중)";

--- a/src/server/lib/runtimeEssentials.test.ts
+++ b/src/server/lib/runtimeEssentials.test.ts
@@ -187,4 +187,53 @@ describe("runtime essentials strategy registry", () => {
     expect(r.ok).toBe(true);
     expect(calls).toBe(3);
   });
+
+  // ── ★첫 claude 멤버의 DM 페어링 대기는 결함이 아니라 설계상 정상 경로★ (2026-07-25 맥스튜디오 실기) ──
+  //   allowFrom 은 '기존 claude 멤버의 것을 복사' 하는 방식이라 첫 멤버는 복사해올 데가 없다. 그래서
+  //   seedClaudeAccess 가 dmPolicy:"pairing" + allowFrom:[] 로 시드한다 = 사람이 DM 1회만 하면 끝난다.
+  //   이 상태와 ★진짜 설정 누락★(파일 부재·손상·다른 정책)을 구분하는 신호가 pendingPairing 이다.
+  describe("claude access.json — 페어링 대기 vs 진짜 누락", () => {
+    const claudeCase = async (access: string | null) => {
+      const { home, repo } = tmpRoot();
+      const id = "lisa";
+      const stateDir = join(home, ".claude/channels", `telegram-${id}`);
+      write(join(stateDir, ".env"), "TELEGRAM_BOT_TOKEN=123:abc\n");
+      if (access !== null) write(join(stateDir, "access.json"), access);
+      write(join(stateDir, "bot.pid"), "4242\n");
+      write(join(home, "Library/LaunchAgents", `com.${process.env.USER || "local"}.claude-telegram-${id}.plist`), "<plist />");
+      const registry = createRuntimeEssentialsRegistry({ home, repoRoot: repo, pidAlive: (pid) => pid === 4242 });
+      return await checkEssentialSettings({ id, runtime: "claude_channel" } as any, registry);
+    };
+
+    test("dmPolicy=pairing + allowFrom:[] → allowFrom 누락이되 pendingPairing (첫 멤버 정상 경로)", async () => {
+      const r = await claudeCase(JSON.stringify({ dmPolicy: "pairing", allowFrom: [], groups: {} }));
+      expect(r.ok).toBe(false);
+      expect(r.missing).toEqual(["allowFrom:claude access.json"]);
+      expect(r.pendingPairing).toBe(true);
+    });
+
+    test("access.json 부재 → 진짜 누락(pendingPairing 아님)", async () => {
+      const r = await claudeCase(null);
+      expect(r.missing).toContain("allowFrom:claude access.json");
+      expect(r.pendingPairing).toBe(false);
+    });
+
+    test("access.json 손상 → 진짜 누락(pendingPairing 아님)", async () => {
+      const r = await claudeCase('{"dmPolicy":"pairing", allowFrom');
+      expect(r.missing).toContain("allowFrom:claude access.json");
+      expect(r.pendingPairing).toBe(false);
+    });
+
+    test("dmPolicy=allowlist + allowFrom:[] → 페어링 대기 아님(승인 정책인데 비었다 = 진짜 문제)", async () => {
+      const r = await claudeCase(JSON.stringify({ dmPolicy: "allowlist", allowFrom: [] }));
+      expect(r.missing).toContain("allowFrom:claude access.json");
+      expect(r.pendingPairing).toBe(false);
+    });
+
+    test("allowFrom 승인 있음 → 누락 없음, pendingPairing 아님", async () => {
+      const r = await claudeCase(JSON.stringify({ dmPolicy: "allowlist", allowFrom: ["777"] }));
+      expect(r.ok).toBe(true);
+      expect(r.pendingPairing).toBe(false);
+    });
+  });
 });

--- a/src/server/lib/runtimeEssentials.ts
+++ b/src/server/lib/runtimeEssentials.ts
@@ -8,6 +8,13 @@ export interface EssentialCheckResult {
   ok: boolean;
   missing: string[];
   canAutoFix: boolean;
+  /** ★설계상 예정된 '사람 1회 조작 대기' 상태★ — 결함이 아니다.
+   *  claude_channel 첫 멤버는 allowFrom 을 복사해올 참조봇이 없어 access.json 이
+   *  `dmPolicy:"pairing", allowFrom:[]` 로 시드된다(launcher.seedClaudeAccess). 남은 일은
+   *  팀장이 그 봇에게 DM 을 한 번 보내는 것뿐이므로, 활성화를 '실패' 로 표시해선 안 된다.
+   *  (2026-07-25 맥스튜디오 실기 클린테스트: 첫 멤버가 '활성화 실패 — 재시도 필요' 로 떴는데
+   *   DM 한 통으로 재시도 없이 통과했다. 두 번째 멤버는 첫 멤버 것을 시드받아 DM 없이 통과.) */
+  pendingPairing?: boolean;
 }
 
 export interface RuntimeEssentials {
@@ -69,6 +76,16 @@ function hasJsonArrayKey(path: string, key: string, deps: Required<Pick<RuntimeE
   if (!obj || typeof obj !== "object") return false;
   const value = (obj as Record<string, unknown>)[key];
   return Array.isArray(value) && value.length > 0;
+}
+
+/** claude access.json 이 ★첫 멤버 페어링 대기★ 상태인가 — 파일이 정상 존재하고 dmPolicy 가 "pairing"
+ *  이며 allowFrom 이 ★빈 배열★ 인 경우만. 파일 부재·손상·다른 정책은 진짜 설정 누락이라 false. */
+function isClaudePairingPending(path: string, deps: Required<Pick<RuntimeEssentialDeps, "exists" | "readText">>): boolean {
+  if (!deps.exists(path)) return false;
+  const obj = parseJson(deps.readText(path));
+  if (!obj || typeof obj !== "object") return false;
+  const access = obj as Record<string, unknown>;
+  return access.dmPolicy === "pairing" && Array.isArray(access.allowFrom) && access.allowFrom.length === 0;
 }
 
 function hasDotenvKey(path: string, key: string, deps: Required<Pick<RuntimeEssentialDeps, "exists" | "readText">>): boolean {
@@ -137,14 +154,20 @@ export function createRuntimeEssentialsRegistry(deps: RuntimeEssentialDeps = {})
         botPid: `${stateDir}/bot.pid`,
         plist: `${d.home}/Library/LaunchAgents/${launchdPrefix()}.claude-telegram-${agent.id}.plist`,
       };
+      const accessFile = `${paths.stateDir}/access.json`;
       const missing: string[] = [];
       if (!hasDotenvKey(paths.envFile, "TELEGRAM_BOT_TOKEN", d)) missing.push("token:claude .env TELEGRAM_BOT_TOKEN");
-      if (!hasJsonArrayKey(`${paths.stateDir}/access.json`, "allowFrom", d)) missing.push("allowFrom:claude access.json");
+      let pendingPairing = false;
+      if (!hasJsonArrayKey(accessFile, "allowFrom", d)) {
+        missing.push("allowFrom:claude access.json");
+        // 첫 claude 멤버는 시드 원본이 없어 pairing 대기로 시작한다 = 설계상 정상 경로.
+        pendingPairing = isClaudePairingPending(accessFile, d);
+      }
       const marker = readPidMarker(paths.botPid, d);
       if (marker == null) missing.push("poller:claude bot.pid");
       else if (!d.pidAlive(marker.pid)) missing.push("poller:claude bot.pid not alive");
       if (!d.exists(paths.plist)) missing.push("channel:claude LaunchAgent plist");
-      return result(missing, missing.length > 0);
+      return { ...result(missing, missing.length > 0), pendingPairing };
     }
   }
 

--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -876,7 +876,14 @@ describe("영입 OT / 능력 카탈로그", () => {
     expect(joinStep.detail).toContain("거의 완료 — 마지막 한 단계");
     expect(joinStep.detail).toMatch(/@[a-z0-9_]+에게/i); // 봇 username 이 찍히고 조사 앞에 공백이 없다
     expect(joinStep.detail).not.toContain("<bot_username>");
-    expect(joinStep.detail).not.toContain(" 에게");
+    // ★조사 앞 공백 검사는 사용자에게 나가는 문자열 ★전부★ 에 건다★ — joinStep.detail 만 보면
+    //   pairing_hint 가 ' 에게' 인 채로 남는다(Bill 지적: 절반만 고쳐졌다).
+    for (const text of [joinStep.detail, body.pairing_hint]) {
+      expect(text).not.toContain(" 에게");
+      expect(text).not.toContain(" 에서");
+      expect(text).not.toContain("DM 을");
+    }
+    expect(body.pairing_hint).toMatch(/@[a-z0-9_]+에게/i);
   });
 
   test("activate: 중앙 팀원 상한 가드 실패를 409로 전달", async () => {

--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -615,6 +615,24 @@ describe("영입 OT / 능력 카탈로그", () => {
     expect(body.message).toContain("먼저 팀명·팀장ID·팀장이름 세팅");
     expect(body.missing.owner_name).toBe(true);
   });
+
+  // ★'팀장ID' 가 뭔지 응답만 보고 알 수 있어야 한다★ (2026-07-25 맥스튜디오 실기).
+  //   전엔 placeholder 가 웹 UI 에만 있어서, API 응답만 본 사용자는 소스를 읽어야 알 수 있었다.
+  //   사용자가 코드를 읽어야 아는 건 결함이다 — 필드별 hint 를 응답에 싣는다.
+  test("setup_incomplete 응답에 필드별 hint — lead_id 는 형식 규칙 + 예시까지", async () => {
+    const { app } = setup();
+    const r = await app.request("/members/recruit", json({ id: "lui", display_name: "Lui", role: "fullstack", runtime: "openclaw" }));
+    const body = await r.json();
+    expect(Object.keys(body.hints).sort()).toEqual(["lead_id", "owner_name", "team_name"]);
+    expect(body.hints.lead_id).toContain("소문자/숫자/-/_, 1~40자");
+    expect(body.hints.lead_id).toContain("예: gd");
+    expect(body.hints.team_name).toContain("예:");
+    expect(body.hints.owner_name).toContain("예:");
+    // missing 인 필드에 대응하는 hint 가 반드시 있어야 한다(빠진 필드만 보고 hint 가 없으면 무용).
+    for (const [field, isMissing] of Object.entries(body.missing)) {
+      if (isMissing) expect(typeof body.hints[field]).toBe("string");
+    }
+  });
   test("capabilities 카탈로그", async () => {
     const { app } = setup();
     const caps = (await (await app.request("/capabilities")).json()) as any[];

--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -817,6 +817,68 @@ describe("영입 OT / 능력 카탈로그", () => {
     expect(joinStep.detail).toContain("subscription_needed");
     expect(body.ot.stage).toBe("join");
   });
+  // ── ★페어링 안내가 '더 먼저 풀어야 하는 차단'을 덮으면 안 된다★ (Bill 교차검증 2026-07-25) ──
+  //   DM 을 보낸다고 결제 문제가 풀리지 않는다. 페어링 안내를 앞에 두면 '따라 해도 절대 안 풀리는 안내' 라는
+  //   ★이 PR 이 없애려던 바로 그 패턴★ 이 다른 조합에서 재현된다. 순서: 구독차단 → 첫콜실패 → 페어링대기.
+  const pairingActivate = async () => ({
+    ok: true,
+    needsPairing: true,
+    steps: [{ step: "runtime", ok: true, detail: "mock runtime" }, { step: "bus-wake", ok: true, detail: "mock wake" }],
+  });
+  const authOkFn = async (runtime: string) => ({ runtime, loggedIn: true, detail: "auth ok", fixHint: "" });
+  const activateThenProvision = async (app: any, id: string, runtime: string) => {
+    const { ot_id } = await (await app.request("/members/recruit", json({ id, display_name: id, role: "dev", runtime }))).json();
+    expect((await app.request(`/ot/${ot_id}/provision`, json({ bot_token: "1234567:" + "A".repeat(35) }))).status).toBe(200);
+    return await (await app.request(`/ot/${ot_id}/activate`, json({}))).json();
+  };
+
+  test("★페어링 대기 + 구독/한도 실패 → 구독 차단이 이긴다★ (페어링은 병기하되 감추지 않는다)", async () => {
+    const quotaFail = async (input: { id: string; runtime: string }) => ({
+      runtime: input.runtime, ok: false, subscriptionNeeded: true, detail: "429 insufficient_quota billing",
+    });
+    const { app } = setupReady(AGENTS, { checkRuntimeAuth: authOkFn, activateMember: pairingActivate, firstModelCall: quotaFail, validateBotToken: okBotToken });
+    const body = await activateThenProvision(app, "lisa", "claude_channel");
+
+    expect(body.ok).toBe(false);                    // 구독 문제는 '거의 완료' 가 아니다
+    expect(body.subscription_needed).toBe(true);
+    expect(body.error).toBe("subscription_needed");
+    const joinStep = body.ot.steps.find((s: any) => s.key === "join");
+    expect(joinStep.state).toBe("blocked");
+    expect(joinStep.detail).toContain("subscription_needed");
+    expect(joinStep.detail).toContain("결제/구독");
+    expect(joinStep.detail).toContain("페어링도 남아 있습니다"); // 사실이니 병기는 한다
+    expect(joinStep.detail).not.toContain("거의 완료");          // 다만 '거의 완료' 로 읽히면 안 된다
+  });
+
+  test("페어링 대기 + 구독 무관 첫 모델호출 실패 → 페어링 안내가 실패를 가리지 않는다", async () => {
+    const plainFail = async (input: { id: string; runtime: string }) => ({
+      runtime: input.runtime, ok: false, subscriptionNeeded: false, detail: "첫 호출 응답 없음",
+    });
+    const { app } = setupReady(AGENTS, { checkRuntimeAuth: authOkFn, activateMember: pairingActivate, firstModelCall: plainFail, validateBotToken: okBotToken });
+    const body = await activateThenProvision(app, "jane", "claude_channel");
+
+    const joinStep = body.ot.steps.find((s: any) => s.key === "join");
+    expect(joinStep.state).not.toBe("done");
+    expect(joinStep.detail).not.toContain("거의 완료");
+    expect(joinStep.detail).toContain("페어링도 남아 있습니다");
+  });
+
+  test("페어링 대기 + 첫 모델호출 성공 → '거의 완료 — 마지막 한 단계' 안내(봇 username 포함, 조사 앞 공백 없음)", async () => {
+    const callOk = async (input: { id: string; runtime: string }) => ({ runtime: input.runtime, ok: true, subscriptionNeeded: false, detail: "첫 호출 확인" });
+    const { app } = setupReady(AGENTS, { checkRuntimeAuth: authOkFn, activateMember: pairingActivate, firstModelCall: callOk, validateBotToken: okBotToken });
+    const body = await activateThenProvision(app, "mina", "claude_channel");
+
+    expect(body.ok).toBe(true);
+    expect(body.needs_pairing).toBe(true);
+    expect(body.pairing_hint).toContain("DM");
+    const joinStep = body.ot.steps.find((s: any) => s.key === "join");
+    expect(joinStep.state).toBe("pending");        // 실패(blocked)도, 완료(done)도 아니다
+    expect(joinStep.detail).toContain("거의 완료 — 마지막 한 단계");
+    expect(joinStep.detail).toMatch(/@[a-z0-9_]+에게/i); // 봇 username 이 찍히고 조사 앞에 공백이 없다
+    expect(joinStep.detail).not.toContain("<bot_username>");
+    expect(joinStep.detail).not.toContain(" 에게");
+  });
+
   test("activate: 중앙 팀원 상한 가드 실패를 409로 전달", async () => {
     const authOk = async (runtime: string) => ({ runtime, loggedIn: true, detail: "auth ok", fixHint: "" });
     const activateLimited = async () => ({

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1686,20 +1686,30 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
           detail: firstCall.subscriptionNeeded ? "subscription_needed: 구독/한도 확인 필요" : firstCall.detail,
         });
       }
-      if (result.needsPairing && result.ok) {
+      // ★분기 순서 = 사용자가 먼저 해결해야 하는 것 순★ (Bill 교차검증 2026-07-25).
+      //   페어링 안내를 앞에 두면 '페어링 대기 + 구독/한도 실패' 조합에서 결제 문제를 덮어버린다 —
+      //   DM 을 보낸다고 결제가 풀리지 않으니, 이 PR 이 없애려던 바로 그 패턴('따라 해도 안 풀리는 안내')이
+      //   다른 조합에서 재현된다. 그래서 ①확정 차단(구독/한도) ②첫 모델호출 실패 ③페어링 대기 순으로 본다.
+      //   페어링은 감추지 않고 ★병기★ 한다 — 둘 다 사실이고, 둘 다 해야 끝난다.
+      const pairingNote = result.needsPairing
+        ? ` (첫 연결 페어링도 남아 있습니다: Telegram 에서 ${botMention}에게 DM 을 한 번 보내주세요.)`
+        : "";
+      const firstCallFailed = firstCall != null && !firstCall.ok;
+      if (firstCall?.subscriptionNeeded) {
+        jn.state = "blocked";
+        jn.detail = "subscription_needed: 구독 또는 사용 한도 때문에 첫 모델 호출이 실패했습니다. 결제/구독 상태를 확인한 뒤 다시 활성화하세요." + pairingNote;
+      } else if (result.needsPairing && result.ok && !firstCallFailed) {
         // ★실패가 아니라 '거의 완료 — 마지막 한 단계'★. 첫 claude 멤버는 allowFrom 을 복사해올 참조봇이
         //   없어 DM 페어링 1회가 필요하다(두 번째 멤버부터는 첫 멤버 것을 시드받아 자동 통과). 재시도로는
         //   안 풀리는 상태라 '재시도 필요' 로 안내하면 사용자를 헛돌게 만든다.
         jn.state = "pending";
-        jn.detail = `거의 완료 — 마지막 한 단계: Telegram 에서 ${botMention} 에게 DM 을 한 번 보내주세요(첫 연결 페어링). 승인하면 바로 연결됩니다. 다음 팀원부터는 이 단계가 없습니다.`;
+        jn.detail = `거의 완료 — 마지막 한 단계: Telegram 에서 ${botMention}에게 DM 을 한 번 보내주세요(첫 연결 페어링). 승인하면 바로 연결됩니다. 다음 팀원부터는 이 단계가 없습니다.`;
       } else if (result.ok && noPairingRuntime && (!firstCallRuntime || firstCall?.ok)) {
         const rtLabel = agent.runtime === "codex" ? "codex 브릿지" : agent.runtime === "claude_channel" ? "claude 봇" : "hermes 게이트웨이";
-        jn.state = "done"; jn.detail = `활성화됨 (${rtLabel} 가동 + 첫 모델 호출 확인) — 합류. 이제 Telegram에서 ${botMention} 에게 DM으로 인사해 보세요. 답이 오면 연동 성공입니다.`;
-      } else if (firstCall?.subscriptionNeeded) {
-        jn.state = "blocked";
-        jn.detail = "subscription_needed: 구독 또는 사용 한도 때문에 첫 모델 호출이 실패했습니다. 결제/구독 상태를 확인한 뒤 다시 활성화하세요.";
+        jn.state = "done"; jn.detail = `활성화됨 (${rtLabel} 가동 + 첫 모델 호출 확인) — 합류. 이제 Telegram에서 ${botMention}에게 DM으로 인사해 보세요. 답이 오면 연동 성공입니다.`;
       } else {
-        jn.detail = result.ok ? "활성화됨 — 첫 모델 호출 확인/첫 응답(ack) 대기" : "활성화 대기";
+        // 구독 무관 첫 모델호출 실패도 여기로 온다 — 페어링 안내로 가리지 않고, 페어링은 병기만 한다.
+        jn.detail = (result.ok ? "활성화됨 — 첫 모델 호출 확인/첫 응답(ack) 대기" : "활성화 대기") + pairingNote;
       }
     }
     parsed.steps = steps;

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -111,6 +111,15 @@ function pickIcon(list: any[], requested: string): string {
 }
 const ID_RE = /^[a-z][a-z0-9_-]{1,31}$/;
 const LEAD_ID_RE = /^[a-z0-9_-]{1,40}$/;
+/** setup_incomplete 응답에 실어 보내는 필드별 안내 — ★단일 출처★.
+ *  lead_id 문구는 lead_id_invalid 검증 응답의 hint 와 같은 규칙을 쓴다(두 곳이 갈라지지 않게).
+ *  웹 UI placeholder 만 알고 API 응답은 모르던 갭을 닫는다(2026-07-25 맥스튜디오 실기). */
+const LEAD_ID_RULE = "소문자/숫자/-/_, 1~40자";
+const SETUP_FIELD_HINTS: Record<string, string> = {
+  team_name: "팀 이름 — 자유 텍스트, 예: b3rys",
+  lead_id: `팀장 ID — ${LEAD_ID_RULE}, 예: gd (팀장을 가리키는 짧은 식별자)`,
+  owner_name: "팀장 이름 — 팀원들이 부를 호칭, 예: GD",
+};
 const SLACK_USER_ID_RE = /^U[A-Z0-9]{8,}$/;
 const SLACK_APP_ID_RE = /^A[A-Z0-9]{8,}$/;
 const SLACK_BOT_TOKEN_RE = /^xoxb-[A-Za-z0-9-]+$/;
@@ -363,7 +372,7 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     }
     if (body.lead_id !== undefined) {
       if (typeof body.lead_id !== "string" || !LEAD_ID_RE.test(body.lead_id.trim()))
-        return c.json({ error: "lead_id_invalid", hint: "소문자/숫자/-/_, 1~40자" }, 400);
+        return c.json({ error: "lead_id_invalid", hint: LEAD_ID_RULE }, 400);
       const v = body.lead_id.trim();
       setSetting(db, "lead_id", v);
       out.lead_id = v;
@@ -1044,6 +1053,10 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
           lead_id: !getSetting(db, "lead_id")?.trim(),
           owner_name: !getSetting(db, "owner_name")?.trim(),
         },
+        // ★필드별 hint 를 응답에 실어 보낸다★ — 특히 '팀장ID' 는 이름만으로 뭘 넣는지 알 수 없다.
+        //   전엔 placeholder 가 웹 UI 에만 있어서, API 응답만 본 사용자는 ★소스를 읽어야★ 알 수 있었다
+        //   (2026-07-25 맥스튜디오 실기). 사용자가 코드를 읽어야 아는 건 결함이다.
+        hints: SETUP_FIELD_HINTS,
       }, 400);
     }
     const id = typeof body.id === "string" ? body.id.trim().toLowerCase() : "";
@@ -1548,6 +1561,17 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     } catch {
       return c.json({ error: "store_failed", hint: "토큰 저장에 실패했어요. 잠시 후 다시 시도해 주세요." }, 500);
     }
+    // ★getMe 로 검증된 봇 username 을 레지스트리에 영속화★ — 안내 문구가 '@<bot_username>' 같은
+    //   미치환 플레이스홀더로 나가지 않게 하는 단일 출처다(2026-07-25 실기: 사용자는 어느 봇에 DM 할지
+    //   알 수 없었다). 공개값이라 노출 안전(토큰은 파일로만). best-effort — 실패해도 영입은 계속.
+    try {
+      const list = readAgents();
+      const target = list.find((a: any) => a.id === row.member_id);
+      if (target && live.username && target.telegram_bot_username !== live.username) {
+        target.telegram_bot_username = live.username;
+        writeAgents(list);
+      }
+    } catch { /* best-effort — 안내 문구가 username 없이 나갈 뿐 */ }
     // 단계 진행: provision done, bundle done(자료 준비). join 은 런타임 기동 후 첫 ack 시.
     const steps = Array.isArray(parsed.steps) ? parsed.steps : initOtSteps();
     const pv = steps.find((s: any) => s.key === "provision"); if (pv) { pv.state = "done"; pv.detail = `봇 토큰 연결됨 (@${live.username})`; } // getMe로 검증된 실제 봇 username — 긍정 증거(공개값이라 노출 안전)
@@ -1644,6 +1668,9 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     const pf = steps.find((s: any) => s.key === "preflight"); if (pf) { pf.state = "done"; pf.detail = "런타임 인증 확인됨"; }
     const bd = steps.find((s: any) => s.key === "bundle");
     if (bd) { bd.state = result.ok ? "done" : "pending"; bd.detail = result.ok ? "런타임 활성화 + 팀지식 주입 완료" : "활성화 실패 — 재시도 필요"; }
+    // ★첫 claude 멤버 DM 페어링 안내(2026-07-25 맥스튜디오 실기)★ — 봇 username 은 provision 의 getMe 로
+    //   레지스트리에 저장돼 있다. 없으면 '봇' 으로만 안내한다(플레이스홀더를 그대로 내보내지 않는다).
+    const botMention = agent.telegram_bot_username ? `@${agent.telegram_bot_username}` : "봇";
     const jn = steps.find((s: any) => s.key === "join");
     if (jn) {
       // codex/claude/hermes 는 openclaw 같은 pairing 게이트가 없다 → preflight 인증 통과 + 봇/브릿지 기동 성공 =
@@ -1659,9 +1686,15 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
           detail: firstCall.subscriptionNeeded ? "subscription_needed: 구독/한도 확인 필요" : firstCall.detail,
         });
       }
-      if (result.ok && noPairingRuntime && (!firstCallRuntime || firstCall?.ok)) {
+      if (result.needsPairing && result.ok) {
+        // ★실패가 아니라 '거의 완료 — 마지막 한 단계'★. 첫 claude 멤버는 allowFrom 을 복사해올 참조봇이
+        //   없어 DM 페어링 1회가 필요하다(두 번째 멤버부터는 첫 멤버 것을 시드받아 자동 통과). 재시도로는
+        //   안 풀리는 상태라 '재시도 필요' 로 안내하면 사용자를 헛돌게 만든다.
+        jn.state = "pending";
+        jn.detail = `거의 완료 — 마지막 한 단계: Telegram 에서 ${botMention} 에게 DM 을 한 번 보내주세요(첫 연결 페어링). 승인하면 바로 연결됩니다. 다음 팀원부터는 이 단계가 없습니다.`;
+      } else if (result.ok && noPairingRuntime && (!firstCallRuntime || firstCall?.ok)) {
         const rtLabel = agent.runtime === "codex" ? "codex 브릿지" : agent.runtime === "claude_channel" ? "claude 봇" : "hermes 게이트웨이";
-        jn.state = "done"; jn.detail = `활성화됨 (${rtLabel} 가동 + 첫 모델 호출 확인) — 합류. 이제 Telegram에서 @<bot_username>에게 DM으로 인사해 보세요. 답이 오면 연동 성공입니다.`;
+        jn.state = "done"; jn.detail = `활성화됨 (${rtLabel} 가동 + 첫 모델 호출 확인) — 합류. 이제 Telegram에서 ${botMention} 에게 DM으로 인사해 보세요. 답이 오면 연동 성공입니다.`;
       } else if (firstCall?.subscriptionNeeded) {
         jn.state = "blocked";
         jn.detail = "subscription_needed: 구독 또는 사용 한도 때문에 첫 모델 호출이 실패했습니다. 결제/구독 상태를 확인한 뒤 다시 활성화하세요.";
@@ -1674,7 +1707,16 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     db.query("UPDATE ot SET steps_json = ?, stage = ?, updated_at = datetime('now') WHERE id = ?").run(JSON.stringify(parsed), stage, ot_id);
     const subscriptionNeeded = steps.some((s: any) => s.key === "join" && s.state === "blocked" && /subscription_needed/i.test(String(s.detail ?? "")));
     appendAudit(db, "user", result.ok ? "ot_activated" : "ot_activate_failed", row.member_id, { ot_id, steps: result.steps.map((s) => ({ step: s.step, ok: s.ok })) });
-    return c.json({ ok: result.ok && !subscriptionNeeded, subscription_needed: subscriptionNeeded, error: subscriptionNeeded ? "subscription_needed" : result.error, steps: result.steps, ot: { ot_id, member_id: row.member_id, stage, steps } }, result.ok || subscriptionNeeded ? 200 : result.code === "member_limit" ? 409 : 502);
+    return c.json({
+      ok: result.ok && !subscriptionNeeded,
+      subscription_needed: subscriptionNeeded,
+      // 첫 claude 멤버 DM 페어링 대기 — 실패가 아니라 사람이 할 마지막 한 단계. hint 에 봇 username 을 실어 보낸다.
+      needs_pairing: result.needsPairing === true,
+      ...(result.needsPairing ? { pairing_hint: `${botMention} 에게 Telegram DM 을 한 번 보내주세요(첫 연결 페어링). 다음 팀원부터는 이 단계가 없습니다.` } : {}),
+      error: subscriptionNeeded ? "subscription_needed" : result.error,
+      steps: result.steps,
+      ot: { ot_id, member_id: row.member_id, stage, steps },
+    }, result.ok || subscriptionNeeded ? 200 : result.code === "member_limit" ? 409 : 502);
   });
 
   // ── preflight 재확인: GD가 터미널에서 codex login / claude 로그인한 직후 즉시 재점검 ──

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1692,7 +1692,7 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
       //   다른 조합에서 재현된다. 그래서 ①확정 차단(구독/한도) ②첫 모델호출 실패 ③페어링 대기 순으로 본다.
       //   페어링은 감추지 않고 ★병기★ 한다 — 둘 다 사실이고, 둘 다 해야 끝난다.
       const pairingNote = result.needsPairing
-        ? ` (첫 연결 페어링도 남아 있습니다: Telegram 에서 ${botMention}에게 DM 을 한 번 보내주세요.)`
+        ? ` (첫 연결 페어링도 남아 있습니다: Telegram에서 ${botMention}에게 DM을 한 번 보내주세요.)`
         : "";
       const firstCallFailed = firstCall != null && !firstCall.ok;
       if (firstCall?.subscriptionNeeded) {
@@ -1703,7 +1703,7 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
         //   없어 DM 페어링 1회가 필요하다(두 번째 멤버부터는 첫 멤버 것을 시드받아 자동 통과). 재시도로는
         //   안 풀리는 상태라 '재시도 필요' 로 안내하면 사용자를 헛돌게 만든다.
         jn.state = "pending";
-        jn.detail = `거의 완료 — 마지막 한 단계: Telegram 에서 ${botMention}에게 DM 을 한 번 보내주세요(첫 연결 페어링). 승인하면 바로 연결됩니다. 다음 팀원부터는 이 단계가 없습니다.`;
+        jn.detail = `거의 완료 — 마지막 한 단계: Telegram에서 ${botMention}에게 DM을 한 번 보내주세요(첫 연결 페어링). 승인하면 바로 연결됩니다. 다음 팀원부터는 이 단계가 없습니다.`;
       } else if (result.ok && noPairingRuntime && (!firstCallRuntime || firstCall?.ok)) {
         const rtLabel = agent.runtime === "codex" ? "codex 브릿지" : agent.runtime === "claude_channel" ? "claude 봇" : "hermes 게이트웨이";
         jn.state = "done"; jn.detail = `활성화됨 (${rtLabel} 가동 + 첫 모델 호출 확인) — 합류. 이제 Telegram에서 ${botMention}에게 DM으로 인사해 보세요. 답이 오면 연동 성공입니다.`;
@@ -1722,7 +1722,7 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
       subscription_needed: subscriptionNeeded,
       // 첫 claude 멤버 DM 페어링 대기 — 실패가 아니라 사람이 할 마지막 한 단계. hint 에 봇 username 을 실어 보낸다.
       needs_pairing: result.needsPairing === true,
-      ...(result.needsPairing ? { pairing_hint: `${botMention} 에게 Telegram DM 을 한 번 보내주세요(첫 연결 페어링). 다음 팀원부터는 이 단계가 없습니다.` } : {}),
+      ...(result.needsPairing ? { pairing_hint: `${botMention}에게 Telegram DM을 한 번 보내주세요(첫 연결 페어링). 다음 팀원부터는 이 단계가 없습니다.` } : {}),
       error: subscriptionNeeded ? "subscription_needed" : result.error,
       steps: result.steps,
       ot: { ot_id, member_id: row.member_id, stage, steps },


### PR DESCRIPTION
Bill 맥스튜디오 실기 클린테스트 결함 2건. 둘 다 PR#47 과 같은 유형 — **정상 상태를 결함으로 표시**.

## 결함 1 (심각) — 첫 claude 팀원 활성화가 '실패' 로 표시된다

봇은 정상 기동했는데(runtime OK · poller OK · 토큰 OK) essentials 의 `allowFrom` 누락 하나로 `claude 필수설정 누락 — 재활성화/설정 복구 필요` + OT `활성화 실패 — 재시도 필요` 가 떴다.

**근본**: allowFrom 자동 시드는 **기존 claude 멤버의 access.json 을 복사**하는 방식이라 첫 멤버는 복사해올 데가 없다 (`launcher.seedClaudeAccess` → `dmPolicy:"pairing", allowFrom:[]`). 즉 **설계상 예정된 정상 경로**이고 남은 일은 사람이 봇에게 DM 1회 — **재시도로는 절대 안 풀린다**.

| 계층 | 변경 |
|---|---|
| `runtimeEssentials.ts` | `access.json` 이 `dmPolicy:"pairing"` + `allowFrom:[]` 일 때만 `pendingPairing` 신호. 파일 부재·손상·다른 정책은 진짜 누락이라 종전대로 하드실패 |
| `activation.ts` | 판정부를 순수 함수 `classifyEssentials` 로 분리(활성화 전체는 tmux·launchd 를 타서 유닛 불가) + `tolerateWhenPairing` 으로 **페어링 대기일 때 allowFrom 에만** 관용. 토큰·채널이 같이 빠지면 관용 안 함(`pairingOnly` 경계) |
| `ActivateResult` | `needsPairing` 추가 → 라우트가 OT join 을 `pending: 거의 완료 — 마지막 한 단계` 로 표시, 응답에 `needs_pairing` + `pairing_hint` |
| 안내 문구 | **봇 username 을 찍는다** — provision 의 `getMe` 결과를 레지스트리 `telegram_bot_username` 에 영속화(단일 출처) |

> 덤: join 문구에 하드코딩돼 있던 미치환 플레이스홀더 `@<bot_username>` 도 실제 값으로 바뀐다 — 사용자가 어느 봇에 DM 할지 알 수 없던 문제.

## 결함 2 (중간) — '팀장ID' 가 뭔지 응답만 보고 알 수 없다

`setup_incomplete` 는 `missing` 필드만 주고 placeholder 는 웹 UI 에만 있었다 → **API 응답만 본 사용자는 소스를 읽어야** 알았다. 사용자가 코드를 읽어야 아는 건 결함이다.

- `hints` 를 응답에 싣는다
- `lead_id` 문구는 `lead_id_invalid` 검증 응답과 **같은 상수**(`LEAD_ID_RULE`)로 단일화 — 두 곳이 갈라지지 않게

## 검증 — mutation 되돌림으로 테스트가 실제로 잡는지 확인

| mutation | 결과 |
|---|---|
| `pendingPairing` 신호 제거 | 1건 fail |
| `tolerateWhenPairing` 관용 제거 | 3건 fail |
| `pairingOnly` 경계 제거(다른 누락도 페어링으로 위장) | 2건 fail |
| `setup_incomplete` hints 제거 | 1건 fail |

- 신규 테스트 13건 (essentials 5 · classifyEssentials 7 · setup hint 1)
- `bun test src/server src/web`: 1578 pass / 5 skip / 6 fail — 사전 실패 6건과 동일(회귀 0)
- `tsc --noEmit` 통과

## 검증 안 한 범위

- **실기 재현(맥스튜디오에서 첫 멤버 영입 e2e)** — 활성화는 tmux·launchd·실제 봇 토큰을 타서 이 머신에서 돌리면 라이브를 건드린다. 판정 규칙·응답 형태까지만 유닛으로 고정했다. 실기 확인은 Bill 쪽 재검증에 부탁한다
- 대시보드 UI 렌더(`join` 이 `pending` 상태로 어떻게 보이는지) — OT 응답 JSON 까지만 검증
- `first-model-call` 이 비대화형 세션(ssh)에서 macOS Keychain 때문에 거짓 실패하는 건 이 PR 범위 밖(Bill 확인: 실사용자 미해당, CI·자동화에선 발생)

## 롤백

`git revert` 1커밋. 스키마 변경 없음. `telegram_bot_username` 영속화는 기존 필드에 값을 채우는 것뿐(읽는 쪽은 이미 null 허용).