### PR TITLE
fix(web): 공개 스튜디오 호스트에서 라이브 배지 숨김

### DIFF
--- a/src/web/components/LiveBadge.test.ts
+++ b/src/web/components/LiveBadge.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+import { shouldShowLiveBadge } from "./LiveBadge";
+
+describe("LiveBadge host gating", () => {
+  test("shows only on the private live dashboard", () => {
+    expect(shouldShowLiveBadge("dev.b3rys.com")).toBe(true);
+    expect(shouldShowLiveBadge("studio.b3rys.com")).toBe(false);
+    expect(shouldShowLiveBadge("localhost")).toBe(false);
+  });
+});

--- a/src/web/components/LiveBadge.ts
+++ b/src/web/components/LiveBadge.ts
@@ -1,12 +1,15 @@
-// LiveBadge — 배포된(비-localhost) 대시보드 상단 구별 스트립. (GD 2026-07-02)
-// 로컬 개발(localhost/127.0.0.1)에는 렌더하지 않고, 배포 origin이면 #app 최상단에 초록 바 +
-// ★자기 hostname★ + 빌드 식별자를 띄운다 → 로컬 dev 와 배포 인스턴스를 한눈에 구별.
-// (특정 도메인 하드코딩 없이 origin 기준으로 판단 — public=source: 어느 배포처든 자기 hostname 표시.)
+// LiveBadge — 라이브(정본) 대시보드 상단 구별 스트립. (GD 2026-07-02)
+// dev.b3rys.com에서만 #app 최상단에 초록 바 + 빌드 식별자를 띄운다.
+// 퍼블릭(studio.b3rys.com)·로컬·기타 origin에는 렌더하지 않는다.
 // 색: #23895C(GD 확정 B) + 하얀 글씨. 빌드 식별자 = 로드된 번들 해시(index-XXXX.js).
 
-const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1", ""]);
+const LIVE_HOSTS = new Set(["dev.b3rys.com"]);
 // b3os 제품 버전. package.json version과 맞춰 관리.
 const APP_VERSION = "0.5.0";
+
+export function shouldShowLiveBadge(hostname: string): boolean {
+  return LIVE_HOSTS.has(hostname);
+}
 
 function buildTag(): string {
   const s = document.querySelector<HTMLScriptElement>('script[src*="/assets/index-"]');
@@ -15,7 +18,7 @@ function buildTag(): string {
 }
 
 export function renderLiveBadge(app: HTMLElement): void {
-  if (LOCAL_HOSTS.has(location.hostname)) return;
+  if (!shouldShowLiveBadge(location.hostname)) return;
   if (document.getElementById("live-badge")) return; // 멱등
   const bar = document.createElement("div");
   bar.id = "live-badge";


### PR DESCRIPTION
> **Steve 작성 커밋(32a7d4e)** 을 대신 올립니다. 라이브 트리에만 있고 원격에 없어서, 라이브를 main 으로 되돌리기 전에 보존이 필요했습니다.

## 배경

라이브 서버 폴더가 이 브랜치에 체크아웃돼 있었습니다. 그래서 **어제 머지한 것들이 라이브에서 하나도 안 돌고 있었습니다.** 라이브를 main 으로 되돌리려는데, 이 커밋이 원격 어디에도 없어 그냥 전환하면 사라집니다.

## 내용

`LiveBadge` — 공개 스튜디오 호스트에서 dev 용 배지를 숨깁니다. 테스트 포함(+10줄).

## 검증

**저는 코드를 읽지 않았습니다.** 이 PR 은 **보존 목적**이고, 리뷰는 Steve 또는 다른 팀원이 해야 합니다.
제가 확인한 것은 커밋 존재와 파일 범위(`LiveBadge.ts` · `LiveBadge.test.ts` 2파일)뿐입니다.

## 라이브 영향

라이브를 main 으로 되돌리면 **이 수정은 머지 전까지 라이브에서 빠집니다.** 배지는 dev 표시라 기능 영향은 없다고 판단해 되돌림을 먼저 진행합니다.