### PR TITLE
fix(rules): TEAM-OS 렌더본을 원자적으로 교체 (tmp → rename)

### DIFF
--- a/src/server/lib/teamOsRender.ts
+++ b/src/server/lib/teamOsRender.ts
@@ -4,7 +4,7 @@
 //   - 런타임이 읽는 파일: rules/TEAM-OS.md           ({{OWNER}}→owner_name 렌더; owner 비면 템플릿 그대로)
 // claude_channel: workspace 심링크(→ rules/TEAM-OS.md) · openclaw/hermes: AGENTS.md 가 rules/TEAM-OS.md 절대경로
 // 둘 다 rules/TEAM-OS.md 를 읽으므로 한 곳 렌더로 전 런타임 적용. 심링크 재지정은 표준 타깃(TEAM-OS.md) 보장용.
-import { readFileSync, writeFileSync, lstatSync, unlinkSync, symlinkSync, readlinkSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, renameSync, lstatSync, unlinkSync, symlinkSync, readlinkSync, existsSync } from "node:fs";
 import { REPO_ROOT, MEMBERS_ROOT } from "./personaTemplates";
 
 const RULES_DIR = `${REPO_ROOT}/rules`; // 포터블: repo 루트 기준(GD 2026-06-27 — 하드코딩 제거)
