### PR TITLE
feat(bus): 차단되면 발신자에게 알린다 — send 성공이 배달을 뜻하지 않던 문제

### DIFF
--- a/src/server/bus/blockNotice.test.ts
+++ b/src/server/bus/blockNotice.test.ts
@@ -1,0 +1,139 @@
+/**
+ * ★차단되면 발신자에게 알린다★ (GD 승인 2026-07-26).
+ *
+ * 무슨 일이 있었나: 빌→스티브 4건이 pingpong 가드에 막혔는데
+ *   · 발신자 — send.sh 가 ★"✓ sent" 를 찍었다★
+ *   · 수신자 — ★아무것도 안 왔다★
+ *   · ★양쪽 다 몰랐다★ → 빌이 스티브를 무응답으로 판단하고 리뷰를 재배치했다
+ *
+ * ★스티브 요청: "통보 자체가 안 막히는지 실측하라. 문구만 그럴싸하고 실제로 안 오면
+ *   오늘 하루 우리가 고친 것과 같은 형태가 된다."★
+ * 그래서 이 테스트는 소스를 grep 하지 않는다 — ★실제로 차단을 일으키고, 통보를 만들고,
+ * 그 통보를 다시 가드에 넣어본다.★
+ */
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { migrate } from "../db/migrate";
+import { insertMessage } from "../db/inboxQueries";
+import { checkPingpong } from "./antiPingpong";
+import { notifySenderOfBlock } from "./wakeDispatcher";
+import type { PendingDispatchRow } from "./types";
+import type { AgentRecord } from "../types";
+
+const AGENTS = [
+  { id: "bill", display_name: "Bill" },
+  { id: "steve", display_name: "Steve" },
+] as unknown as AgentRecord[];
+const ROSTER = new Set(["bill", "steve"]);
+
+/** 실 스키마 DB. message.thread_id 는 thread(id) FK 라 스레드를 먼저 만든다. */
+function freshDb(): Database {
+  const d = new Database(":memory:");
+  migrate(d);
+  d.run(`INSERT INTO thread (id, title, kind, participants_json, opened_by) VALUES ('t-chain','t','dm','[]','bill')`);
+  return d;
+}
+
+/** bill↔steve 가 n번 주고받은 체인을 실제로 만든다. 마지막 메시지 id 를 돌려준다. */
+function buildChain(db: Database, n: number): string {
+  let parent: string | null = null;
+  let last = "";
+  for (let i = 0; i < n; i++) {
+    const m = insertMessage(db, {
+      thread_id: "t-chain",
+      from_agent_id: i % 2 === 0 ? "steve" : "bill",
+      to_agent_id: i % 2 === 0 ? "bill" : "steve",
+      type: "dm", body: `msg ${i}`, source: "agent",
+      hop_count: 0, priority: "normal",
+      ...(parent ? { in_reply_to: parent } : {}),
+    } as Parameters<typeof insertMessage>[1]);
+    parent = m.id; last = m.id;
+  }
+  return last;
+}
+
+function row(over: Partial<PendingDispatchRow>): PendingDispatchRow {
+  return {
+    message_id: "m-new", agent_id: "steve", delivery_state: "pending", retry_count: 0, last_error: null,
+    from_agent_id: "bill", to_agent_id: "steve", body: "x", source: "agent", created_by: null,
+    max_hop: 16, hop_count: 0, in_reply_to: null, parent_message_id: null, sync: "none",
+    thread_id: "t-chain", type: "dm", created_at: "2026-07-26", priority: "normal",
+    ...over,
+  };
+}
+
+describe("★차단 통보 — 실제로 막히고, 실제로 통보가 나가고, 그 통보는 안 막힌다★", () => {
+  test("① 6왕복 넘으면 실제로 차단된다 (전제 확인)", () => {
+    const db = freshDb();
+    const parent = buildChain(db, 6);
+    const v = checkPingpong(db, row({ parent_message_id: parent }), ROSTER);
+    expect(v.allowed).toBe(false);
+    expect(v.reason).toContain("pingpong_limit_exceeded");
+  });
+
+  test("② 차단되면 ★발신자에게★ 통보가 실제로 들어간다", () => {
+    const db = freshDb();
+    const parent = buildChain(db, 6);
+    const blocked = row({ parent_message_id: parent, message_id: "m-blocked" });
+    notifySenderOfBlock(db, blocked, AGENTS, "pingpong_limit_exceeded:rounds=6,max=6");
+
+    const n = db.query("SELECT * FROM message WHERE from_agent_id='system' ORDER BY rowid DESC LIMIT 1").get() as any;
+    expect(n).toBeTruthy();
+    expect(n.to_agent_id).toBe("bill");                 // ★수신자가 아니라 발신자에게★
+    expect(n.source).toBe("system");
+    expect(String(n.body)).toContain("m-blocked");       // ★차단된 메시지 id 포함★ (재전송·이관용)
+    expect(String(n.body)).toContain("새 스레드");        // 실행 가능한 복구 행동
+  });
+
+  test("③ ★그 통보 자체는 같은 가드에 안 걸린다★ — 이게 핵심이다", () => {
+    const db = freshDb();
+    const parent = buildChain(db, 6);
+    notifySenderOfBlock(db, row({ parent_message_id: parent }), AGENTS, "pingpong_limit_exceeded:rounds=6,max=6");
+    const n = db.query("SELECT * FROM message WHERE from_agent_id='system' ORDER BY rowid DESC LIMIT 1").get() as any;
+
+    // ★체인 밖★ — parent 가 없어야 한다. 있으면 통보가 통보를 막는다.
+    expect(n.parent_message_id).toBeNull();
+    expect(n.hop_count).toBe(0);
+
+    // 그 통보를 그대로 가드에 넣어본다 → ★통과해야 한다★
+    const v = checkPingpong(db, row({
+      message_id: n.id, source: "system", from_agent_id: "system", created_by: "system",
+      to_agent_id: "bill", agent_id: "bill", parent_message_id: n.parent_message_id, hop_count: 0,
+    }), ROSTER);
+    expect(v.allowed).toBe(true);
+  });
+
+  test("④ ★통보가 통보를 부르지 않는다★ — system 발신에는 통보하지 않는다", () => {
+    const db = freshDb();
+    notifySenderOfBlock(db, row({ source: "system", from_agent_id: "system" }), AGENTS, "x");
+    const cnt = db.query("SELECT COUNT(*) c FROM message WHERE from_agent_id='system'").get() as any;
+    expect(cnt.c).toBe(0);
+  });
+
+  test("⑤ 같은 차단으로 두 번 알리지 않는다 (dedupe)", () => {
+    const db = freshDb();
+    const parent = buildChain(db, 6);
+    const r = row({ parent_message_id: parent, message_id: "m-dup" });
+    notifySenderOfBlock(db, r, AGENTS, "pingpong_limit_exceeded:rounds=6,max=6");
+    notifySenderOfBlock(db, r, AGENTS, "pingpong_limit_exceeded:rounds=6,max=6");
+    const cnt = db.query("SELECT COUNT(*) c FROM message WHERE from_agent_id='system'").get() as any;
+    expect(cnt.c).toBe(1);
+  });
+});
+
+/* ★배선 검사 — 위 동작 테스트만으로는 부족하다.★
+ * 내가 뮤테이션을 돌려보니 ★차단 지점의 호출을 통째로 지워도 5건이 다 통과했다.★
+ * 동작 테스트가 notifySenderOfBlock 을 직접 부르기 때문이다 — 함수는 맞는데 ★아무도 안 부르면★ 소용없다.
+ * 오늘 하루 계속 나온 형태(요구가 아니라 구현을 확인)를 내 테스트가 또 저지르고 있었다.
+ * 소스 문자열 검사는 약하지만, 이 배선을 지키는 다른 방법이 지금 없다(디스패처 전체를 띄워야 한다). */
+describe("★배선 — 차단 지점이 실제로 통보를 부른다★", () => {
+  const SRC = readFileSync(join(import.meta.dir, "wakeDispatcher.ts"), "utf8");
+
+  test("checkPingpong 차단 분기 안에서 통보를 호출한다", () => {
+    const blockBranch = SRC.slice(SRC.indexOf("const verdict = checkPingpong("));
+    const untilReturn = blockBranch.slice(0, blockBranch.indexOf('return { kind: "skip" };'));
+    expect(untilReturn).toContain("notifySenderOfBlock(db, row, agents, verdict.reason)");
+  });
+});

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -1058,6 +1058,8 @@ function buildDispatchPlan(
       reason: verdict.reason,
       from: row.from_agent_id,
     });
