### PR TITLE
fix(onoff): hermes 기동이 LaunchAgent 를 되돌리지 않아 대시보드로 복구가 안 되던 것

### DIFF
--- a/src/server/lib/agentControl.test.ts
+++ b/src/server/lib/agentControl.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, test } from "bun:test";
-import { claudeTelegramLaunchdLabel } from "./agentControl";
+import { claudeTelegramLaunchdLabel, hermesLaunchdLabel } from "./agentControl";
+
+/* 2026-07-26 맥스튜디오 실측: 비상정지 뒤 대시보드 '기동' 으로 hermes 가 안 살아났다. 정지는 LaunchAgent 를
+ * bootout 하는데 기동은 게이트웨이만 띄우고 bootstrap 을 안 해서다. 그 비대칭을 고치면서, 두 경로가 ★같은
+ * 라벨★ 을 보도록 한 곳으로 모았다(예전엔 정지가 프로필 기반 문자열을 직접 만들어 gateway_service 를 무시했다). */
+describe("hermesLaunchdLabel", () => {
+  test("gateway_service 가 없으면 프로필 기반으로 도출한다", () => {
+    expect(hermesLaunchdLabel(undefined, "herm")).toBe("ai.hermes.gateway-herm");
+    expect(hermesLaunchdLabel({ gateway_service: null }, "mes")).toBe("ai.hermes.gateway-mes");
+  });
+
+  test("★gateway_service 가 있으면 그것이 정본★ — 라벨과 프로필이 다른 설치본에서 정지·기동이 엇갈리지 않는다", () => {
+    expect(hermesLaunchdLabel({ gateway_service: "ai.hermes.custom-gw" }, "herm")).toBe("ai.hermes.custom-gw");
+  });
+
+  test("빈 문자열·공백은 미설정으로 본다 (빈 라벨로 bootout 하면 엉뚱한 대상이 된다)", () => {
+    expect(hermesLaunchdLabel({ gateway_service: "" }, "herm")).toBe("ai.hermes.gateway-herm");
+    expect(hermesLaunchdLabel({ gateway_service: "   " }, "herm")).toBe("ai.hermes.gateway-herm");
+  });
+});
 
 describe("claudeTelegramLaunchdLabel", () => {
   test("기본 prefix 는 현재 USER 기반 com.${USER}", () => {

--- a/src/server/lib/agentControl.ts
+++ b/src/server/lib/agentControl.ts
@@ -100,19 +100,46 @@ async function setClaude(id: string, enabled: boolean): Promise<ControlResult> {
   return { ok: r.code === 0, detail: r.code === 0 ? `claude ${id} 정지(봇 tmux kill + LaunchAgent bootout)` : `정지 실패: ${r.out.slice(-150)}` };
 }
 
+/** hermes 게이트웨이 LaunchAgent 라벨. ★기동·정지가 반드시 같은 값을 써야 한다★ —
+ *  정지만 bootout 하고 기동이 다른 라벨을 보면 되살아나지 않는다. 그래서 한 곳에서 도출한다.
+ *  gateway_service 가 있으면 그것이 정본(프로필명과 라벨이 다른 설치본 대응). */
+export function hermesLaunchdLabel(agent: { gateway_service?: string | null } | undefined, profile: string): string {
+  const explicit = agent?.gateway_service?.trim();
+  return explicit ? explicit : `ai.hermes.gateway-${profile}`;
+}
+
 /** hermes 에이전트: 프로필 게이트웨이 stop/start. */
 async function setHermes(id: string, enabled: boolean): Promise<ControlResult> {
   // 프로필 = agent.hermes_profile ?? id (restartAgent와 동일) — HERMES_PROFILE=id 하드코딩이면 프로필≠id일 때 on/off가 엉뚱한 프로필을 건드린다.
   const agent = ambientAgents().find((a) => a.id === id);
   const profile = agent?.hermes_profile ?? id;
+  const uid = process.getuid?.() ?? 0;
+  const label = hermesLaunchdLabel(agent, profile);
   if (enabled) {
+    // ★정지가 bootout 한 LaunchAgent 를 되돌린다★ — 이게 없어서 기동/정지가 비대칭이었다.
+    //   'hermes gateway start' 는 게이트웨이 프로세스를 띄우지만 ★launchd 관리 밖★ 이라
+    //   ①KeepAlive 보호 없음 ②재부팅 후 안 올라옴 ③상태 판정이 라벨을 보므로 계속 offline 이다.
+    //   (2026-07-26 맥스튜디오 실측: 비상정지 뒤 대시보드 '기동' 으로 hermes 를 살릴 수 없었다.
+    //    응답은 ok 인데 launchctl list 에 라벨이 없었다 — 즉 ok 가 복구를 뜻하지 않았다.)
+    //   ★start 와 bootstrap 을 같이 부르면 안 된다★ — 게이트웨이가 2개 떠서 텔레그램 폴링이
+    //   충돌한다(같은 날 수동 복구 중 실제로 재현). plist 가 있으면 bootstrap 으로 일원화한다.
+    const plist = `${HOME}/Library/LaunchAgents/${label}.plist`;
+    if (existsSync(plist)) {
+      const b = await run(["launchctl", "bootstrap", `gui/${uid}`, plist]);
+      // 이미 로드돼 있으면 bootstrap 이 실패한다 → kickstart 로 되살린다(codex 경로와 동일 패턴).
+      if (b.code !== 0) {
+        const k = await run(["launchctl", "kickstart", "-k", `gui/${uid}/${label}`]);
+        return { ok: k.code === 0, detail: k.code === 0 ? `hermes ${id} 기동(LaunchAgent kickstart, 프로필 ${profile})` : `기동 실패: ${k.out.slice(-150)}` };
+      }
+      return { ok: true, detail: `hermes ${id} 기동(LaunchAgent bootstrap, 프로필 ${profile})` };
+    }
+    // plist 가 없는 설치본(활성화 전·수동 구성) → 종전대로 게이트웨이만 띄운다. launchd 보호는 없으므로 그렇게 알린다.
     const r = await run(["hermes", "gateway", "start"], { HERMES_PROFILE: profile });
-    return { ok: r.code === 0, detail: r.code === 0 ? `hermes ${id} 기동(프로필 ${profile})` : `기동 실패: ${r.out.slice(-150)}` };
+    return { ok: r.code === 0, detail: r.code === 0 ? `hermes ${id} 기동(게이트웨이 직접 · LaunchAgent 없음 — 재부팅 후 수동 기동 필요, 프로필 ${profile})` : `기동 실패: ${r.out.slice(-150)}` };
   }
   // 정지: 게이트웨이 stop + LaunchAgent bootout. bootout 안 하면 KeepAlive LaunchAgent가 게이트웨이를 되살려 '퇴사해도 계속 응답'(GD 2026-07-01 mes 실측 버그). 프로필별 라벨 타겟.
   const stopR = await run(["hermes", "gateway", "stop"], { HERMES_PROFILE: profile });
-  const uid = process.getuid?.() ?? 0;
-  await run(["launchctl", "bootout", `gui/${uid}/ai.hermes.gateway-${profile}`]);
+  await run(["launchctl", "bootout", `gui/${uid}/${label}`]);
   return { ok: true, detail: `hermes ${id} 정지(게이트웨이 stop + LaunchAgent bootout, 프로필 ${profile})${stopR.code !== 0 ? " [stop 경고]" : ""}` };
 }
 


### PR DESCRIPTION
GD 요청으로 맥스튜디오 대시보드 버튼을 전수 테스트하다 실측(2026-07-26). 비상정지 → 기동을 눌러도 hermes 팀원이 살아나지 않았다. ★응답은 ok 인데 launchctl list 에 라벨이 없었다★ — ok 가 복구를 뜻하지 않았다.

## 원인 — 기동·정지가 비대칭
| | 하는 일 |
|---|---|
| 정지 | `hermes gateway stop` ★+ `launchctl bootout`★ |
| 기동 | `hermes gateway start` ★만★ (bootstrap 없음) |

`gateway start` 가 프로세스를 띄우긴 한다. 하지만 ★launchd 관리 밖★ 이라 ①KeepAlive 보호 없음 ②재부팅 후 안 올라옴 ③상태 판정이 라벨을 보므로 계속 offline.

즉 비상 상황에서 ★대시보드만으로 hermes 를 복구할 수 없다.★ 서킷브레이커의 절반이 없는 셈이다.

## 수정
- plist 가 있으면 ★bootstrap 으로 일원화★, 이미 로드면 kickstart 폴백(codex 경로와 동일 패턴)
- ★start 와 bootstrap 을 같이 부르면 안 된다★ — 게이트웨이가 2개 떠서 텔레그램 폴링이 충돌한다. 같은 날 수동 복구 중 실제로 재현해서 분기로 갈랐다
- plist 가 없는 설치본은 종전대로 start 하되 ★launchd 보호가 없다는 것을 detail 에 명시★ — 조용히 반쪽 상태로 두지 않는다
- 라벨 도출을 `hermesLaunchdLabel` 로 추출해 기동·정지가 ★같은 값★ 을 쓰게 했다. 정지가 프로필 기반 문자열을 직접 만들어 `gateway_service` 를 무시하고 있었다 — 라벨≠프로필인 설치본에서 서로 다른 대상을 건드릴 수 있었다

## 검증
- 신규 테스트 3건(gateway_service 우선 · 미설정 폴백 · 빈문자열/공백 방어) · 파일 5 pass / 0 fail
- ★실행 확인★ `-t 'hermesLaunchdLabel'` → 3 pass (통과 테스트는 기본 출력에 안 나온다)
- `tsc --noEmit` exit=0
- ★실환경★ 맥스튜디오에서 bootout 상태에 `launchctl bootstrap` 을 직접 걸어 라벨 복귀 확인(status 0). herm 은 지금 정상 복구 상태다

## 미검증 범위 (숨기지 않고 적는다)
`setHermes` 자체는 실명령을 spawn 해 단위테스트가 없다 — `run` 주입 리팩터가 선행돼야 한다. 같은 이유로 setClaude/setOpenclaw/setCodex 도 미커버다. ★기존 갭이고 이 PR 에서 넓히지 않았다.★

## 같이 발견된 별건 (이 PR 범위 밖)
비상정지 후에도 대시보드가 openclaw 팀원을 `idle · gateway healthy` 로 표시한다. 실제로는 `disabled, stopped` 였다. 프로버가 게이트웨이만 보고 개별 에이전트를 안 본다(코드가 "per-agent probe TBD" 라고 스스로 적어뒀다). ★폭주 대응 때 제일 알아야 할 정보가 화면에 안 나온다.★ GD 께 방향 확인 후 별도 PR.