@@ -24,7 +24,20 @@ export function renderTeamOs(ownerName: string | null | undefined): { ok: boolea
     if (owner) text = text.split("{{OWNER}}").join(owner);
     // skip-if-unchanged: 렌더 결과가 기존 LIVE 와 동일하면 재작성 생략 (GD 2026-07-19 — 룰 변화 없으면 매 부팅 렌더하지 마라).
     if (existsSync(LIVE) && readFileSync(LIVE, "utf-8") === text) return { ok: true, owner };
-    writeFileSync(LIVE, text, "utf-8");
+    // ★원자적 쓰기: 임시파일 → rename★ (infra-safety ② "상태 파일은 임시파일 작성 → 원자적 mv").
+    //   이 파일은 ★전 런타임이 읽는 정본★ 이라, 쓰는 도중을 다른 프로세스가 읽으면 ★반쪽짜리 룰★ 을
+    //   읽게 된다(writeFileSync 는 원자적이지 않다 — truncate 후 기록이라 그 사이에 창이 있다).
+    //   서버 부팅·설정 저장·테스트가 동시에 렌더를 부를 수 있으므로 rename 으로 갈아끼운다
+    //   (같은 파일시스템이라 rename 은 원자적: 읽는 쪽은 옛 내용 아니면 새 내용, 그 중간은 없다).
+    //   tmp 이름에 pid 를 넣어 동시 렌더끼리 서로의 임시파일을 덮지 않게 한다.
+    const tmp = `${LIVE}.tmp-${process.pid}`;
+    try {
+      writeFileSync(tmp, text, "utf-8");
+      renameSync(tmp, LIVE);
+    } catch (e) {
+      try { if (existsSync(tmp)) unlinkSync(tmp); } catch { /* 정리 실패는 무시 — 원래 오류를 덮지 않는다 */ }
+      throw e;
+    }
     return { ok: true, owner };
   } catch (e) {
     return { ok: false, owner, error: e instanceof Error ? e.message : String(e) };

--- a/src/server/lib/teamOsRenderAtomic.test.ts
+++ b/src/server/lib/teamOsRenderAtomic.test.ts
@@ -1,0 +1,75 @@
+// rules/TEAM-OS.md 렌더는 ★제자리 수정이 아니라 통째 교체★ 여야 한다.
+//
+// 왜: 이 파일은 ★전 런타임이 읽는 정본★ 이다(claude 는 워크스페이스 심링크로, openclaw/hermes 는
+// AGENTS.md 의 절대경로로 같은 파일을 읽는다). writeFileSync 는 truncate 후 기록이라 원자적이지
+// 않아서, 쓰는 도중에 읽는 프로세스는 ★반쪽짜리 룰★ 을 볼 수 있다. 서버 부팅·설정 저장·테스트가
+// 동시에 렌더를 부를 수 있으므로 tmp 에 쓰고 rename 으로 갈아끼운다(infra-safety ② 와 같은 규칙).
+//
+// ★이 테스트가 무엇을 세우고, 무엇은 못 세우나★
+//   세우는 것: 렌더가 ★같은 파일을 고쳐 쓰지 않고 새 파일로 교체★ 한다는 것(inode 가 바뀐다).
+//     rename 은 같은 파일시스템에서 원자적이므로, 이게 성립하면 읽는 쪽은 옛 내용 아니면 새 내용만
+//     본다 — 중간 상태가 존재할 수 없다. 비원자적 writeFileSync 로 되돌리면 inode 가 유지되어
+//     ★이 단언이 즉시 깨진다★(= 뮤턴트가 잡힌다).
+//   ★못 세우는 것★: "동시 접근에서 찢어진 읽기가 실제로 관측된다" 는 실측으로 보이지 못했다.
+//     실제 파일 크기(약 9KB)에서는 창이 너무 좁아 이 플랫폼에선 재현되지 않는다(리뷰의 20/20
+//     통과와 같은 이유). 3MB 로 키우면 재현되지만, 실물과 무관한 크기의 스트레스 테스트를 상시로
+//     두는 건 비용만 크고 근거는 약하다. 그래서 ★관측 대신 메커니즘★ 을 고정한다.
+//
+// ★격리★: REPO_ROOT 는 모듈 로드 시점 const 라 이 프로세스에서 바꿀 수 없다. 라이브 트리에서
+//   돌 때 정본 rules/TEAM-OS.md 를 잠깐이라도 건드리면 그 순간 런타임이 반쪽 룰을 읽을 수 있으므로
+//   (infra-safety ④), ★TEAM_COLLAB_ROOT 를 tmp 로 지정한 하위 프로세스★ 에서만 렌더한다.
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let root: string;
+const TEMPLATE_TEXT = "# TEAM-OS (fixture)\n\nowner={{OWNER}}\n\n본문 몇 줄.\n";
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "b3os-render-"));
+  mkdirSync(join(root, "rules"), { recursive: true });
+  writeFileSync(join(root, "rules", "TEAM-OS.template.md"), TEMPLATE_TEXT, "utf-8");
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+/** 격리 repo 루트에서 renderTeamOs 를 n회 실행하고, 매회 렌더 전/후 inode 를 돌려준다. */
+function renderInIsolation(times: number, seed?: string): Array<{ before: number; after: number; text: string }> {
+  const entry = join(import.meta.dir, "teamOsRender.ts");
+  const script = `
+    const { statSync, writeFileSync, readFileSync } = require("node:fs");
+    const LIVE = ${JSON.stringify(join(root, "rules", "TEAM-OS.md"))};
+    ${seed === undefined ? "" : `writeFileSync(LIVE, ${JSON.stringify(seed)}, "utf-8");`}
+    const { renderTeamOs } = await import(${JSON.stringify(entry)});
+    const out = [];
+    for (let i = 0; i < ${times}; i++) {
+      const before = statSync(LIVE).ino;
+      const r = renderTeamOs(null);
+      if (!r.ok) throw new Error("render failed: " + r.error);
+      out.push({ before, after: statSync(LIVE).ino, text: readFileSync(LIVE, "utf-8") });
+    }
+    console.log(JSON.stringify(out));
+  `;
+  const p = Bun.spawnSync(["bun", "-e", script], { env: { ...process.env, TEAM_COLLAB_ROOT: root } });
+  const stdout = p.stdout.toString().trim();
+  if (p.exitCode !== 0) throw new Error(`subprocess failed: ${p.stderr.toString().slice(-500)}`);
+  return JSON.parse(stdout.slice(stdout.lastIndexOf("[")));
+}
+
+test("★렌더는 제자리 수정이 아니라 파일 교체다★ (inode 가 바뀐다 = rename 경로)", () => {
+  const [r] = renderInIsolation(1, "SENTINEL-BEFORE\n");
+  expect(r!.text).not.toBe("SENTINEL-BEFORE\n");        // 실제로 다시 썼는가(헛통과 방지)
+  expect(r!.text).toBe(TEMPLATE_TEXT);                  // owner 없음 → 템플릿 그대로
+  expect(r!.after).not.toBe(r!.before);                 // ★핵심: 갈아끼웠다★
+});
+
+test("내용이 같으면 아예 쓰지 않는다 (skip-if-unchanged 유지 — 매 부팅 렌더 방지)", () => {
+  const [first, second] = renderInIsolation(2, "SENTINEL-BEFORE\n");
+  expect(first!.after).not.toBe(first!.before);         // 1회차: 교체
+  expect(second!.after).toBe(second!.before);           // 2회차: 같은 결과 → 교체조차 안 함
+});
+
+test("임시파일을 남기지 않는다", () => {
+  renderInIsolation(2, "SENTINEL-BEFORE\n");
+  expect(readdirSync(join(root, "rules")).filter((f) => f.includes("TEAM-OS.md.tmp-"))).toEqual([]);
+});


