### PR TITLE
docs(skill): 영입 스킬이 실재하는 정본을 가리키게 — 없는 문서 참조 제거

### DIFF
--- a/skills/b3os-team-member-lifecycle/SKILL.md
+++ b/skills/b3os-team-member-lifecycle/SKILL.md
@@ -7,11 +7,31 @@ description: Use when adding, testing, disabling, offboarding, or archiving a b3
 
 Use this skill for team-member onboarding(영입), offboarding(퇴사/비활성화), runtime migration(실행 환경 이전), and lifecycle dry-runs.
 
-Authoritative context:
-- Team rules: `<repo>/rules/TEAM-OS.md`
-- Shared state: `<repo>/rules/SHARED.md`
-- Existing guide: `<repo>/docs/TEAM_MEMBER_ONBOARDING.md`
-- Registry: `<repo>/agents.json`
+## Onboarding(영입) — do NOT execute this file's checklist
+
+**The recruit flow is documented in full elsewhere, and that documentation is the current one. Go there first.**
+
+| What you need | Where |
+|---|---|
+| The recruit flow itself — dashboard wizard **and** API, OT stages, pairing | `skills/b3os/references/recruit.md` |
+| Runtime prerequisites — install, auth, what preflight actually checks | `skills/b3os/references/runtime-setup.md` |
+| A member that joined but won't answer | `skills/b3os/references/troubleshooting.md` |
+
+Fastest path is the dashboard: **Settings ▸ + 영입**. One form takes `id`, name, role, runtime, mention aliases and persona together; the bot token and the rest are collected during provisioning.
+
+For BYO runtimes (Hermes / OpenClaw) the runtime picker shows a setup link — **follow it before recruiting.** Preflight blocks activation until that runtime's auth exists, and finding that out mid-recruit wastes a cycle.
+
+The numbered onboarding steps further down are a **policy checklist, not a procedure**: read them for the gates the recruit flow does not decide for you (owner routing, context visibility, approval boundaries).
+
+Authoritative context — note which of these a fresh clone actually has:
+
+| File | Present in a fresh clone? |
+|---|---|
+| `<repo>/rules/SHARED.md` | yes |
+| `<repo>/rules/TEAM-OS.md` | **no** — render output, generated at startup from `rules/TEAM-OS.template.ko.md`. Edit the template, never the output. |
+| `<repo>/agents.json` | **no** — per-machine roster, deliberately untracked. `loadRegistry` returns `[]` until someone is recruited. |
+
+Never tell a reader to open a file their clone does not have.
 
 ## Principles
 
@@ -56,10 +76,15 @@ For every new runtime, verify the same owner policy at every possible inbound pa
 - context visibility: specialists receive only addressed message/reply context by default. Full team context is for approved coordinator roles.
 - observed context: disable gateway features that store unmentioned team-room messages unless the team lead explicitly approves them for the member's role.
 
-## Onboarding Workflow
+## Onboarding Policy Checklist
+
+> These are **gates to verify**, not steps to type. The actual recruit procedure lives in
+> `skills/b3os/references/recruit.md`; steps 1–6 below are handled by the dashboard form and
+> provisioning. Read them to know **what the flow assumes**, and spend your attention on 7–14,
+> which the flow does not decide for you.
 
 1. Define identity: `id`, display name, Korean name, role, aliases, owner, intended permanence.
-2. Choose runtime.
+2. Choose runtime. **BYO runtimes need their auth in place first** — see `runtime-setup.md`.
 3. Prepare workspace/persona; reference TEAM-OS and SHARED instead of copying common rules.
 4. Connect credentials/channel; store tokens only in approved runtime env/credential locations.
 5. For OpenClaw agents, verify `openclaw.json` Telegram account + `tokenFile` registration. The team-collab bridge reads this token for group reactions and visible replies.
