### PR TITLE
fix(slack): 연동 마법사가 빈 매니페스트를 그럴싸하게 그리던 것 + 우리 채널명 기본값 제거

### DIFF
--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -1051,3 +1051,56 @@ describe("settings: 전체 재적용 롤백 (6h .bak 복원)", () => {
     expect((await (await app.request("/members/regenerate-all-personas/rollback")).json()).available).toBe(false);
   });
 });
+
+/* 2026-07-26 맥스튜디오 실측: Slack 연동 마법사가 ★빈 매니페스트★({"settings":{"socket_mode_enabled":true}})와
+ * ★빈 scope★("—")를 그럴싸하게 그렸다. 원인은 이 엔드포인트가 TEAM_PUBLIC_BASE_URL 없으면 400 을 내고,
+ * 클라이언트가 r.ok 를 안 보고 그 본문을 정상 데이터로 썼기 때문. 사용자가 그 매니페스트를 붙여넣으면
+ * ★권한 0개짜리 Slack 앱★ 이 만들어진다 — 실패보다 나쁘다.
+ * UI 는 "Socket Mode = 공개 URL 불필요" 라고 안내하는데 서버가 공개 URL 을 필수로 요구한 자기모순도 있었다. */
+describe("slack reinstall-info", () => {
+  const withBase = (v: string | undefined, fn: () => Promise<void>) => async () => {
+    const old = process.env.TEAM_PUBLIC_BASE_URL;
+    if (v === undefined) delete process.env.TEAM_PUBLIC_BASE_URL; else process.env.TEAM_PUBLIC_BASE_URL = v;
+    try { await fn(); } finally {
+      if (old === undefined) delete process.env.TEAM_PUBLIC_BASE_URL; else process.env.TEAM_PUBLIC_BASE_URL = old;
+    }
+  };
+
+  test("★공개 URL 이 없어도 완전한 매니페스트를 준다★ (Socket Mode 는 그것 없이 되어야 한다)", withBase(undefined, async () => {
+    const { app } = setup();
+    const res = await app.request("/members/bill/slack/reinstall-info");
+    expect(res.status).toBe(200);
+    const b = await res.json() as any;
+    expect(b.ok).toBe(true);
+    // ★scope 가 비면 권한 없는 앱이 만들어진다★ — 이게 이번 사고의 핵심이라 개수까지 고정한다
+    expect(b.needed_scopes).toEqual(["app_mentions:read", "chat:write", "groups:history", "channels:history"]);
+    expect(b.manifest?.oauth_config?.scopes?.bot).toEqual(b.needed_scopes);
+    expect(b.manifest?.display_information?.name).toBeTruthy();
+    // 공개 URL 이 없으면 event_subscriptions 자체를 넣지 않는다(request_url:null 매니페스트는 Slack 이 거부)
+    expect(b.event_request_url).toBeNull();
+    expect(b.manifest?.settings?.event_subscriptions).toBeUndefined();
+    expect(b.public_base_missing).toBe(true);
+    expect(typeof b.public_base_hint).toBe("string");
+  }));
+
+  test("공개 URL 이 있으면 event_subscriptions 를 포함한다", withBase("https://example.test/", async () => {
+    const { app } = setup();
+    const b = await (await app.request("/members/bill/slack/reinstall-info")).json() as any;
+    expect(b.event_request_url).toBe("https://example.test/team/api/slack/events");
+    expect(b.manifest?.settings?.event_subscriptions?.request_url).toBe("https://example.test/team/api/slack/events");
+    expect(b.public_base_missing).toBe(false);
+  }));
+
+  test("★채널이 설정 안 됐으면 빈 문자열★ — 남의 채널명을 기본값으로 주지 않는다", withBase("https://example.test", async () => {
+    const old = process.env.TEAM_SLACK_POLL_CHANNELS;
+    delete process.env.TEAM_SLACK_POLL_CHANNELS;
+    try {
+      const { app } = setup();
+      const b = await (await app.request("/members/bill/slack/reinstall-info")).json() as any;
+      expect(b.channel).toBe("");
+      expect(JSON.stringify(b)).not.toContain("300-gd-ai-team");
+    } finally {
+      if (old === undefined) delete process.env.TEAM_SLACK_POLL_CHANNELS; else process.env.TEAM_SLACK_POLL_CHANNELS = old;
+    }
+  }));
+});

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -987,15 +987,14 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     try { agent = readAgents().find((a) => a.id === id) ?? null; } catch { /* ignore */ }
     if (!agent) return c.json({ ok: false, error: "unknown_member", id }, 404);
     const creds = loadAgentCreds(id);
