### PR TITLE
fix(slack): Socket 매니페스트에 app_mention 구독이 빠지던 것 (#73 후속)

### DIFF
--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -1076,9 +1076,12 @@ describe("slack reinstall-info", () => {
     expect(b.needed_scopes).toEqual(["app_mentions:read", "chat:write", "groups:history", "channels:history"]);
     expect(b.manifest?.oauth_config?.scopes?.bot).toEqual(b.needed_scopes);
     expect(b.manifest?.display_information?.name).toBeTruthy();
-    // 공개 URL 이 없으면 event_subscriptions 자체를 넣지 않는다(request_url:null 매니페스트는 Slack 이 거부)
     expect(b.event_request_url).toBeNull();
-    expect(b.manifest?.settings?.event_subscriptions).toBeUndefined();
+    // ★event_subscriptions 는 남아 있어야 한다★ — 처음엔 통째로 빼서 "undefined 여야 한다" 고 단언했는데
+    //   ★그게 잘못된 불변식이었다★(코덱스 리뷰). 구독이 없으면 앱은 만들어져도 멘션을 못 받는다.
+    //   request_url 만 없으면 된다.
+    expect(b.manifest?.settings?.event_subscriptions?.bot_events).toEqual(["app_mention"]);
+    expect(b.manifest?.settings?.event_subscriptions?.request_url).toBeUndefined();
     expect(b.public_base_missing).toBe(true);
     expect(typeof b.public_base_hint).toBe("string");
   }));

--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -12,6 +12,8 @@ import { appendAudit, listAgents } from "../db/queries";
 import { syncRegistry } from "../lib/registry";
 import { allowedRuntimes, createSettingsApp, MAX_OFFICIAL_TEAM_MEMBERS, publicRuntimeOptions, removePathWithRetries } from "./settings";
 import { MEMBERS_ROOT } from "../lib/personaTemplates";
+// 사용자가 붙여넣는 최종 JSON 은 서버 매니페스트 + 이 변환의 합성이다. 접합부를 검사하려고 가져온다.
+import { socketManifest } from "../../web/components/AgentSlack";
 
 // 테스트 격리: codex 퇴사 테스트의 off-file 기록이 라이브 var/agent-off.txt를 오염하지 않게 temp로.
 process.env.TEAMOS_AGENT_OFF_FILE = join(tmpdir(), "settings-test-off.txt");
@@ -1086,12 +1088,29 @@ describe("slack reinstall-info", () => {
     expect(typeof b.public_base_hint).toBe("string");
   }));
 
