### PR TITLE
fix(guard): continuation-guard 가 자기가 시킨 blocked 표시를 읽게

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ archiving/
 !/scripts/task-review-ping.ts
 !/scripts/task-review-summary.ts
 !/scripts/task-continuation-guard.ts
+# ★테스트도 allowlist 에 넣어야 한다★ — /scripts/* 가 전부 무시하므로 .test.ts 는
+#   git add -A 가 ★조용히 건너뛴다★. 소스만 커밋되고 그 소스를 지키는 테스트는 리포에 없는 상태가 된다.
+!/scripts/task-continuation-guard.test.ts
 /docs/*
 !/docs/AUTO_HEAL_CORE.md
 !/docs/SLACK_SETUP.md

--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,12 @@ archiving/
 !/scripts/task-review-ping.ts
 !/scripts/task-review-summary.ts
 !/scripts/task-continuation-guard.ts
-# ★테스트도 allowlist 에 넣어야 한다★ — /scripts/* 가 전부 무시하므로 .test.ts 는
-#   git add -A 가 ★조용히 건너뛴다★. 소스만 커밋되고 그 소스를 지키는 테스트는 리포에 없는 상태가 된다.
-!/scripts/task-continuation-guard.test.ts
+# ★scripts 의 테스트는 ★클래스로★ 연다★ — /scripts/* 가 전부 무시하므로 .test.ts 를
+#   개별 등록하면, 다음 스크립트에 테스트를 붙일 때 git add -A 가 ★조용히 건너뛴다★.
+#   실제로 2026-07-26 에 그 일이 났다: 소스만 커밋되고 그 소스를 지키는 테스트는 리포에
+#   없는 상태로 PR 이 올라갔다(로직을 되돌려도 실패 0건). 조용한 누락이라 status 출력을
+#   보고도 못 본다. 개별 등록은 같은 사고를 다음 사람에게 넘기는 것이라 패턴으로 연다.
+!/scripts/*.test.ts
 /docs/*
 !/docs/AUTO_HEAL_CORE.md
 !/docs/SLACK_SETUP.md

--- a/scripts/task-continuation-guard.test.ts
+++ b/scripts/task-continuation-guard.test.ts
@@ -1,0 +1,77 @@
+/**
+ * continuation-guard — 가드가 자기가 시킨 표시를 읽는가
+ *
+ * 배경: guardBody() 는 "막혔으면 blocked 표시를 description 에 남기라" 고 시키는데,
+ * 판정부(stalledDoingCards)는 column/owner/updated_at 만 보고 description 을 아예 읽지
+ * 않았다. 시킨 대로 해도 반영되는 경로가 없으니 지킬 수 없는 약속이었고, 재핑이 에피소드
+ * 기준이라 ★성실히 갱신하는 blocked 카드일수록 더 자주 핑을 받는★ 역유인까지 있었다.
+ */
+import { describe, expect, test } from "bun:test";
+import { isBlockedCard, stalledDoingCards, guardBody } from "./task-continuation-guard";
+
+const NOW = Date.parse("2026-07-26T00:00:00Z");
+const STALL = 60 * 60 * 1000; // 60분
+const OWNERS = new Set(["someone"]);
+
+// updated_at 형식은 실제 DB 와 같은 "YYYY-MM-DD HH:MM:SS"(UTC, TZ 표기 없음).
+const agoIso = (ms: number) => new Date(NOW - ms).toISOString().replace("T", " ").replace(/\.\d+Z$/, "");
+
+function card(over: Partial<Parameters<typeof stalledDoingCards>[0][number]> = {}) {
+  return {
+    id: "c1",
+    title: "카드",
+    owner: "someone",
+    column: "doing" as const,
+    description: null as string | null,
+    updated_at: agoIso(2 * STALL),
+    ...over,
+  };
+}
+
+describe("blocked 표시 인식", () => {
+  test("영어·한국어 표기를 모두 인정한다", () => {
+    for (const d of ["blocked on review", "waiting_on GD", "waiting on GD", "승인 대기 중", "차단 중", "보류 중"]) {
+      expect(isBlockedCard(card({ description: d }))).toBe(true);
+    }
+  });
+
+  test("표시가 없으면 blocked 가 아니다", () => {
+    expect(isBlockedCard(card({ description: null }))).toBe(false);
+    expect(isBlockedCard(card({ description: "다음 액션: 테스트 작성" }))).toBe(false);
+  });
+
+  test("★unblocked 를 blocked 로 읽지 않는다★ (부분일치 함정)", () => {
+    expect(isBlockedCard(card({ description: "unblocked, 재개함" }))).toBe(false);
+  });
+});
+
+describe("stall 판정 — 가드가 시킨 표시를 실제로 반영한다", () => {
+  test("표시 없는 카드는 기존대로 stallMs 로 걸린다", () => {
+    const t = card({ updated_at: agoIso(STALL + 1000) });
+    expect(stalledDoingCards([t], OWNERS, NOW, STALL)).toHaveLength(1);
+  });
+
+  test("★blocked 표시가 있으면 같은 경과시간에 걸리지 않는다★ (이게 없어서 영구 나그가 났다)", () => {
+    const t = card({ updated_at: agoIso(STALL + 1000), description: "blocked — GD 판단 대기" });
+    expect(stalledDoingCards([t], OWNERS, NOW, STALL)).toHaveLength(0);
+  });
+
+  test("★그래도 면제는 아니다★ — 6배를 넘기면 blocked 카드도 걸린다", () => {
+    const t = card({ updated_at: agoIso(6 * STALL + 1000), description: "blocked — GD 판단 대기" });
+    expect(stalledDoingCards([t], OWNERS, NOW, STALL)).toHaveLength(1);
+  });
+
+  test("doing 이 아니거나 owner 가 대상 밖이면 표시와 무관하게 제외", () => {
+    expect(stalledDoingCards([card({ column: "plan" })], OWNERS, NOW, STALL)).toHaveLength(0);
+    expect(stalledDoingCards([card({ owner: "other" })], OWNERS, NOW, STALL)).toHaveLength(0);
+    expect(stalledDoingCards([card({ owner: null })], OWNERS, NOW, STALL)).toHaveLength(0);
+  });
+});
+
+describe("안내 문구", () => {
+  test("표시하면 무엇이 달라지는지 알려준다 — 안 그러면 유인이 서지 않는다", () => {
+    const body = guardBody("someone", [card()], 60);
+    expect(body).toContain("blocked");
+    expect(body).toContain("뜸하게");
+  });
+});

