### PR TITLE
test(env): 테스트가 환경을 타던 9건 격리 — 라이브 폴더·깨끗한 clone 양쪽 0 fail

### DIFF
--- a/src/server/lib/activation.test.ts
+++ b/src/server/lib/activation.test.ts
@@ -9,7 +9,8 @@
  *   waitForClaudePoller에 opts.homeDir=temp dir + 짧은 intervalMs를 주입해 tmp 경로만 검사한다.
  *   process.env.HOME은 읽지도 쓰지도 않는다(opts.homeDir override가 우선).
  */
-import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { describe, expect, test, beforeAll, beforeEach, afterEach } from "bun:test";
+import { ensureRenderedTeamOs } from "./testSupport";
 import { Database } from "bun:sqlite";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, lstatSync } from "node:fs";
 import { join } from "node:path";
@@ -35,6 +36,8 @@ function tmpHome(id: string, present: boolean): string {
 }
 
 describe("activation: claude poller 헬스게이트 (waitForClaudePoller)", () => {
+  // 워크스페이스 TEAM-OS.md 심링크 타깃(rules/TEAM-OS.md)은 런타임 렌더본이라 clone 엔 없다.
+  beforeAll(() => ensureRenderedTeamOs());
   test("bot.pid 존재 → true, 빠르게 반환(첫 검사에서 확인)", async () => {
     const id = "nova";
     const home = tmpHome(id, true);

--- a/src/server/lib/registry.ts
+++ b/src/server/lib/registry.ts
@@ -68,19 +68,27 @@ function isAgentCodexSandbox(value: unknown): value is AgentRecord["codex_sandbo
 // 기본값)는 agent id 문자열만 받고 AgentRecord 배열을 받지 못한다(공개 시그니처 보존 — 기존
 // 테스트가 string id 로 호출). 이런 경우만 여기서 agents.json 을 lazy 로드(mtime 캐시)해 capability
 // 를 조회한다. 인메모리 agents 배열을 받는 호출부는 그 배열을 직접 쓰고 ambient 를 쓰지 않는다.
-const AMBIENT_REGISTRY_PATH =
-  process.env.TEAM_AGENT_REGISTRY ?? join(import.meta.dir, "../../../agents.json");
-let _ambientCache: { mtimeMs: number; agents: AgentRecord[] } | null = null;
+// ★경로는 호출 시점에 읽는다(모듈 로드 시점 const 가 아니다).★ const 로 두면
+//   TEAM_AGENT_REGISTRY override 가 "이 모듈이 처음 import 되기 전에 env 를 세웠는가"라는
+//   import 순서에 좌우된다 — 한 프로세스에서 여러 테스트 파일이 도는 bun test 에선 사실상
+//   제어 불가라, 파일 단독 실행은 통과하고 전체 실행은 깨진다. 함수로 읽으면 순서와 무관하다.
+function ambientRegistryPath(): string {
+  return process.env.TEAM_AGENT_REGISTRY ?? join(import.meta.dir, "../../../agents.json");
+}
+// 캐시 키에 ★경로까지★ 넣는다 — 경로가 바뀌었는데 mtime 만 비교하면 옛 로스터를 돌려준다.
+let _ambientCache: { path: string; mtimeMs: number; agents: AgentRecord[] } | null = null;
 
 export function ambientAgents(): AgentRecord[] {
+  const path = ambientRegistryPath();
   try {
-    const mtimeMs = statSync(AMBIENT_REGISTRY_PATH).mtimeMs;
-    if (_ambientCache && _ambientCache.mtimeMs === mtimeMs) return _ambientCache.agents;
-    const agents = loadRegistry(AMBIENT_REGISTRY_PATH);
-    _ambientCache = { mtimeMs, agents };
+    const mtimeMs = statSync(path).mtimeMs;
+    if (_ambientCache && _ambientCache.path === path && _ambientCache.mtimeMs === mtimeMs) return _ambientCache.agents;
+    const agents = loadRegistry(path);
+    _ambientCache = { path, mtimeMs, agents };
     return agents;
   } catch {
-    return _ambientCache?.agents ?? [];
+    // 파일 없음(공개 clone 첫 부팅 등) → ★같은 경로★ 캐시가 있으면 그것, 없으면 빈 로스터.
+    return _ambientCache?.path === path ? _ambientCache.agents : [];
   }
 }
 

--- a/src/server/lib/teamContextPolicy.test.ts
+++ b/src/server/lib/teamContextPolicy.test.ts
@@ -1,13 +1,12 @@
-// full_context 는 ★agents.json 의 capabilities 가 정본★ (GD 2026-07-12: "full context 는
-//   agents.json 설정을 따라야 함. bill, codex 로 박혀있으면 고쳐야 됨").
+// full_context 는 ★agents.json 의 capabilities 가 정본★ — 특정 멤버 id 가 아니다.
 //
 // ★이 테스트가 환경을 타면 안 되는 이유★
 //   agents.json 은 각 머신 고유 로스터라 .gitignore 대상이다 — ★clone 한 사람에겐 없다.★
 //   예전 이 파일은 (a) 실제 로스터가 있다고 전제하고 `ambientAgents().length > 0` 을 단언했고
-//   (b) 아래 테스트는 codex/bill 이 full_context 를 가진다고 ★멤버 이름을 하드코딩★ 했다
+//   (b) 아래 테스트는 특정 멤버 id 두 개가 full_context 를 가진다고 ★이름을 하드코딩★ 했다
 //       — 바로 위 주석이 하지 말라고 적어둔 그것을.
 //   그래서 라이브 폴더에서만 통과하고 clone 에서는 100% 깨졌고, 운영이 로스터를 바꾸면
-//   ★코드가 아니라 테스트가★ 깨졌다(steve 에 full_context 부여 시 실패).
+//   ★코드가 아니라 테스트가★ 깨졌다(다른 멤버에게 full_context 를 주면 실패).
 //   → 실제 로스터에 의존하지 말고 ★픽스처 로스터를 주입★해서 "capabilities 를 따르는가" 만 본다.
 //
 //   (registry 는 레지스트리 경로를 ★호출 시점★에 읽는다 — 모듈 로드 시점 const 였을 땐

--- a/src/server/lib/teamContextPolicy.test.ts
+++ b/src/server/lib/teamContextPolicy.test.ts
@@ -1,31 +1,78 @@
-import { describe, expect, test } from "bun:test";
-import { canReceiveFullTeamContext, teamContextForAgent } from "./teamContextPolicy";
+// full_context 는 ★agents.json 의 capabilities 가 정본★ (GD 2026-07-12: "full context 는
+//   agents.json 설정을 따라야 함. bill, codex 로 박혀있으면 고쳐야 됨").
+//
+// ★이 테스트가 환경을 타면 안 되는 이유★
+//   agents.json 은 각 머신 고유 로스터라 .gitignore 대상이다 — ★clone 한 사람에겐 없다.★
+//   예전 이 파일은 (a) 실제 로스터가 있다고 전제하고 `ambientAgents().length > 0` 을 단언했고
+//   (b) 아래 테스트는 codex/bill 이 full_context 를 가진다고 ★멤버 이름을 하드코딩★ 했다
+//       — 바로 위 주석이 하지 말라고 적어둔 그것을.
+//   그래서 라이브 폴더에서만 통과하고 clone 에서는 100% 깨졌고, 운영이 로스터를 바꾸면
+//   ★코드가 아니라 테스트가★ 깨졌다(steve 에 full_context 부여 시 실패).
+//   → 실제 로스터에 의존하지 말고 ★픽스처 로스터를 주입★해서 "capabilities 를 따르는가" 만 본다.
+//
+//   (registry 는 레지스트리 경로를 ★호출 시점★에 읽는다 — 모듈 로드 시점 const 였을 땐
+//    import 순서에 따라 override 가 먹기도/안 먹기도 해서, 파일 단독 실행만 통과했다.)
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { ambientAgents } from "./registry";
+import { canReceiveFullTeamContext, teamContextForAgent } from "./teamContextPolicy";
+
+// 픽스처 로스터 — ★실제 팀원 이름을 쓰지 않는다★(이름 하드코딩 금지 규칙을 이 파일 스스로 지킨다).
+const FIXTURE = [
+  { id: "fixture-full-a", display_name: "Fixture Full A", role: "coordinator", capabilities: ["full_context", "coordinator"] },
+  { id: "fixture-full-b", display_name: "Fixture Full B", role: "developer", capabilities: ["full_context"] },
+  { id: "fixture-specialist", display_name: "Fixture Specialist", role: "specialist", capabilities: ["research"] },
+  { id: "fixture-nocaps", display_name: "Fixture NoCaps", role: "specialist", capabilities: [] },
+];
+
+let dir: string;
+const prevRegistry = process.env.TEAM_AGENT_REGISTRY;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "b3os-ctxpolicy-"));
+  const path = join(dir, "agents.json");
+  writeFileSync(path, JSON.stringify(FIXTURE), "utf-8");
+  process.env.TEAM_AGENT_REGISTRY = path;
+});
+
+afterAll(() => {
+  if (prevRegistry === undefined) delete process.env.TEAM_AGENT_REGISTRY;
+  else process.env.TEAM_AGENT_REGISTRY = prevRegistry;
+  rmSync(dir, { recursive: true, force: true });
+});
 
 describe("teamContextPolicy", () => {
-  // full_context 는 ★agents.json 의 capabilities 가 정본★ (GD 2026-07-12: "full context 는
-  //   agents.json 설정을 따라야 함. bill, codex 로 박혀있으면 고쳐야 됨").
-  //   코드(canReceiveFullTeamContext)는 이미 capabilities 를 읽는데 이 테스트만 멤버 이름을
-  //   하드코딩해서, 운영이 agents.json 에서 멤버를 추가/제거하면 ★코드가 아니라 테스트가★ 깨졌다
-  //   (실제로 steve 에 full_context 부여 시 실패). → 이름 고정 대신 agents.json 을 정본으로 검증.
-  test("full_context 는 agents.json capabilities 를 따른다 (멤버 이름 하드코딩 금지)", () => {
+  test("주입한 로스터가 실제로 읽힌다 (로딩 실패 시 전원 false 라 헛통과하는 것 방지)", () => {
     const agents = ambientAgents();
-    expect(agents.length).toBeGreaterThan(0); // 로딩 실패 시 전원 false 라 헛통과하는 것 방지
+    expect(agents.length).toBe(FIXTURE.length);
+    expect(agents.map((a) => a.id).sort()).toEqual(FIXTURE.map((a) => a.id).sort());
+  });
 
-    for (const a of agents) {
+  test("full_context 는 로스터의 capabilities 를 따른다 (멤버 이름 하드코딩 금지)", () => {
+    for (const a of ambientAgents()) {
       const expected = (a.capabilities ?? []).includes("full_context");
       expect(canReceiveFullTeamContext(a.id)).toBe(expected);
     }
+    // 픽스처가 양쪽 경우를 모두 담아야 위 루프가 의미를 갖는다(전원 false 헛통과 방지).
+    expect(FIXTURE.some((a) => a.capabilities.includes("full_context"))).toBe(true);
+    expect(FIXTURE.some((a) => !a.capabilities.includes("full_context"))).toBe(true);
 
     // capability 없는(=미등록) id 는 항상 false
     expect(canReceiveFullTeamContext("__no_such_agent__")).toBe(false);
     expect(canReceiveFullTeamContext("")).toBe(false);
   });
 
-  test("redacts team context for specialist agents", () => {
-    const context = "[bill] internal coordination\n[codex] implementation notes";
-    expect(teamContextForAgent("codex", context)).toBe(context);
-    expect(teamContextForAgent("bill", context)).toBe(context);
-    expect(teamContextForAgent("hermes", context)).toBe("");
+  test("full_context 없는 팀원에게는 팀 컨텍스트를 가린다", () => {
+    const context = "[fixture-full-a] internal coordination\n[fixture-specialist] implementation notes";
+    // 가진 쪽 = 그대로
+    expect(teamContextForAgent("fixture-full-a", context)).toBe(context);
+    expect(teamContextForAgent("fixture-full-b", context)).toBe(context);
+    // 없는 쪽 = 빈 문자열
+    expect(teamContextForAgent("fixture-specialist", context)).toBe("");
+    expect(teamContextForAgent("fixture-nocaps", context)).toBe("");
+    // 미등록 id 도 가린다
+    expect(teamContextForAgent("__no_such_agent__", context)).toBe("");
   });
 });

--- a/src/server/lib/testSupport.ts
+++ b/src/server/lib/testSupport.ts
@@ -1,0 +1,21 @@
+// 테스트 전용 지원 유틸(프로덕션 경로에서 import 하지 않는다).
+//
+// ★왜 필요한가★ — `rules/TEAM-OS.md` 는 ★런타임 렌더본★ 이라 .gitignore 대상이다
+//   (정본 소스 = `rules/TEAM-OS.template.md`, 렌더는 서버 부팅/설정 저장 시 1회).
+//   그래서 라이브 폴더에는 있고 ★깨끗한 clone 에는 없다★ → 이 파일을 읽거나 여기로
+//   심링크를 거는 테스트가 clone 에서만 100% 깨졌다(환경 의존 = 한쪽만 green).
+//   테스트는 "부팅을 한 번 거친 상태"를 전제하므로, 없을 때만 그 부팅 단계를 재현한다.
+import { existsSync } from "node:fs";
+import { renderTeamOs } from "./teamOsRender";
+import { REPO_ROOT } from "./personaTemplates";
+
+/**
+ * `rules/TEAM-OS.md`(런타임 렌더본)가 없으면 템플릿에서 렌더해 만든다.
+ *
+ * ★이미 있으면 손대지 않는다★ — 라이브 폴더에는 owner 이름까지 치환된 렌더본이 있는데
+ * 여기서 다시 렌더하면 그 값을 덮어써 ★라이브에 부작용★ 을 낸다. 없을 때만 만든다.
+ */
+export function ensureRenderedTeamOs(): void {
+  if (existsSync(`${REPO_ROOT}/rules/TEAM-OS.md`)) return;
+  renderTeamOs(null); // owner 미치환 = 템플릿 그대로. 내용 단언은 owner 와 무관한 문구만 본다.
+}

--- a/src/server/lib/tmuxInject.test.ts
+++ b/src/server/lib/tmuxInject.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
+import { ensureRenderedTeamOs } from "./testSupport";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { buildTmuxInjectionPrompt } from "./tmuxInject";
@@ -133,6 +134,8 @@ describe("buildTmuxInjectionPrompt", () => {
 
 describe("Korean runtime loading templates", () => {
   const rulesDir = join(import.meta.dir, "../../../rules");
+  // rules/TEAM-OS.md 는 런타임 렌더본(gitignore) — 깨끗한 clone 엔 없다. 없을 때만 부팅 렌더를 재현한다.
+  beforeAll(() => ensureRenderedTeamOs());
   const section = (text: string, start: string, next: string) => {
     const from = text.indexOf(start);
     const to = text.indexOf(next, from + start.length);

--- a/src/server/lib/writeMemberPersona.test.ts
+++ b/src/server/lib/writeMemberPersona.test.ts
@@ -8,11 +8,16 @@
 //   결과: 12명 중 7명이 어긋났고 — GD 가 손질한 5명은 ★렌더 한 번에 되돌아갈 위치★,
 //   lui·forin 은 purpose 가 비어 찍힌 24자 껍데기가 굳어 ★페르소나가 실제로 없었다.★
 //   ★렌더는 플래그 토글로도 돈다.★ → 소스를 하나(SOUL)로 두면 이 문제가 아예 생기지 않는다.
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, existsSync, writeFileSync, lstatSync, readlinkSync, mkdirSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { writeMemberPersona, savePersonaFile } from "./writeMemberPersona";
+import { ensureRenderedTeamOs } from "./testSupport";
+
+// 워크스페이스의 TEAM-OS.md 심링크는 rules/TEAM-OS.md(런타임 렌더본·gitignore)를 가리킨다.
+// 깨끗한 clone 엔 그 파일이 없어 심링크가 깨진 것으로 보인다 → 없을 때만 부팅 렌더를 재현.
+beforeAll(() => ensureRenderedTeamOs());
 
 describe("writeMemberPersona — 룰 렌더러(SOUL 은 안 건드린다)", () => {
   const mk = () => mkdtempSync(join(tmpdir(), "wmp-"));

--- a/src/server/routes/broadcastToGroup.test.ts
+++ b/src/server/routes/broadcastToGroup.test.ts
@@ -18,8 +18,21 @@ import { migrate } from "../db/migrate";
 import { createInboxRoutes } from "./inbox";
 import { channelRegistry } from "../channels/registry";
 import type { ChannelAdapter } from "../channels/types";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const GROUP_ID = "-2000000000001";
+// 라이브 상태파일 차단용 tmp 디렉터리(파일은 만들지 않는다 → getCaptureGroupId 가 env fallback 을 쓴다).
+const tmpGroupDir = mkdtempSync(join(tmpdir(), "b3os-bcast-"));
+const prevGroupFile = process.env.CAPTURE_GROUP_FILE;
+const prevGroupId = process.env.CAPTURE_GROUP_ID;
+function restoreEnv(): void {
+  if (prevGroupFile === undefined) delete process.env.CAPTURE_GROUP_FILE;
+  else process.env.CAPTURE_GROUP_FILE = prevGroupFile;
+  if (prevGroupId === undefined) delete process.env.CAPTURE_GROUP_ID;
+  else process.env.CAPTURE_GROUP_ID = prevGroupId;
+}
 let sent: Array<{ target: string; text: string }> = [];
 let realTelegram: ChannelAdapter | undefined;
 
@@ -78,11 +91,17 @@ describe("--to broadcast → 언제나 단톡방", () => {
   beforeEach(() => {
     sent = [];
     realTelegram = channelRegistry.get("telegram");
+    // ★env 만으로는 부족하다★ — getCaptureGroupId() 는 파일(var/capture-group-id.txt)을 ★먼저★ 보고
+    // env 는 fallback 이다. 라이브 폴더에는 그 파일이 실제 chat_id 로 존재하므로, env 만 세팅하면
+    // 픽스처가 무시되고 ★실제 팀방 chat_id 가 실패 출력에 찍힌다★(clone 에서만 green = 환경 의존).
+    // 그래서 파일 경로 자체를 tmp 의 존재하지 않는 파일로 돌려 라이브 상태를 차단한다.
+    process.env.CAPTURE_GROUP_FILE = join(tmpGroupDir, "capture-group-id.txt");
     process.env.CAPTURE_GROUP_ID = GROUP_ID;
     channelRegistry.set("telegram", fakeTelegram(true));
   });
   afterEach(() => {
     if (realTelegram) channelRegistry.set("telegram", realTelegram);
+    restoreEnv();
   });
 
   test("그룹 스레드(tg-<chatid>) → 게시된다 (기존에도 됐던 것 — 회귀 방지)", async () => {


### PR DESCRIPTION
같은 커밋(main `cafcd2f`)인데 **어디서 돌리느냐에 따라 다른 테스트가 깨졌다.** 라이브 폴더 3 fail / 깨끗한 clone 6 fail. 원인은 3가지였고, 9건이 모두 여기서 나온다.

## ① 라이브 3건 — 상태파일이 env 픽스처를 이긴다 (실제 chat_id 가 실패 출력에 찍히던 경로)

`broadcastToGroup.test.ts` 는 `CAPTURE_GROUP_ID` **env 만** 더미로 세팅했다. 그런데 `getCaptureGroupId()` 는

```
1순위  var/capture-group-id.txt      ← 라이브 폴더엔 실제 값으로 존재
2순위  process.env.CAPTURE_GROUP_ID  ← 테스트가 세팅한 더미
```

순서라, 라이브에서는 **픽스처가 무시되고 실제 팀방 chat_id 가 Received 로 출력**됐다. clone 엔 그 파일이 없어 env fallback 이 먹어서 통과했다 — 정확히 한쪽만 green.

→ 테스트가 `CAPTURE_GROUP_FILE` 을 tmp 의 **없는 경로**로 돌려 라이브 상태를 차단한다. **구현 변경 없음** — 코드에 이미 있던 override seam 을 쓴다. env 는 `afterEach` 에서 원복.

## ② clone 4건 — `rules/TEAM-OS.md` 가 런타임 렌더본이라 clone 엔 없다

리뷰에서 "원인 미확인"으로 남았던 4건(activation swapRuntime persona · TEAM-OS.md 심링크 · 한국어 템플릿 2)은 **전부 한 뿌리**였다. 이 파일은 `rules/TEAM-OS.template.md` 에서 **부팅 시 렌더되는 산출물**이고 `.gitignore:73` 대상이다.

테스트는 "부팅을 한 번 거친 상태"를 전제하므로 그 단계를 재현한다 — `testSupport.ensureRenderedTeamOs()` 가 **없을 때만** `renderTeamOs(null)` 로 만든다. **이미 있으면 손대지 않는다**(라이브엔 owner 치환본이 있어 덮으면 부작용).

## ③ clone 2건 — `agents.json`(머신 고유 로스터, gitignore)에 의존

`teamContextPolicy.test` 가 실제 로스터 존재를 전제했고, 두 번째 테스트는 특정 멤버 id 두 개가 `full_context` 를 가진다고 **이름을 하드코딩**했다 — 바로 위 주석이 하지 말라고 적어둔 그것을.

→ 픽스처 로스터(`fixture-*` 4명, full_context 보유/미보유 양쪽 포함)를 tmp 에 만들어 주입하고 "capabilities 를 따르는가"만 검증한다. **실제 팀원 이름은 이 파일에서 사라졌다.**

### 이 과정에서 registry 의 실제 결함도 하나 고쳤다

`AMBIENT_REGISTRY_PATH` 가 **모듈 로드 시점 const** 라 `TEAM_AGENT_REGISTRY` override 가 *"이 모듈이 처음 import 되기 전에 env 를 세웠는가"* 라는 **import 순서**에 좌우됐다. 한 프로세스에서 여러 테스트 파일이 도는 `bun test` 에선 제어 불가라 **파일 단독 실행은 통과하고 전체 실행은 깨진다.** 호출 시점에 읽도록 함수화하고, 캐시 키에 경로를 포함시켰다(경로가 바뀌었는데 mtime 만 보면 옛 로스터를 돌려줌).

## 검증

**환경 2종 × 실제 clone 으로 확인했다.** worktree 만으로 판단하지 않고 브랜치를 push 해서 **진짜 `git clone`** 을 떴다.

| 환경 | 결과 |
|---|---|
| **진짜 fresh clone** (`git clone` 직후, env 아무것도 안 줌 — `agents.json`·`rules/TEAM-OS.md`·`var/capture-group-id.txt` 전부 없음) | **1572 pass / 5 skip / 0 fail** |
| 같은 clone + **라이브 폴더의 실제 상태파일 복사**(`agents.json` 12명 + 실제 `var/capture-group-id.txt`) | **1572 / 5 / 0 fail** |
| `tsc --noEmit` | 0 |

한쪽만 green 이 아니라 **양쪽 green** 이다.

### 뮤턴트 4종 — 격리가 통과율만 올린 게 아님

| 뮤턴트 | 결과 |
|---|---|
| M1 `CAPTURE_GROUP_FILE` 격리 제거 (실제 라이브 상태파일로) | **3 fail** — 원래 증상 그대로 재현 |
| M2 `canReceiveFullTeamContext` 를 항상 true 로 (**제품 결함 주입**) | **2 fail** — 여전히 잡는다 |
| M3 registry 경로를 다시 모듈로드 const 로 | **2 fail** — 전체 실행에서만 드러나는 그 회귀 |
| M4 `ensureRenderedTeamOs` 제거 + clone 조건 | **4 fail** — ②의 4건 그대로 재현 |

각 뮤턴트 복원 후 다시 0 fail 확인.

## 변경 파일

| 파일 | 성격 |
|---|---|
| `src/server/lib/registry.ts` | **구현** — ambient 레지스트리 경로를 호출 시점 조회로, 캐시 키에 경로 포함 |
| `src/server/lib/testSupport.ts` | 신규(테스트 전용) — `ensureRenderedTeamOs()` |
| `broadcastToGroup.test.ts` · `teamContextPolicy.test.ts` · `tmuxInject.test.ts` · `writeMemberPersona.test.ts` · `activation.test.ts` | 테스트 격리 |

프로덕션 동작 변경은 registry 한 곳뿐이고, 기존 계약(경로 기본값·mtime 캐시·파일 부재 시 빈 로스터)은 그대로다.


---

### 후속 정리 (647d853)

리뷰 지적대로 **주석에 남아 있던 실제 멤버 id 3개**를 제거했다. 단언에서는 이미 걷어냈는데 주석에 남아 있어서, 이 변경의 목적(테스트에서 실제 식별자 제거) 기준으로는 절반만 한 상태였다. 설명은 "특정 멤버 id" 로 일반화했다 — 어느 멤버가 무슨 capability 를 갖는지는 `agents.json` 이 정본이고, 테스트 주석이 그걸 복제하면 그 자체가 또 다른 하드코딩이다. 주석만 바뀌었고 단언·픽스처는 무변경(3 pass / 0 fail 재확인).

※ `broadcastToGroup.test.ts` 에 남아 있는 멤버 id 들은 **이 PR 이 만든 게 아니라 기존 픽스처 행**이며(테스트용 agent 레코드), 팀원 핸들 자체는 GD 기준 '의도된 노출' 범주라 이 PR 범위에서 건드리지 않았다.