-  test("공개 URL 이 있으면 event_subscriptions 를 포함한다", withBase("https://example.test/", async () => {
+  test("공개 URL 이 있으면 request_url 과 ★bot_events 둘 다★ 포함한다", withBase("https://example.test/", async () => {
     const { app } = setup();
     const b = await (await app.request("/members/bill/slack/reinstall-info")).json() as any;
     expect(b.event_request_url).toBe("https://example.test/team/api/slack/events");
     expect(b.manifest?.settings?.event_subscriptions?.request_url).toBe("https://example.test/team/api/slack/events");
+    // ★이 줄이 없어서 기본 경로가 무방비였다★ — 마법사 기본 모드가 webhook 이라 '공개 URL 있음' 이
+    //   대부분 사용자의 경로다. 그런데 여기 bot_events 단언이 없어서, event_subscriptions 를 삼항으로
+    //   갈라 URL 있을 때 bot_events 를 빼도 ★전 테스트가 통과했다★(하네스 검증에서 변이로 실증).
+    //   #73 과 똑같은 피해가 다시 통과될 수 있었다.
+    expect(b.manifest?.settings?.event_subscriptions?.bot_events).toEqual(["app_mention"]);
     expect(b.public_base_missing).toBe(false);
+  }));
+
+  /* ★서버 산출물 → 클라이언트 변환★ 접합부. 양쪽을 따로만 검사하면, 서버가 모양을 바꿔도 클라이언트
+   * 테스트는 손으로 베낀 fixture 를 계속 통과시킨다(하네스 지적). 사용자가 붙여넣는 것은 이 합성 결과다. */
+  test("★사용자가 붙여넣는 최종 Socket JSON★ — 서버 응답을 그대로 변환해 확인한다", withBase(undefined, async () => {
+    const { app } = setup();
+    const b = await (await app.request("/members/bill/slack/reinstall-info")).json() as any;
+    const final = socketManifest(b.manifest) as any;
+    expect(final.settings.socket_mode_enabled).toBe(true);
+    expect(final.settings.event_subscriptions?.bot_events).toEqual(["app_mention"]);
+    expect(final.settings.event_subscriptions?.request_url).toBeUndefined();
+    expect(final.oauth_config?.scopes?.bot).toContain("app_mentions:read");
   }));
 
   test("★채널이 설정 안 됐으면 빈 문자열★ — 남의 채널명을 기본값으로 주지 않는다", withBase("https://example.test", async () => {

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1016,9 +1016,14 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
         display_information: { name: appName },
         features: { bot_user: { display_name: agent.slack_app_name || `gd_${id}`, always_online: true } },
         oauth_config: { scopes: { bot: scopes } },
-        // 공개 URL 이 없으면 event_subscriptions 자체를 넣지 않는다 — request_url 이 null 인 매니페스트는 Slack 이 거부한다.
+        // ★event_subscriptions 는 항상 넣는다★ — bot_events 가 있어야 봇이 멘션을 받는다.
+        //   공개 URL 이 없을 때 이 블록을 통째로 빼봤더니(첫 시도), Socket 매니페스트에 app_mention 구독이
+        //   사라져서 ★앱은 만들어지는데 멘션에 반응하지 않는 상태★ 가 됐다(코덱스 리뷰에서 잡힘).
+        //   scope(app_mentions:read)만 있고 구독이 없으면 이벤트가 오지 않는다 — 둘 다 필요하다.
+        //   request_url 만 조건부로 넣는다: null 이 든 매니페스트는 Slack 이 거부하고,
+        //   Socket Mode 는 애초에 request_url 없이 bot_events 만으로 동작한다.
         settings: {
-          ...(eventUrl ? { event_subscriptions: { request_url: eventUrl, bot_events: ["app_mention"] } } : {}),
+          event_subscriptions: { ...(eventUrl ? { request_url: eventUrl } : {}), bot_events: ["app_mention"] },
           org_deploy_enabled: false,
           socket_mode_enabled: false,
         },

--- a/src/web/components/AgentSlack.test.ts
+++ b/src/web/components/AgentSlack.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { socketManifest } from "./AgentSlack";
+
+/* 2026-07-26: 공개 URL 이 없을 때 서버가 event_subscriptions 를 통째로 빼도록 고쳤더니, Socket 매니페스트에
+ * ★app_mention 구독이 사라졌다.★ 그러면 사용자는 앱을 만들 수는 있는데 ★봇이 멘션에 반응하지 않는다.★
+ * scope(app_mentions:read)만으로는 이벤트가 오지 않는다 — 구독이 함께 있어야 한다.
+ * 여기서는 ★사용자가 실제로 붙여넣는 최종 JSON★ 을 검증한다(중간 단계가 아니라). */
+describe("socketManifest — 사용자가 붙여넣는 최종 JSON", () => {
+  const base = (withUrl: boolean) => ({
+    display_information: { name: "gd lisa" },
+    features: { bot_user: { display_name: "gd_lisa", always_online: true } },
+    oauth_config: { scopes: { bot: ["app_mentions:read", "chat:write"] } },
+    settings: {
+      event_subscriptions: { ...(withUrl ? { request_url: "https://x.test/team/api/slack/events" } : {}), bot_events: ["app_mention"] },
+      org_deploy_enabled: false,
+      socket_mode_enabled: false,
+    },
+  });
+
+  test("★공개 URL 이 없어도 app_mention 구독이 남는다★ (없으면 봇이 멘션을 못 받는다)", () => {
+    const m = socketManifest(base(false)) as any;
+    expect(m.settings.socket_mode_enabled).toBe(true);
+    expect(m.settings.event_subscriptions?.bot_events).toEqual(["app_mention"]);
+    expect(m.settings.event_subscriptions?.request_url).toBeUndefined();
+  });
+
+  test("공개 URL 이 있어도 Socket 변환은 request_url 만 지운다", () => {
+    const m = socketManifest(base(true)) as any;
+    expect(m.settings.event_subscriptions?.bot_events).toEqual(["app_mention"]);
+    expect(m.settings.event_subscriptions?.request_url).toBeUndefined();
+    expect(m.oauth_config.scopes.bot).toContain("app_mentions:read");
+  });
+});

--- a/src/web/components/AgentSlack.test.ts
+++ b/src/web/components/AgentSlack.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { socketManifest } from "./AgentSlack";
+import { socketManifest, webhookBlockedNotice } from "./AgentSlack";
 
 /* 2026-07-26: 공개 URL 이 없을 때 서버가 event_subscriptions 를 통째로 빼도록 고쳤더니, Socket 매니페스트에
  * ★app_mention 구독이 사라졌다.★ 그러면 사용자는 앱을 만들 수는 있는데 ★봇이 멘션에 반응하지 않는다.★
@@ -60,5 +60,28 @@ describe("공개 URL 없이 Event URL 모드 — Slack 이 거부하는 조합",
     expect(slackAccepts(serverManifest(true))).toBe(true);                          // URL 있음 × Event URL
     expect(slackAccepts(socketManifest(serverManifest(false)))).toBe(true);         // URL 없음 × Socket
     expect(slackAccepts(socketManifest(serverManifest(true)))).toBe(true);          // URL 있음 × Socket
+  });
+});
+
+/* ★안내는 그 사람이 실제로 할 수 있는 행동이어야 한다.★
+ * 처음엔 "Socket Mode 를 선택하세요" 라고 썼는데, 방식 선택 토글을 없앤 뒤라 ★고를 버튼이 없었다★ —
+ * 막다른 안내였다(코덱스 리뷰). 오늘 하루 우리가 고친 게 정확히 그 형태인데 내가 다시 만들었다. */
+describe("webhookBlockedNotice — 실행 가능한 행동만 안내한다", () => {
+  test("★기존 Event URL 멤버 + 공개 URL 없음 → 공개 주소 설정을 안내★", () => {
+    const n = webhookBlockedNotice("webhook", null);
+    expect(n).toBeTruthy();
+    expect(n).toContain("TEAM_PUBLIC_BASE_URL");
+    // ★없는 버튼을 누르라고 하지 않는다★ — 토글은 제거됐다
+    expect(n).not.toContain("Socket Mode 를 선택");
+    expect(n).not.toContain("choose Socket Mode");
+  });
+
+  test("공개 URL 이 있으면 막지 않는다", () => {
+    expect(webhookBlockedNotice("webhook", "https://x.test/e")).toBeNull();
+  });
+
+  test("Socket 모드는 공개 URL 과 무관하게 막지 않는다", () => {
+    expect(webhookBlockedNotice("socket", null)).toBeNull();
+    expect(webhookBlockedNotice("socket", "https://x.test/e")).toBeNull();
   });
 });

--- a/src/web/components/AgentSlack.test.ts
+++ b/src/web/components/AgentSlack.test.ts
@@ -31,3 +31,34 @@ describe("socketManifest — 사용자가 붙여넣는 최종 JSON", () => {
     expect(m.oauth_config.scopes.bot).toContain("app_mentions:read");
   });
 });
+
+/* ★네 사분면 중 하나(공개URL 없음 × Event URL)를 아무도 안 찍어봤다★ — #73 을 놓친 것과 같은 종류의
+ * 사각이다. 그 조합의 매니페스트는 Slack 이 거부한다:
+ *   "Event Subscription requires either Request URL or Socket Mode Enabled"
+ * request_url 도 없고 socket_mode_enabled 도 false 면 event_subscriptions 블록 자체가 불법이다.
+ * 그래서 화면에서 그 조합을 못 고르게 막았고, 여기서는 ★왜 막아야 하는지(=불법 조합)★ 를 고정한다. */
+describe("공개 URL 없이 Event URL 모드 — Slack 이 거부하는 조합", () => {
+  const serverManifest = (withUrl: boolean) => ({
+    settings: {
+      event_subscriptions: { ...(withUrl ? { request_url: "https://x.test/e" } : {}), bot_events: ["app_mention"] },
+      org_deploy_enabled: false,
+      socket_mode_enabled: false,
+    },
+  });
+  // Slack 규격: event_subscriptions 가 있으면 request_url 또는 socket_mode_enabled 중 하나는 있어야 한다.
+  const slackAccepts = (m: any): boolean => {
+    const ev = m?.settings?.event_subscriptions;
+    if (!ev) return true;
+    return Boolean(ev.request_url) || m?.settings?.socket_mode_enabled === true;
+  };
+
+  test("★공개 URL 없음 × Event URL = 거부되는 조합★ (그래서 화면에서 막는다)", () => {
+    expect(slackAccepts(serverManifest(false))).toBe(false);
+  });
+
+  test("나머지 세 조합은 통과한다", () => {
+    expect(slackAccepts(serverManifest(true))).toBe(true);                          // URL 있음 × Event URL
+    expect(slackAccepts(socketManifest(serverManifest(false)))).toBe(true);         // URL 없음 × Socket
+    expect(slackAccepts(socketManifest(serverManifest(true)))).toBe(true);          // URL 있음 × Socket
+  });
+});

--- a/src/web/components/AgentSlack.ts
+++ b/src/web/components/AgentSlack.ts
@@ -59,7 +59,8 @@ async function clip(text: string): Promise<boolean> {
 }
 
 // Socket Mode용 매니페스트 변환 — socket_mode_enabled=true + event_subscriptions.request_url 제거(공개 URL 불필요).
-function socketManifest(manifest: unknown): unknown {
+// ★bot_events 는 남긴다★ — 그게 없으면 앱은 만들어지는데 멘션을 못 받는다. export 는 최종 JSON 을 테스트하기 위한 것.
+export function socketManifest(manifest: unknown): unknown {
   try {
     const m = JSON.parse(JSON.stringify(manifest ?? {})) as Record<string, any>;
     m.settings = m.settings || {};

--- a/src/web/components/AgentSlack.ts
+++ b/src/web/components/AgentSlack.ts
@@ -195,16 +195,13 @@ export function renderAgentSlack(host: HTMLElement, agentId: string, _displayNam
          <div class="mb-2.5"><label class="${labelCls}">Signing Secret <span class="text-slate-600">(${pick("선택", "optional")})</span></label>
            <input class="sl-pf ${inputCls}" data-key="slack_signing_secret" type="password" autocomplete="off" spellcheck="false" placeholder="signing secret" /></div>`;
 
-    const seg = (m: string, label: string) =>
-      `<button data-wmode="${m}" class="px-3 py-1 text-[12px] font-medium transition-colors ${wizardMode === m ? "bg-accent-btn text-accent-on" : "text-slate-400 hover:text-slate-200"}">${label}</button>`;
 
     return `
       <div class="rounded-lg border border-accent-green/30 bg-surface-0/60 p-3.5">
         <div class="flex flex-wrap items-center gap-2 mb-3">
           <span class="text-[12px] text-slate-500">${pick("연결 방식", "Connection method")}</span>
-          <div class="inline-flex rounded-md border border-surface-3 overflow-hidden">${seg("socket", "Socket Mode")}${seg("webhook", "Event URL")}</div>
-          <span class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold" style="color:rgb(var(--accent)/.95);background:rgb(var(--accent)/.12)">${pick("Socket 권장", "Socket recommended")}</span>
-          <span class="text-[11px] text-slate-500">${isSocket ? pick("공개 URL 불필요 · 외부 사용자에 권장", "No public URL needed · recommended for external users") : pick("공개 URL(자동·고정) · 이미 호스팅 있으면", "Public URL (automatic·fixed) · if you already have hosting")}</span>
+          <span class="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-semibold" style="color:rgb(var(--accent)/.95);background:rgb(var(--accent)/.12)">${isSocket ? "Socket Mode" : "Event URL"}</span>
+          <span class="text-[11px] text-slate-500">${isSocket ? pick("공개 URL 불필요", "No public URL needed") : pick("기존 설정 유지 중", "keeping existing setup")}</span>
         </div>
         ${unusableWebhook ? `<div class="rounded-md border border-txt-amber/40 bg-surface-0 p-3 mb-3 text-[12px] text-slate-300">
           <div class="font-semibold text-txt-amber mb-1">${pick("이 방식은 지금 쓸 수 없습니다 — Socket Mode 를 선택하세요", "This method is unavailable right now — choose Socket Mode")}</div>
@@ -362,21 +359,6 @@ export function renderAgentSlack(host: HTMLElement, agentId: string, _displayNam
       }
     });
 
-    // 마법사 안 연결 방식 선택 — 로컬 상태만 바꾸고 다시 그림(서버 persist는 '저장 & 검증' 때 함께).
-    // 모순(소켓인데 Event URL 절차) 제거: 고른 방식의 절차·매니페스트·입력칸만 보인다.
-    host.querySelectorAll<HTMLButtonElement>("[data-wmode]").forEach((b) => {
-      b.addEventListener("click", () => {
-        const m = b.dataset.wmode as "webhook" | "socket";
-        if (m === wizardMode) return;
-        // 입력 보존: 모드 전환 render가 innerHTML을 갈아엎어 입력값(특히 양모드 공유 Bot Token)이 날아가는 것 방지.
-        // 토큰은 value 속성 대신 .value(라이브 DOM)로만 재시드 → HTML/로그 노출 없음.
-        const draft: Record<string, string> = {};
-        host.querySelectorAll<HTMLInputElement>(".sl-pf").forEach((el) => { if (el.value) draft[el.dataset.key!] = el.value; });
-        wizardMode = m;
-        render();
-        host.querySelectorAll<HTMLInputElement>(".sl-pf").forEach((el) => { const v = draft[el.dataset.key!]; if (v != null) el.value = v; });
-      });
-    });
   };
 
   (async () => { me = await fetchStatus(); render(); loadInfo(); })();

--- a/src/web/components/AgentSlack.ts
+++ b/src/web/components/AgentSlack.ts
@@ -72,6 +72,20 @@ export function socketManifest(manifest: unknown): unknown {
   }
 }
 
+// ★기존 Event URL 멤버가 공개 URL 없이 마법사를 열면★ Slack 이 거부하는 매니페스트가 나온다:
+//   "Event Subscription requires either Request URL or Socket Mode Enabled"
+// 이때 안내는 ★그 사람이 실제로 할 수 있는 행동★ 이어야 한다. 처음엔 "Socket Mode 를 선택하세요" 라고
+// 썼는데, 방식 선택 토글을 없앤 뒤라 ★고를 버튼이 없었다★ — 막다른 안내였다(코덱스 리뷰).
+// 방식 전환은 App-Level Token 재발급이 필요한 별도 작업이라 이 화면에서 시킬 수 없다.
+// 그래서 공개 주소 설정을 안내한다. 그건 지금 바로 할 수 있는 일이다.
+export function webhookBlockedNotice(mode: "webhook" | "socket", eventRequestUrl: string | null): string | null {
+  if (mode === "socket" || eventRequestUrl) return null;
+  return pick(
+    "이 팀원은 Event URL 방식으로 설정돼 있는데 공개 HTTPS 주소가 없습니다. 그대로 두면 Slack 이 매니페스트를 거부합니다(Event Subscription requires either Request URL or Socket Mode Enabled). 서버에 TEAM_PUBLIC_BASE_URL 로 공개 HTTPS 주소를 설정한 뒤 이 화면을 다시 여세요.",
+    "This member is set up with Event URL mode but no public HTTPS address is configured. Slack will reject the manifest (Event Subscription requires either Request URL or Socket Mode Enabled). Set TEAM_PUBLIC_BASE_URL on the server to a public HTTPS address, then reopen this screen.",
+  );
+}
+
 export function renderAgentSlack(host: HTMLElement, agentId: string, _displayName: string): void {
   let open = false;
   let me: SlackMember | null = null;
@@ -130,13 +144,7 @@ export function renderAgentSlack(host: HTMLElement, agentId: string, _displayNam
     // ★기본값에 우리 채널명을 쓰지 않는다★ — 예전엔 "#300-gd-ai-team"(우리 채널)이 박혀 있어서, 채널이
     //   설정되지 않은 설치본에서 ★남의 채널로 초대하라는 안내★ 가 그대로 떴다(공개 소스·번들에도 포함).
     const channel = info.channel || "";
-    // ★공개 URL 없이 Event URL 방식은 성립하지 않는다★ — Slack 이 그 매니페스트를 거부한다:
-    //   "Event Subscription requires either Request URL or Socket Mode Enabled".
-    //   request_url 도 없고 socket_mode_enabled 도 false 면 event_subscriptions 블록 자체가 불법이다.
-    //   그런데 세그먼트 버튼에 아무 게이트가 없어서 누구나 이 조합을 고를 수 있었고, 화면은
-    //   "그대로 붙여넣기" 라고 안내했다 — ★실패가 우리 화면이 아니라 Slack 화면에서 터진다.★
-    //   그러면 사용자는 제품이 고장 난 건지 자기 설정이 틀린 건지 알 수 없다. 그래서 여기서 막는다.
-    const unusableWebhook = !isSocket && !info.event_request_url;
+    const blockedNotice = webhookBlockedNotice(wizardMode, info.event_request_url);
     const appLink = `<a class="text-accent-greenSoft underline" href="https://api.slack.com/apps?new_app=1" target="_blank" rel="noopener">api.slack.com/apps</a>`;
 
     const steps = isSocket
@@ -203,10 +211,9 @@ export function renderAgentSlack(host: HTMLElement, agentId: string, _displayNam
           <span class="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-semibold" style="color:rgb(var(--accent)/.95);background:rgb(var(--accent)/.12)">${isSocket ? "Socket Mode" : "Event URL"}</span>
           <span class="text-[11px] text-slate-500">${isSocket ? pick("공개 URL 불필요", "No public URL needed") : pick("기존 설정 유지 중", "keeping existing setup")}</span>
         </div>
-        ${unusableWebhook ? `<div class="rounded-md border border-txt-amber/40 bg-surface-0 p-3 mb-3 text-[12px] text-slate-300">
-          <div class="font-semibold text-txt-amber mb-1">${pick("이 방식은 지금 쓸 수 없습니다 — Socket Mode 를 선택하세요", "This method is unavailable right now — choose Socket Mode")}</div>
-          <div class="text-slate-400">${pick("공개 HTTPS 주소가 설정되지 않아 Request URL 을 만들 수 없습니다. 그 상태의 매니페스트는 Slack 이 거부합니다 — 「Event Subscription requires either Request URL or Socket Mode Enabled」.", "No public HTTPS address is configured, so a Request URL cannot be produced. Slack rejects that manifest — 「Event Subscription requires either Request URL or Socket Mode Enabled」.")}</div>
-          <div class="text-slate-500 mt-1.5">${esc(info.public_base_hint ?? "")}</div>
+        ${blockedNotice ? `<div class="rounded-md border border-txt-amber/40 bg-surface-0 p-3 mb-3 text-[12px] text-slate-300">
+          <div class="font-semibold text-txt-amber mb-1">${pick("지금은 설정을 진행할 수 없습니다", "Setup cannot proceed right now")}</div>
+          <div class="text-slate-400">${esc(blockedNotice)}</div>
         </div>` : `
         <div class="text-[13px] font-semibold text-slate-200 mb-2 flex items-center gap-1.5"><span class="text-slate-400 inline-flex">${renderIcon("user-circle", { size: 15 })}</span>${pick("Slack에서 (사람 단계 — 복붙만 하면 됩니다)", "In Slack (human step — just copy & paste)")}</div>
         <ol class="text-[13px] text-slate-300 leading-relaxed ml-4 list-decimal space-y-2 mb-3">

--- a/src/web/components/AgentSlack.ts
+++ b/src/web/components/AgentSlack.ts
@@ -130,6 +130,13 @@ export function renderAgentSlack(host: HTMLElement, agentId: string, _displayNam
     // ★기본값에 우리 채널명을 쓰지 않는다★ — 예전엔 "#300-gd-ai-team"(우리 채널)이 박혀 있어서, 채널이
     //   설정되지 않은 설치본에서 ★남의 채널로 초대하라는 안내★ 가 그대로 떴다(공개 소스·번들에도 포함).
     const channel = info.channel || "";
+    // ★공개 URL 없이 Event URL 방식은 성립하지 않는다★ — Slack 이 그 매니페스트를 거부한다:
+    //   "Event Subscription requires either Request URL or Socket Mode Enabled".
+    //   request_url 도 없고 socket_mode_enabled 도 false 면 event_subscriptions 블록 자체가 불법이다.
+    //   그런데 세그먼트 버튼에 아무 게이트가 없어서 누구나 이 조합을 고를 수 있었고, 화면은
+    //   "그대로 붙여넣기" 라고 안내했다 — ★실패가 우리 화면이 아니라 Slack 화면에서 터진다.★
+    //   그러면 사용자는 제품이 고장 난 건지 자기 설정이 틀린 건지 알 수 없다. 그래서 여기서 막는다.
+    const unusableWebhook = !isSocket && !info.event_request_url;
     const appLink = `<a class="text-accent-greenSoft underline" href="https://api.slack.com/apps?new_app=1" target="_blank" rel="noopener">api.slack.com/apps</a>`;
 
     const steps = isSocket
@@ -199,6 +206,11 @@ export function renderAgentSlack(host: HTMLElement, agentId: string, _displayNam
           <span class="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold" style="color:rgb(var(--accent)/.95);background:rgb(var(--accent)/.12)">${pick("Socket 권장", "Socket recommended")}</span>
           <span class="text-[11px] text-slate-500">${isSocket ? pick("공개 URL 불필요 · 외부 사용자에 권장", "No public URL needed · recommended for external users") : pick("공개 URL(자동·고정) · 이미 호스팅 있으면", "Public URL (automatic·fixed) · if you already have hosting")}</span>
         </div>
+        ${unusableWebhook ? `<div class="rounded-md border border-txt-amber/40 bg-surface-0 p-3 mb-3 text-[12px] text-slate-300">
+          <div class="font-semibold text-txt-amber mb-1">${pick("이 방식은 지금 쓸 수 없습니다 — Socket Mode 를 선택하세요", "This method is unavailable right now — choose Socket Mode")}</div>
+          <div class="text-slate-400">${pick("공개 HTTPS 주소가 설정되지 않아 Request URL 을 만들 수 없습니다. 그 상태의 매니페스트는 Slack 이 거부합니다 — 「Event Subscription requires either Request URL or Socket Mode Enabled」.", "No public HTTPS address is configured, so a Request URL cannot be produced. Slack rejects that manifest — 「Event Subscription requires either Request URL or Socket Mode Enabled」.")}</div>
+          <div class="text-slate-500 mt-1.5">${esc(info.public_base_hint ?? "")}</div>
+        </div>` : `
         <div class="text-[13px] font-semibold text-slate-200 mb-2 flex items-center gap-1.5"><span class="text-slate-400 inline-flex">${renderIcon("user-circle", { size: 15 })}</span>${pick("Slack에서 (사람 단계 — 복붙만 하면 됩니다)", "In Slack (human step — just copy & paste)")}</div>
         <ol class="text-[13px] text-slate-300 leading-relaxed ml-4 list-decimal space-y-2 mb-3">
           ${steps.map((s) => `<li>${s}</li>`).join("")}
@@ -210,7 +222,7 @@ export function renderAgentSlack(host: HTMLElement, agentId: string, _displayNam
           </div>
           <pre class="text-[12px] font-mono text-slate-300 max-h-56 overflow-auto leading-normal">${esc(manifestStr)}</pre>
         </div>
-        ${copyRows}
+        ${copyRows}`}
 
         <div class="border-t border-surface-3 my-3"></div>
         <div class="text-[13px] font-semibold text-slate-200 mb-2 flex items-center gap-1.5"><span class="text-slate-400 inline-flex">${renderIcon("key", { size: 14 })}</span>${pick("복사한 값 입력", "Enter the copied values")}</div>


### PR DESCRIPTION
★#73 이 머지된 직후 코덱스 리뷰에서 잡혔다. 머지된 코드에 결함이 있다.★

내가 "공개 URL 없으면 `event_subscriptions` 자체를 뺀다" 로 고쳤는데, 그러면 ★Socket 매니페스트에 `app_mention` 구독이 사라진다.★

머지된 코드로 최종 JSON 을 계산해봤다:
```json
"settings": { "org_deploy_enabled": false, "socket_mode_enabled": true }
```
→ ★event_subscriptions 없음 = 봇이 멘션을 못 받는다★

## ★#73 전보다 나쁜 지점이 생겼었다★
전에는 매니페스트가 깨져서 아무도 진행을 못 했다. 고친 뒤에는 ★진행은 되고 봇만 조용히 반응을 안 한다.★ `app_mentions:read` scope 는 있는데 구독이 없으면 이벤트 자체가 오지 않는다 — ★둘 다 필요하다.★

## 수정
- `event_subscriptions` 를 ★항상★ 넣고 `bot_events: ["app_mention"]` 유지. `request_url` 만 조건부(null 이 든 매니페스트는 Slack 이 거부, Socket 은 원래 request_url 없이 돈다)
- `socketManifest()` 를 export 해서 ★사용자가 실제로 붙여넣는 최종 JSON★ 을 테스트한다. ★중간 단계만 보면 이 결함을 못 잡는다★ — 서버 응답만 보면 멀쩡해 보인다

## ★내 테스트가 결함을 승인하고 있었다★
"`event_subscriptions` 가 undefined 여야 한다" 고 단언해서 ★이 결함을 통과로 만들었다.★ 구현을 확인했지 요구를 지키지 않은 테스트였다. 그 단언을 바로잡았다.

## 검증
- 신규 테스트 2건(최종 Socket JSON) · 실행 확인 2 pass
- ★뮤테이션★ 조건부 `event_subscriptions` 로 되돌리면 1 fail (치환 적용도 grep 확인)
- 80 pass / 0 fail · `tsc` 0 · `build` 0