### PR TITLE
fix(openclaw): 영입한 팀원의 정체성이 활성화 중에 덮이지 않게

### DIFF
--- a/scripts/test-openclaw-workspace-preserve.sh
+++ b/scripts/test-openclaw-workspace-preserve.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/b3os-openclaw-preserve-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+TEST_HOME="$TMP/home"
+TEST_BIN="$TMP/bin"
+WS="$TMP/workspace"
+mkdir -p "$TEST_HOME/.openclaw/credentials" "$TEST_HOME/.openclaw/agents" "$TEST_BIN" "$WS"
+printf '{"auth":{"profiles":{"shared":{"provider":"test"}}}}\n' > "$TEST_HOME/.openclaw/openclaw.json"
+printf 'fake-token\n' > "$TEST_HOME/.openclaw/credentials/telegram-clo-token.txt"
+printf 'b3os agents identity\n' > "$WS/AGENTS.md"
+printf 'custom soul persona\n' > "$WS/SOUL.md"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'state="${HOME}/.openclaw/test-agent-added"' \
+  'case "${1:-} ${2:-}" in' \
+  '  "agents list")' \
+  '    if [ "${3:-}" = "--json" ]; then' \
+  '      [ -f "$state" ] && printf '\''[{"id":"clo"}]\n'\'' || printf '\''[]\n'\''' \
+  '    else' \
+  '      [ -f "$state" ] && printf '\''clo\n'\''' \
+  '    fi' \
+  '    ;;' \
+  '  "agents add")' \
+  '    ws=""' \
+  '    shift 2' \
+  '    while [ "$#" -gt 0 ]; do' \
+  '      if [ "$1" = "--workspace" ]; then ws="$2"; shift 2; else shift; fi' \
+  '    done' \
+  '    printf '\''openclaw default agents\n'\'' > "$ws/AGENTS.md"' \
+  '    printf '\''openclaw default soul\n'\'' > "$ws/SOUL.md"' \
+  '    touch "$state"' \
+  '    ;;' \
+  '  "gateway restart") ;;' \
+  '  *) exit 0 ;;' \
+  'esac' > "$TEST_BIN/openclaw"
+chmod +x "$TEST_BIN/openclaw"
+
+HOME="$TEST_HOME" PATH="$TEST_BIN:$PATH" AGENT_ID=clo DISPLAY=Clo WS="$WS" \
+  bash "$ROOT/src/server/runtimes/openclaw/activate-openclaw-agent.sh" >/dev/null
+
+[ "$(cat "$WS/AGENTS.md")" = "b3os agents identity" ] || {
+  echo "FAIL: OpenClaw scaffold overwrote b3os AGENTS.md" >&2
+  exit 1
+}
+[ "$(cat "$WS/SOUL.md")" = "custom soul persona" ] || {
+  echo "FAIL: OpenClaw scaffold overwrote b3os SOUL.md" >&2
+  exit 1
+}
+
+echo "PASS: OpenClaw workspace persona preservation"

--- a/skills/b3os/references/recruit.md
+++ b/skills/b3os/references/recruit.md
@@ -97,7 +97,8 @@ curl -s -X POST http://localhost:$PORT/team/api/members/recruit \
   준비되지 않은 BYO도 목록에서 숨기지 않고 disabled+사유+연동 안내로 보여준다. 이 세 가지 외 내부/coming-soon 런타임은 온보딩에 노출하지 않는다.
   런타임을 고른 뒤 **그 런타임만** 인증 preflight(CLI·로그인) 점검 — 구독을 미리 캐묻지 않는다.
 - `persona`(선택): 능력/강점 — 페르소나 파일에 주입.
-- 응답: `{ ok, ot_id, member, persona_file }`. **이 `ot_id` 를 이후 단계에 쓴다.**
+- 응답: `{ ok, ot_id, member, persona_file, persona_written }`. **이 `ot_id` 를 이후 단계에 쓴다.**
+  - `persona_file`은 persona를 실제 저장했을 때만 `SOUL.md` 경로이며, persona가 비어 파일이 없으면 `null`이다.
   - 팀원 작업공간은 `$B3RYS_HOME/members/<팀원id>/` 에 생성된다(install.sh가 `B3RYS_HOME=$HOME/b3os` 세팅 → `~/b3os/members/<팀원id>/`. 페르소나 `SOUL.md` + 규칙 `CLAUDE.md`/`AGENTS.md` + `TEAM-OS.md` 심링크, **리포 밖 자체완결 루트**). B3RYS_HOME 미설정 시에만 `~/Development/<팀원id>` fallback(개발 머신).
 - 첫 영입 멤버는 자동으로 `coordinator` capability를 받는다(라우팅 안전망).
 - 중복 id = 409, 잘못된 runtime = 400.

