### PR TITLE
fix(deadline): 팀장 1:1 DM 으로 간 보고를 마감 판정이 못 보던 결함

### DIFF
--- a/src/server/bus/collectionDeadline.test.ts
+++ b/src/server/bus/collectionDeadline.test.ts
@@ -460,3 +460,70 @@ describe("★독촉 본문 — 개별보고면 무시하라고 알림이 직접 
     expect(sentBody(d, "demis")).toBeNull();
   });
 });
+
+/**
+ * ★감시하는 쪽이 자기가 요구한 것을 볼 수 있어야 한다★ (2026-07-26, steve 발견)
+ *
+ * 독촉 문구는 "지금 종합해서 요청자에게 보내세요" 다. 그런데 claude 멤버가 팀장 1:1 에 답하는
+ * ★정본 경로는 텔레그램 reply 도구★ 이고, 그 산출물은 dm_message 로 들어간다(thread_id 없음).
+ * 판정이 message 테이블만 보면 그 보고는 ★영원히 안 보인다★ → 이미 보고한 사람에게 또 보내라고 한다.
+ * 따르면 "같은 요청에 두 번 보고하지 마라" 를 어기게 된다 —
+ * ★규칙을 지킨 사람에게 규칙 위반을 유도하는 알림★ 이라 단순 노이즈가 아니다.
+ */
+describe("보고 인정 — 팀장 1:1 DM(dm_message)도 보고로 센다", () => {
+  let db: Database;
+
+  // 실제 스키마와 같은 모양(thread_id 없음 — 그래서 시각 기준이 될 수밖에 없다)
+  function withDm(d: Database) {
+    d.run(`CREATE TABLE dm_message (
+      id TEXT PRIMARY KEY, member_id TEXT NOT NULL, runtime TEXT,
+      direction TEXT NOT NULL, body TEXT, created_at TEXT NOT NULL,
+      dedupe_key TEXT NOT NULL, source_ref TEXT)`);
+    return d;
+  }
+  let dn = 0;
+  function dm(d: Database, member: string, direction: "in" | "out", minsAgo: number) {
+    d.run(
+      `INSERT INTO dm_message (id, member_id, runtime, direction, body, created_at, dedupe_key)
+       VALUES (?, ?, 'claude_channel', ?, 'x', datetime('now', '-' || ? || ' minutes'), ?)`,
+      [`d${++dn}`, member, direction, String(minsAgo), `k${dn}`],
+    );
+  }
+  /** 팬아웃 2명 + 1명만 답 = 마감 대상이 되는 표준 상황 */
+  function stalledFanout(d: Database) {
+    msg(d, "tg-dm", "steve", "demis", 20);
+    msg(d, "tg-dm", "steve", "hermes", 20);
+    msg(d, "tg-dm", "demis", "steve", 15);
+  }
+
+  beforeEach(() => { db = withDm(db0()); n = 0; dn = 0; });
+
+  it("dm_message 가 없으면 (기존 동작) 잡는다 — 대조군", () => {
+    stalledFanout(db);
+    expect(findStalledCollections(db, AGENTS)).toHaveLength(1);
+  });
+
+  it("★팬아웃 이후 팀장 1:1 로 보고했으면 독촉하지 않는다★ (이게 없어서 중복보고를 시켰다)", () => {
+    stalledFanout(db);
+    dm(db, "steve", "out", 10);          // 마지막 질문(20분 전) 이후 = 종합 보고
+    expect(findStalledCollections(db, AGENTS)).toHaveLength(0);
+  });
+
+  it("팬아웃 ★이전★ DM 은 보고가 아니다 (시각 경계)", () => {
+    stalledFanout(db);
+    dm(db, "steve", "out", 30);          // 질문보다 먼저 = 이번 수집의 보고일 수 없다
+    expect(findStalledCollections(db, AGENTS)).toHaveLength(1);
+  });
+
+  it("들어온 DM(direction='in')은 보고가 아니다", () => {
+    stalledFanout(db);
+    dm(db, "steve", "in", 10);
+    expect(findStalledCollections(db, AGENTS)).toHaveLength(1);
+  });
+
+  it("★다른 멤버의 DM 은 이 사람의 보고가 아니다★", () => {
+    stalledFanout(db);
+    dm(db, "bill", "out", 10);
+    expect(findStalledCollections(db, AGENTS)).toHaveLength(1);
+  });
+});