+    // ★공개 URL 이 없어도 매니페스트를 준다★ — 마법사가 권하는 Socket Mode 는 공개 URL 이 필요 없다.
+    //   예전엔 여기서 400 을 냈는데, 클라이언트가 그 400 을 정상 응답으로 받아 ★빈 매니페스트를
+    //   그럴싸하게 그렸다★ (실측: {"settings":{"socket_mode_enabled":true}} · 필요 scope "—").
+    //   사용자가 그걸 붙여넣으면 ★권한 0개짜리 Slack 앱이 조용히 만들어진다.★ 실패가 아니라
+    //   '망가진 걸 만들어 주는' 형태라 더 나쁘다. UI 가 "Socket Mode = 공개 URL 불필요" 라고
+    //   안내하면서 서버는 공개 URL 을 필수로 요구하던 ★자기모순★ 도 여기서 없앤다.
     const publicBase = (process.env.TEAM_PUBLIC_BASE_URL ?? "").replace(/\/$/, "");
-    if (!publicBase) {
-      return c.json({
-        ok: false,
-        error: "missing_public_base_url",
-        hint: "Slack 매니페스트 생성 전 TEAM_PUBLIC_BASE_URL을 공개 HTTPS 도메인/터널로 설정하세요",
-      }, 400);
-    }
-    const eventUrl = `${publicBase}/team/api/slack/events`;
+    const eventUrl = publicBase ? `${publicBase}/team/api/slack/events` : null;
     const channel = (process.env.TEAM_SLACK_POLL_CHANNELS ?? "").split(",")[0]!.trim();
     const scopes = ["app_mentions:read", "chat:write", "groups:history", "channels:history"];
     const appName = agent.slack_app_name || `gd ${id}`;
@@ -1008,13 +1007,21 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
       slack_bot_user_id: agent.slack_bot_user_id ?? null,
       state: slackMemberStatus(agent).state,
       event_request_url: eventUrl,
+      // 공개 URL 이 없으면 Event URL 방식만 못 쓴다는 뜻 — Socket Mode 는 그대로 된다. 화면이 그렇게 안내하도록 알린다.
+      public_base_missing: !publicBase,
+      public_base_hint: publicBase ? null : "Event URL 방식을 쓰려면 TEAM_PUBLIC_BASE_URL 에 공개 HTTPS 주소(도메인/터널)를 설정하세요. Socket Mode 는 설정 없이 됩니다.",
       channel,
       needed_scopes: scopes,
       manifest: {
         display_information: { name: appName },
         features: { bot_user: { display_name: agent.slack_app_name || `gd_${id}`, always_online: true } },
         oauth_config: { scopes: { bot: scopes } },
-        settings: { event_subscriptions: { request_url: eventUrl, bot_events: ["app_mention"] }, org_deploy_enabled: false, socket_mode_enabled: false },
+        // 공개 URL 이 없으면 event_subscriptions 자체를 넣지 않는다 — request_url 이 null 인 매니페스트는 Slack 이 거부한다.
+        settings: {
+          ...(eventUrl ? { event_subscriptions: { request_url: eventUrl, bot_events: ["app_mention"] } } : {}),
+          org_deploy_enabled: false,
+          socket_mode_enabled: false,
+        },
       },
     });
   });

