### PR TITLE
fix(deadline): 예외 삼킴을 "테이블 없음" 으로만 좁힌다

### DIFF
--- a/src/server/bus/collectionDeadline.test.ts
+++ b/src/server/bus/collectionDeadline.test.ts
@@ -526,4 +526,19 @@ describe("보고 인정 — 팀장 1:1 DM(dm_message)도 보고로 센다", () =
     dm(db, "bill", "out", 10);
     expect(findStalledCollections(db, AGENTS)).toHaveLength(1);
   });
+
+  it("★테이블이 없는 것(마이그레이션 이전)은 견딘다 — 예외 없이 기존 동작★", () => {
+    const bare = db0();                       // dm_message 없는 DB
+    stalledFanout(bare);
+    expect(() => findStalledCollections(bare, AGENTS)).not.toThrow();
+    expect(findStalledCollections(bare, AGENTS)).toHaveLength(1);   // 수정 이전과 동일
+  });
+
+  it("★진짜 DB 고장은 삼키지 않는다★ (넓은 catch 가 남으면 손상·락이 조용히 묻힌다)", () => {
+    stalledFanout(db);
+    // dm_message 를 조회 불가 상태로 만든다 — '테이블 없음' 이 아닌 다른 오류.
+    db.run("DROP TABLE dm_message");
+    db.run("CREATE VIEW dm_message AS SELECT 1 AS member_id WHERE 1=0");  // 컬럼 불일치 → no such column
+    expect(() => findStalledCollections(db, AGENTS)).toThrow();
+  });
 });

--- a/src/server/bus/collectionDeadline.ts
+++ b/src/server/bus/collectionDeadline.ts
@@ -117,7 +117,13 @@ export function hasReportedSince(
       )
       .get(collector, since) as { n: number }).n;
     return viaDm > 0;
-  } catch {
+  } catch (e) {
+    // ★"테이블이 없다" 만 삼킨다★ — 그건 마이그레이션 이전 DB 의 ★정상 상태★ 다.
+    //   그 외(DB 손상·락·디스크 오류)는 ★진짜 고장★ 이라 조용히 묻으면 안 된다 → 다시 던진다.
+    //   같은 파일에서 넓은 삼킴이 무엇을 낳았는지 이미 봤다: 로스터 읽기 실패를 "0명" 으로 삼킨 탓에
+    //   ★"새 설치의 정상 상태입니다" 라는 적극적 거짓 주장★ 이 나갔다(2026-07-26 PR#49 에서 고침).
+    //   여기서 넓게 삼키면 같은 형태를 새로 만드는 것이다.
+    if (!/no such table/i.test(String((e as { message?: unknown })?.message ?? e))) throw e;
     return false;
   }
 }


### PR DESCRIPTION
PR#59 에서 `dm_message` 조회를 try/catch 로 감쌌습니다. 마이그레이션 이전 DB 에 그 테이블이 없어 감시 루프가 통째로 죽는 걸 막기 위해서였고, 그 판단은 맞았습니다 — Steve 가 재현으로 확인해줬습니다(catch 없으면 SQLiteError 도배로 마감 감지가 전부 멈춤).

**그런데 모든 예외를 삼켰습니다.** DB 손상·락·디스크 오류 같은 진짜 고장도 조용히 `false` 가 됩니다.

## 왜 좁히나

같은 파일에서 넓은 삼킴이 무엇을 낳았는지 **오늘 이미 봤습니다** — 로스터 읽기 실패를 "0명" 으로 삼킨 탓에 **"새 설치의 정상 상태입니다" 라는 적극적 거짓 주장**이 나갔습니다(PR#49 에서 고침).

여기서 넓게 삼키면 같은 형태를 새로 만드는 것이고, 오늘 하루 그 패턴을 계속 지적해온 것과 앞뒤가 맞지 않습니다.

## 변경

`catch` 에서 `no such table` 만 삼키고 나머지는 다시 던집니다. **테이블 부재는 마이그레이션 이전 DB 의 정상 상태**이고, 그 외는 고장입니다.

## 검증

| 시나리오 | 기대 | 결과 |
|---|---|---|
| 테이블 없는 DB | 예외 없이 기존 동작 | ✅ |
| 조회 불가(컬럼 불일치) | **던진다** | ✅ |
| 넓은 catch 로 되돌림(mutation) | RED | ✅ 1 fail |

37 pass / 0 fail · 전체 1665 tests 0 fail · typecheck 통과

---
지적: Steve. 차단은 아니라고 판단했지만 좁힐 값어치가 있다고 봤습니다.