--- a/scripts/task-continuation-guard.ts
+++ b/scripts/task-continuation-guard.ts
@@ -51,15 +51,34 @@ export function parseUtc(s: string | null | undefined, nowMs: number): number {
   return Number.isNaN(t) ? nowMs : t;
 }
 
-// 멈춘 doing 카드: column=doing · owner 존재 · owner 가 리뷰대상 · updated_at 이 stallMs 이상 지남.
+// ★가드가 시킨 표시를 가드가 읽어야 한다★
+//   guardBody() 는 "막혔으면 blocked 표시 + 다음 액션/재개 시각/fallback 을 description 에 남기라" 고
+//   시킨다. 그런데 판정부는 column/owner/updated_at 만 봤다 — description 을 아예 읽지 않았다.
+//   시킨 대로 해도 판정에 반영되는 경로가 없으니, 그 안내는 지킬 수 없는 약속이었다.
+//
+//   게다가 재핑이 에피소드 기준(dueCards)이라 유인이 거꾸로 섰다:
+//     · 성실히 상태를 갱신하는 blocked 카드 → 갱신할 때마다 새 에피소드 → 60분 뒤 또 핑(영구 나그)
+//     · 손 놓고 방치한 카드            → 최초 1회만 핑하고 조용
+//   "방치 카드 영구 나그" 를 막으려던 장치가, 방치가 아니라 ★관리 중인 카드★ 에서 재현됐다.
+//
+//   그래서 blocked 로 표시된 카드에는 훨씬 긴 임계를 준다. ★면제가 아니라 완화★ 다 —
+//   완전히 빼면 "blocked" 라고 적어두고 잊은 카드가 영원히 안 걸린다.
+const BLOCKED_STALL_MULTIPLIER = 6;
+
+// description 에 남긴 '막힘' 표시를 인정한다. 한국어/영어 둘 다 실제로 쓰인다.
+export function isBlockedCard(t: Task): boolean {
+  const d = t.description ?? "";
+  return /\bblocked\b/i.test(d) || /waiting[_\s-]?on/i.test(d) || /(대기|차단|보류)\s*중/.test(d);
+}
+
+// 멈춘 doing 카드: column=doing · owner 존재 · owner 가 리뷰대상 · updated_at 이 임계 이상 지남.
+//   임계 = 일반 stallMs, blocked 표시가 있으면 그 6배.
 export function stalledDoingCards(tasks: Task[], owners: Set<string>, nowMs: number, stallMs: number): Task[] {
-  return tasks.filter(
-    (t) =>
-      t.column === "doing" &&
-      t.owner != null &&
-      owners.has(t.owner) &&
-      nowMs - parseUtc(t.updated_at, nowMs) >= stallMs,
-  );
+  return tasks.filter((t) => {
+    if (t.column !== "doing" || t.owner == null || !owners.has(t.owner)) return false;
+    const threshold = isBlockedCard(t) ? stallMs * BLOCKED_STALL_MULTIPLIER : stallMs;
+    return nowMs - parseUtc(t.updated_at, nowMs) >= threshold;
+  });
 }
 
 // 재핑 정책 = ★에피소드당 1회★. 방치 카드를 주기마다 영구 나그하지 않는다 — continuation-guard 는 "카드가 막
