### PR TITLE
fix(monitoring): 조용한 것을 이상으로 세지 않는다 — Hermes 패널이 늘 '확인 필요' 이던 것

### DIFF
--- a/src/web/components/MonitoringView.ts
+++ b/src/web/components/MonitoringView.ts
@@ -151,7 +151,13 @@ function dmPanel(d: DmHealth): string {
 }
 
 function runtimePanel(h: HermesRuntimeHealth, i: IngressStatus): string {
-  const hasIssue = h.offline > 0 || h.blocked > 0;
+  // ★blocked 를 이상으로 세지 않는다★ — blocked 는 "막혔다" 가 아니라 ★터미널 출력이 5분 넘게
+  //   갱신되지 않았다★ 는 뜻이다(statusProbe: 1분 running / 5분 idle / 그 뒤 blocked). 팀원은 메시지를
+  //   받을 때만 움직이므로 ★평상시가 blocked★ 이고, 이걸 이상으로 세면 패널이 거의 항상 "확인 필요" 가
+  //   된다 — 신호가 아니라 잡음이다. AgentCard 도 blocked 를 "최근 활동 시간" 으로 중립 표시하고
+  //   TopologyView 도 응답가능(healthy)으로 분류한다. 여기만 이상 취급하고 있었다.
+  //   진짜 이상은 offline(세션 없음·상태 확인 실패)이다.
+  const hasIssue = h.offline > 0;
   const hermesColor = h.total === 0 ? GRAY : hasIssue ? AMBER : GREEN;
   const hermesStatus = h.total === 0
     ? pick("Hermes 없음", "No Hermes agents")


### PR DESCRIPTION
GD 승인. Hermes 런타임 패널이 hermes 팀원 하나라도 5분 조용하면 "확인 필요"(앰버)로 바뀌었다.

그런데 `blocked` 는 "막혔다" 가 아니라 ★터미널 출력이 5분 넘게 갱신되지 않았다★ 는 뜻이다(statusProbe: 1분 running / 5분 idle / 그 뒤 blocked). ★팀원은 메시지를 받을 때만 움직인다★ — 그래서 평상시가 blocked 이고, 이걸 이상으로 세면 패널이 거의 항상 "확인 필요" 다. 신호가 아니라 잡음이고, 진짜 이상이 났을 때 구분이 안 된다.

## 우리 코드 안에서도 여기만 달랐다
| 위치 | blocked 취급 |
|---|---|
| AgentCard | "최근 활동 시간"(중립) + "작업 중단이라는 뜻은 아니다" 툴팁 |
| TopologyView | healthy(응답가능) |
| MonitoringView | ★이상★ ← 이것만 |

## 수정
`hasIssue` 에서 `blocked` 를 뺀다. 진짜 이상은 `offline`(세션 없음·상태 확인 실패)이다.

## ★내 오보를 정정하며 찾은 것★
맥스튜디오 테스트 중 API 의 `state=blocked` 만 보고 GD 께 "화면에 차단됨으로 뜬다" 고 보고했는데 ★틀렸다.★ 화면은 이미 중립적으로 그리고 있었다. 코드를 열어 정정했고, 그 과정에서 TopologyView 의 "차단" 라벨을 고칠 뻔했다 — ★그건 버스 메시지 상태지 팀원 상태가 아니다★(이름만 같다). 실제 문제는 이 한 줄이었다.

## 검증
`tsc --noEmit` exit=0 · `bun run build` exit=0(0 error).

## 미커버
표시 판정이라 전용 테스트는 없다(MonitoringView 에 기존 테스트 파일 자체가 없다). 숨기지 않고 적는다.