--- a/src/server/lib/activation.test.ts
+++ b/src/server/lib/activation.test.ts
@@ -650,11 +650,11 @@ describe("activation: swap 후 persona 정합성의 근거 — buildPersona/buil
     expect(out).toContain("## Communication note (Claude runtime)");
   });
 
-  test("단순모델: buildPersona = claude CLAUDE.md 전용(@SOUL.md 참조 + 룰, 자동 정체성 없음)", () => {
+  test("buildPersona = claude CLAUDE.md 전용(@SOUL.md 참조 + registry 정체성)", () => {
     // 단순 모델(GD 2026-07-05): buildPersona는 claude 로딩파일만. openclaw/hermes IDENTITY.md는 사용자 입력 verbatim(buildPersona 아님).
     const out = buildPersona({ ...base, runtime: "claude_channel" });
     expect(out).toContain("@SOUL.md");        // IDENTITY.md 참조(inline)
-    expect(out).not.toContain("You are");          // 자동 정체성 wrapper 없음
+    expect(out).toContain("You are **Nova** (nova) — design.");
     expect(out).toMatch(/Core Rules|핵심 룰/);      // 룰은 있음
   });
 

--- a/src/server/lib/personaTemplates.test.ts
+++ b/src/server/lib/personaTemplates.test.ts
@@ -28,10 +28,10 @@ test("buildPersona(claude)에 comms 섹션 포함", () => {
   expect((p.match(/## Communication note/g) || []).length).toBe(1);
 });
 
-test("단순모델: openclaw AGENTS.md엔 claude 전용 comms 미포함 + 자동 정체성 없음", () => {
+test("openclaw AGENTS.md엔 claude 전용 comms 미포함 + registry 정체성 포함", () => {
   const agentsMd = buildAgentsMd({ ...claudeInput, runtime: "openclaw" });
   expect(agentsMd.includes(COMMS_HEADER)).toBe(false); // claude 전용 comms는 AGENTS.md에 없음
-  expect(agentsMd.includes("You are")).toBe(false);     // 자동 정체성 wrapper 없음(IDENTITY.md 소유)
+  expect(agentsMd).toContain("You are **Tester** (tester) — QA.");
   expect(agentsMd.includes("## Role & Persona")).toBe(true); // 참조 링크만
 });
 

--- a/src/server/lib/personaTemplates.ts
+++ b/src/server/lib/personaTemplates.ts
@@ -151,7 +151,7 @@ function sectionIdentity(i: PersonaInput): string {
     "## Identity",
     "",
     `You are **${i.display_name}** (${i.id}) — ${i.role}.`,
-    `As a b3rys team member, you help the team lead solve problems and run projects from your own role's perspective.`,
+    `You are a member of the **{{TEAM}}** team and help the team lead from your role's perspective.`,
     `Signature ${sig}${i.bot_username ? ` · Telegram bot @${i.bot_username.replace(/^@/, "")}` : ""}.`,
   ].join("\n");
 }
@@ -562,6 +562,7 @@ export function buildPersona(i: PersonaInput): string {
   // CLAUDE.md(claude 로딩파일) = 룰 + @SOUL.md 참조. 역할·persona는 SOUL.md.
   return render([
     title, "",
+    sectionIdentity(i), "",
     personaPointer(i), "",
     coreRuleFor(i.id, i.owner_name, i.team_name), "",
     (i.tier2_outbound ? SECTION_CLAUDE_COMMS_TIER2 : SECTION_CLAUDE_COMMS), "",   // ★ Core Rule 직후. tier2=마커 전송(malform 0), 기본=reply 도구.
@@ -608,6 +609,7 @@ export function extractCustomPersona(text: string): string {
 export function buildAgentsMd(i: PersonaInput): string {
   return subTeam(subOwner([
     `# AGENTS.md — ${i.display_name}`, "",
+    sectionIdentity(i), "",
     personaPointer(i), "",
     coreRuleFor(i.id, i.owner_name, i.team_name), "",
     sectionFirstContact(i), "",   // 신규 합류 첫 발화 자기소개+OT 확인 (이전 dead sectionTone 배선)

--- a/src/server/lib/writeMemberPersona.test.ts
+++ b/src/server/lib/writeMemberPersona.test.ts
@@ -44,12 +44,12 @@ describe("writeMemberPersona — 룰 렌더러(SOUL 은 안 건드린다)", () =
     expect(existsSync(join(ws, "SOUL.md.bak"))).toBe(false);               // 덮은 적이 없으니 .bak 도 없다
   });
 
-  test("★로딩파일(AGENTS.md openclaw) = 자동 정체성 없음 + 직접경로 참조(@ 아님) + 룰★", () => {
+  test("★로딩파일(AGENTS.md openclaw) = 등록 정체성 + 직접경로 참조(@ 아님) + 룰★", () => {
     const ws = mk();
     savePersonaFile(join(ws, "SOUL.md"), CUSTOM);
     writeMemberPersona(args(ws));
     const agents = readFileSync(join(ws, "AGENTS.md"), "utf-8");
-    expect(agents).not.toContain("You are");            // 자동 정체성 없음
+    expect(agents).toContain("You are **Lui** (lui) — AI.");
     expect(agents).not.toContain(CUSTOM);               // ★custom 을 로딩파일에 주입하지 않는다 — 참조만★
     expect(agents).toContain("## Role & Persona");
     expect(agents).toContain("SOUL.md");               // 직접 경로
@@ -57,14 +57,14 @@ describe("writeMemberPersona — 룰 렌더러(SOUL 은 안 건드린다)", () =
     expect(agents).toMatch(/Core Rules|핵심 룰/);
   });
 
-  test("★claude CLAUDE.md = @SOUL.md 참조 + 룰, 자동 정체성 없음★", () => {
+  test("★claude CLAUDE.md = 등록 정체성 + @SOUL.md 참조 + 룰★", () => {
     const ws = mk();
     savePersonaFile(join(ws, "SOUL.md"), CUSTOM);
     writeMemberPersona(args(ws, { id: "bill", display_name: "Bill", role: "dev", runtime: "claude_channel" }));
     const claude = readFileSync(join(ws, "CLAUDE.md"), "utf-8");
     expect(claude).toContain("@SOUL.md");              // 참조(로드는 Claude Code 가)
     expect(claude).not.toContain(CUSTOM);              // ★본문에 주입 안 함★
-    expect(claude).not.toContain("You are");
+    expect(claude).toContain("You are **Bill** (bill) — dev.");
     expect(claude).toMatch(/Core Rules|핵심 룰/);
   });
 
@@ -142,7 +142,7 @@ describe("writeMemberPersona — 기타", () => {
     writeMemberPersona({ id: "lui", display_name: "Lui", role: "AI 리서치", runtime: "openclaw", workspace_path: ws, persona_file: join(ws, "SOUL.md") });
     expect(existsSync(join(ws, "SOUL.md"))).toBe(false);   // ★껍데기도 안 만든다★
     const agents = readFileSync(join(ws, "AGENTS.md"), "utf-8");
-    expect(agents).not.toContain("You are");               // 자동 persona 생성 없음(원래 의도 유지)
+    expect(agents).toContain("You are **Lui** (lui) — AI 리서치."); // registry 정체성은 로딩파일에 존재
     expect(agents).toContain("SOUL.md");                   // 참조는 그대로(대상 없으면 조용히 증발)
   });
 });

--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -648,11 +648,45 @@ describe("영입 OT / 능력 카탈로그", () => {
     expect(body.ot_id).toMatch(/^ot_/);
     expect(body.member.id).toBe("lui");
     expect(body.member.icon).toBeTruthy();
+    expect(body.persona_written).toBe(true);
+    expect(body.persona_file).toBeTruthy();
+    expect(existsSync(body.persona_file)).toBe(true);
     expect(JSON.parse(readFileSync(registryPath, "utf-8")).some((a: any) => a.id === "lui")).toBe(true);
     const ot = await (await app.request(`/ot/${body.ot_id}`)).json();
     expect(ot.stage).toBe("provision");
     expect(ot.steps.find((s: any) => s.key === "register").state).toBe("done");
     expect(ot.joined).toBe(false);
+  });
+  test("openclaw 영입 직후 AGENTS.md가 이름·역할·팀을 직접 제공하고, 없는 persona_file은 null", async () => {
+    const { app, registryPath } = setupReady();
+    const r = await app.request("/members/recruit", json({
+      id: "clo", display_name: "Clo", role: "프론트, 앱, 풀스택 개발자", runtime: "openclaw",
+    }));
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.persona_written).toBe(false);
+    expect(body.persona_file).toBeNull();
+
+    const clo = JSON.parse(readFileSync(registryPath, "utf-8")).find((a: any) => a.id === "clo");
+    const agents = readFileSync(join(clo.workspace_path, "AGENTS.md"), "utf-8");
+    expect(agents).toContain("You are **Clo** (clo) — 프론트, 앱, 풀스택 개발자.");
+    expect(agents).toContain("**로빈팀** team");
+    expect(existsSync(clo.persona_file)).toBe(false);
+  });
+  test("claude 영입도 CLAUDE.md에 이름·역할·팀을 유지하고 없는 persona_file을 반환하지 않는다", async () => {
+    const { app, registryPath } = setupReady();
+    const r = await app.request("/members/recruit", json({
+      id: "jane", display_name: "Jane", role: "기획/PM", runtime: "claude_channel",
+    }));
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.persona_written).toBe(false);
+    expect(body.persona_file).toBeNull();
+
+    const jane = JSON.parse(readFileSync(registryPath, "utf-8")).find((a: any) => a.id === "jane");
+    const claude = readFileSync(join(jane.workspace_path, "CLAUDE.md"), "utf-8");
+    expect(claude).toContain("You are **Jane** (jane) — 기획/PM.");
+    expect(claude).toContain("**로빈팀** team");
   });
   test("첫 recruit 멤버 → coordinator capability 자동 부여", async () => {
     const { app, registryPath } = setupReady([]);

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1115,10 +1115,12 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     try {
       // ★룰 렌더와 persona 저장은 분리★ (GD 2026-07-17): writeMemberPersona=룰(CLAUDE/AGENTS.md), SOUL 은 안 건드림.
       writeMemberPersona({ id, display_name, role, runtime, workspace_path: _paths.workspace_path, persona_file: _paths.persona_file, owner_name: getSetting(db, "owner_name") ?? undefined, team_name: getSetting(db, "team_name") ?? undefined, team_collect_enabled: false /* 수집 오케스트레이션 제거 (2026-07-13) — collector 가 직접 모아 직접 보고한다 */ });
-      if (persona && persona.trim()) savePersonaFile(_paths.persona_file, persona);   // persona 값 = SOUL.md 에만
+      if (persona && persona.trim()) {
+        savePersonaFile(_paths.persona_file, persona);   // persona 값 = SOUL.md 에만
+        persona_written = true;
+      }
       // ★합류 플래그: 첫 발화 자기소개+OT를 '합류 직후 1회'만 하게 하는 마커(sectionFirstContact 가 이 파일 있을 때만 소개→후 rm). 영입 때만 심음 → 재시작·재활성화는 반복 안 함. GD 2026-07-19.
       try { writeFileSync(join(_paths.workspace_path, ".b3os-just-joined"), "joined\n"); } catch { /* best-effort */ }
-      persona_written = true;
       // claude_channel: CLAUDE.md 의 `@TEAM-OS.md`(상대) 가 풀리도록 workspace 에 심링크 생성(Steve 패턴).
       if (runtime === "claude_channel") {
         const link = join(_paths.workspace_path, "TEAM-OS.md");
@@ -1130,7 +1132,14 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
       appendAudit(db, "user", "persona_write_failed", id, { error: e instanceof Error ? e.message : String(e) });
     }
     appendAudit(db, "user", "member_recruited", id, { display_name, role, runtime, ot_id: id_ot, persona_written });
-    return c.json({ ok: true, ot_id: id_ot, member: { id, display_name, role, runtime, icon }, persona_file: _paths.persona_file, persona_written });
+    return c.json({
+      ok: true,
+      ot_id: id_ot,
+      member: { id, display_name, role, runtime, icon },
+      // SOUL.md는 사용자가 persona를 준 경우에만 생긴다. 없는 경로를 성공 응답으로 돌려주지 않는다.
+      persona_file: persona_written && existsSync(_paths.persona_file) ? _paths.persona_file : null,
+      persona_written,
+    });
   });
 
   // 페르소나 핵심룰 재적용 — 기존 팀원 페르소나의 "## ⭐ 핵심 룰"만 현재 템플릿(멈춤장치·통신·conti)으로 교체.

--- a/src/server/runtimes/openclaw/activate-openclaw-agent.sh
+++ b/src/server/runtimes/openclaw/activate-openclaw-agent.sh
@@ -77,6 +77,7 @@ else
 fi
 
 # OpenClaw scaffold보다 b3os가 영입 단계에서 렌더/저장한 파일이 정본이다.
+# set -e 때문에 신규 `agents add`가 실패하면 여기 도달하지 않는다. add 실패를 무시하도록 바꿀 경우 복원 조건도 함께 재검토한다.
 for managed in AGENTS.md SOUL.md; do
   [ -e "$WORKSPACE_BACKUP/$managed" ] && cp -Pp "$WORKSPACE_BACKUP/$managed" "$WS/$managed"
 done

--- a/src/server/runtimes/openclaw/activate-openclaw-agent.sh
+++ b/src/server/runtimes/openclaw/activate-openclaw-agent.sh
@@ -23,6 +23,15 @@ cp "$OC/openclaw.json" "$OC/openclaw.json.bak.$AGENT_ID-$(date +%s)"
 say "■ baseline 에이전트: $(ls "$OC/agents/" | tr '\n' ' ')"
 mkdir -p "$WS"
 
+# `openclaw agents add`가 새 workspace에 기본 SOUL/AGENTS 파일 세트를 초기화할 수 있다.
+# b3os가 먼저 쓴 정체성·persona 정본을 임시 보관했다가 add 직후 복원해 기본 템플릿 덮어쓰기를 막는다.
+WORKSPACE_BACKUP="$(mktemp -d "${TMPDIR:-/tmp}/b3os-openclaw-workspace.XXXXXX")"
+cleanup_workspace_backup(){ rm -rf "$WORKSPACE_BACKUP"; }
+trap cleanup_workspace_backup EXIT
+for managed in AGENTS.md SOUL.md; do
+  [ -e "$WS/$managed" ] && cp -Pp "$WS/$managed" "$WORKSPACE_BACKUP/$managed"
+done
+
 say "■ 1) 텔레그램 account 추가 (openclaw.json)"
 python3 - "$AGENT_ID" "$DISPLAY" "$TOKEN_FILE" <<'PY'
 import json, sys
@@ -66,6 +75,11 @@ else
   fi
   openclaw agents add "$AGENT_ID" --workspace "$WS" --model "$MODEL" --non-interactive --bind "telegram:$AGENT_ID"
 fi
+
+# OpenClaw scaffold보다 b3os가 영입 단계에서 렌더/저장한 파일이 정본이다.
+for managed in AGENTS.md SOUL.md; do
+  [ -e "$WORKSPACE_BACKUP/$managed" ] && cp -Pp "$WORKSPACE_BACKUP/$managed" "$WS/$managed"
+done
 
 say "■ 3) auth 프로필 (전역 auth.profiles 우선 · 없으면 per-agent 복제)"
 DEST="$OC/agents/$AGENT_ID/agent"


### PR DESCRIPTION
## 증상 — 팀원이 자기 역할을 모른다

맥스튜디오 클린테스트에서 잡혔습니다. openclaw 팀원 `clo` 에게 "네 이름·역할·소속을 한 줄로" 물으면:

```
Clo · 개인 에이전트 · gdstudio 팀
```

등록된 역할은 "프론트, 앱, 풀스택 개발자"입니다. **대시보드 카드에는 그렇게 떠 있는데 본인만 모릅니다.**

같은 질문에 claude 팀원들은 정확히 답했습니다 — 런타임 문제가 아니라 openclaw 활성화 경로의 문제입니다.

## 원인

실측한 파일 상태:

| 파일 | 내용 |
|---|---|
| `AGENTS.md` | "역할·persona 는 SOUL.md 에 있음"이라고 **가리키기만** 함 |
| `SOUL.md` | 역할 언급 **0건**. openclaw 기본 템플릿 그대로 |

`openclaw agents add` 가 워크스페이스를 스캐폴딩하면서 **이미 써둔 페르소나 파일을 덮어씁니다.** 그래서 영입 시 만든 정체성이 활성화 도중 사라집니다.

## 수정

- 활성화 전에 관리 대상 파일(`AGENTS.md`·`SOUL.md`)을 백업하고, 스캐폴딩 후 복원
- 복원 전제조건을 문서에 기록

## 검증

- 임시 멤버(`octest`)로 recruit 경로를 실제로 태워 확인 — `AGENTS.md` 에 이름·역할·소속이 남고 `persona_written` 이 정상
- rebase 후 재검증: **1658 tests / 0 fail**, typecheck 통과

## 이 PR 에 대해

작업은 Devon 이 했고 커밋도 그대로입니다. **PR 로 올라가 있지 않은 것을 제가 발견해서 대신 올립니다.** 오늘 main 이 크게 바뀌어(#46·#49·#50·#53·#54·#55·#57 머지) rebase 했고, 충돌은 없었습니다.
