### PR TITLE
fix(test): 테스트가 팀장 실제 Claude 세션 저장소를 오염시키던 것 (#77 후속)

### DIFF
--- a/src/server/lib/claudeUsage.ts
+++ b/src/server/lib/claudeUsage.ts
@@ -13,7 +13,8 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import type { AgentRecord } from "../types";
 
-const PROJECTS_DIR = join(homedir(), ".claude", "projects");
+// ★단일 정본 재사용★ — 경로를 두 곳에 적으면 한쪽만 격리돼 어긋난다(dmSource 와 같은 저장소를 본다).
+import { claudeProjectsDir } from "../runtimes/claude/dmSource";
 
 // Max 5x rolling-window message ceiling (approx, per Anthropic docs as of 2026-05).
 export const MAX5X_REQUESTS_5H_CEILING = 225;
@@ -70,7 +71,7 @@ async function readAgentUsage(agent: AgentRecord, now: number): Promise<AgentUsa
     tokens_7d: 0,
     last_activity_at: null,
   };
-  const dir = join(PROJECTS_DIR, encodeWorkspace(agent.workspace_path));
+  const dir = join(claudeProjectsDir(), encodeWorkspace(agent.workspace_path));
   let files: string[];
   try {
     files = readdirSync(dir).filter((f) => f.endsWith(".jsonl"));

--- a/src/server/lib/personaTemplates.test.ts
+++ b/src/server/lib/personaTemplates.test.ts
@@ -316,9 +316,14 @@ test("resolveMembersRoot — env 우선순위: B3RYS_MEMBERS_ROOT > B3RYS_HOME/m
 //   사고: 가드가 `~/Development` 하나만 보고 있어서, 기본값이 퍼블릭-안전(`~/b3os/members`)으로 바뀐 뒤
 //   ★신규·공개 유저의 실 팀원이 통째로 가드 밖★ 이었다. 맥스튜디오 실 팀원(jane/lisa/clo)이 그 자리에
 //   살아 테스트가 정체성 파일을 덮어썼다. 두 루트 모두 지키는지 못박는다.
-test("live-fs 가드 — 레거시(~/Development)와 퍼블릭 기본(~/b3os/members) 둘 다 막는다", () => {
+// ★HOME 이 없으면 가드는 설계상 무동작★ (보호 대상이 전부 HOME 기준이라 지킬 것이 없다).
+//   그 환경(HOME 없는 컨테이너/CI)에서 이 테스트들을 그냥 돌리면 ★수트가 통째로 빨간불★ 이 된다 —
+//   결함이 아니라 전제 불성립이므로 명시적으로 건너뛴다. 조용히 통과시키지는 않는다.
+const HAS_HOME = Boolean(process.env.HOME);
+const guardTest = HAS_HOME ? test : test.skip;
+
+guardTest("live-fs 가드 — 레거시(~/Development)와 퍼블릭 기본(~/b3os/members) 둘 다 막는다", () => {
   const home = process.env.HOME ?? "";
-  expect(home).not.toBe("");                        // 가드는 HOME 없으면 무동작 — 전제 확인
   expect(process.env.NODE_ENV).toBe("test");        // 가드는 test 에서만 — 전제 확인
 
   // ① 퍼블릭-안전 기본값 = 공개 유저의 실 팀원 자리. ★이게 뚫려 있던 구멍이다.★
@@ -351,7 +356,7 @@ test("live-fs 가드 — 명시 opt-in(B3RYS_TEST_ALLOW_LIVE_FS=1)이면 통과"
 
 // ★배선 테스트★ — 가드 함수가 옳아도 writer 가 부르지 않으면 소용없다. 실제 writer 를 태워 확인한다.
 //   (savePersonaFile 은 SOUL.md 를 쓰는 유일한 통로인데 2026-07-27 까지 가드가 없었다.)
-test("live-fs 가드 배선 — savePersonaFile 이 실 팀원 경로를 거부한다(파일 안 만듦)", () => {
+guardTest("live-fs 가드 배선 — savePersonaFile 이 실 팀원 경로를 거부한다(파일 안 만듦)", () => {
   const home = process.env.HOME ?? "";
   // ★경로를 실행마다 고유하게★ — 고정 이름이면 이전 실행이 남긴 흔적에 판정이 흔들린다
   //   (실제로 겪음: 가드를 되돌린 뮤테이션 실행이 폴더를 만들자 이후 정상 실행까지 실패).
@@ -389,7 +394,7 @@ test("live-fs 가드 — 이름만 겹치는 형제 경로는 막지 않는다",
 });
 
 // `..` 로 우회되면 가드가 무의미하다.
-test("live-fs 가드 — 상대경로/.. 로 우회되지 않는다", () => {
+guardTest("live-fs 가드 — 상대경로/.. 로 우회되지 않는다", () => {
   const home = process.env.HOME ?? "";
   expect(() => assertNotLiveMemberFsUnderTest(`${home}/b3os/members/../members/jane`, "t")).toThrow(/live-fs-guard/);
 });
@@ -397,7 +402,7 @@ test("live-fs 가드 — 상대경로/.. 로 우회되지 않는다", () => {
 // ★opt-in override 실검증 (subprocess)★ — MEMBERS_ROOT 는 import 시점 상수라, 같은 프로세스 안에서는
 //   "다른 루트로 뜬 상태" 를 만들 수 없다. 그래서 별도 프로세스를 띄워 실제로 확인한다(Codex 재리뷰 요청).
 //   확인할 것 두 가지: ①지정한 non-temp 루트는 통과한다 ②그래도 실 팀원 루트는 여전히 막힌다.
-test("opt-in override — 지정 루트는 통과하되 실 팀원 루트 보호는 그대로", () => {
+guardTest("opt-in override — 지정 루트는 통과하되 실 팀원 루트 보호는 그대로", () => {
   const optRoot = "/workspace/isolated-optin";           // non-temp. 존재하지 않아도 가드 판정엔 무관
   const mod = join(import.meta.dir, "personaTemplates.ts");
   const script = `
@@ -426,7 +431,7 @@ test("opt-in override — 지정 루트는 통과하되 실 팀원 루트 보호
 });
 
 // override 가 ★실 팀원 루트를 가리켜도★ 보호가 풀리면 안 된다 (이 변수로 우회 금지).
-test("opt-in override — 실 팀원 루트를 가리키면 무시하고 계속 막는다", () => {
+guardTest("opt-in override — 실 팀원 루트를 가리키면 무시하고 계속 막는다", () => {
   const home = process.env.HOME ?? "";
   const real = `${home}/b3os/members`;
   const mod = join(import.meta.dir, "personaTemplates.ts");

--- a/src/server/runtimes/claude/dmSource.ts
+++ b/src/server/runtimes/claude/dmSource.ts
@@ -33,10 +33,20 @@ export function readTail(fp: string, tailBytes: number = TAIL_BYTES): string {
   }
 }
 
+/**
+ * Claude Code 세션 저장소 루트. 기본 `~/.claude/projects` — ★운영 동작 불변★.
+ * env override 는 ★테스트 격리용★ (2026-07-27): 이 경로를 하드코딩해 두니 세션 픽스처를 만드는
+ * 테스트가 팀장 실제 세션 저장소에 폴더를 쌓았다(이 맥에 5,157개 누적). 파괴적이진 않지만
+ * 사용자 디렉터리를 오염시킨다. 호출 시점에 읽는다 — preload 가 세팅한 값이 반영되게.
+ */
+export function claudeProjectsDir(): string {
+  return process.env.B3OS_CLAUDE_PROJECTS_DIR || `${homedir()}/.claude/projects`;
+}
+
 function sessionDirFor(workspacePath: string): string {
-  // Claude Code 세션 저장 경로: ~/.claude/projects/<workspace의 / 를 - 로 치환>/
+  // Claude Code 세션 저장 경로: <projects루트>/<workspace의 / 를 - 로 치환>/
   const encoded = workspacePath.replace(/\//g, "-");
-  return `${homedir()}/.claude/projects/${encoded}`;
+  return `${claudeProjectsDir()}/${encoded}`;
 }
 
 // 최근 세션 jsonl (mtime 최신 N개). fresh 재시작으로 세션이 갈리므로 여러 개 스캔.

--- a/src/server/workers/dmSyncWorker.test.ts
+++ b/src/server/workers/dmSyncWorker.test.ts
@@ -7,6 +7,7 @@
 //   ② DM 적재는 팀원 세션 기록을 읽는 기능이라 ★끌 수 있어야★ 한다(dm_capture=off).
 //      끄면 적재만 멈추고 버스·위임·발신은 그대로여야 한다 — dm_message 는 크리티컬이 아니다.
 import { describe, expect, spyOn, test } from "bun:test";
+import { claudeProjectsDir } from "../runtimes/claude/dmSource";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -34,7 +35,9 @@ function interruptEvent(chatId: string, mid: string, body: string) {
 function writeSession(events: unknown[]): string {
   const ws = mkdtempSync(join(tmpdir(), "dmsync-ws-"));
   // dmSource 는 ~/.claude/projects/<워크스페이스경로의 / 를 - 로> 에서 세션을 찾는다.
-  const sessionDir = join(process.env.HOME ?? tmpdir(), ".claude", "projects", ws.replace(/\//g, "-"));
+  // ★실 HOME 이 아니라 격리된 저장소 루트를 쓴다★ — preload(test-isolation.ts)가 temp 로 세팅한다.
+  //   전엔 process.env.HOME 을 직접 조립해서 팀장 실제 세션 저장소에 폴더를 쌓았다(5,157개 누적).
+  const sessionDir = join(claudeProjectsDir(), ws.replace(/\//g, "-"));
   mkdirSync(sessionDir, { recursive: true });
   writeFileSync(join(sessionDir, "s1.jsonl"), events.map((e) => JSON.stringify(e)).join("\n") + "\n");
   return ws;

--- a/src/test/test-isolation.ts
+++ b/src/test/test-isolation.ts
@@ -29,6 +29,13 @@ if (!process.env.B3OS_AUDIT_LOG_DIR) {
 process.env.B3RYS_MEMBERS_ROOT =
   process.env.B3OS_TEST_MEMBERS_ROOT ?? mkdtempSync(join(tmpdir(), "b3os-test-members-"));
 
+// ★Claude Code 세션 저장소 격리 (2026-07-27)★
+//   dmSyncWorker 계열 테스트가 세션 픽스처를 만들려고 실 `~/.claude/projects/` 에 폴더를 쌓았다
+//   (이 맥에 5,157개 누적). 이름이 고유해 덮어쓰기는 없지만 ★사용자 디렉터리 오염★이고,
+//   실 팀원 워크스페이스 사고와 같은 계열(테스트가 실제 사용자 경로에 쓴다)이다.
+process.env.B3OS_CLAUDE_PROJECTS_DIR =
+  process.env.B3OS_CLAUDE_PROJECTS_DIR || mkdtempSync(join(tmpdir(), "b3os-test-claude-projects-"));
+
 // 테스트는 ★라이브 모드★(B3OS_LIVE=1 → PUBLIC_BUILD=false)로 돈다 = 전 기능(codex 영입·런타임 swap·
 // 롤백 등 라이브 전용)을 검증한다. 공개 모드(PUBLIC_BUILD=true) 동작은 해당 테스트가 인자를 명시적으로
 // 넘겨(allowedRuntimes(true) 등) 따로 검증한다. (public=source 런타임 토글 — docs/BUILD_MODES.md)


### PR DESCRIPTION
## 증상

`dmSyncWorker` 테스트가 세션 픽스처를 만들려고 `~/.claude/projects/` 를 직접 조립해 썼다.
그 결과 **실행마다 실제 Claude Code 세션 저장소에 폴더가 쌓였다 — 이 맥에 5,213개 누적**(정리 완료).

이름이 고유해 실제 세션을 덮어쓰진 않는다. 파일이 망가진 게 아니라 **사용자 디렉터리 오염**이다.
**#77 과 같은 계열** — 테스트가 실제 사용자 경로에 쓴다. #77 검증 중 "같은 계열이 더 있나" 를 쓸어보다 지문 diff 로 찾았다.

## 고친 것

- `claudeProjectsDir()` — 호출 시점 해석 + env override. **기본값은 그대로 `~/.claude/projects` 라 운영 동작 불변**
- `claudeUsage` 도 같은 함수를 쓰게 통일 — 경로를 두 곳에 적으면 한쪽만 격리돼 어긋난다
- preload 가 temp 로 세팅 → 테스트는 실 저장소를 건드리지 않는다
- 테스트가 `process.env.HOME` 조립 대신 그 함수를 쓰게 수정
- **HOME 없는 환경에서 가드 테스트가 수트를 빨간불로 만들던 것**(하네스 적발) — HOME 이 없으면 가드는 설계상 무동작인데 테스트가 그걸 몰라 5건 실패했다. 전제 불성립이므로 명시적으로 skip 한다(조용히 통과시키지 않는다)

## 검증

```
검증 범위:  bun test 전체 (147파일) · bunx tsc --noEmit · 세션 폴더 지문 diff
baseline:   1695 pass / 5 skip / 0 fail · tsc 0
mutation:   preload 의 B3RYS_MEMBERS_ROOT 세팅 제거 → 4건 실패(KILLED), 실 팀원 파일 변경 0
            (= 격리를 뚫어도 가드가 2차 방어선으로 작동함이 하네스 실측으로 확인됨)
지문:       수트 전후 ~/.claude/projects 신규 0건 (수정 전엔 1회 실행에 14개)
환경별:     HOME 없음 → 5 skip / 0 fail (수정 전 5 fail)
미검증:     라이브 서버 프로세스에서의 동작은 확인하지 않았다(운영 기본값 불변이라 영향 없다고 판단).
            테스트 모드 밖 writer(스크립트·e2e)는 이 격리가 닿지 않는다.
            하네스가 지적한 남은 구멍 — MEMBERS_ROOT 에 무가드로 쓰는 writer 6곳,
            `~/.claude/channels`·`~/Library/LaunchAgents`·`~/.claude.json`·`~/.codex-agents` 는
            격리 자체가 안 닿음(현재는 테스트 작성자 규율로만 안전) — **이 PR 범위 밖, 후속 카드**
```

---

> 원래 #79 였다. 팀 규칙(`skills/b3os-github-workflow` ⑤: 팀원 PR = 팀 계정 / 승인 = gd452)을 못 보고 `gd452` 로 만들어 **자기승인 금지에 걸려 팀 내 승인 경로가 0** 이었다. 작성자는 사후에 못 바꿔 닫고 다시 연다. 내용·브랜치 동일, base 는 main 으로 재지정(#77 머지 완료).