--- a/src/server/bus/collectionDeadline.ts
+++ b/src/server/bus/collectionDeadline.ts
@@ -68,6 +68,60 @@ interface StalledCollection {
  *   · 마감 시간이 지났다
  *   → 깨운다. ★한 번만.★
  */
+/**
+ * ★"보고했나" 는 여기 한 곳에서만 판단한다.★
+ *
+ * 이 판정은 같은 병으로 이미 두 번 기워졌다 — 매번 ★어디로 간 보고를 인정할 것인가★ 였다:
+ *   2026-07-13  codex 가 팀장께 직보(to='user')했는데 팀원 발신만 보고 있어 ★불필요한 재촉 6건★
+ *               → `to_agent_id IN ('user','broadcast')` 를 추가해 기움
+ *   2026-07-26  claude 멤버가 ★텔레그램 reply 도구★ 로 팀장 1:1 에 종합을 보냈는데(그게 정본 경로다)
+ *               그 산출물은 `dm_message` 로 들어가고 thread_id 조차 없다 → message 조회로는 ★영원히 0★
+ *               → 이미 보고한 사람에게 "지금 종합해서 보내세요" 독촉이 갔다. 따르면 ★중복 보고★ 가 되어
+ *                 팀 규칙("같은 요청에 두 번 보고하지 마라")을 어기게 된다.
+ *                 ★규칙을 지킨 사람에게 규칙 위반을 유도하는 알림★ 이라 단순 노이즈가 아니다.
+ *
+ * 그래서 개별로 또 깁지 않고 경로를 여기로 모은다. ★새 보고 경로가 생기면 이 함수만 고친다.★
+ */
+export function hasReportedSince(
+  db: Database,
+  opts: { collector: string; thread_id: string; since: string; targets: string[] },
+): boolean {
+  const { collector, thread_id, since, targets } = opts;
+
+  // ① 버스 — 기여자가 아닌 ★어디로든★ 나갔으면 보고다(중간보고도 발신이다).
+  //   'gd' 리터럴은 옛 owner agent-id 표기의 잔재다. 실제로는 'user'(팀장 DM)·'broadcast'(방) 로 가고
+  //   바로 아래 NOT IN (targets) 가 '기여자가 아닌 어디로든' 을 이미 잡으므로 없어도 동작은 같다(하위호환).
+  const viaBus = (db
+    .prepare(
+      `SELECT COUNT(*) AS n FROM message
+        WHERE thread_id = ? AND from_agent_id = ? AND created_at > ?
+          AND (to_agent_id IS NULL
+               OR to_agent_id IN ('user','broadcast','gd')
+               OR to_agent_id NOT IN (${targets.map(() => "?").join(",")}))`,
+    )
+    .get(thread_id, collector, since, ...targets) as { n: number }).n;
+  if (viaBus > 0) return true;
+
+  // ② 팀장 1:1 DM — claude 멤버가 팀장에게 답하는 ★정본 경로★(텔레그램 reply 도구)의 산출물.
+  //   dm_message 에는 thread_id 가 없어 ★시각 기준★ 이 될 수밖에 없다.
+  //   그래서 무관한 DM 을 보고로 오인할 수 있는데, 그 오탐은 ★독촉을 한 번 안 하는★ 쪽이다.
+  //   이미 보고한 사람을 독촉해 중복 보고를 시키는 지금의 오탐보다 안전 측이다.
+  //   ★테이블이 없어도 죽지 않는다★ — dm_message 는 뒤에 추가된 테이블이라 마이그레이션 이전 DB 에는
+  //   없다. 감시 루프가 그것 때문에 통째로 예외로 멈추면 ★수집 마감 감지 전체★ 가 죽는다.
+  //   없을 때의 결과(false)는 이 수정 이전 동작과 정확히 같으므로 회귀가 아니다.
+  try {
+    const viaDm = (db
+      .prepare(
+        `SELECT COUNT(*) AS n FROM dm_message
+          WHERE member_id = ? AND direction = 'out' AND created_at > ?`,
+      )
+      .get(collector, since) as { n: number }).n;
+    return viaDm > 0;
+  } catch {
+    return false;
+  }
+}
+
 export function findStalledCollections(db: Database, agents: AgentRecord[]): StalledCollection[] {
   const ids = new Set(agents.map((a) => a.id));
   const collectors = [...ids];
@@ -166,26 +220,8 @@ export function findStalledCollections(db: Database, agents: AgentRecord[]): Sta
       //   (정상 경로는 5분에 잡힌다. 여기까지 온 건 감지가 뭔가 놓친 것이다 → ★조용히 넘긴다★)
       if (minsSince > MAX_DEADLINE_AGE_MIN) continue;
 
-      // 마지막 질문 이후 ★기여자가 아닌 누군가에게★ 보냈나 = 보고했다 (중간보고도 발신이다)
-      //
-      // ★sends 는 팀원에게 간 것만 본다★ — 그런데 보고는 ★팀장(user)·방(broadcast)★ 으로도 간다.
-      //   실측(2026-07-13): codex 가 팀장께 직보(to='user')했는데 sends 에 안 잡혀 ★불필요한 재촉★ 6건.
-      //   ★"보고했나" 는 수신자를 가리지 않는다.★ 기여자 아닌 ★어디로든★ 나갔으면 보고한 것이다.
-      // 'gd' 리터럴에 대하여:
-      //   아래 `IN ('user','broadcast','gd')` 의 'gd' 는 옛 owner agent-id 표기의 잔재다. 리포트는
-      //   'user'(owner DM)·'broadcast'(방) 로 가고 이 둘이 실제 케이스를 다 커버하므로 'gd' 는
-      //   매칭되지 않는 무해한 leftover다. 게다가 바로 아래 `NOT IN (targets)` 절이 '기여자가 아닌
-      //   어디로든' 을 이미 잡으므로 'gd' 없이도 동작은 동일하다(하위호환을 위해 남겨 둠).
-      const reportedElsewhere = (db
-        .prepare(
-          `SELECT COUNT(*) AS n FROM message
-            WHERE thread_id = ? AND from_agent_id = ? AND created_at > ?
-              AND (to_agent_id IS NULL
-                   OR to_agent_id IN ('user','broadcast','gd')
-                   OR to_agent_id NOT IN (${targets.map(() => "?").join(",")}))`,
-        )
-        .get(thread_id, C, lastAsk, ...targets) as { n: number }).n;
-      if (reportedElsewhere > 0) continue;
+      // 마지막 질문 이후 보고했나 — 판단은 hasReportedSince() 한 곳에서만 한다(아래 정의).
+      if (hasReportedSince(db, { collector: C, thread_id, since: lastAsk, targets })) continue;
 
       const missing: string[] = [];
       const answered: string[] = [];


### PR DESCRIPTION
## 무엇이 문제였나

수집 마감 독촉의 "보고했나" 판정이 `message` 테이블만 봤습니다. 그런데 claude 멤버가 팀장 1:1 에 답하는 **정본 경로는 텔레그램 reply 도구**이고(CLAUDE.md 명시), 그 산출물은 `dm_message` 로 들어갑니다. `thread_id` 조차 없어 `message` 조회로는 **영원히 0** 입니다.

**실측** (2026-07-26, Steve):
```
16:43:01  steve → 팀장 1:1 DM 으로 종합 보고     (dm_message 에 기록됨)
16:47     [마감] "전원이 이미 답했습니다.
                 지금 종합해서 요청자에게 보내세요."
```

## 왜 단순 노이즈가 아닌가

독촉이 **"지금 종합해서 보내세요"** 라고 합니다. **이미 보낸 사람에게 한 번 더 보내라고 시킵니다.**

따르면 *"같은 요청에 두 번 보고하지 마라"* 를 어기게 되고, 팀장은 같은 보고를 두 번 받습니다. **규칙을 지킨 사람에게 규칙 위반을 유도하는 알림**입니다. DM 발 수집은 claude 멤버에게 상시 경로라 매번 뜹니다.

## 개별로 또 깁지 않았습니다

이 판정은 **같은 병으로 이미 기워진 적이 있습니다** — 2026-07-13 에 codex 가 팀장께 직보(`to='user'`)했는데 안 잡혀 재촉 6건이 났고, 그때 `user`/`broadcast` 를 추가했습니다.

매번 **"어디로 간 보고를 인정할 것인가"** 였습니다. 그래서 `hasReportedSince()` 로 **보고 인정 경로를 한 곳에 모았습니다.** 새 경로가 생기면 그 함수만 고칩니다.

## ⚠️ 테이블 부재를 견딥니다

`dm_message` 는 뒤에 추가된 테이블이라 **마이그레이션 이전 DB 에는 없습니다.** 그대로 두면 감시 루프 전체가 예외로 멈춥니다 — 실제로 이 수정 도중 기존 테스트 15건이 그렇게 깨졌습니다.

없을 때의 결과(`false`)는 이 수정 **이전 동작과 정확히 같으므로** 회귀가 아닙니다.

## 오탐 방향

`dm_message` 에 `thread_id` 가 없어 **시각 기준**이 될 수밖에 없습니다. 무관한 DM 을 보고로 오인할 수 있는데, 그 오탐은 **독촉을 한 번 안 하는** 쪽입니다. 이미 보고한 사람을 독촉해 중복 보고를 시키는 지금의 오탐보다 안전 측입니다.

## 검증

**신규 테스트 5건** — 대조군 / DM 보고 인정 / **시각 경계**(팬아웃 이전 DM 은 보고 아님) / `direction='in'` 은 보고 아님 / 다른 멤버 DM 은 이 사람 보고 아님

**mutation 3종 전부 RED**:

| 변형 | 결과 |
|---|---|
| DM 경로 통째 제거 | 1 fail |
| `direction` 검사 제거 | 1 fail |
| 시각 검사 제거 | 1 fail |

기존 30건 포함 **35 pass / 0 fail**, 전체 **1663 tests 0 fail**, typecheck 통과.

---
발견: Steve.