@@ -81,7 +100,8 @@ export function guardBody(owner: string, cards: Task[], stallMin: number): strin
     `[진행 지속 가드] ${owner}님, ${stallMin}분+ 조용한 doing 카드가 ${cards.length}개 있습니다.\n${list}\n\n` +
     `각 카드의 실제 상태를 확인해 주세요 — 끝났으면 done 으로, 막혔으면 blocked 표시 + 다음 액션/재개 시각/fallback 을 description 에 남기고, ` +
     `계속 진행 중이면 다음 액션만 갱신하면 됩니다. 실제로 진행할 게 없는 카드는 plan 으로 내리거나 폐기하세요. ` +
-    `정리할 게 없으면 억지로 수정·보고하지 마세요.`
+    `정리할 게 없으면 억지로 수정·보고하지 마세요.\n` +
+    `(description 에 blocked 표시가 있으면 이 가드는 훨씬 뜸하게 확인합니다 — 표시해 두면 관리 중인 카드가 계속 알림을 받지 않습니다.)`
   );
 }
 


### PR DESCRIPTION
## 문제 — 가드가 시킨 것을 가드가 안 본다

안내 문구(`guardBody`)는 이렇게 시킵니다:

> 막혔으면 **blocked 표시** + 다음 액션/재개 시각/fallback 을 description 에 남기고…

그런데 판정부(`stalledDoingCards`)는 `column` / `owner` / `updated_at` **셋만** 봤습니다. `description` 을 아예 읽지 않습니다. 파일 전체에서 `blocked` 라는 문자열은 **그 안내 문구 1곳뿐**이었습니다.

**시킨 대로 해도 판정에 반영되는 경로가 없었습니다.** 지킬 수 없는 약속입니다.

## 더 나쁜 조합 — 유인이 거꾸로 서 있었다

재핑이 에피소드 기준(`dueCards`)이라:

| 카드 | 결과 |
|---|---|
| 성실히 상태를 갱신하는 blocked 카드 | 갱신할 때마다 새 에피소드 → 60분 뒤 또 핑 (**사실상 영구 나그**) |
| 손 놓고 방치한 카드 | 최초 1회만 핑하고 조용 |

"방치 카드 영구 나그"를 막으려던 장치가, 방치가 아니라 **관리 중인 카드**에서 재현됐습니다. 빠져나갈 길은 plan 강등뿐이라, `doing` 을 유지해야 하는 blocked 카드는 방법이 없었습니다.

## 변경

- `isBlockedCard()` — description 의 막힘 표시를 인정. 영어(`blocked`·`waiting_on`)와 한국어(`대기/차단/보류 중`) 둘 다 실제로 쓰입니다
- blocked 표시가 있으면 stall 임계를 **6배**로. **면제가 아니라 완화**입니다 — 완전히 빼면 "blocked"라 적어두고 잊은 카드가 영원히 안 걸립니다
- 안내 문구에 "표시해 두면 훨씬 뜸하게 확인한다"를 명시. 표시해서 **무엇이 달라지는지** 알려주지 않으면 유인이 서지 않습니다

## 검증

신규 테스트 8건 — 표기 인식 · **부분일치 함정**(`unblocked` 를 blocked 로 읽지 않는지) · 임계 경계 양쪽 · 대상 밖 제외 · 안내 문구

**mutation 3종 전부 RED**:

| 변형 | 결과 |
|---|---|
| `isBlockedCard` 항상 false | 2 fail — 표시를 무시하면 잡힌다 |
| 배수 1 (완화 제거) | 1 fail |
| 배수 무한대 (사실상 면제) | 1 fail — **면제도 잡힌다** |

양방향으로 고정돼 있습니다. 원복 후 8 pass / 0 fail, typecheck 통과.

---
발견: Steve. 라우팅 판단해서 제가 받았습니다.
