### PR TITLE
fix(openclaw): PATH 만 믿다 openclaw 팀원 wake 가 조용히 실패하던 것

### DIFF
--- a/scripts/runtime-drift-check.sh
+++ b/scripts/runtime-drift-check.sh
@@ -62,7 +62,9 @@ resolve_bin() {
 # 설치 위치가 표준을 벗어나는 환경(리눅스·nix·커스텀 prefix)을 위한 주입구.
 # 테스트에서 실패 경로를 재현할 때도 쓴다.
 CLAUDE_BIN="${B3OS_CLAUDE_BIN:-$(resolve_bin claude "$HOME/.local/bin/claude" "$HOME/.claude/local/claude" || true)}"
-OPENCLAW_BIN="${B3OS_OPENCLAW_BIN:-$(resolve_bin openclaw /opt/homebrew/bin/openclaw /usr/local/bin/openclaw || true)}"
+# ~/.local/bin 이 맨 앞 — openclaw 는 npm global 로 깔려 거기 들어간다(2026-07-27). 이게 빠져 있어
+# 서버(launchd, PATH 에 ~/.local/bin 없음)가 openclaw 를 못 찾은 적이 있다. 드리프트 감시도 같은 눈을 갖는다.
+OPENCLAW_BIN="${B3OS_OPENCLAW_BIN:-$(resolve_bin openclaw "$HOME/.local/bin/openclaw" /opt/homebrew/bin/openclaw /usr/local/bin/openclaw || true)}"
 HERMES_BIN="${B3OS_HERMES_BIN:-$(resolve_bin hermes /opt/homebrew/bin/hermes "$HOME/.local/bin/hermes" || true)}"
 BUN_BIN="${B3OS_BUN_BIN:-$(resolve_bin bun "$HOME/.bun/bin/bun" /opt/homebrew/bin/bun || true)}"
 NODE_BIN="${B3OS_NODE_BIN:-$(resolve_bin node /opt/homebrew/bin/node /usr/local/bin/node || true)}"

--- a/src/server/lib/openclawBridge.test.ts
+++ b/src/server/lib/openclawBridge.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { AgentRecord } from "../types";
-import { __setOpenclawBridgeTestDeps, injectOpenclawTelegramTurn } from "./openclawBridge";
+import {
+  OPENCLAW_BIN_CANDIDATES,
+  __setOpenclawBridgeTestDeps,
+  injectOpenclawTelegramTurn,
+  resolveOpenclawBin,
+} from "./openclawBridge";
 import { clearRuntimeBlock } from "./runtimeBlocks";
 
 const codex: AgentRecord = {
@@ -44,6 +49,51 @@ afterEach(() => {
   if (originalTimeoutNotice === undefined) delete process.env.OPENCLAW_TIMEOUT_NOTICE;
   else process.env.OPENCLAW_TIMEOUT_NOTICE = originalTimeoutNotice;
   delete process.env.OPENCLAW_TURN_FAIL_GRACE_MS;
+});
+
+/**
+ * ★2026-07-27 라이브 회귀★ — 서버가 launchd 로 뜨면 PATH 에 npm global prefix(`~/.local/bin`)가
+ * 없다. openclaw 가 멀쩡히 설치돼 있는데도 spawn 이 `Executable not found in $PATH` 로 죽었고,
+ * openclaw 런타임 팀원에게 가는 ★모든 directed 버스 메시지의 wake 가 조용히 실패★했다
+ * (message row 는 저장되므로 발신자에겐 "보냈다"로 보인다 — 그래서 몇 시간 안 들켰다).
+ *
+ * 실 FS 를 건드리지 않도록 후보 목록·실행가능 판정을 주입해서 고정한다(b3os-infra-safety ④).
+ */
+describe("resolveOpenclawBin — PATH 만 믿지 않는다", () => {
+  const never = () => false;
+  const always = () => true;
+
+  test("기본 후보 맨 앞은 ~/.local/bin — openclaw 의 npm global 설치 위치", () => {
+    expect(OPENCLAW_BIN_CANDIDATES[0]).toBe(`${process.env.HOME ?? ""}/.local/bin/openclaw`);
+  });
+
+  test("OPENCLAW_BIN 이 있으면 그대로 존중한다 (비표준 prefix 주입구)", () => {
+    expect(resolveOpenclawBin({ OPENCLAW_BIN: "/nix/store/xyz/bin/openclaw" }, [], never)).toBe(
+      "/nix/store/xyz/bin/openclaw",
+    );
+  });
+
+  test("OPENCLAW_BIN 이 공백뿐이면 무시하고 후보 탐색으로 넘어간다", () => {
+    expect(resolveOpenclawBin({ OPENCLAW_BIN: "   " }, ["/a/openclaw"], always)).toBe("/a/openclaw");
+  });
+
+  test("★핵심★ env 가 없어도 실경로 후보에서 찾는다 — PATH 에 없어도 산다", () => {
+    const seen: string[] = [];
+    const found = resolveOpenclawBin({}, ["/miss/openclaw", "/hit/openclaw"], (p) => {
+      seen.push(p);
+      return p === "/hit/openclaw";
+    });
+    expect(found).toBe("/hit/openclaw");
+    expect(seen).toEqual(["/miss/openclaw", "/hit/openclaw"]); // 순서대로, 첫 히트에서 멈춤
+  });
+
+  test("실행 불가(존재하지만 +x 없음)는 건너뛴다", () => {
+    expect(resolveOpenclawBin({}, ["/no-x/openclaw"], never)).toBe("openclaw");
+  });
+
+  test("후보를 다 놓치면 기존 동작(PATH 폴백)을 유지한다 — 회귀 0", () => {
+    expect(resolveOpenclawBin({}, OPENCLAW_BIN_CANDIDATES, never)).toBe("openclaw");
+  });
 });
 
 describe("injectOpenclawTelegramTurn visible reply bridge", () => {

--- a/src/server/lib/openclawBridge.ts
+++ b/src/server/lib/openclawBridge.ts
@@ -1,11 +1,13 @@
-import { existsSync, readFileSync } from "node:fs";
+import { accessSync, constants, existsSync, readFileSync } from "node:fs";
 import type { AgentRecord } from "../types";
 import { pick, type Locale } from "./i18n";
 import { teamContextLabel } from "../channels/registry";
 import { appendAuditFile } from "./auditFile";
 import { hasCapability } from "./capabilities";
 import { clearRuntimeBlock, recordRuntimeBlock } from "./runtimeBlocks";
-import { openclawEnvPath } from "./paths";
+import { LOCAL_BIN, openclawEnvPath } from "./paths";
+
+const { X_OK } = constants;
 
 interface RunOpenclawTurnOptions {
   agent: AgentRecord;
@@ -119,7 +121,45 @@ async function describeOpenclawSessionStatus(key: string): Promise<string | unde
   return (await describeOpenclawSession(key))?.status;
 }
 
-const OPENCLAW_BIN = process.env.OPENCLAW_BIN ?? "openclaw";
+/** openclaw 바이너리 후보 — 실경로 우선순위. npm global(~/.local/bin)이 기본 설치 위치다. */
+export const OPENCLAW_BIN_CANDIDATES = [
+  `${LOCAL_BIN}/openclaw`, // npm global prefix — openclaw 기본 설치 위치
+  "/opt/homebrew/bin/openclaw", // homebrew (apple silicon)
+  "/usr/local/bin/openclaw", // homebrew (intel) · 수동 설치
+];
+
+function isExecutableFile(path: string): boolean {
+  try {
+    accessSync(path, X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * ★PATH 만 믿지 않는다★ (2026-07-27 라이브) — launchd 로 뜨는 서버의 PATH 에는 npm global
+ * prefix(`~/.local/bin`)가 없다. 그래서 openclaw 가 정상 설치돼 있는데도 spawn 이
+ * `Executable not found in $PATH: "openclaw"` 로 죽었고, openclaw 런타임 팀원에게 가는
+ * ★모든 directed 버스 메시지의 wake 가 조용히 실패★했다(메시지 row 는 저장되므로 발신자에겐
+ * 보내진 것처럼 보인다). claude·hermes·bun 은 `scripts/runtime-drift-check.sh` 의 resolve_bin
+ * 이 실경로 후보를 먼저 보게 돼 있었는데 openclaw 만 그 방어가 없었다 — 그 비대칭을 없앤다.
+ *
+ * 규약은 resolve_bin 과 동일: 명시 env → 실경로 후보 → PATH.
+ * spawn 시점마다 해석한다(서버 기동 후 설치된 경우도 재시작 없이 잡히게).
+ */
+export function resolveOpenclawBin(
+  env: Record<string, string | undefined> = process.env,
+  candidates: readonly string[] = OPENCLAW_BIN_CANDIDATES,
+  executable: (path: string) => boolean = isExecutableFile,
+): string {
+  const explicit = env.OPENCLAW_BIN?.trim();
+  if (explicit) return explicit; // 비표준 prefix(리눅스·nix) 주입구. 존재검사 없이 그대로 존중.
+  for (const candidate of candidates) {
+    if (executable(candidate)) return candidate;
+  }
+  return "openclaw"; // 최후 폴백 — PATH 에 맡긴다(기존 동작).
+}
 // 2026-07-06 (GD live): 300초는 코드 수정·검증 같은 긴 turn에서 bridge가 먼저 포기해
 // "Codex가 끝까지 답했지만 Telegram에는 안 보이는" 상태를 만들었다. 팀방 visible reply는 실제 최종보고가
 // 보이는 것이 완료 기준이다. 팀 기본 과제 수행시간 단위에 맞춰 기본 대기 시간을 10분으로 둔다.
@@ -165,11 +205,30 @@ async function runOpenclawJson(args: string[], timeoutMs = 30_000): Promise<unkn
   //   timeoutMs(230s)와 무관하게 ★전송이 10초에 끊겨★ {ok:false,error:{kind:"timeout"}} 를 뱉는다
   //   (status 없음 → done?.status==="ok" false → codex 가 10초 넘는 턴을 정상 처리했는데도 '전달 실패' 오탐).
   //   → 전송 타임아웃 = spawn-kill 타임아웃(timeoutMs)으로 맞춘다.
-  const proc = Bun.spawn([OPENCLAW_BIN, "gateway", "call", ...args, "--timeout", String(timeoutMs), "--json"], {
-    stdout: "pipe",
-    stderr: "pipe",
-    env,
-  });
+  const bin = resolveOpenclawBin();
+  const spawnArgs = [bin, "gateway", "call", ...args, "--timeout", String(timeoutMs), "--json"];
+  const proc = (() => {
+    try {
+      // ★자식의 PATH 도 보강한다★ — 절대경로 해석은 openclaw 자신만 구한다. openclaw 는
+      //   `#!/usr/bin/env node` 셔뱅이라 ★node 를 상속 PATH 에서★ 찾는다. launchd PATH 에
+      //   node 가 없으면 바이너리를 제대로 찾아놓고도 셔뱅 단계에서 죽고, 아래 catch 가 그걸
+      //   "실행파일을 찾지 못했습니다" 로 ★오진★ 한다. activation.ts 의 openclaw spawn 이 이미
+      //   같은 방식으로 풀고 있다 — 두 call site 를 같은 규약으로 맞춘다.
+      const pathForChild = [`${LOCAL_BIN}`, "/opt/homebrew/bin", env.PATH ?? ""].filter(Boolean).join(":");
+      return Bun.spawn(spawnArgs, { stdout: "pipe", stderr: "pipe", env: { ...env, PATH: pathForChild } });
+    } catch (e) {
+      // ★원인 추적 가능한 실패로 바꾼다★ — 기존엔 Bun 의 `Executable not found in $PATH: "openclaw"`
+      //   가 그대로 올라와, 서버 PATH 문제인지 미설치인지 구분이 안 됐다(라이브에서 실제로 헤맴).
+      //   ★실제로 시도한 경로(bin)를 맨 앞에 적는다★ — OPENCLAW_BIN 이 설정돼 있으면 후보를
+      //   하나도 훑지 않으므로, 후보 목록만 적으면 ★가장 헷갈리는 케이스(명시 env 오설정)에서
+      //   거짓 정보★ 를 준다(lisa 리뷰 2026-07-27).
+      throw new Error(
+        `openclaw 실행파일을 찾지 못했습니다. 실행 시도: ${bin} ` +
+          `(${e instanceof Error ? e.message : String(e)}). ` +
+          `${process.env.OPENCLAW_BIN?.trim() ? "OPENCLAW_BIN 환경변수로 지정된 경로입니다 — 값이 맞는지 확인하세요." : `후보: ${OPENCLAW_BIN_CANDIDATES.join(", ")} → PATH. 비표준 위치에 설치했다면 OPENCLAW_BIN 환경변수로 절대경로를 지정하세요 (launchd 서비스면 plist 의 EnvironmentVariables 에 추가).`}`,
+      );
+    }
+  })();
   const timeout = setTimeout(() => proc.kill(), timeoutMs);
   try {
     const [stdout, stderr, exitCode] = await Promise.all([


### PR DESCRIPTION
## 무슨 일이 있었나

2026-07-27 오전, 팀원 한 명(openclaw 런타임)에게 보낸 버스 메시지가 **전부 도달하지 않았습니다.** 발신 쪽에서는 아무 이상이 없어 보였습니다 — `send.sh` 는 성공했고 message row 도 정상 저장됐습니다. 그런데 수신자는 아무것도 못 받았습니다.

```
[전달 실패] clo 가 응답하지 못했습니다
(openclaw_directed_error: Executable not found in $PATH: "openclaw")
```

정확히는 **"전달 실패"가 아니라 "wake 실패"** 였습니다. b3os 는 메시지를 밀어넣는 구조가 아니라 런타임별로 수신자를 깨웁니다. claude 는 tmux 주입, hermes 는 게이트웨이, openclaw 는 **`openclaw` CLI spawn**. 그 CLI 를 못 찾으니 깨우질 못했고, DB 에는 멀쩡히 쌓였습니다.

증상이 고약한 건 **아웃바운드는 정상**이었다는 점입니다. 해당 팀원은 살아서 다른 팀원에게 메시지를 보내고 있었습니다. 그래서 "팀원이 살아있음 + 메시지 저장됨 = 정상"으로 보였고, 실제로는 한 방향만 끊겨 있었습니다.

## 원인

`openclawBridge.ts` 가 PATH 에만 의존했습니다.

```ts
const OPENCLAW_BIN = process.env.OPENCLAW_BIN ?? "openclaw";
```

그런데 서버는 launchd 로 뜨고, 그 plist 의 PATH 에는 npm global prefix 인 `~/.local/bin` 이 없습니다. openclaw 의 기본 설치 위치가 바로 거기입니다.

```
plist PATH : ~/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
실제 설치   : ~/.local/bin/openclaw -> ../lib/node_modules/openclaw/openclaw.mjs
```

## 핵심은 비대칭입니다

이게 openclaw 만의 문제가 아니라 **openclaw 만 빠진** 문제라는 게 중요합니다. `scripts/runtime-drift-check.sh` 는 이미 같은 함정을 알고 있고, `resolve_bin` 으로 실경로 후보를 먼저 봅니다:

```sh
CLAUDE_BIN=... resolve_bin claude "$HOME/.local/bin/claude" ...
HERMES_BIN=... resolve_bin hermes /opt/homebrew/bin/hermes "$HOME/.local/bin/hermes" ...
BUN_BIN=...    resolve_bin bun    "$HOME/.bun/bin/bun" ...
OPENCLAW_BIN=... resolve_bin openclaw /opt/homebrew/bin/openclaw /usr/local/bin/openclaw ...
                                      ^^^ ~/.local/bin 없음
```

claude·hermes·bun 은 방어돼 있는데 openclaw 만 없습니다. 그것도 두 군데에서 — 브릿지 코드에도, 드리프트 감시에도. 이 PR 은 그 비대칭을 없앱니다.

## 변경

**1. `resolveOpenclawBin()` — `openclawBridge.ts`**

`resolve_bin` 과 동일한 규약입니다: 명시 env → 실경로 후보 → PATH.

```ts
export const OPENCLAW_BIN_CANDIDATES = [
  `${LOCAL_BIN}/openclaw`,      // npm global prefix
  "/opt/homebrew/bin/openclaw", // homebrew (apple silicon)
  "/usr/local/bin/openclaw",    // homebrew (intel) · 수동 설치
];
```

- `OPENCLAW_BIN` 이 있으면 존재검사 없이 그대로 존중합니다. 리눅스·nix·커스텀 prefix 를 위한 주입구이므로, 여기서 막으면 그 환경들이 갈 곳이 없어집니다.
- 후보는 `access(X_OK)` 로 봅니다 — 존재만 하고 실행권한이 없는 파일에 걸리지 않게.
- **후보를 다 놓치면 `"openclaw"` 를 반환해 기존 PATH 동작을 그대로 유지합니다. 회귀 0.**
- 모듈 로드 시점이 아니라 **spawn 시점마다** 해석합니다. 서버 기동 후에 openclaw 를 설치한 경우 재시작 없이 잡힙니다.

**2. 실패 메시지를 추적 가능하게 — 같은 파일**

기존에는 Bun 의 `Executable not found in $PATH: "openclaw"` 가 그대로 올라와서, 서버 PATH 문제인지 미설치인지 구분이 안 됐습니다(오늘 실제로 여기서 시간을 썼습니다).

이제 **실제로 실행을 시도한 경로**를 맨 앞에 적고, 원인에 따라 안내를 나눕니다:

- `OPENCLAW_BIN` 이 설정돼 있었다면 → "그 env 로 지정된 경로다, 값을 확인하라"
- 아니라면 → 훑어본 후보 목록과 `OPENCLAW_BIN` 지정 방법

후보 목록만 찍으면 **가장 헷갈리는 케이스에서 거짓 정보**가 됩니다. `OPENCLAW_BIN` 이 설정돼 있으면 후보를 하나도 훑지 않는데, 메시지는 세 경로를 다 시도한 것처럼 말하기 때문입니다. 리뷰에서 잡힌 지적입니다.

**3. 자식 프로세스의 PATH 보강 — 같은 파일**

절대경로 해석은 **openclaw 자신만** 구합니다. `~/.local/bin/openclaw` 는 `#!/usr/bin/env node` 셔뱅이라 **node 는 상속 PATH 에서** 찾습니다. 그 PATH 에 node 가 없으면 바이너리를 제대로 찾아놓고도 셔뱅 단계에서 죽고, 위 ②의 새 메시지가 그걸 "실행파일을 찾지 못했습니다"로 **오진**합니다.

`activation.ts` 의 openclaw spawn 이 이미 같은 문제를 spawn env 의 PATH 보강으로 풀고 있습니다. 두 call site 를 같은 규약으로 맞춥니다.

**4. `runtime-drift-check.sh`**

openclaw 후보에도 `$HOME/.local/bin/openclaw` 를 최우선으로 추가. 드리프트 감시가 브릿지와 같은 눈을 갖게 합니다. 지금은 감시 쪽도 이 위치를 못 봐서 "openclaw absent" 로 잘못 보고할 수 있습니다.

**5. 회귀 테스트 6건**

실 파일시스템을 건드리지 않도록 후보 목록과 실행가능 판정을 주입합니다(`b3os-infra-safety` ④). 폴백 순서·공백 env·실행권한 없는 파일·전부 실패 시 PATH 폴백을 각각 고정합니다.

## 검증

| 항목 | 결과 |
|---|---|
| `tsc --noEmit` | 통과 |
| `sh -n scripts/runtime-drift-check.sh` | 통과 |
| `bun test src/server/lib src/server/bus` | **843 pass / 4 fail** |
| 라이브 | plist 에 `OPENCLAW_BIN` 을 박는 수동 우회로 wake 복구 확인 (아래 단서 참고) |

⚠️ **4 fail 은 이 PR 과 무관한 선재 이슈입니다.** 전부 `teamRouter.llm.test.ts` (EXAONE 라우터)이고, `main`(046eeea)에서 그대로 돌려도 동일하게 4건 실패합니다. 확인하고 넘어갔습니다.

⚠️ **라이브 확인의 단서** — 저희 머신은 급한 불을 끄느라 plist 에 `OPENCLAW_BIN` 을 먼저 박아뒀습니다. 그래서 그 서버는 **명시 env 분기만 타고 이 PR 의 후보 스캔에는 진입하지 않습니다.** 즉 "라이브에서 후보 스캔이 도는 것을 확인했다"고는 말할 수 없습니다. 확인된 것은 "바이너리 경로를 제대로 주면 wake 가 복구된다"까지이고, 후보 스캔 자체는 단위 테스트로만 고정돼 있습니다. 리뷰에서 잡힌 지적이라 그대로 적어둡니다.

## 운영 중인 머신을 위한 즉시 조치

이 PR 이 머지되기 전이라도, 같은 증상을 겪는 설치본은 plist 한 줄로 풀 수 있습니다:

```xml
<key>OPENCLAW_BIN</key><string>/Users/<you>/.local/bin/openclaw</string>
```

```sh
launchctl bootout   gui/$(id -u) ~/Library/LaunchAgents/<prefix>.team-collab.plist
launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/<prefix>.team-collab.plist
```

저희 머신에는 이미 적용했고 정상 동작을 확인했습니다. 이 PR 은 그 수동 조치를 필요 없게 만드는 쪽입니다.

## 더 볼 만한 것 (이 PR 범위 밖)

기동 시 openclaw 런타임 팀원이 등록돼 있으면 **바이너리 해석 여부를 헬스체크**하면 좋겠습니다. 지금은 실제로 메시지를 한 번 보내봐야 이 문제를 알 수 있고, 그마저도 발신자에게는 성공처럼 보입니다. 조용히 실패하는 게 이 버그의 가장 나쁜 성질이었습니다.

---

환경: macOS Darwin 25.5.0 / launchd (gui/501) / bun 1.3.14 / OpenClaw 2026.7.1-2 (0790d9f)

---

## 검증 근거

```text
검증 범위:  bun test src/server/lib src/server/bus (68 파일 / 847 테스트)
            tsc --noEmit
            sh -n scripts/runtime-drift-check.sh
baseline:   4 fail — 전부 teamRouter.llm.test.ts (EXAONE 라우터).
            main(046eeea)에서 그대로 돌려도 동일하게 4건 실패. 이 PR 과 무관.
mutation:   resolveOpenclawBin 을 옛 동작(env ?? "openclaw")으로 되돌림
            → openclawBridge.test.ts 11 pass 중 2 fail (핵심 케이스 포함)
            → 복원 시 11 pass. 테스트가 이 수정을 실제로 고정하고 있음.
미검증:     ① 이 PR 의 후보 스캔 경로가 라이브에서 도는 것은 확인하지 못했다.
               조치 당시 이 머신 plist 에 OPENCLAW_BIN 을 이미 박아둔 상태라,
               서버는 명시 env 분기만 타고 후보 스캔에 진입하지 않는다.
               라이브에서 확인하려면 OPENCLAW_BIN 을 빼고 wake 를 태워야 한다.
               (신규 설치 방어라는 가치는 그대로)
            ② teamRouter.llm 4 fail 의 원인은 파고들지 않았다 — 선재 확인까지만.
            ③ 리눅스·nix·컨테이너 환경에서의 동작은 코드 리뷰로만 판단했고 실행 검증은 없다.
            ④ 셔뱅 PATH 보강은 이 맥에서 실패를 재현할 수 없어(이미 /opt/homebrew/bin 이
               job PATH 에 있음) 논리 검증까지만 했다.
```

리뷰: Lisa (gdstudio) — OK, 머지 가능. 위 미검증 ①·④ 는 리뷰에서 지적받아 추가된 항목이다.

## 작성 계정에 대해

이 PR 은 **Jane(gdstudio 팀원)이 작성했고, 팀장 계정으로 올라갔습니다.** 팀원 작업용 GitHub 계정(`github_team_account`)이 아직 설정돼 있지 않아, 절차상 요구되는 "작성자 ≠ 승인자" 분리가 이 PR 에서는 성립하지 않습니다. 팀장 승인을 받고 그 사실을 명시하는 쪽을 택했습니다. 팀 계정 설정은 별건으로 남습니다.