### PR DESCRIPTION
PR#55 리뷰에서 "머지 차단 사유는 아니니 판단에 맡긴다"고 넘어온 렌더 race 를 정리한다. #55 가 머지되어 이제 가능해졌다.

## 무엇이 문제였나

`rules/TEAM-OS.md` 는 **전 런타임이 읽는 정본**이다 — claude 는 워크스페이스 심링크로, openclaw/hermes 는 `AGENTS.md` 의 절대경로로 같은 파일을 읽는다. 그런데 렌더가 `writeFileSync` 로 **제자리에** 썼다. `writeFileSync` 는 truncate 후 기록이라 원자적이지 않아, 쓰는 도중에 읽는 프로세스는 **반쪽짜리 룰**을 볼 수 있다. 서버 부팅·설정 저장·테스트가 동시에 렌더를 부를 수 있다.

→ tmp 에 쓰고 `rename` 으로 갈아끼운다. 같은 파일시스템에서 rename 은 원자적이라 읽는 쪽은 **옛 내용 아니면 새 내용**만 본다. tmp 이름에 pid 를 넣어 동시 렌더끼리 서로의 임시파일을 덮지 않게 했고, 실패 시 tmp 를 정리하되 원래 오류를 덮지 않는다.

이건 우리 `b3os-infra-safety` ② — *"상태 파일은 임시파일 작성 → 검증 → 원자적 mv"* — 가 이미 요구하던 것이다.

## 테스트가 무엇을 세우고, 무엇은 못 세우나

**세우는 것**: 렌더가 **제자리 수정이 아니라 파일 교체**라는 것(inode 가 바뀐다). rename 이 원자적이므로 이게 성립하면 찢어진 읽기는 존재할 수 없다.

> **뮤턴트 확인: 원자적 쓰기를 되돌리면 1 pass / 2 fail (KILLED). 복원하면 3 pass / 0 fail.**

**못 세우는 것**: *"찢어진 읽기가 실제로 관측된다"* 는 실측으로 보이지 못했다. 실제 파일 크기(약 9KB)에서는 창이 너무 좁아 이 플랫폼에서 재현되지 않는다 — 리뷰에서 20/20 이 통과한 것과 같은 이유다.

3MB 로 키우면 재현된다(실제로 확인했다). 하지만 실물과 무관한 크기의 스트레스 테스트를 상시로 두는 건 비용만 크고 근거는 약해서 넣지 않았다. **관측 대신 메커니즘을 고정했다**는 걸 테스트 주석에 그대로 적어뒀다. 처음에 만든 동시성 레이스 테스트는 **비원자적 버전에서도 통과**해서(= 아무것도 증명하지 못해서) 버렸다.

`skip-if-unchanged` 도 함께 고정했다 — 같은 결과면 교체조차 안 한다(매 부팅 렌더 방지).

## 테스트 격리

`REPO_ROOT` 는 모듈 로드 시점 const 라 이 프로세스에서 바꿀 수 없다. 라이브 트리에서 돌 때 정본 `rules/TEAM-OS.md` 를 잠깐이라도 건드리면 그 순간 런타임이 반쪽 룰을 읽을 수 있으므로(infra-safety ④), **`TEAM_COLLAB_ROOT` 를 tmp 로 준 하위 프로세스**에서만 렌더한다.

처음엔 실제 `rules/` 를 쓰고 복구하는 방식으로 짰다가, 바로 그 이유로 다시 만들었다.

## 검증

| 항목 | 결과 |
|---|---|
| `bun test src/server src/web` | **1616 pass / 5 skip / 0 fail** |
| main(`1d18a76`) 베이스라인 | 1613 / 5 / 0 |
| 차이 | **+3 = 이번에 추가한 테스트 수와 정확히 일치, 회귀 0** |
| `tsc --noEmit` | 0 |

워크트리의 `rules/TEAM-OS.md` 테스트 전후 해시 동일(무변경) · 라이브 트리 무수정.