--- a/src/web/components/AgentSlack.ts
+++ b/src/web/components/AgentSlack.ts
@@ -27,8 +27,11 @@ interface SlackMember {
 interface ReinstallInfo {
   ok: boolean; id: string; display_name: string;
   slack_app_name: string | null; slack_app_id: string | null; slack_bot_user_id: string | null;
-  state: string; event_request_url: string; channel: string;
+  state: string; event_request_url: string | null; channel: string;
   needed_scopes: string[]; manifest: unknown;
+  // 공개 URL 미설정 = Event URL 방식만 불가. Socket Mode 는 그대로 된다.
+  public_base_missing?: boolean; public_base_hint?: string | null;
+  error?: string; hint?: string;
 }
 
 function esc(s: string): string {
@@ -73,6 +76,7 @@ export function renderAgentSlack(host: HTMLElement, agentId: string, _displayNam
   let me: SlackMember | null = null;
   let info: ReinstallInfo | null = null;
   let infoLoading = false;
+  let infoError: string | null = null;
   // 마법사 안에서 고르는 연결 방식(로컬). 저장 시 slack_connection_mode로 persist.
   // 마법사 열 때 현재 persist된 방식으로 초기화. (메인 화면엔 토글 없음 — 방식 선택은 마법사 안에서만)
   let wizardMode: "webhook" | "socket" = "webhook";
@@ -87,20 +91,44 @@ export function renderAgentSlack(host: HTMLElement, agentId: string, _displayNam
 
   const loadInfo = async () => {
     infoLoading = true;
+    infoError = null;
     try {
       const r = await fetch(`${apiBase()}/api/members/${encodeURIComponent(agentId)}/slack/reinstall-info`, { headers: { accept: "application/json" } });
-      info = await r.json();
-    } catch { info = null; }
+      const body = await r.json().catch(() => null) as ReinstallInfo | null;
+      // ★응답 성공 여부를 확인한다★ — 예전엔 r.ok 를 안 보고 body 를 그대로 info 에 넣었다. 그래서 400 이
+      //   와도 화면은 '정상' 으로 그려졌고, manifest/needed_scopes 가 undefined 인 채 ★빈 매니페스트와
+      //   빈 scope 를 그럴싸하게 표시★ 했다(실측). 사용자는 그걸 Slack 에 붙여넣어 ★권한 0개짜리 앱★ 을
+      //   만들게 된다 — 실패보다 나쁘다. 실패면 실패라고 보여준다.
+      if (!r.ok || !body || body.ok === false) {
+        info = null;
+        infoError = body?.hint || body?.error || `HTTP ${r.status}`;
+      } else {
+        info = body;
+      }
+    } catch (e) {
+      info = null;
+      infoError = e instanceof Error ? e.message : String(e);
+    }
     infoLoading = false;
     render();
   };
 
   const wizardHtml = (): string => {
-    if (infoLoading || !info) return `<div class="rounded-lg border border-surface-3 bg-surface-0/40 p-3.5 text-[12px] text-slate-500">${pick("설정 정보 불러오는 중…", "Loading settings…")}</div>`;
+    if (infoLoading) return `<div class="rounded-lg border border-surface-3 bg-surface-0/40 p-3.5 text-[12px] text-slate-500">${pick("설정 정보 불러오는 중…", "Loading settings…")}</div>`;
+    // 실패했으면 ★가짜 안내 대신 실패를 보여준다.★ 반쪽 매니페스트를 그리면 사용자가 그걸 붙여넣는다.
+    if (infoError || !info) {
+      return `<div class="rounded-lg border border-status-blocked/40 bg-surface-0/40 p-3.5 text-[12px] text-slate-300">
+        <div class="font-semibold text-status-blocked mb-1">${pick("설정 정보를 불러오지 못했습니다", "Could not load setup info")}</div>
+        <div class="text-slate-400">${esc(infoError ?? "unknown")}</div>
+        <div class="text-slate-500 mt-1.5">${pick("이 상태에서는 매니페스트가 불완전해 Slack 앱이 권한 없이 만들어집니다. 원인을 먼저 해결하세요.", "The manifest would be incomplete here and the Slack app would be created without permissions. Fix the cause first.")}</div>
+      </div>`;
+    }
     const isSocket = wizardMode === "socket";
     const manifestStr = JSON.stringify(isSocket ? socketManifest(info.manifest) : (info.manifest ?? {}), null, 2);
     const scopes = (info.needed_scopes ?? []).join(", ");
-    const channel = info.channel || "#300-gd-ai-team";
+    // ★기본값에 우리 채널명을 쓰지 않는다★ — 예전엔 "#300-gd-ai-team"(우리 채널)이 박혀 있어서, 채널이
+    //   설정되지 않은 설치본에서 ★남의 채널로 초대하라는 안내★ 가 그대로 떴다(공개 소스·번들에도 포함).
+    const channel = info.channel || "";
     const appLink = `<a class="text-accent-greenSoft underline" href="https://api.slack.com/apps?new_app=1" target="_blank" rel="noopener">api.slack.com/apps</a>`;
 
     const steps = isSocket
@@ -118,8 +146,8 @@ export function renderAgentSlack(host: HTMLElement, agentId: string, _displayNam
             `<b>OAuth & Permissions</b> → <b>Bot User OAuth Token</b>(<code>xoxb-…</code>) 복사 → 아래 폼에 <b>xoxb</b>·<b>xapp</b> 붙여넣기.`,
             `<b>OAuth & Permissions</b> → copy the <b>Bot User OAuth Token</b>(<code>xoxb-…</code>) → paste <b>xoxb</b> and <b>xapp</b> into the form below.`),
           pick(
-            `봇을 <b>${esc(channel)}</b>에 초대: <code>/invite @봇이름</code>.`,
-            `Invite the bot to <b>${esc(channel)}</b>: <code>/invite @botname</code>.`),
+            `봇을 <b>${channel ? esc(channel) : pick("사용할 채널", "your channel")}</b>에 초대: <code>/invite @봇이름</code>.${channel ? "" : pick(" <span class=\"text-slate-500\">(채널이 아직 설정되지 않았습니다 — 아래 채널 칸에 입력하세요)</span>", "")}`,
+            `Invite the bot to <b>${channel ? esc(channel) : "your channel"}</b>: <code>/invite @botname</code>.${channel ? "" : " <span class=\"text-slate-500\">(no channel configured yet — set it in the Channel field below)</span>"}`),
         ]
       : [
           pick(
@@ -132,16 +160,21 @@ export function renderAgentSlack(host: HTMLElement, agentId: string, _displayNam
             `<b>Bot User OAuth Token</b>(<code>xoxb-…</code>)과 <b>Signing Secret</b> 복사 → 아래 폼에 붙여넣기.`,
             `Copy the <b>Bot User OAuth Token</b>(<code>xoxb-…</code>) and <b>Signing Secret</b> → paste into the form below.`),
           pick(
-            `봇을 <b>${esc(channel)}</b>에 초대: <code>/invite @봇이름</code>.`,
-            `Invite the bot to <b>${esc(channel)}</b>: <code>/invite @botname</code>.`),
+            `봇을 <b>${channel ? esc(channel) : pick("사용할 채널", "your channel")}</b>에 초대: <code>/invite @봇이름</code>.${channel ? "" : pick(" <span class=\"text-slate-500\">(채널이 아직 설정되지 않았습니다 — 아래 채널 칸에 입력하세요)</span>", "")}`,
+            `Invite the bot to <b>${channel ? esc(channel) : "your channel"}</b>: <code>/invite @botname</code>.${channel ? "" : " <span class=\"text-slate-500\">(no channel configured yet — set it in the Channel field below)</span>"}`),
           pick(
             `Event Subscriptions Request URL = 아래 값 등록 + <code>app_mention</code> 구독 (URL은 우리 서버 고정 주소 — 매니페스트에 이미 포함, 붙여넣으면 바로 Verified).`,
             `Event Subscriptions Request URL = register the value below + subscribe to <code>app_mention</code> (the URL is our server's fixed address — already in the manifest, so it turns Verified as soon as you paste it).`),
         ];
 
+    // Event URL 방식은 공개 HTTPS 주소가 있어야 한다. 없으면 "—" 만 띄우지 말고 ★무엇을 하면 되는지★ 알린다
+    // (Socket Mode 는 이 값 없이도 되므로 그쪽으로 안내). 예전엔 이 조건에서 화면 전체가 못 뜨고 있었다.
+    const eventUrlRow = info.event_request_url
+      ? copyRow("Event URL", info.event_request_url)
+      : `<div class="mb-1.5 rounded border border-txt-amber/30 bg-surface-0 px-2 py-1.5 text-[12px] text-txt-amber">${esc(info.public_base_hint ?? pick("Event URL 방식을 쓰려면 공개 HTTPS 주소 설정이 필요합니다. Socket Mode 는 설정 없이 됩니다.", "Event URL mode needs a public HTTPS address. Socket Mode works without it."))}</div>`;
     const copyRows = isSocket
       ? copyRow(pick("채널", "Channel"), channel, false)
-      : copyRow("Event URL", info.event_request_url || "—") + copyRow(pick("채널", "Channel"), channel, false);
+      : eventUrlRow + copyRow(pick("채널", "Channel"), channel, false);
 
     const tokenInputs = isSocket
       ? `<div class="mb-2.5"><label class="${labelCls}">Bot Token <span class="text-slate-600">(xoxb-…)</span></label>


### PR DESCRIPTION
GD 가 맥스튜디오에서 리사 슬랙 설정 화면을 열어보고 잡았다. 화면에 이렇게 떴다:

```
매니페스트: {"settings":{"socket_mode_enabled":true}}
필요 scope: —
"봇을 #300-gd-ai-team 에 초대하세요"   ← ★우리 채널이다★
```

## ★그냥 실패하는 게 아니라 더 나쁘다★
사용자가 그 껍데기를 Slack 에 붙여넣으면 ★권한 0개짜리 앱★ 이 만들어진다. 그리고 왜 안 되는지 알 방법이 없다. 실패를 안 보여주고 ★망가진 걸 만들어 주는★ 형태다.

## 원인 3개
| | |
|---|---|
| ① | 서버가 `TEAM_PUBLIC_BASE_URL` 없으면 ★400★ |
| ② | 클라이언트가 ★`r.ok` 를 안 보고★ 그 본문을 데이터로 사용 → manifest·scope 가 undefined 인 채 '정상' 처럼 렌더 |
| ③ | 채널 기본값이 ★`"#300-gd-ai-team"`(우리 채널)★ — origin/main 과 ★빌드 번들에도 포함★ |

## ★자기모순도 있었다★
UI 는 "Socket Mode = 공개 URL 불필요" 라고 권하는데 서버는 공개 URL 을 ★필수★ 로 요구했다. Socket Mode 를 고른 사용자는 영영 제대로 된 매니페스트를 못 받는다.

## 수정
- 서버: 공개 URL 없어도 ★완전한 매니페스트★ 제공. `event_request_url: null` + `public_base_missing/hint` 로 무엇이 빠졌는지 알림
  - ★`request_url: null` 을 넣지 않고 `event_subscriptions` 자체를 뺀다★ — null 이 든 매니페스트는 Slack 이 거부한다
- 클라이언트: `r.ok`/`ok===false` 확인 → ★실패면 실패를 보여준다★
- 채널 기본값 제거 → 미설정이면 "사용할 채널" + 설정 안내
- Event URL 없을 때 "—" 대신 ★할 일 안내★ (Socket Mode 로 유도)

## 검증
- 신규 테스트 3건 · ★실행 확인★ `-t 'reinstall-info'` → 3 pass
- ★뮤테이션★ 400 반환을 되살리면 2 fail (치환 적용도 grep 확인)
- 78 pass / 0 fail · `tsc` exit=0 · `bun run build` exit=0
- ★번들 실측★ 빌드 후 dist 에서 `300-gd-ai-team` ★0건★ (이전엔 `index-*.js` 에 있었다)

## 남은 것 (이 PR 밖)
`origin/main` 히스토리에는 채널명이 남는다. 채널 ★이름★ 은 자격증명이 아니라 급하지 않지만, 텔레그램 ID 히스토리 재작성과 함께 처리할 후보다.