### PR TITLE
revert(deadline): dm_message 를 보고 근거로 쓰지 않는다 (GD 결정)

### DIFF
--- a/src/server/bus/collectionDeadline.test.ts
+++ b/src/server/bus/collectionDeadline.test.ts
@@ -462,7 +462,14 @@ describe("★독촉 본문 — 개별보고면 무시하라고 알림이 직접 
 });
 
 /**
- * ★감시하는 쪽이 자기가 요구한 것을 볼 수 있어야 한다★ (2026-07-26, steve 발견)
+ * ★팀장 1:1 DM(dm_message)은 보고 근거로 쓰지 않는다★ (GD 2026-07-26 결정)
+ *
+ * 한 번 넣었다가 되돌렸다. 이 테스트들은 ★그 결정을 고정한다★ — 누가 다시 넣으면 여기서 잡힌다.
+ * 이유: dm_message 는 openclaw 에서 팀원 발신이 영구 0건, hermes 는 대부분 유실이다(2026-07-17 실측).
+ *       그걸 근거로 삼으면 claude 만 면제되고 나머지는 그대로 독촉받는 ★런타임별 불공평★ 이 생긴다.
+ *       보고 리마인드는 expect-report(pending_followup)로 간다.
+ *
+ * 아래는 원래 문제 기록 (2026-07-26, steve 발견) — 문제 자체는 여전히 유효하다:
  *
  * 독촉 문구는 "지금 종합해서 요청자에게 보내세요" 다. 그런데 claude 멤버가 팀장 1:1 에 답하는
  * ★정본 경로는 텔레그램 reply 도구★ 이고, 그 산출물은 dm_message 로 들어간다(thread_id 없음).
@@ -470,7 +477,7 @@ describe("★독촉 본문 — 개별보고면 무시하라고 알림이 직접 
  * 따르면 "같은 요청에 두 번 보고하지 마라" 를 어기게 된다 —
  * ★규칙을 지킨 사람에게 규칙 위반을 유도하는 알림★ 이라 단순 노이즈가 아니다.
  */
