### PR TITLE
fix(slack): 공개 URL 없는 사용자에게 Slack 이 거부하는 매니페스트를 주던 것 (#74 후속)

### DIFF
--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -1059,6 +1059,34 @@ describe("settings: 전체 재적용 롤백 (6h .bak 복원)", () => {
  * 클라이언트가 r.ok 를 안 보고 그 본문을 정상 데이터로 썼기 때문. 사용자가 그 매니페스트를 붙여넣으면
  * ★권한 0개짜리 Slack 앱★ 이 만들어진다 — 실패보다 나쁘다.
  * UI 는 "Socket Mode = 공개 URL 불필요" 라고 안내하는데 서버가 공개 URL 을 필수로 요구한 자기모순도 있었다. */
+// ★생산자에 대한 검증★ — 앞서 이 불변식은 손으로 쓴 픽스처(AgentSlack.test.ts)에만 있었고,
+// ★서버가 실제로 무엇을 내보내는지는 아무도 안 봤다.★ 그래서 #74 가 불법 매니페스트를 내보내는데도
+// 전 수트가 초록이었다(2026-07-27 Steve 리뷰). 규칙은 만드는 쪽에 걸어야 한다.
+describe("★서버가 내보내는 매니페스트는 어떤 경우에도 Slack 규격을 만족한다★", () => {
+  // Slack: event_subscriptions 가 있으면 request_url 또는 socket_mode_enabled 중 하나가 필수.
+  //   ("Event Subscription requires either Request URL or Socket Mode Enabled")
+  const slackAccepts = (m: any): boolean => {
+    const ev = m?.settings?.event_subscriptions;
+    if (!ev) return true;
+    return Boolean(ev.request_url) || m?.settings?.socket_mode_enabled === true;
+  };
+
+  for (const [label, base] of [["공개 URL 없음", undefined], ["공개 URL 있음", "https://example.test/"]] as const) {
+    test(`${label} — 서버 매니페스트가 Slack 규격을 만족한다`, async () => {
+      const old = process.env.TEAM_PUBLIC_BASE_URL;
+      if (base === undefined) delete process.env.TEAM_PUBLIC_BASE_URL; else process.env.TEAM_PUBLIC_BASE_URL = base;
+      try {
+        const { app } = setup();
+        const b = await (await app.request("/members/bill/slack/reinstall-info")).json() as any;
+        expect(b.ok).toBe(true);
+        expect(slackAccepts(b.manifest)).toBe(true);
+      } finally {
+        if (old === undefined) delete process.env.TEAM_PUBLIC_BASE_URL; else process.env.TEAM_PUBLIC_BASE_URL = old;
+      }
+    });
+  }
+});
+
 describe("slack reinstall-info", () => {
   const withBase = (v: string | undefined, fn: () => Promise<void>) => async () => {
     const old = process.env.TEAM_PUBLIC_BASE_URL;
@@ -1079,11 +1107,14 @@ describe("slack reinstall-info", () => {
     expect(b.manifest?.oauth_config?.scopes?.bot).toEqual(b.needed_scopes);
     expect(b.manifest?.display_information?.name).toBeTruthy();
     expect(b.event_request_url).toBeNull();
-    // ★event_subscriptions 는 남아 있어야 한다★ — 처음엔 통째로 빼서 "undefined 여야 한다" 고 단언했는데
-    //   ★그게 잘못된 불변식이었다★(코덱스 리뷰). 구독이 없으면 앱은 만들어져도 멘션을 못 받는다.
-    //   request_url 만 없으면 된다.
-    expect(b.manifest?.settings?.event_subscriptions?.bot_events).toEqual(["app_mention"]);
-    expect(b.manifest?.settings?.event_subscriptions?.request_url).toBeUndefined();
+    // ★event_subscriptions 블록 자체가 없어야 한다★ (2026-07-27 Steve 리뷰).
+    //   이 응답은 webhook 매니페스트(socket_mode_enabled=false)다. Slack 규격상 이 블록이 있으면
+    //   request_url 또는 socket_mode_enabled 중 하나가 필수라, 공개 URL 없이 블록을 넣으면
+    //   ★Slack 이 거부하는 매니페스트를 사용자에게 내주게 된다.★
+    //   앞선 판(#74)은 "구독이 없으면 멘션을 못 받는다" 를 이유로 무조건 넣었는데, 그건
+    //   ★Socket 매니페스트가 풀 문제를 webhook 매니페스트에서 풀려 한 것★ 이었다.
+    //   Socket 쪽 구독은 클라이언트 socketManifest() 가 주입한다(AgentSlack.test.ts 에서 고정).
+    expect(b.manifest?.settings?.event_subscriptions).toBeUndefined();
     expect(b.public_base_missing).toBe(true);
     expect(typeof b.public_base_hint).toBe("string");
   }));

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1016,14 +1016,18 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
         display_information: { name: appName },
         features: { bot_user: { display_name: agent.slack_app_name || `gd_${id}`, always_online: true } },
         oauth_config: { scopes: { bot: scopes } },
-        // ★event_subscriptions 는 항상 넣는다★ — bot_events 가 있어야 봇이 멘션을 받는다.
-        //   공개 URL 이 없을 때 이 블록을 통째로 빼봤더니(첫 시도), Socket 매니페스트에 app_mention 구독이
-        //   사라져서 ★앱은 만들어지는데 멘션에 반응하지 않는 상태★ 가 됐다(코덱스 리뷰에서 잡힘).
-        //   scope(app_mentions:read)만 있고 구독이 없으면 이벤트가 오지 않는다 — 둘 다 필요하다.
-        //   request_url 만 조건부로 넣는다: null 이 든 매니페스트는 Slack 이 거부하고,
-        //   Socket Mode 는 애초에 request_url 없이 bot_events 만으로 동작한다.
+        // ★event_subscriptions 는 request_url 이 있을 때만 넣는다.★
+        //   Slack 규격: 이 블록이 있으면 request_url 또는 socket_mode_enabled 중 하나가 반드시 있어야 한다
+        //   ("Event Subscription requires either Request URL or Socket Mode Enabled").
+        //   이 응답은 ★webhook 방식 매니페스트★ 이고 socket_mode_enabled=false 다. 그러므로 공개 URL 이
+        //   없는데 블록을 넣으면 ★Slack 이 거부하는 매니페스트★ 를 사용자에게 그대로 내주게 된다.
+        //   (2026-07-27 Steve 리뷰. 직전 판(#74)은 bot_events 를 살리려고 무조건 넣었는데,
+        //    그 주석이 "Socket Mode 는 request_url 없이 된다" 고 적어놓고 ★정작 여기서 false 를 내보냈다★ —
+        //    주석은 의도를, 코드는 다른 것을 말하고 있었다.)
+        //   ★Socket 쪽 bot_events 는 클라이언트 socketManifest() 가 주입한다★ — 서버가 안 내보내도 안전하다.
+        //   공개 URL 이 없는 webhook 사용자에겐 webhookBlockedNotice() 가 이미 안내한다.
         settings: {
-          event_subscriptions: { ...(eventUrl ? { request_url: eventUrl } : {}), bot_events: ["app_mention"] },
+          ...(eventUrl ? { event_subscriptions: { request_url: eventUrl, bot_events: ["app_mention"] } } : {}),
           org_deploy_enabled: false,
           socket_mode_enabled: false,
         },

--- a/src/web/components/AgentSlack.test.ts
+++ b/src/web/components/AgentSlack.test.ts
@@ -11,7 +11,7 @@ describe("socketManifest — 사용자가 붙여넣는 최종 JSON", () => {
     features: { bot_user: { display_name: "gd_lisa", always_online: true } },
     oauth_config: { scopes: { bot: ["app_mentions:read", "chat:write"] } },
     settings: {
-      event_subscriptions: { ...(withUrl ? { request_url: "https://x.test/team/api/slack/events" } : {}), bot_events: ["app_mention"] },
+      ...(withUrl ? { event_subscriptions: { request_url: "https://x.test/team/api/slack/events", bot_events: ["app_mention"] } } : {}),
       org_deploy_enabled: false,
       socket_mode_enabled: false,
     },
@@ -32,19 +32,15 @@ describe("socketManifest — 사용자가 붙여넣는 최종 JSON", () => {
   });
 });
 
-/* ★네 사분면 중 하나(공개URL 없음 × Event URL)를 아무도 안 찍어봤다★ — #73 을 놓친 것과 같은 종류의
- * 사각이다. 그 조합의 매니페스트는 Slack 이 거부한다:
+/* ★네 사분면 중 하나(공개URL 없음 × Event URL)를 아무도 안 찍어봤다★ — #73 을 놓친 것과 같은 사각이다.
+ * 그 조합의 매니페스트는 Slack 이 거부한다:
  *   "Event Subscription requires either Request URL or Socket Mode Enabled"
- * request_url 도 없고 socket_mode_enabled 도 false 면 event_subscriptions 블록 자체가 불법이다.
- * 그래서 화면에서 그 조합을 못 고르게 막았고, 여기서는 ★왜 막아야 하는지(=불법 조합)★ 를 고정한다. */
-describe("공개 URL 없이 Event URL 모드 — Slack 이 거부하는 조합", () => {
-  const serverManifest = (withUrl: boolean) => ({
-    settings: {
-      event_subscriptions: { ...(withUrl ? { request_url: "https://x.test/e" } : {}), bot_events: ["app_mention"] },
-      org_deploy_enabled: false,
-      socket_mode_enabled: false,
-    },
-  });
+ *
+ * ★그런데 앞선 판의 이 테스트는 손으로 쓴 픽스처만 검사했다★ — "그 조합은 불법이다" 는 알지만
+ * ★서버가 실제로 그걸 내보내는지는 아무도 안 봤다.★ 그래서 #74 가 불법 매니페스트를 내보내게 됐는데도
+ * 여기는 초록이었다(2026-07-27 Steve 리뷰). 실제 서버 출력에 대한 검증은 settings.test.ts 에 있다.
+ * 여기서는 ★클라이언트 변환(socketManifest)이 어떤 입력을 받아도 유효한 결과를 낸다★ 를 고정한다. */
+describe("Slack 규격 — 어떤 입력이 와도 최종 JSON 은 유효해야 한다", () => {
   // Slack 규격: event_subscriptions 가 있으면 request_url 또는 socket_mode_enabled 중 하나는 있어야 한다.
   const slackAccepts = (m: any): boolean => {
     const ev = m?.settings?.event_subscriptions;
@@ -52,14 +48,27 @@ describe("공개 URL 없이 Event URL 모드 — Slack 이 거부하는 조합",
     return Boolean(ev.request_url) || m?.settings?.socket_mode_enabled === true;
   };
 
-  test("★공개 URL 없음 × Event URL = 거부되는 조합★ (그래서 화면에서 막는다)", () => {
-    expect(slackAccepts(serverManifest(false))).toBe(false);
+  // 서버가 낼 수 있는 두 형태 (수정 후: URL 없으면 블록 자체가 없다)
+  const serverWithUrl = { settings: { event_subscriptions: { request_url: "https://x.test/e", bot_events: ["app_mention"] }, org_deploy_enabled: false, socket_mode_enabled: false } };
+  const serverNoUrl = { settings: { org_deploy_enabled: false, socket_mode_enabled: false } };
+
+  test("webhook 매니페스트는 두 경우 다 유효하다", () => {
+    expect(slackAccepts(serverWithUrl)).toBe(true);   // URL 있음 → request_url 로 성립
+    expect(slackAccepts(serverNoUrl)).toBe(true);     // URL 없음 → 블록이 없어서 성립
   });
 
-  test("나머지 세 조합은 통과한다", () => {
-    expect(slackAccepts(serverManifest(true))).toBe(true);                          // URL 있음 × Event URL
-    expect(slackAccepts(socketManifest(serverManifest(false)))).toBe(true);         // URL 없음 × Socket
-    expect(slackAccepts(socketManifest(serverManifest(true)))).toBe(true);          // URL 있음 × Socket
+  test("★Socket 변환은 서버가 블록을 안 줘도 구독을 만들어 넣는다★ (보존이 아니라 주입)", () => {
+    const m = socketManifest(serverNoUrl) as any;
+    expect(m.settings.socket_mode_enabled).toBe(true);
+    expect(m.settings.event_subscriptions?.bot_events).toEqual(["app_mention"]);  // ← 없으면 멘션 못 받는다
+    expect(slackAccepts(m)).toBe(true);
+  });
+
+  test("Socket 변환은 URL 이 있던 경우에도 유효하다", () => {
+    const m = socketManifest(serverWithUrl) as any;
+    expect(m.settings.event_subscriptions?.request_url).toBeUndefined();
+    expect(m.settings.event_subscriptions?.bot_events).toEqual(["app_mention"]);
+    expect(slackAccepts(m)).toBe(true);
   });
 });
 

--- a/src/web/components/AgentSlack.ts
+++ b/src/web/components/AgentSlack.ts
@@ -58,14 +58,23 @@ async function clip(text: string): Promise<boolean> {
   try { await navigator.clipboard.writeText(text); return true; } catch { return false; }
 }
 
-// Socket Mode용 매니페스트 변환 — socket_mode_enabled=true + event_subscriptions.request_url 제거(공개 URL 불필요).
-// ★bot_events 는 남긴다★ — 그게 없으면 앱은 만들어지는데 멘션을 못 받는다. export 는 최종 JSON 을 테스트하기 위한 것.
+// Socket Mode용 매니페스트 변환 — socket_mode_enabled=true + request_url 제거(공개 URL 불필요).
+//
+// ★bot_events 를 "보존" 이 아니라 "주입" 한다★ (2026-07-27 Steve 리뷰).
+//   서버는 공개 URL 이 없으면 event_subscriptions 를 아예 안 내보낸다(그 조합은 Slack 이 거부한다).
+//   그래서 여기서 보존만 하면 ★공개 URL 없는 Socket 사용자가 구독을 못 받아 멘션에 반응하지 않는다★ —
+//   #74 가 고쳤던 그 버그가 다른 경로로 되살아난다. Socket 은 request_url 없이 bot_events 만으로 되므로
+//   이 자리에서 만들어 넣는 것이 맞다.
+// export 는 최종 JSON 을 테스트하기 위한 것.
 export function socketManifest(manifest: unknown): unknown {
   try {
     const m = JSON.parse(JSON.stringify(manifest ?? {})) as Record<string, any>;
     m.settings = m.settings || {};
     m.settings.socket_mode_enabled = true;
-    if (m.settings.event_subscriptions) delete m.settings.event_subscriptions.request_url;
+    const ev = m.settings.event_subscriptions || {};
+    delete ev.request_url;                                   // Socket 은 공개 URL 이 필요없다
+    if (!Array.isArray(ev.bot_events) || ev.bot_events.length === 0) ev.bot_events = ["app_mention"];
+    m.settings.event_subscriptions = ev;                     // 서버가 안 줬으면 여기서 만든다
     return m;
   } catch {
     return manifest;


### PR DESCRIPTION
■ 증상
공개 HTTPS 주소가 없는 사용자가 마법사를 열면 ★Slack 이 거부하는 매니페스트★ 가 그대로 나왔다.
  event_subscriptions 있음 + request_url 없음 + socket_mode_enabled=false
  → "Event Subscription requires either Request URL or Socket Mode Enabled"
앱을 만들 수 없으니 그 사용자는 거기서 막힌다.

■ 원인 — ★내 주석이 나를 속였다★
#74 는 "구독이 없으면 멘션을 못 받는다" 를 이유로 event_subscriptions 를 무조건 넣었고,
주석에 "Socket Mode 는 request_url 없이 bot_events 만으로 동작한다" 고 적었다.
★맞는 말이지만 이 응답은 webhook 매니페스트라 socket_mode_enabled=false 를 내보낸다.★
즉 ★주석은 의도를 적었고 코드는 다른 것을 내보냈다.★ Socket 매니페스트가 풀 문제를
webhook 매니페스트에서 풀려 한 것이 근본이다.

■ 고친 것
· 서버: event_subscriptions 는 ★request_url 이 있을 때만★ 내보낸다(그때는 유효한 조합)
· 클라 socketManifest(): bot_events 를 ★보존이 아니라 주입★ 한다
  — 서버가 블록을 안 줘도 Socket 사용자는 구독을 받는다. 이게 없으면 #74 가 고친 버그가
    다른 경로로 되살아난다(공개 URL 없는 Socket 사용자가 멘션을 못 받음)

세 경우 모두 유효해진다:
  webhook + 공개URL  → request_url + bot_events (멘션 O)
  webhook + URL없음  → 블록 없음 (유효) + webhookBlockedNotice 가 공개주소 설정을 안내
  socket            → socketManifest 주입 (멘션 O)

■ ★테스트를 생산자 쪽에 걸었다 — 이게 진짜 원인이다★
이 불변식은 ★손으로 쓴 픽스처에만★ 있었다. "그 조합은 불법이다" 는 알았지만
★서버가 실제로 그걸 내보내는지는 아무도 안 봤다.★ 그래서 #74 가 불법 매니페스트를 내보내는데도
전 수트가 초록이었다. 규칙은 만드는 쪽에 건다:
  settings.test.ts — 공개 URL 유/무 두 경우 모두 서버 응답이 Slack 규격을 만족하는지 단언

■ 검증
· 1698 pass / 0 fail · tsc 0
· ★뮤테이션: #74 의 무조건 삽입으로 되돌리면 → 2건 실패(KILLED)★
· 미검증: 실제 Slack 에 매니페스트를 붙여넣어 앱 생성까지는 안 해봤다(규격은 문서·에러문구 기준).
  라이브 서버에서 마법사 화면을 실제로 열어보지도 않았다.

리뷰: Steve 지적(조건부 BLOCK). 대안 그대로 구현했고, socketManifest 주입 한 곳이 추가됐다.