### PR TITLE
fix(ot): 승인이 라우트 밖에서 끝나면 영입 위저드가 영구히 안 닫히던 것

### DIFF
--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -116,6 +116,7 @@ describe("Claude pairing backend contract", () => {
     // 수동 승인이 끝난 뒤의 실제 모양: allowlist + allowFrom 1건 + pending 비어 있음
     const approvedAccess = { dmPolicy: "allowlist", allowFrom: ["1000000001"], groups: {}, pending: {} };
     writeFileSync(join(accessDir, "access.json"), JSON.stringify(approvedAccess));
+    db.query("INSERT INTO setting (key, value) VALUES ('owner_chat_id', '1000000001')").run();
     const steps = [
       { key: "register", state: "done" }, { key: "provision", state: "done" },
       { key: "preflight", state: "done" }, { key: "bundle", state: "done" }, { key: "join", state: "pending" },
@@ -169,6 +170,65 @@ describe("Claude pairing backend contract", () => {
     expect((db.query("SELECT stage FROM ot WHERE id='ot_other'").get() as any).stage).toBe("joined");
     delete process.env.CLAUDE_CHANNELS_DIR;
     if (oldEnv === undefined) delete process.env.GD_CHAT_ID; else process.env.GD_CHAT_ID = oldEnv;
+  });
+
+  /* 코덱스 리뷰: "모르면 조건을 뺀다" 는 ★강화한 척★ 이었다. owner_chat_id 는 부팅 시 1회만 자동
+   * persist 되고 Settings 입력도 선택이라, 정작 필요한 순간(첫 페어링·수동 promote 직후)에는 비어 있다.
+   * 그래서 팀장 id 를 모르면 정합하지 않고, 대신 ★무엇을 하면 열리는지★ 를 알려준다. */
+  test("★팀장 id 를 모르면 정합하지 않는다★ — owner_identity_unknown (막다른 길이 아니라 복구행동 명시)", async () => {
+    const oldEnv = process.env.GD_CHAT_ID; delete process.env.GD_CHAT_ID;
+    const { app, dir, db } = setup();
+    const channels = join(dir, "claude-channels");
+    process.env.CLAUDE_CHANNELS_DIR = channels;
+    const accessDir = join(channels, "telegram-bill");
+    mkdirSync(accessDir, { recursive: true });
+    writeFileSync(join(accessDir, "access.json"), JSON.stringify({
+      dmPolicy: "allowlist", allowFrom: ["999999999"], groups: {}, pending: {},
+    }));
+    const steps = [
+      { key: "register", state: "done" }, { key: "provision", state: "done" },
+      { key: "preflight", state: "done" }, { key: "bundle", state: "done" }, { key: "join", state: "pending" },
+    ];
+    db.query("INSERT INTO ot(id,member_id,stage,steps_json) VALUES('ot_noowner','bill','join',?)").run(JSON.stringify({ steps }));
+
+    const res = await app.request("/ot/ot_noowner/claude-pair-approve", json({ code: "abc123" }));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: "owner_identity_unknown" });
+    expect((db.query("SELECT stage FROM ot WHERE id='ot_noowner'").get() as any).stage).toBe("join");
+    delete process.env.CLAUDE_CHANNELS_DIR;
+    if (oldEnv === undefined) delete process.env.GD_CHAT_ID; else process.env.GD_CHAT_ID = oldEnv;
+  });
+
+  /* 위 fail-closed 가 막다른 길이 되지 않으려면 ★정상 승인이 owner_chat_id 를 채워야★ 한다.
+   * 정상 승인은 팀장 신원을 확인할 수 있는 유일한 지점이다(검증된 senderId). */
+  test("★정상 승인은 owner_chat_id 를 채운다★ — 단 팀장이 직접 넣은 값은 덮지 않는다", async () => {
+    const { app, dir, db } = setup();
+    const channels = join(dir, "claude-channels");
+    process.env.CLAUDE_CHANNELS_DIR = channels;
+    const accessDir = join(channels, "telegram-bill");
+    mkdirSync(accessDir, { recursive: true });
+    writeFileSync(join(accessDir, "access.json"), JSON.stringify({
+      dmPolicy: "pairing", allowFrom: [], groups: {},
+      pending: { abc123: { senderId: "1000000001", chatId: "1000000001", expiresAt: Date.now() + 60_000 } },
+    }));
+    const steps = [
+      { key: "register", state: "done" }, { key: "provision", state: "done" },
+      { key: "preflight", state: "done" }, { key: "bundle", state: "done" }, { key: "join", state: "pending" },
+    ];
+    db.query("INSERT INTO ot(id,member_id,stage,steps_json) VALUES('ot_persist','bill','join',?)").run(JSON.stringify({ steps }));
+
+    expect((await app.request("/ot/ot_persist/claude-pair-approve", json({ code: "abc123" }))).status).toBe(200);
+    expect((db.query("SELECT value FROM setting WHERE key='owner_chat_id'").get() as any)?.value).toBe("1000000001");
+
+    // 이미 값이 있으면 나중 페어링이 조용히 바꾸지 않는다
+    writeFileSync(join(accessDir, "access.json"), JSON.stringify({
+      dmPolicy: "pairing", allowFrom: [], groups: {},
+      pending: { def456: { senderId: "2222222222", chatId: "2222222222", expiresAt: Date.now() + 60_000 } },
+    }));
+    db.query("INSERT INTO ot(id,member_id,stage,steps_json) VALUES('ot_persist2','bill','join',?)").run(JSON.stringify({ steps }));
+    expect((await app.request("/ot/ot_persist2/claude-pair-approve", json({ code: "def456" }))).status).toBe(200);
+    expect((db.query("SELECT value FROM setting WHERE key='owner_chat_id'").get() as any)?.value).toBe("1000000001");
+    delete process.env.CLAUDE_CHANNELS_DIR;
   });
 
   test("승인도 pending 도 없으면 여전히 409 — 정합이 미승인을 합류로 만들지 않는다", async () => {

--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -134,6 +134,43 @@ describe("Claude pairing backend contract", () => {
     delete process.env.CLAUDE_CHANNELS_DIR;
   });
 
+  /* 정합 조건을 '누군가 승인됨' 이 아니라 '★팀장이 실제로 닿을 수 있음★' 까지 좁힌다.
+   * 팀장 chat_id 는 setting(owner_chat_id)/env 같은 ★비순환★ 출처에서만 읽는다 — resolveOwnerDmId() 는
+   * 못 찾으면 access.json 의 allowFrom[0] 을 읽는 폴백이 있어서, 그걸로 allowFrom 을 검증하면
+   * 자기 자신을 확인하는 순환이 되어 무조건 통과한다. */
+  test("★팀장 id 를 아는데 allowlist 에 없으면 합류로 만들지 않는다★ (남이 승인된 경우)", async () => {
+    const oldEnv = process.env.GD_CHAT_ID; delete process.env.GD_CHAT_ID;
+    const { app, dir, db } = setup();
+    const channels = join(dir, "claude-channels");
+    process.env.CLAUDE_CHANNELS_DIR = channels;
+    const accessDir = join(channels, "telegram-bill");
+    mkdirSync(accessDir, { recursive: true });
+    // 승인은 돼 있지만 허용된 사람이 팀장이 아니다
+    writeFileSync(join(accessDir, "access.json"), JSON.stringify({
+      dmPolicy: "allowlist", allowFrom: ["999999999"], groups: {}, pending: {},
+    }));
+    db.query("INSERT INTO setting (key, value) VALUES ('owner_chat_id', '1000000001')").run();
+    const steps = [
+      { key: "register", state: "done" }, { key: "provision", state: "done" },
+      { key: "preflight", state: "done" }, { key: "bundle", state: "done" }, { key: "join", state: "pending" },
+    ];
+    db.query("INSERT INTO ot(id,member_id,stage,steps_json) VALUES('ot_other','bill','join',?)").run(JSON.stringify({ steps }));
+
+    const res = await app.request("/ot/ot_other/claude-pair-approve", json({ code: "abc123" }));
+    expect(res.status).toBe(409);
+    expect((db.query("SELECT stage FROM ot WHERE id='ot_other'").get() as any).stage).toBe("join");
+
+    // 같은 상태에서 팀장이 allowlist 에 들어가면 정합된다
+    writeFileSync(join(accessDir, "access.json"), JSON.stringify({
+      dmPolicy: "allowlist", allowFrom: ["999999999", "1000000001"], groups: {}, pending: {},
+    }));
+    const res2 = await app.request("/ot/ot_other/claude-pair-approve", json({ code: "abc123" }));
+    expect(res2.status).toBe(200);
+    expect((db.query("SELECT stage FROM ot WHERE id='ot_other'").get() as any).stage).toBe("joined");
+    delete process.env.CLAUDE_CHANNELS_DIR;
+    if (oldEnv === undefined) delete process.env.GD_CHAT_ID; else process.env.GD_CHAT_ID = oldEnv;
+  });
+
   test("승인도 pending 도 없으면 여전히 409 — 정합이 미승인을 합류로 만들지 않는다", async () => {
     const { app, dir, db } = setup();
     const channels = join(dir, "claude-channels");

--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -220,6 +220,18 @@ describe("Claude pairing backend contract", () => {
     expect((await app.request("/ot/ot_persist/claude-pair-approve", json({ code: "abc123" }))).status).toBe(200);
     expect((db.query("SELECT value FROM setting WHERE key='owner_chat_id'").get() as any)?.value).toBe("1000000001");
 
+    // ★빈 행이 있어도 채워야 한다★ — INSERT…WHERE NOT EXISTS 로 쓰면 여기서 PK 충돌이 나고
+    //   catch 가 삼켜 값이 영영 안 채워진다(코덱스 리뷰). UPSERT 라야 통과한다.
+    db.query("DELETE FROM setting WHERE key='owner_chat_id'").run();
+    db.query("INSERT INTO setting (key, value) VALUES ('owner_chat_id','')").run();
+    writeFileSync(join(accessDir, "access.json"), JSON.stringify({
+      dmPolicy: "pairing", allowFrom: [], groups: {},
+      pending: { aaa111: { senderId: "1000000001", chatId: "1000000001", expiresAt: Date.now() + 60_000 } },
+    }));
+    db.query("INSERT INTO ot(id,member_id,stage,steps_json) VALUES('ot_empty','bill','join',?)").run(JSON.stringify({ steps }));
+    expect((await app.request("/ot/ot_empty/claude-pair-approve", json({ code: "aaa111" }))).status).toBe(200);
+    expect((db.query("SELECT value FROM setting WHERE key='owner_chat_id'").get() as any)?.value).toBe("1000000001");
+
     // 이미 값이 있으면 나중 페어링이 조용히 바꾸지 않는다
     writeFileSync(join(accessDir, "access.json"), JSON.stringify({
       dmPolicy: "pairing", allowFrom: [], groups: {},

--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -175,6 +175,39 @@ describe("Claude pairing backend contract", () => {
   /* 코덱스 리뷰: "모르면 조건을 뺀다" 는 ★강화한 척★ 이었다. owner_chat_id 는 부팅 시 1회만 자동
    * persist 되고 Settings 입력도 선택이라, 정작 필요한 순간(첫 페어링·수동 promote 직후)에는 비어 있다.
    * 그래서 팀장 id 를 모르면 정합하지 않고, 대신 ★무엇을 하면 열리는지★ 를 알려준다. */
+  /* ★persist 가 실패해도 조용히 넘기지 않는다★(코덱스 리뷰). 승인은 이미 access.json 에 기록됐으니
+   * 되돌릴 수 없다 — 대신 응답에 사실을 밝힌다. 안 그러면 나중에 정합이 owner_identity_unknown 으로
+   * 막혔을 때 ★왜 막혔는지 알 방법이 없다.★ 침묵을 고치는 PR 에서 침묵을 남길 뻔했다. */
+  test("★신원 저장이 실패해도 승인은 유지하되 사실을 알린다★", async () => {
+    const { app, dir, db } = setup();
+    const channels = join(dir, "claude-channels");
+    process.env.CLAUDE_CHANNELS_DIR = channels;
+    const accessDir = join(channels, "telegram-bill");
+    mkdirSync(accessDir, { recursive: true });
+    writeFileSync(join(accessDir, "access.json"), JSON.stringify({
+      dmPolicy: "pairing", allowFrom: [], groups: {},
+      pending: { fff999: { senderId: "1000000001", chatId: "1000000001", expiresAt: Date.now() + 60_000 } },
+    }));
+    const steps = [
+      { key: "register", state: "done" }, { key: "provision", state: "done" },
+      { key: "preflight", state: "done" }, { key: "bundle", state: "done" }, { key: "join", state: "pending" },
+    ];
+    db.query("INSERT INTO ot(id,member_id,stage,steps_json) VALUES('ot_pfail','bill','join',?)").run(JSON.stringify({ steps }));
+    // setting 테이블을 지워 persist 를 실패시킨다(승인 자체는 파일에 기록되므로 영향 없어야 한다)
+    db.query("DROP TABLE setting").run();
+
+    const res = await app.request("/ot/ot_pfail/claude-pair-approve", json({ code: "fff999" }));
+    expect(res.status).toBe(200);                       // ★승인은 유지된다★ — 되돌리면 안 된다
+    const b = await res.json() as any;
+    expect(b.ok).toBe(true);
+    expect(b.owner_identity_persisted).toBe(false);     // ★사실을 숨기지 않는다★
+    expect(typeof b.warning).toBe("string");
+    // 승인 자체는 파일에 기록됐다
+    const stored = JSON.parse(readFileSync(join(accessDir, "access.json"), "utf-8"));
+    expect(stored.allowFrom).toContain("1000000001");
+    delete process.env.CLAUDE_CHANNELS_DIR;
+  });
+
   test("★팀장 id 를 모르면 정합하지 않는다★ — owner_identity_unknown (막다른 길이 아니라 복구행동 명시)", async () => {
     const oldEnv = process.env.GD_CHAT_ID; delete process.env.GD_CHAT_ID;
     const { app, dir, db } = setup();

--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -103,6 +103,55 @@ describe("Claude pairing backend contract", () => {
     expect(after).toMatchObject({ pairing_required: false, pending: false, awaiting_input: null });
     delete process.env.CLAUDE_CHANNELS_DIR;
   });
+
+  /* 2026-07-26 리사 고착 재현. 승인이 이 라우트 밖에서 먼저 끝나면(스킬 [6] 이 안내하는 access.json
+   * 수동 편집·플러그인 promote-pending) pending 이 비어 409 만 반복되고 위저드를 닫을 길이 사라졌다.
+   * 승인이 이미 성립했으면 어느 경로였든 합류로 정합돼야 한다. */
+  test("이미 승인된 상태면 pending 이 없어도 합류로 정합된다 (access.json 은 불변)", async () => {
+    const { app, dir, db } = setup();
+    const channels = join(dir, "claude-channels");
+    process.env.CLAUDE_CHANNELS_DIR = channels;
+    const accessDir = join(channels, "telegram-bill");
+    mkdirSync(accessDir, { recursive: true });
+    // 수동 승인이 끝난 뒤의 실제 모양: allowlist + allowFrom 1건 + pending 비어 있음
+    const approvedAccess = { dmPolicy: "allowlist", allowFrom: ["1000000001"], groups: {}, pending: {} };
+    writeFileSync(join(accessDir, "access.json"), JSON.stringify(approvedAccess));
+    const steps = [
+      { key: "register", state: "done" }, { key: "provision", state: "done" },
+      { key: "preflight", state: "done" }, { key: "bundle", state: "done" }, { key: "join", state: "pending" },
+    ];
+    db.query("INSERT INTO ot(id,member_id,stage,steps_json) VALUES('ot_done','bill','join',?)").run(JSON.stringify({ steps }));
+
+    const res = await app.request("/ot/ot_done/claude-pair-approve", json({ code: "abc123" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, already_approved: true });
+
+    // 위저드가 닫혔다
+    const row = db.query("SELECT stage FROM ot WHERE id='ot_done'").get() as any;
+    expect(row.stage).toBe("joined");
+    // 승인 파일은 건드리지 않는다 — 이 경로는 표시 정합일 뿐이다
+    expect(JSON.parse(readFileSync(join(accessDir, "access.json"), "utf-8"))).toEqual(approvedAccess);
+    delete process.env.CLAUDE_CHANNELS_DIR;
+  });
+
+  test("승인도 pending 도 없으면 여전히 409 — 정합이 미승인을 합류로 만들지 않는다", async () => {
+    const { app, dir, db } = setup();
+    const channels = join(dir, "claude-channels");
+    process.env.CLAUDE_CHANNELS_DIR = channels;
+    const accessDir = join(channels, "telegram-bill");
+    mkdirSync(accessDir, { recursive: true });
+    writeFileSync(join(accessDir, "access.json"), JSON.stringify({ dmPolicy: "pairing", allowFrom: [], groups: {}, pending: {} }));
+    const steps = [
+      { key: "register", state: "done" }, { key: "provision", state: "done" },
+      { key: "preflight", state: "done" }, { key: "bundle", state: "done" }, { key: "join", state: "pending" },
+    ];
+    db.query("INSERT INTO ot(id,member_id,stage,steps_json) VALUES('ot_none','bill','join',?)").run(JSON.stringify({ steps }));
+
+    const res = await app.request("/ot/ot_none/claude-pair-approve", json({ code: "abc123" }));
+    expect(res.status).toBe(409);
+    expect((db.query("SELECT stage FROM ot WHERE id='ot_none'").get() as any).stage).toBe("join");
+    delete process.env.CLAUDE_CHANNELS_DIR;
+  });
 });
 
 test("공개 빌드 runtime_invalid allowed는 live-only 런타임을 노출하지 않는다", () => {

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -57,6 +57,8 @@ import { isHermesProfileProtected } from "../lib/hermesBaseProfile";
 import { latestCaptureNonBotSender, listDiscoveredGroups } from "../lib/telegramLeadDetection";
 import { activeOfficialMemberCount, isTeamOfficialMember, MAX_OFFICIAL_TEAM_MEMBERS } from "../lib/agentMembership";
 import { writeRegistrySafely, type RegistryWriteOptions } from "../lib/registrySafety";
+// persist 실패는 ★DB 밖★ 에 남겨야 한다 — 실패 원인이 DB 자체일 수 있다.
+import { appendAuditFile } from "../lib/auditFile";
 
 export { MAX_OFFICIAL_TEAM_MEMBERS } from "../lib/agentMembership";
 
@@ -1892,16 +1894,33 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     //   (Settings 가 빈 값을 저장할 수 있다) NOT EXISTS 가 참이 되어 INSERT → PK 충돌 →
     //   catch 가 삼켜서 ★값이 영영 안 채워진다.★ 조용히 실패하는 자리라 특히 나쁘다.
     //   3케이스 동작: 행 없음→채움 · 빈 행→채움 · ★값 있음→보존★(팀장이 직접 넣은 값이 정본).
+    //   ★실패하면 조용히 넘기지 않는다★(코덱스 리뷰) — 여기서 삼키면 나중에 정합 경로가
+    //   owner_identity_unknown 으로 막혔을 때 ★왜 막혔는지 알 방법이 없다.★ 승인은 이미 파일에
+    //   기록됐으므로 되돌릴 수 없고(500 부적절), 대신 ★사실을 남기고 응답에 밝힌다.★
+    //   기록은 DB 밖(auditFile)에 한다 — 실패 원인이 DB 자체일 수 있다.
+    let ownerIdentityPersisted = true;
     try {
       db.query(
         "INSERT INTO setting (key, value) VALUES ('owner_chat_id', ?) " +
         "ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now') " +
         "WHERE TRIM(COALESCE(setting.value,'')) = ''",
       ).run(senderId);
-    } catch { /* persist 실패는 승인을 무르지 않는다 — access.json 이 정본이다 */ }
+    } catch (e) {
+      ownerIdentityPersisted = false;
+      appendAuditFile("settings", "owner_chat_id_persist_failed", row.member_id, {
+        ot_id, error: e instanceof Error ? e.message : String(e),
+      });
+    }
     markOtJoined(row, ot_id, "Claude Telegram 접근 승인 완료 — 합류");
     appendAudit(db, "user", "ot_claude_pair_approved", row.member_id, { ot_id });
-    return c.json({ ok: true, pairing_required: false, pending: false, awaiting_input: null });
+    return c.json({
+      ok: true, pairing_required: false, pending: false, awaiting_input: null,
+      // ★승인은 됐지만 신원 저장은 실패했다는 사실을 숨기지 않는다★ — 나중에 정합이 막힐 때 단서가 된다.
+      owner_identity_persisted: ownerIdentityPersisted,
+      ...(ownerIdentityPersisted ? {} : {
+        warning: "승인은 완료됐지만 팀장 chat_id 저장에 실패했습니다. Settings 에서 직접 설정하지 않으면 이후 합류 정합이 막힐 수 있습니다.",
+      }),
+    });
   });
 
   // ── OT 번들: 신규 영입이 합류 시 받는 패키지(무엇이 다운로드되나) ──

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1871,9 +1871,8 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     //   부팅 시 1회 자동 persist 에만 기대면 첫 페어링 직후에는 비어 있어 위 정합 경로가 항상 막힌다.
     //   ★기존 값은 덮지 않는다★ — 팀장이 Settings 에 직접 넣은 값이 정본이고, 나중 페어링이 그걸
     //   조용히 바꾸면 신뢰 기준이 흔들린다.
-    try {
-      db.query("INSERT INTO setting (key, value) SELECT 'owner_chat_id', ? WHERE NOT EXISTS (SELECT 1 FROM setting WHERE key = 'owner_chat_id' AND TRIM(COALESCE(value,'')) <> '')").run(senderId);
-    } catch { /* persist 실패는 승인 자체를 막지 않는다 — access.json 이 정본이다 */ }
+    //   ★승인이 실제로 기록된 뒤에 채운다★(코덱스 리뷰) — access.json 쓰기가 실패하면 승인은 없던 일인데
+    //   owner_chat_id 만 남으면 안 된다. 그래서 아래 원자적 교체가 성공한 다음에 persist 한다.
     state.access.allowFrom = [...new Set([...(Array.isArray(state.access.allowFrom) ? state.access.allowFrom.map(String) : []), senderId])];
     state.access.dmPolicy = "allowlist";
     delete state.access.pending[code];
@@ -1887,6 +1886,19 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
       try { if (existsSync(tmp)) rmSync(tmp); } catch { /* ignore */ }
       return c.json({ error: "claude_access_write_failed", detail: e instanceof Error ? e.message : String(e) }, 500);
     }
+    // ★승인이 파일에 기록된 뒤에 팀장 chat_id 를 채운다★ — 위 원자적 교체가 성공한 다음이다.
+    //   먼저 채우면 access.json 쓰기가 실패했을 때 ★승인은 없는데 신원만 남는다.★
+    //   ★UPSERT 여야 한다★: INSERT…WHERE NOT EXISTS 로 쓰면 ★행은 있는데 값만 빈 경우★
+    //   (Settings 가 빈 값을 저장할 수 있다) NOT EXISTS 가 참이 되어 INSERT → PK 충돌 →
+    //   catch 가 삼켜서 ★값이 영영 안 채워진다.★ 조용히 실패하는 자리라 특히 나쁘다.
+    //   3케이스 동작: 행 없음→채움 · 빈 행→채움 · ★값 있음→보존★(팀장이 직접 넣은 값이 정본).
+    try {
+      db.query(
+        "INSERT INTO setting (key, value) VALUES ('owner_chat_id', ?) " +
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now') " +
+        "WHERE TRIM(COALESCE(setting.value,'')) = ''",
+      ).run(senderId);
+    } catch { /* persist 실패는 승인을 무르지 않는다 — access.json 이 정본이다 */ }
     markOtJoined(row, ot_id, "Claude Telegram 접근 승인 완료 — 합류");
     appendAudit(db, "user", "ot_claude_pair_approved", row.member_id, { ot_id });
     return c.json({ ok: true, pairing_required: false, pending: false, awaiting_input: null });

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1798,6 +1798,20 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     return c.json({ ok: r.ok, detail: r.detail, reason: r.reason }, r.ok ? 200 : (r.reason === "no_request" ? 409 : 502));
   });
 
+  // join 스텝을 done 으로 닫고 stage 를 재도출한다. 승인 수행 경로와 이미-승인 정합 경로가 공유한다.
+  // steps_json 파싱 실패는 무시 — access.json 의 승인 상태가 정본이고 이건 표시 정합일 뿐이다.
+  const markOtJoined = (row: { steps_json?: string }, ot_id: string, detail: string) => {
+    try {
+      const parsed = JSON.parse(row.steps_json ?? "{}") as any;
+      const steps = Array.isArray(parsed.steps) ? parsed.steps : initOtSteps();
+      const joinStep = steps.find((s: any) => s.key === "join");
+      if (joinStep) { joinStep.state = "done"; joinStep.detail = detail; }
+      parsed.steps = steps; parsed.awaiting_input = null;
+      db.query("UPDATE ot SET steps_json = ?, stage = ?, updated_at = datetime('now') WHERE id = ?")
+        .run(JSON.stringify(parsed), deriveStage(steps), ot_id);
+    } catch { /* access approval remains authoritative */ }
+  };
+
   // Claude telegram plugin promote-pending equivalent. Mutates only access.json,
   // validates the submitted code, and atomically replaces the file.
   app.post("/ot/:ot_id/claude-pair-approve", async (c) => {
@@ -1812,12 +1826,28 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     if (agent.runtime !== "claude_channel") return c.json({ error: "runtime_not_claude" }, 400);
     const body = await c.req.json().catch(() => ({})) as { code?: unknown };
     const code = typeof body.code === "string" ? body.code.trim().toLowerCase() : "";
-    if (!/^[a-f0-9]{6}$/.test(code)) return c.json({ error: "pairing_code_invalid" }, 400);
+    const codeWellFormed = /^[a-f0-9]{6}$/.test(code);
     let state: ReturnType<typeof readClaudePairing>;
     try { state = readClaudePairing(agent.id); } catch { return c.json({ error: "claude_access_invalid" }, 500); }
-    const pending = state.access.pending?.[code];
-    if (!pending || Number(pending.expiresAt ?? Infinity) <= Date.now()) return c.json({ error: "pairing_request_not_found" }, 409);
-    const senderId = String(pending.senderId ?? "").trim();
+    const pending = codeWellFormed ? state.access.pending?.[code] : undefined;
+    const pendingFresh = !!pending && Number(pending.expiresAt ?? Infinity) > Date.now();
+    // ★승인 판정 기준 = "내가 승인을 수행했는가" 가 아니라 "실제로 승인돼 있는가"★
+    //   이 라우트는 원래 승인을 수행한 부수효과로만 join 스텝을 닫았다. 그래서 승인이 다른 경로로
+    //   먼저 끝나면(우리 스킬 [6] 이 안내하는 access.json 수동 편집·플러그인 promote-pending) pending 이
+    //   비어 409 만 반복되고 위저드를 닫을 방법이 사라진다 — 실제로 고착 사례 발생(2026-07-26 리사).
+    //   승인이 이미 성립한 상태면 어느 경로였든 합류로 정합시킨다. access.json 은 건드리지 않는다.
+    if (!pendingFresh) {
+      const allowFrom = Array.isArray(state.access.allowFrom) ? state.access.allowFrom.map(String).filter(Boolean) : [];
+      const alreadyApproved = state.access.dmPolicy === "allowlist" && allowFrom.length > 0;
+      if (alreadyApproved) {
+        markOtJoined(row, ot_id, "Claude Telegram 접근 승인 확인됨 — 합류");
+        appendAudit(db, "user", "ot_claude_pair_reconciled", row.member_id, { ot_id, reason: "already_approved" });
+        return c.json({ ok: true, already_approved: true, pairing_required: false, pending: false, awaiting_input: null });
+      }
+      if (!codeWellFormed) return c.json({ error: "pairing_code_invalid" }, 400);
+      return c.json({ error: "pairing_request_not_found" }, 409);
+    }
+    const senderId = String(pending!.senderId ?? "").trim();
     if (!/^\d+$/.test(senderId)) return c.json({ error: "pairing_request_invalid" }, 409);
     state.access.allowFrom = [...new Set([...(Array.isArray(state.access.allowFrom) ? state.access.allowFrom.map(String) : []), senderId])];
     state.access.dmPolicy = "allowlist";
@@ -1832,15 +1862,7 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
       try { if (existsSync(tmp)) rmSync(tmp); } catch { /* ignore */ }
       return c.json({ error: "claude_access_write_failed", detail: e instanceof Error ? e.message : String(e) }, 500);
     }
-    try {
-      const parsed = JSON.parse(row.steps_json ?? "{}") as any;
-      const steps = Array.isArray(parsed.steps) ? parsed.steps : initOtSteps();
-      const joinStep = steps.find((s: any) => s.key === "join");
-      if (joinStep) { joinStep.state = "done"; joinStep.detail = "Claude Telegram 접근 승인 완료 — 합류"; }
-      parsed.steps = steps; parsed.awaiting_input = null;
-      db.query("UPDATE ot SET steps_json = ?, stage = ?, updated_at = datetime('now') WHERE id = ?")
-        .run(JSON.stringify(parsed), deriveStage(steps), ot_id);
-    } catch { /* access approval remains authoritative */ }
+    markOtJoined(row, ot_id, "Claude Telegram 접근 승인 완료 — 합류");
     appendAudit(db, "user", "ot_claude_pair_approved", row.member_id, { ot_id });
     return c.json({ ok: true, pairing_required: false, pending: false, awaiting_input: null });
   });

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1838,9 +1838,17 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     //   승인이 이미 성립한 상태면 어느 경로였든 합류로 정합시킨다. access.json 은 건드리지 않는다.
     if (!pendingFresh) {
       const allowFrom = Array.isArray(state.access.allowFrom) ? state.access.allowFrom.map(String).filter(Boolean) : [];
-      const alreadyApproved = state.access.dmPolicy === "allowlist" && allowFrom.length > 0;
+      // ★팀장 chat_id 는 '비순환' 출처에서만 얻는다★ — resolveOwnerDmId() 는 못 찾으면 access.json 의
+      //   allowFrom[0] 을 읽는 폴백이 있어서, 그걸로 allowFrom 을 검증하면 ★자기 자신을 확인하는 순환★ 이
+      //   되어 무조건 통과한다. 검증이 검증처럼 보이기만 하는 게 이번 사고의 뿌리라 같은 형태를 만들지 않는다.
+      const ownerRow = db.query("SELECT value FROM setting WHERE key = 'owner_chat_id'").get() as { value?: string } | undefined;
+      const ownerChatId = (ownerRow?.value ?? "").trim() || (process.env.GD_CHAT_ID ?? "").trim();
+      // 팀장 id 를 알면 ★그가 실제 allowlist 에 있는지★ 까지 본다(남이 승인됐는데 합류로 처리하지 않도록).
+      // 모르면 그 조건은 뺀다 — 알 수 없다는 이유로 복구를 막으면 원래 고착으로 되돌아간다.
+      const leadReachable = ownerChatId === "" || allowFrom.includes(ownerChatId);
+      const alreadyApproved = state.access.dmPolicy === "allowlist" && allowFrom.length > 0 && leadReachable;
       if (alreadyApproved) {
-        markOtJoined(row, ot_id, "Claude Telegram 접근 승인 확인됨 — 합류");
+        markOtJoined(row, ot_id, ownerChatId ? "Claude Telegram 접근 승인 확인됨(팀장 DM 허용) — 합류" : "Claude Telegram 접근 승인 확인됨 — 합류");
         appendAudit(db, "user", "ot_claude_pair_reconciled", row.member_id, { ot_id, reason: "already_approved" });
         return c.json({ ok: true, already_approved: true, pairing_required: false, pending: false, awaiting_input: null });
       }

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1843,10 +1843,20 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
       //   되어 무조건 통과한다. 검증이 검증처럼 보이기만 하는 게 이번 사고의 뿌리라 같은 형태를 만들지 않는다.
       const ownerRow = db.query("SELECT value FROM setting WHERE key = 'owner_chat_id'").get() as { value?: string } | undefined;
       const ownerChatId = (ownerRow?.value ?? "").trim() || (process.env.GD_CHAT_ID ?? "").trim();
-      // 팀장 id 를 알면 ★그가 실제 allowlist 에 있는지★ 까지 본다(남이 승인됐는데 합류로 처리하지 않도록).
-      // 모르면 그 조건은 뺀다 — 알 수 없다는 이유로 복구를 막으면 원래 고착으로 되돌아간다.
-      const leadReachable = ownerChatId === "" || allowFrom.includes(ownerChatId);
-      const alreadyApproved = state.access.dmPolicy === "allowlist" && allowFrom.length > 0 && leadReachable;
+      // ★팀장 id 를 모르면 정합하지 않는다(fail-closed)★ — 코덱스 리뷰 반영.
+      //   처음엔 "모르면 조건을 뺀다" 로 했는데, 그게 ★강화한 척★ 이었다: owner_chat_id 는 서버 부팅
+      //   시 1회만 자동 persist 되고 Settings 입력도 선택이라, ★정작 필요한 순간(첫 페어링·수동 promote
+      //   직후)에는 비어 있다.★ 그 상태에서 조건을 빼면 타인 allowFrom 1건으로도 합류가 된다.
+      //   여기서 막아도 ★막다른 길이 아니다★ — 아래 정상 승인 경로가 owner_chat_id 를 채우고,
+      //   이미 어긋난 설치본은 Settings 에서 한 번 넣으면 이 경로가 열린다. 원래 버그(닫을 방법 자체가
+      //   없음)와 다르다: ★복구 행동이 명시된 거부★ 다.
+      if (ownerChatId === "") {
+        return c.json({
+          error: "owner_identity_unknown",
+          detail: "팀장 chat_id 를 확인할 수 없어 합류로 정합하지 않습니다. Settings 에서 팀장 chat_id 를 설정한 뒤 다시 시도하세요.",
+        }, 409);
+      }
+      const alreadyApproved = state.access.dmPolicy === "allowlist" && allowFrom.length > 0 && allowFrom.includes(ownerChatId);
       if (alreadyApproved) {
         markOtJoined(row, ot_id, ownerChatId ? "Claude Telegram 접근 승인 확인됨(팀장 DM 허용) — 합류" : "Claude Telegram 접근 승인 확인됨 — 합류");
         appendAudit(db, "user", "ot_claude_pair_reconciled", row.member_id, { ot_id, reason: "already_approved" });
@@ -1857,6 +1867,13 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     }
     const senderId = String(pending!.senderId ?? "").trim();
     if (!/^\d+$/.test(senderId)) return c.json({ error: "pairing_request_invalid" }, 409);
+    // ★정상 승인 = 팀장 신원을 확인할 수 있는 유일한 지점★ — 여기서 owner_chat_id 를 채워둔다(코덱스 리뷰).
+    //   부팅 시 1회 자동 persist 에만 기대면 첫 페어링 직후에는 비어 있어 위 정합 경로가 항상 막힌다.
+    //   ★기존 값은 덮지 않는다★ — 팀장이 Settings 에 직접 넣은 값이 정본이고, 나중 페어링이 그걸
+    //   조용히 바꾸면 신뢰 기준이 흔들린다.
+    try {
+      db.query("INSERT INTO setting (key, value) SELECT 'owner_chat_id', ? WHERE NOT EXISTS (SELECT 1 FROM setting WHERE key = 'owner_chat_id' AND TRIM(COALESCE(value,'')) <> '')").run(senderId);
+    } catch { /* persist 실패는 승인 자체를 막지 않는다 — access.json 이 정본이다 */ }
     state.access.allowFrom = [...new Set([...(Array.isArray(state.access.allowFrom) ? state.access.allowFrom.map(String) : []), senderId])];
     state.access.dmPolicy = "allowlist";
     delete state.access.pending[code];


### PR DESCRIPTION
GD 맥스튜디오 클린테스트에서 실제로 발생(리사). 첫 claude 팀원 영입 후 '합류 확인' 이 끝나지 않고, 남은 버튼은 '영입 취소 — 지금까지 등록한 것 지움' 뿐이라 ★동작 중인 팀원을 지울 위험만 남는 상태★ 였다.

## 원인
claude-pair-approve 가 join 스텝을 ★승인을 수행한 부수효과로만★ 닫는다. pending[code] 를 찾아 승인하고 그 흐름 안에서만 done 으로 바꾼다. 승인이 다른 경로로 먼저 끝나면 pending 이 비어 409 만 반복되고 ★위저드를 닫을 방법이 없어진다.★

실환경 실증:
```
allowFrom=1 · dmPolicy=allowlist · pending=0  (승인은 이미 완료)
POST .../claude-pair-approve  →  {"error":"pairing_request_not_found"}
```

★우리 문서가 그 경로를 정답으로 가르친다★ — skills/b3os/SKILL.md [6] 이 수동 승인(access.json 의 allowFrom 추가 + dmPolicy=allowlist)을 안내한다. 문서대로 하면 반드시 고착된다. 플러그인 promote-pending 도 같다.

## 수정
판정 기준을 '내가 승인을 수행했는가' → ★'실제로 승인돼 있는가'★ 로 전환. pending 이 없어도 승인이 성립해 있으면 합류로 정합시킨다.

- ★access.json 은 건드리지 않는다★ — 표시 정합일 뿐이고 승인 파일이 정본이다
- 미승인을 합류로 만들지 않는다 — 승인도 pending 도 없으면 종전대로 409
- join 마감 로직을 markOtJoined 로 추출해 두 경로가 공유

## 검증
- 신규 테스트 2건(정합 성공 / 미승인 409 유지)
- ★실행 확인★ `-t '정합'` → 2 pass — 통과 테스트는 기본 출력에 안 나와서 별도로 확인
- ★뮤테이션★ alreadyApproved 를 false 로 되돌리면 1 fail (치환이 실제로 적용됐는지 grep 으로 먼저 확인)
- 파일 전체 77 pass / 0 fail · `tsc --noEmit` exit=0
- 실환경 복구: advance API 로 리사 joined 처리 (DB 직접 수정 안 함)

## 남는 것
'영입 취소' 버튼이 합류한 팀원까지 지울 것처럼 보이는 문구는 이 PR 범위 밖이다(코드상 joined 는 취소 불가지만, 고착 상태에선 사용자에게 그렇게 보이지 않는다).