-describe("보고 인정 — 팀장 1:1 DM(dm_message)도 보고로 센다", () => {
+describe("보고 인정 — 팀장 1:1 DM(dm_message)은 근거로 쓰지 않는다", () => {
   let db: Database;
 
   // 실제 스키마와 같은 모양(thread_id 없음 — 그래서 시각 기준이 될 수밖에 없다)
@@ -503,10 +510,12 @@ describe("보고 인정 — 팀장 1:1 DM(dm_message)도 보고로 센다", () =
     expect(findStalledCollections(db, AGENTS)).toHaveLength(1);
   });
 
-  it("★팬아웃 이후 팀장 1:1 로 보고했으면 독촉하지 않는다★ (이게 없어서 중복보고를 시켰다)", () => {
+  it("★팀장 1:1 로 보고해도 이 판정은 인정하지 않는다★ — 신뢰할 수 없는 캡처라 근거로 안 쓴다", () => {
     stalledFanout(db);
-    dm(db, "steve", "out", 10);          // 마지막 질문(20분 전) 이후 = 종합 보고
-    expect(findStalledCollections(db, AGENTS)).toHaveLength(0);
+    dm(db, "steve", "out", 10);          // 마지막 질문(20분 전) 이후에 DM 이 나갔지만
+    expect(findStalledCollections(db, AGENTS)).toHaveLength(1);   // ★그래도 독촉 대상★
+    // 되돌린 이유는 오탐이 없어서가 아니다 — openclaw 는 out 이 영구 0건이라
+    // 이 근거를 쓰면 claude 만 면제되는 불공평이 생기기 때문이다.
   });
 
   it("팬아웃 ★이전★ DM 은 보고가 아니다 (시각 경계)", () => {
@@ -534,11 +543,4 @@ describe("보고 인정 — 팀장 1:1 DM(dm_message)도 보고로 센다", () =
     expect(findStalledCollections(bare, AGENTS)).toHaveLength(1);   // 수정 이전과 동일
   });
 
-  it("★진짜 DB 고장은 삼키지 않는다★ (넓은 catch 가 남으면 손상·락이 조용히 묻힌다)", () => {
-    stalledFanout(db);
-    // dm_message 를 조회 불가 상태로 만든다 — '테이블 없음' 이 아닌 다른 오류.
-    db.run("DROP TABLE dm_message");
-    db.run("CREATE VIEW dm_message AS SELECT 1 AS member_id WHERE 1=0");  // 컬럼 불일치 → no such column
-    expect(() => findStalledCollections(db, AGENTS)).toThrow();
-  });
 });

--- a/src/server/bus/collectionDeadline.ts
+++ b/src/server/bus/collectionDeadline.ts
@@ -102,30 +102,27 @@ export function hasReportedSince(
     .get(thread_id, collector, since, ...targets) as { n: number }).n;
   if (viaBus > 0) return true;
 
-  // ② 팀장 1:1 DM — claude 멤버가 팀장에게 답하는 ★정본 경로★(텔레그램 reply 도구)의 산출물.
-  //   dm_message 에는 thread_id 가 없어 ★시각 기준★ 이 될 수밖에 없다.
-  //   그래서 무관한 DM 을 보고로 오인할 수 있는데, 그 오탐은 ★독촉을 한 번 안 하는★ 쪽이다.
-  //   이미 보고한 사람을 독촉해 중복 보고를 시키는 지금의 오탐보다 안전 측이다.
-  //   ★테이블이 없어도 죽지 않는다★ — dm_message 는 뒤에 추가된 테이블이라 마이그레이션 이전 DB 에는
-  //   없다. 감시 루프가 그것 때문에 통째로 예외로 멈추면 ★수집 마감 감지 전체★ 가 죽는다.
-  //   없을 때의 결과(false)는 이 수정 이전 동작과 정확히 같으므로 회귀가 아니다.
-  try {
-    const viaDm = (db
-      .prepare(
-        `SELECT COUNT(*) AS n FROM dm_message
-          WHERE member_id = ? AND direction = 'out' AND created_at > ?`,
-      )
-      .get(collector, since) as { n: number }).n;
-    return viaDm > 0;
-  } catch (e) {
-    // ★"테이블이 없다" 만 삼킨다★ — 그건 마이그레이션 이전 DB 의 ★정상 상태★ 다.
-    //   그 외(DB 손상·락·디스크 오류)는 ★진짜 고장★ 이라 조용히 묻으면 안 된다 → 다시 던진다.
-    //   같은 파일에서 넓은 삼킴이 무엇을 낳았는지 이미 봤다: 로스터 읽기 실패를 "0명" 으로 삼킨 탓에
-    //   ★"새 설치의 정상 상태입니다" 라는 적극적 거짓 주장★ 이 나갔다(2026-07-26 PR#49 에서 고침).
-    //   여기서 넓게 삼키면 같은 형태를 새로 만드는 것이다.
-    if (!/no such table/i.test(String((e as { message?: unknown })?.message ?? e))) throw e;
-    return false;
-  }
+  // ② 팀장 1:1 DM 은 ★근거로 쓰지 않는다★ (GD 2026-07-26 결정)
+  //
+  //   한 번 넣었다가 되돌렸다. 이유를 남긴다 —
+  //   claude 멤버가 팀장 1:1 에 답하는 정본 경로는 텔레그램 reply 도구이고 그 산출물은 dm_message 다.
+  //   그래서 여기서 dm_message 를 보면 오탐이 준다. 실제로 줄었다.
+  //   ★그런데 그 테이블을 신뢰할 수 없다.★ 2026-07-17 실측 기준:
+  //     · openclaw : 팀원 발신(out)이 ★영구 0건★ (sessionKey 불일치)
+  //     · hermes   : 프로필 경로 규칙 불일치로 대부분 유실
+  //     · claude   : 정상
+  //   즉 이걸 근거로 삼으면 ★claude 만 면제되고 openclaw·hermes 는 그대로 독촉받는다.★
+  //   오탐 하나를 고치면서 ★런타임별 불공평★ 을 새로 만드는 셈이다.
+  //   게다가 파서 상태(dm_sync_health)를 봐도 못 거른다 — openclaw 는 "성공" 인데 내용이 0건이다.
+  //
+  //   팀 결정: dm_message 의 소비처는 ★재시작 recall 주입★ 으로 한정한다(확대 금지).
+  //   보고 리마인드는 ★expect-report(pending_followup)★ 로 간다 — 팀원이 스스로 등록하므로
+  //   깨진 캡처에 의존하지 않는다.
+  //
+  //   ★이 자리를 비워두는 게 아니라, 붙일 곳을 명시해 둔다★ — 새 보고 인정 경로가 생기면
+  //   (예: expect-report 연계) 이 함수 안에 넣는다. 개별 호출부에 흩뿌리지 않는다.
+  return false;
+
 }
 
 export function findStalledCollections(db: Database, agents: AgentRecord[]): StalledCollection[] {


### PR DESCRIPTION
PR#59 에서 마감 판정이 팀장 1:1 DM(`dm_message`)도 보고로 인정하게 했습니다. 스티브가 겪은 오탐은 실제로 사라졌습니다. **그런데 근거로 쓰면 안 되는 데이터였습니다.**

## 왜 되돌리나

`dm_message` 는 각 런타임의 사설 저장소를 긁어 채웁니다. **2026-07-17 실측**:

| 런타임 | 상태 |
|---|---|
| **openclaw** | 팀원 발신(out) **영구 0건** (sessionKey 불일치) |
| **hermes** | 프로필 경로 규칙 불일치로 대부분 유실 |
| claude | 정상 |

즉 이걸 근거로 삼으면 **claude 만 면제되고 openclaw·hermes 는 그대로 독촉받습니다.** 오탐 하나를 고치면서 **런타임별 불공평**을 새로 만드는 셈입니다.

파서 상태(`dm_sync_health`)를 같이 보는 보완책도 만들다 폐기했습니다 — openclaw 는 파싱이 "성공"으로 뜨는데 내용이 0건이라 **상태로는 못 거릅니다.**

그리고 팀에 이미 결정이 있었습니다: **`dm_message` 의 소비처는 재시작 recall 주입으로 한정(확대 금지).** 제가 그 결정을 확인하지 않고 판정 근거로 썼습니다.

## 무엇을 남기나

- `hasReportedSince()` **구조는 남깁니다** — "보고 인정 경로는 한 곳에서 판단한다"는 원칙은 유효하고, expect-report 연계를 붙일 자리가 됩니다. 그 자리에 **왜 비어 있는지와 무엇을 붙여야 하는지**를 주석으로 남겼습니다
- 버스 경로(기여자 아닌 어디로든 발신 = 보고)는 그대로입니다

## 앞으로

보고 리마인드는 **expect-report(pending_followup)** 로 갑니다 — 팀원이 스스로 등록하므로 깨진 캡처에 의존하지 않습니다.

> ⚠️ 다만 현재 expect-report 는 **턴기반(openclaw/hermes)만** 등록 가능합니다. 스티브는 claude 라 애초에 쓸 수 없었습니다 — **그게 이 사건의 진짜 사각지대**입니다. 별건으로 다룹니다.

## 검증

테스트를 **결정을 고정하는 방향**으로 전환했습니다 — "DM 으로 보고해도 이 판정은 인정하지 않는다"를 단언합니다. 누가 다시 넣으면 잡힙니다.

**mutation**: `dm_message` 조회를 되살리면 **1 fail**.

> 처음엔 치환 패턴이 안 맞아 **mutation 이 적용조차 안 된 채 "통과"로 읽을 뻔했습니다.** grep 으로 적용 여부를 먼저 확인하고 다시 돌렸습니다.

36 pass / 0 fail · 전체 1664 tests 0 fail · typecheck 통과