@@ -128,10 +153,3 @@ Blocked: missing credentials, bot invite, service restart approval, etc.
 Rollback: how to undo safely
 Next: one concrete next step
 ```
-
-## Current Planned Cases
-
-- Temporary Claude Code channel member: first lifecycle rehearsal for external-user reproducibility; test onboard, verify, then offboard before developer live activation.
-- Skill hardening step: after the temporary Claude rehearsal, update this skill with any missing checks, unsafe ordering, offboarding gaps, approval gates, and verification evidence before using it for developer.
-- New developer agent: runtime OpenClaw (model-hosted); model-based Staff Engineer and primary development executor for design support, implementation, refactoring, tests, debugging, and code-review response; prefer a dedicated Telegram bot. Use this skill for a developer agent only after the temporary rehearsal lessons are folded back in.
-- Project-loop validation: use the temporary Claude test to validate lifecycle mechanics, then use developer-agent onboarding as the first real `b3rys-project-loop` handoff. The coordinator PMs the lifecycle, the developer agent takes development execution after activation, the maintainer reviews ops/infra gates, and the specialist stays reserved for search/AI-specialized work.


### PR DESCRIPTION
## 왜

팀장님이 "b3os 스킬 가이드가 심플하게 안내하는지 봐달라" 하셔서 검토했습니다. 답은 **아니오**였고, 이유가 예상과 달랐습니다.

**안내가 없는 게 아니라 두 벌이고, 이 스킬이 낡은 쪽이었습니다.**

- `skills/b3os/references/recruit.md` (201줄) — 대시보드 마법사 + API + OT 단계 + 페어링까지 완비
- `skills/b3os/references/runtime-setup.md` — 런타임별 설치·인증·preflight 조건까지 상세
- `skills/b3os-team-member-lifecycle/SKILL.md` — **위 둘을 한 번도 가리키지 않고** 자기 버전 14단계를 따로 보유

읽는 사람은 쉬운 길이 있는 줄 모르고 어려운 길을 안내받습니다.

그리고 정본이라며 가리키는 `docs/TEAM_MEMBER_ONBOARDING.md` 는 **존재하지 않습니다.** PR#51 이 정리한 "clone 에 없는 대상을 실행하라고 시키는" 결함과 같은 계열이 스킬에 남아 있었습니다.

> 실제로 오늘 hermes 영입을 준비하다 저 자신이 `runtime-setup.md` 를 못 찾고 라이브 상태만 보고 인증 방식을 **잘못 추측**했습니다. 문서가 없어서가 아니라 연결이 없어서였습니다.

## 무엇을 바꿨나

- 맨 앞에 **"영입은 여기서 하지 마라"** 라우팅 표 — recruit / runtime-setup / troubleshooting 로 보냅니다
- **대시보드 빠른 경로** 명시 (`Settings ▸ + 영입`). 폼이 id·이름·역할·런타임·별칭·페르소나를 한 번에 받는다는 사실을 적었습니다
- **BYO 런타임은 영입 *전에* auth 준비** — preflight 가 막으므로 영입 도중에 알면 한 사이클을 버립니다
- 14단계는 **"policy checklist, not a procedure"** 로 성격을 못박고, 1~6 은 대시보드가 처리하니 7~14(오너 라우팅·컨텍스트 가시성·승인 경계)에 집중하도록
- **clone 에 있는 파일 / 없는 파일을 표로 구분** — `rules/TEAM-OS.md`(렌더 산출물, 소스=template) 와 `agents.json`(머신별 로스터) 둘 다 fresh clone 에 없는데 정본이라 부르고 있었습니다
- 끝난 일이 된 `Current Planned Cases`(2026-06 리허설 계획) 제거

## 검증

수정본이 가리키는 파일 5개 전부 실재 확인 — `rules/TEAM-OS.template.ko.md` · `rules/SHARED.md` · `skills/b3os/references/{recruit,runtime-setup,troubleshooting}.md`

## 이 PR 밖에서 찾은 같은 계열 2건 (미수정)

- `docs/COMMUNICATION_FLOW.md` → `docs/TEAM_SEARCH_SYSTEM_ARCHITECTURE_20260603.md` — "상세 설계"라며 2곳에서 가리키는데 없습니다
- `docs/DEPLOY_MERGE_HOTFIX_WORKFLOW.md` → `scripts/deploy-live.sh` — 배포 절차의 핵심 도구인데 clone 에 없습니다

## 손대지 않은 것 (팀장님 확인 필요)

내부 팀 정보로 보이는 절은 **의도적으로 남겼습니다** — b3rys 전용 조건절, 팀장님 개인 설정(`—-` 구분자), 2026-06 리허설 기록. "일부러 넣어둔 것도 있다" 하셔서 임의 판단하지 않았습니다.