+    // ★막았으면 보낸 사람에게 말해준다.★ 이게 없어서 오늘 4건이 조용히 사라졌다.
+    notifySenderOfBlock(db, row, agents, verdict.reason);
     return { kind: "skip" };
   }
 
@@ -1253,6 +1255,81 @@ function wakeFailurePolicy(runtime: string): WakeFailurePolicy {
  * RECORD — single place that maps the invoke outcome to the delivery state machine + audit + sync:
  * exception / deferred / ok / failure, with openclaw no-retry and unknown-side-effect expiry.
  */
+/**
+ * ★차단되면 발신자에게 알린다.★ (GD 승인 2026-07-26 · 스티브 종합)
+ *
+ * 무슨 일이 있었나: 빌이 스티브에게 보낸 4건이 pingpong 가드에 막혔다. 그런데
+ *   · 발신자 쪽 — send.sh 가 ★"✓ sent" 를 찍었다★
+ *   · 수신자 쪽 — ★아무것도 안 왔다★
+ *   · ★양쪽 다 몰랐다★
+ * 그래서 빌이 스티브를 무응답으로 판단하고 ★리뷰를 다른 사람에게 재배치했다.★
+ * 스티브는 그 4건을 몇 시간 뒤 DB 에서 처음 봤다.
+ *
+ * ★차단 자체는 그대로 둔다.★ 고치는 건 침묵이다 — 알려주면 발신자가 새 스레드로 옮겨
+ * 계속할 수 있다(체인은 부모가 없으면 0으로 리셋되므로 실제로 통한다).
+ *
+ * ★한도를 올리는 것은 답이 아니다★ — 2→6 으로 한 번 올렸고 오늘 6에서 또 걸렸다.
+ * 숫자만 올리면 다음엔 그 숫자에서 걸린다. 세 번째 반복을 하지 않는다.
+ *
+ * ★통보가 같은 가드에 안 걸리는 이유★
+ *   · source='system' — pingpong 검사는 source==='agent' 일 때만 돈다(antiPingpong.ts)
+ *   · in_reply_to 를 넣지 않는다 → parent_message_id 가 null → ★체인 밖★
+ *   · hop_count=0 → hop 한도와 무관
+ * 셋 다 있어야 안전하다. 하나라도 빠지면 통보가 통보를 막는 상황이 생긴다.
+ */
+export function notifySenderOfBlock(
+  db: Database,
+  row: PendingDispatchRow,
+  agents: AgentRecord[],
+  reason: string,
+): void {
+  try {
+    // 사람·시스템 발신은 알릴 대상이 아니다(발신자가 팀원이 아니면 받을 곳이 없다).
+    if (row.source !== "agent") return;
+    const sender = row.created_by ?? row.from_agent_id;
+    if (!sender || sender === row.agent_id) return;
+    // ★통보가 막혀서 통보하는 무한루프 방지★ — system/user 발신에는 통보하지 않는다.
+    if (sender === "system" || sender === "user" || sender === "moderator") return;
+    if (!agents.some((a) => a.id === sender)) return;
+
+    const body =
+      `[전달 차단] ${row.agent_id} 에게 보낸 메시지가 ★배달되지 않았습니다★ (${reason}). ` +
+      `차단된 메시지 id: ${row.message_id} · 스레드: ${row.thread_id}. ` +
+      `★send 는 성공으로 보였지만 실제로는 전달되지 않았습니다.★ ` +
+      `이어서 하려면 ★--in-reply-to 없이 새 스레드로★ 보내세요(체인 카운터가 리셋됩니다). ` +
+      `내용을 옮겨야 하면 위 id 로 원문을 찾을 수 있습니다.`;
+
+    // ★dedupe 는 여기서 직접 확인한다★ — insertMessage 에 dedupe_key 를 넘겨도 ★저장만 되고 막지 않는다★
+    //   (중복 차단은 acceptInbound 계층에서 한다). 테스트로 확인했다: 같은 차단을 두 번 알리면 2건이 들어갔다.
+    //   주석에 "두 번 안 알린다" 고 써놓고 실제로는 알리고 있었다 — 그래서 코드로 막는다.
+    const dedupeKey = `block-notice:${row.message_id}:${row.agent_id}`;
+    const dup = db.prepare(`SELECT 1 FROM message WHERE dedupe_key = ? LIMIT 1`).get(dedupeKey);
+    if (dup) return;
+
+    const msg = insertMessage(db, {
+      thread_id: row.thread_id,
+      from_agent_id: "system",
+      to_agent_id: sender,
+      type: "dm",
+      body,
+      source: "system",           // ★pingpong 검사를 안 탄다★
+      hop_count: 0,               // ★hop 체인 밖★
+      priority: "high",
+      // ★in_reply_to 를 넣지 않는다★ — 넣으면 parent_message_id 가 생겨 체인에 얹힌다
+      dedupe_key: dedupeKey,
+    } as Parameters<typeof insertMessage>[1]);
+
+    appendAudit(db, "bus_dispatcher", "block_notified_sender", row.message_id, {
+      sender, blocked_to: row.agent_id, notice_id: msg.id, reason,
+    });
+  } catch (e) {
+    // ★통보 실패가 원래 흐름을 막지 않는다★ — 차단은 이미 기록됐다.
+    appendAuditFile("bus_dispatcher", "block_notify_failed", row.message_id, {
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+}
+
 /**
  * ★깨우기가 죽었으면 ★요청자에게 알린다.★★ (2026-07-13 — 팀장 라이브 테스트에서 드러남)
  *


### PR DESCRIPTION
빌→스티브 4건이 pingpong 가드에 막혔는데 ★발신자는 "✓ sent" 를 봤고, 수신자는 아무것도 못 받았고, 양쪽 다 몰랐다.★ 그래서 빌이 스티브를 무응답으로 판단하고 리뷰를 재배치했다. 스티브는 그 4건을 몇 시간 뒤 DB 에서 처음 봤다. (GD 승인 · 스티브 종합)

## 고치는 것은 차단이 아니라 ★침묵★
차단은 그대로 둔다. 막혔다고 알려주면 발신자가 새 스레드로 옮겨 계속할 수 있다(체인은 부모가 없으면 0으로 리셋되므로 실제로 통한다).

★한도를 올리는 건 답이 아니다★ — 2→6 으로 한 번 올렸고 오늘 6에서 또 걸렸다. 세 번째 반복을 하지 않는다.

## 통보가 같은 가드에 안 걸리게 하는 세 가지
| | |
|---|---|
| `source='system'` | pingpong 검사는 `source==='agent'` 일 때만 돈다 |
| `in_reply_to` 없음 | `parent_message_id` = null → ★체인 밖★ |
| `hop_count=0` | hop 한도와 무관 |

★하나라도 빠지면 통보가 통보를 막는다.★ system/user 발신에는 통보하지 않는다(무한루프 차단).

## ★테스트가 내 주장 두 개를 거짓으로 잡았다★
① "dedupe_key 로 두 번 안 알린다" → ★거짓★. `insertMessage` 는 dedupe_key 를 저장만 하고 막지 않는다(중복 차단은 acceptInbound 계층). 실제로 2건이 들어갔다 → 코드로 직접 막았다.
② 뮤테이션으로 ★차단 지점의 호출을 통째로 지웠더니 5건이 다 통과★ — 동작 테스트가 함수를 직접 부르기 때문이다. ★함수는 맞는데 아무도 안 부르면 소용없다.★ → 배선 테스트를 따로 넣었다.

## 검증 — ★소스 grep 이 아니라 실제 동작★ (스티브 요청)
- 6왕복 체인을 실제로 만들어 차단을 일으킨다
- 통보가 ★발신자에게★ 실제로 들어가는지 DB 로 확인 (차단된 id · 복구 방법 포함)
- ★그 통보를 다시 가드에 넣어 통과하는지 확인★ ← 핵심. "문구만 그럴싸하고 실제로 안 오면 오늘 고친 것과 같은 형태가 된다"(스티브)
- 뮤테이션 2종: 호출 제거 → 잡힘 · `in_reply_to` 추가 → 잡힘

6 pass / 0 fail · `src/server/bus` 전체 299 pass / 0 fail · tsc 0

## 미포함 (별건)
`report_delivered`→`accepted` 라벨 개명 · ★홉 이중증가 수정★ · 한도 상향(체인 8). 홉 수정이 한도 상향의 전제라 순서가 있다.