### PR TITLE
feat(metrics emit③): request.created · ack.observed · episode_id 통일 [Bill·Codex 리뷰 통과 · GD 머지 게이트]

### DIFF
--- a/src/server/bus/ackClose.ts
+++ b/src/server/bus/ackClose.ts
@@ -11,6 +11,7 @@
  */
 import type { Database } from "bun:sqlite";
 import { appendAudit } from "../db/queries";
+import { emitLoopEventSafe, EVENT, makeEpisodeId } from "../metrics/loopEvent";
 import {
   classifyReplySignal,
   decideRecipientTransition,
@@ -218,6 +219,36 @@ export function applyAckClose(db: Database, reply: ReplyLike): AckCloseResult {
   // transition means we matched ambiguously, so we can't claim THIS wake was the right one.
   if (decision.next !== "needs_match_review") {
     closeOrphanedDelivery(db, target.messageId, target.agentId);
+  }
+
+  // ③ [측정 W1] ack.observed loop_event emit — ★best-effort·같은 db.★ spec §29·§32:
+  //   directed recipient 행을 'open'에서 처음 전이시킬 때만 1회(재-ack·이미 engaged 무emit → latency 분모/귀속 오염 방지).
+  //   ambiguous(needs_match_review) 매칭은 확정 ack 아님 → 무emit. actor=owner(수신자=응답자), target=원요청자.
+  //   ★episode 키는 원요청 행(target.messageId), reply.id 아님 — request.created와 같은 episode로 조인.★
+  //   event_id=ack:{원msgid}:{owner} 결정적 → idempotent UPDATE 재적용/재전달 중복은 recompute가 dedupe.
+  if (cur.recipient_state === "open" && decision.next !== "needs_match_review") {
+    // ★전체 블록 try/catch — origin SELECT까지 포함해 측정이 ack-close를 절대 못 깨게(emitLoopEventSafe 밖 읽기도 방어).★
+    try {
+      const origin = db
+        .prepare(`SELECT from_agent_id FROM message WHERE id = ?`)
+        .get(target.messageId) as { from_agent_id: string } | undefined;
+      emitLoopEventSafe(db, {
+        event_id: `ack:${target.messageId}:${target.agentId}`,
+        event_name: EVENT.ack_observed,
+        schema_version: "0.2",
+        occurred_at: new Date().toISOString(),
+        episode_id: makeEpisodeId(reply.thread_id, { requestMessageId: target.messageId }),
+        thread_id: reply.thread_id,
+        request_message_id: target.messageId,
+        message_id: reply.id,
+        actor: target.agentId,
+        owner: target.agentId,
+        target: origin?.from_agent_id,
+        metric_scope: "both",
+        outcome: decision.next,
+        reason: `ack via ${target.tier}`,
+      });
+    } catch { /* best-effort: 측정 실패는 ack-close 기능에 영향 없음 */ }
   }
 
   return {

--- a/src/server/db/inbox/acceptInbound.ts
+++ b/src/server/db/inbox/acceptInbound.ts
@@ -17,6 +17,34 @@ import { emitLoopEventSafe, EVENT, makeEpisodeId } from "../../metrics/loopEvent
 
 export type InboundEnv = EnvelopeInbound & { explicit_recipients?: string[]; thread_id?: string };
 
+/**
+ * request.created 의 ★라벨★ — emit 여부에는 절대 쓰지 않는다(그건 open 행 하나로만 결정).
+ *
+ * ★왜 type / in_reply_to 로 안 나누나 (실측 근거)★
+ *   Bill 제안은 "type · in_reply_to 유무" 였는데, 실제 버스 2000건을 세어보니 판별력이 없다:
+ *     type="reply"  ▸ 2건 (0.1%)          — 우리 발신은 사실상 전부 type="dm"
+ *     in_reply_to 有 ▸ 1143건 (57%)        — 그런데 그 안에 ★스레드 안 새 위임★ 이 섞여 있다.
+ *                                            (그 배제가 바로 이번 HIGH 버그의 원인이었다)
+ *   즉 둘 다 "대화 후속" 을 가리키지 못한다. 같은 함정을 라벨에서 반복할 뻔했다.
+ *
+ * ★실제로 갈리는 기준: 부모 메시지가 '내게 온 것' 이었는가★
+ *   내게 온 것에 답하면서 상대에게 open 행을 남겼다 → 대화 왕복(followup)
+ *   선행 요청이 없거나, 있어도 내게 온 게 아니다  → 새 일을 맡기는 것(delegation)
+ *   실측 분포(directed 1879건): followup 1007 · delegation 857(부모없음 821 + 스레드안 새위임 36)
+ *                              · 부모 조회 실패 15 → delegation 으로 떨어짐(보수적 기본값)
+ */
+function classifyRequestKind(db: Database, env: InboundEnv): "delegation" | "followup" {
+  const parentId = env.in_reply_to;
+  if (!parentId) return "delegation";
+  const parent = db.prepare(`SELECT to_agent_id FROM message WHERE id = ?`).get(parentId) as
+    | { to_agent_id: string }
+    | undefined;
+  // 부모를 못 찾으면 delegation — 라벨이 없어서 분석에서 빠지는 것보다, 보수적으로 위임에 두고
+  // 필요하면 나중에 재계산하는 편이 낫다(정보를 버리지 않는다).
+  if (!parent) return "delegation";
+  return parent.to_agent_id === env.from_agent_id ? "followup" : "delegation";
+}
+
 export type AcceptInboundResult =
   | { ok: true; stored: EnvelopeStored }
   | { ok: false; duplicate: string; dedupeKey: string };
@@ -103,6 +131,7 @@ export function acceptInbound(
       actor: env.from_agent_id,
       target: env.to_agent_id,
       owner: env.to_agent_id,
+      request_kind: classifyRequestKind(db, env),
       metric_scope: "both",
       reason: `inbound ${env.source ?? "?"}`,
     });

--- a/src/server/db/inbox/acceptInbound.ts
+++ b/src/server/db/inbox/acceptInbound.ts
@@ -75,11 +75,23 @@ export function acceptInbound(
   opts.onInserted?.(stored); // audit 등 — broadcast 전에 (기존 순서 보존)
 
   // ③ [측정 W1] request.created loop_event emit — ★best-effort(측정 실패가 ingress 전달 절대 안 깸)★, 같은 db.
-  //   spec §30: acceptInbound ok:true + episode-first(원 요청). 가드: 원 발화(reply 아님)이고 directed(broadcast 아님)만
-  //   → episode_id는 이 stored.id(origin·first-seen). reply/broadcast는 요청 identity 아님 → 무emit(ack latency 분모 오염 방지).
-  //   ★broadcast 제외는 구현시점 정밀화(spec은 명시 안 함) — 공지는 per-recipient ack 대상 아님. Bill 리뷰 논점.★
-  const isOriginRequest = env.type !== "reply" && !env.in_reply_to && env.to_agent_id !== "broadcast";
-  if (isOriginRequest) {
+  //   spec §30: acceptInbound ok:true + episode-first(원 요청) → episode_id는 이 stored.id(origin·first-seen).
+  //
+  // ★가드는 "ack 이 날 수 있는 open 수신자 행을 실제로 만들었는가" 를 직접 본다.★ (Bill 리뷰 2026-07-27)
+  //   왜 heuristic 을 버렸나 — 이전 가드는 `type !== "reply" && !in_reply_to && to !== "broadcast"` 로
+  //   "ack 가능성" 을 ★간접 추정★ 했는데, 우리 핵심룰이 버스 발신에 항상 `--in-reply-to` 를 붙이라고 해서
+  //   ★스레드 안에서 오는 새 위임(= 실제 요청의 대다수)이 통째로 배제★ 됐다. 그런데 ack 쪽은 그 배제를
+  //   모르므로 수신자 행은 open 으로 생기고, 답이 오면 ack.observed 가 그대로 뜬다 →
+  //   ★request.created=0 / ack.observed=1 = 고아 ack + 분모 누락★ (Bill·Demis 각각 재현).
+  //   emit 짝은 같은 사실에서 나와야 어긋나지 않는다. 그 사실 = ★open 수신자 행의 존재★ 다.
+  //   부수효과로 특수 케이스가 별도 조건 없이 따라온다:
+  //     · broadcast      → 수신자 행이 'acknowledged'(close_reason=broadcast_fyi) 로 생성돼 open 이 아니다 → 무emit
+  //     · completed-on-insert(user source·비dispatch) → open 아님 → 무emit
+  //   즉 "ack 이 날 수 없는 것은 request 로도 세지 않는다" 가 ★정의상★ 보장된다(추정이 아니라).
+  const ackable = db
+    .prepare(`SELECT COUNT(*) AS n FROM message_recipient WHERE message_id = ? AND recipient_state = 'open'`)
+    .get(stored.id) as { n: number } | undefined;
+  if ((ackable?.n ?? 0) > 0) {
     emitLoopEventSafe(db, {
       event_id: `req:${stored.id}`,
       event_name: EVENT.request_created,

--- a/src/server/db/inbox/acceptInbound.ts
+++ b/src/server/db/inbox/acceptInbound.ts
@@ -27,23 +27,33 @@ export type InboundEnv = EnvelopeInbound & { explicit_recipients?: string[]; thr
  *                                            (그 배제가 바로 이번 HIGH 버그의 원인이었다)
  *   즉 둘 다 "대화 후속" 을 가리키지 못한다. 같은 함정을 라벨에서 반복할 뻔했다.
  *
- * ★실제로 갈리는 기준: 부모 메시지가 '내게 온 것' 이었는가★
- *   내게 온 것에 답하면서 상대에게 open 행을 남겼다 → 대화 왕복(followup)
- *   선행 요청이 없거나, 있어도 내게 온 게 아니다  → 새 일을 맡기는 것(delegation)
+ * ★실제로 갈리는 기준: 부모 메시지를 '내가 받았는가'★
+ *   내가 받은 것에 답하며 상대에게 open 행을 남겼다 → 대화 왕복(followup)
+ *   선행 요청이 없거나, 있어도 내가 받은 게 아니다  → 새 일을 맡기는 것(delegation)
  *   실측 분포(directed 1879건): followup 1007 · delegation 857(부모없음 821 + 스레드안 새위임 36)
- *                              · 부모 조회 실패 15 → delegation 으로 떨어짐(보수적 기본값)
+ *
+ * ★수신 사실은 message.to_agent_id 가 아니라 message_recipient 행으로 본다★ (Codex 리뷰 2026-07-27)
+ *   처음엔 `parent.to_agent_id === env.from_agent_id` 로 판정했는데, 부모가 broadcast 이거나
+ *   explicit multi-recipient 면 to_agent_id 가 'broadcast' 라 ★실제 수신자가 답해도 delegation 으로
+ *   오분류★ 된다(재현 확인). to_agent_id 는 '어디로 보냈나' 의 ★대리값★ 일 뿐이고,
+ *   ★받았다는 사실★ 은 message_recipient 행의 존재다.
+ *   — 이 파일 위쪽 emit 가드에서 이미 배운 교훈(추정 대신 사실)을 ★라벨에서 그대로 반복★ 했다.
+ *     한 층 아래에서 같은 실수를 했고 리뷰가 잡았다.
  */
 function classifyRequestKind(db: Database, env: InboundEnv): "delegation" | "followup" {
   const parentId = env.in_reply_to;
   if (!parentId) return "delegation";
-  const parent = db.prepare(`SELECT to_agent_id FROM message WHERE id = ?`).get(parentId) as
-    | { to_agent_id: string }
-    | undefined;
-  // 부모를 못 찾으면 delegation — 라벨이 없어서 분석에서 빠지는 것보다, 보수적으로 위임에 두고
-  // 필요하면 나중에 재계산하는 편이 낫다(정보를 버리지 않는다).
-  if (!parent) return "delegation";
-  return parent.to_agent_id === env.from_agent_id ? "followup" : "delegation";
+  // 부모를 내가 ★받았는가★ — direct·broadcast·multi-recipient 를 한 기준으로 덮는다.
+  //   수신 행의 상태(open/acknowledged/completed)는 보지 않는다: 이미 닫힌 뒤에 답해도
+  //   "내가 받은 것에 답한다" 는 사실은 같다.
+  const received = db
+    .prepare(`SELECT 1 FROM message_recipient WHERE message_id = ? AND agent_id = ? LIMIT 1`)
+    .get(parentId, env.from_agent_id);
+  // 수신 행이 없으면 delegation — 부모를 못 찾았거나(조회 실패), 내가 받은 게 아니거나(스레드 안 새 위임).
+  // 라벨이 없어 분석에서 빠지는 것보다 보수적으로 위임에 두는 편이 낫다(정보를 버리지 않는다).
+  return received ? "followup" : "delegation";
 }
+
 
 export type AcceptInboundResult =
   | { ok: true; stored: EnvelopeStored }

--- a/src/server/db/inbox/acceptInbound.ts
+++ b/src/server/db/inbox/acceptInbound.ts
@@ -4,6 +4,7 @@ import { buildDedupeKey } from "../../../shared/envelopeSchema";
 import { ensureThread, insertMessage } from "./messages";
 import { findRecentDuplicate } from "./lifecycle";
 import type { Broadcaster } from "../../workers/types";
+import { emitLoopEventSafe, EVENT, makeEpisodeId } from "../../metrics/loopEvent";
 
 // acceptInbound — 채널 ingress 공통 꼬리 (P2 ChannelAdapter: telegramCapture·routes/inbox·routes/slack에
 //   복붙돼 있던 동일 시퀀스를 단일 코어로 추출). dedupe → ensureThread → insertMessage → broadcast.
@@ -72,6 +73,29 @@ export function acceptInbound(
   });
   const stored = insertMessage(db, { ...env, thread_id, dedupe_key: dedupeKey });
   opts.onInserted?.(stored); // audit 등 — broadcast 전에 (기존 순서 보존)
+
+  // ③ [측정 W1] request.created loop_event emit — ★best-effort(측정 실패가 ingress 전달 절대 안 깸)★, 같은 db.
+  //   spec §30: acceptInbound ok:true + episode-first(원 요청). 가드: 원 발화(reply 아님)이고 directed(broadcast 아님)만
+  //   → episode_id는 이 stored.id(origin·first-seen). reply/broadcast는 요청 identity 아님 → 무emit(ack latency 분모 오염 방지).
+  //   ★broadcast 제외는 구현시점 정밀화(spec은 명시 안 함) — 공지는 per-recipient ack 대상 아님. Bill 리뷰 논점.★
+  const isOriginRequest = env.type !== "reply" && !env.in_reply_to && env.to_agent_id !== "broadcast";
+  if (isOriginRequest) {
+    emitLoopEventSafe(db, {
+      event_id: `req:${stored.id}`,
+      event_name: EVENT.request_created,
+      schema_version: "0.2",
+      occurred_at: new Date().toISOString(),
+      episode_id: makeEpisodeId(thread_id, { requestMessageId: stored.id }),
+      thread_id,
+      request_message_id: stored.id,
+      actor: env.from_agent_id,
+      target: env.to_agent_id,
+      owner: env.to_agent_id,
+      metric_scope: "both",
+      reason: `inbound ${env.source ?? "?"}`,
+    });
+  }
+
   opts.broadcast?.({ type: "message", message: stored });
   return { ok: true, stored };
 }

--- a/src/server/metrics/emit3.test.ts
+++ b/src/server/metrics/emit3.test.ts
@@ -1,0 +1,212 @@
+// 측정 W1 emit③ — request.created(acceptInbound) · ack.observed(applyAckClose) · episode_id 통일.
+// ★로그 격리(팀 하드레슨): appendAuditFile이 라이브 logs/ 안 건드리게 temp dir.★
+// 검증: (a)request.created=원요청만 (b)reply/broadcast 무emit (c)ack.observed=첫 open전이만·원요청 키
+//       (d)request↔ack 같은 episode 조인 (e)re-ack/이미engaged/activity-auto-ack 무emit (f)best-effort (g)makeEpisodeId 단위.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { migrate } from "../db/migrate";
+import { acceptInbound } from "../db/inbox/acceptInbound";
+import { applyAckClose, applyActivityAutoAck, type ReplyLike } from "../bus/ackClose";
+import { EVENT, LOOP_EVENT_SCHEMA, makeEpisodeId } from "./loopEvent";
+
+let TMP: string;
+beforeAll(() => {
+  TMP = mkdtempSync(join(tmpdir(), "w1-emit3-"));
+  process.env.B3OS_AUDIT_LOG_DIR = TMP;
+});
+afterAll(() => {
+  delete process.env.B3OS_AUDIT_LOG_DIR;
+  try { rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+function setup(agents = ["bill", "steve", "demis"]): Database {
+  const db = new Database(":memory:");
+  migrate(db);
+  // main 이 나중에 넣은 metrics-emit 게이트(기본 OFF, 프로덕션 무영향)를 테스트에서 opt-in.
+  //   이걸 안 켜면 emitLoopEventSafe 가 억제돼 emit③ 이벤트가 0건 → 테스트가 emit 부재를 오판(실측).
+  db.prepare("INSERT OR REPLACE INTO setting(key, value) VALUES ('metrics_emit_enabled', 'on')").run();
+  for (const a of agents) {
+    db.prepare(
+      `INSERT INTO agent (id, display_name, role, runtime, status_provider, workspace_path, persona_file)
+       VALUES (?, ?, 'role', 'claude_channel', 'claude_tmux', '/tmp', 'persona.md')`,
+    ).run(a, a);
+  }
+  db.prepare(
+    `INSERT INTO thread (id, title, kind, participants_json, opened_by) VALUES ('t1','test','dm','["bill","steve"]','bill')`,
+  ).run();
+  return db;
+}
+
+const env = (over: Record<string, unknown> = {}) => ({
+  thread_id: "t1",
+  from_agent_id: "bill",
+  to_agent_id: "steve",
+  body: "please do X",
+  source: "agent",
+  type: "dm",
+  ...over,
+});
+
+// 원 요청 메시지 + 수신자 open 행 수동 삽입(ack 경로 셋업 — mkOriginal 패턴).
+function mkOriginal(db: Database, id: string, from = "bill", to = "steve") {
+  db.prepare(
+    `INSERT INTO message (id, thread_id, from_agent_id, to_agent_id, type, body, source)
+     VALUES (?, 't1', ?, ?, 'dm', 'please do X', 'agent')`,
+  ).run(id, from, to);
+  db.prepare(
+    `INSERT INTO message_recipient (message_id, agent_id, delivery_state, recipient_state)
+     VALUES (?, ?, 'wake_dispatched', 'open')`,
+  ).run(id, to);
+}
+
+function reply(over: Partial<ReplyLike>): ReplyLike {
+  return { id: "r1", from_agent_id: "steve", body: "완료했습니다", thread_id: "t1", in_reply_to: "orig1", source: "agent", type: "reply", ...over };
+}
+
+// audit_event 에서 loop_event 만 추출(raw detail — 내가 emit한 그대로 검증).
+function loopEv(db: Database) {
+  return (db.prepare(`SELECT action, detail_json FROM audit_event ORDER BY id`).all() as { action: string; detail_json: string }[])
+    .map((r) => JSON.parse(r.detail_json) as Record<string, unknown>)
+    .filter((d) => d?.schema === LOOP_EVENT_SCHEMA);
+}
+const byName = (db: Database, name: string) => loopEv(db).filter((d) => d.event_name === name);
+
+describe("emit③ request.created (acceptInbound)", () => {
+  test("directed 원요청 → request.created 1건 (episode=원msgid·first-seen)", () => {
+    const db = setup();
+    const r = acceptInbound(db, env() as never, { dedupeWindowSec: 60 });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const evs = byName(db, EVENT.request_created);
+    expect(evs.length).toBe(1);
+    expect(evs[0]!.request_message_id).toBe(r.stored.id);
+    expect(evs[0]!.episode_id).toBe(`t1:${r.stored.id}`);
+    expect(evs[0]!.actor).toBe("bill");
+    expect(evs[0]!.target).toBe("steve");
+    expect(evs[0]!.event_id).toBe(`req:${r.stored.id}`);
+  });
+
+  test("reply 인바운드(in_reply_to) → request.created 무emit", () => {
+    const db = setup();
+    acceptInbound(db, env({ type: "reply", in_reply_to: "someorig" }) as never, { dedupeWindowSec: 60 });
+    expect(byName(db, EVENT.request_created).length).toBe(0);
+  });
+
+  test("broadcast → request.created 무emit (per-recipient ack 대상 아님)", () => {
+    const db = setup();
+    acceptInbound(db, env({ to_agent_id: "broadcast" }) as never, { dedupeWindowSec: 60 });
+    expect(byName(db, EVENT.request_created).length).toBe(0);
+  });
+
+  test("dedupe로 막힌 재inbound(ok:false)는 무emit", () => {
+    const db = setup();
+    acceptInbound(db, env() as never, { dedupeWindowSec: 60 });
+    acceptInbound(db, env() as never, { dedupeWindowSec: 60 }); // 동일 body → duplicate
+    expect(byName(db, EVENT.request_created).length).toBe(1);
+  });
+});
+
+describe("emit③ ack.observed (applyAckClose)", () => {
+  test("첫 open→전이 → ack.observed 1건 (actor=owner·target=요청자·episode=원요청)", () => {
+    const db = setup();
+    mkOriginal(db, "orig1");
+    const res = applyAckClose(db, reply({}));
+    expect(res.applied).toBe(true);
+    const evs = byName(db, EVENT.ack_observed);
+    expect(evs.length).toBe(1);
+    expect(evs[0]!.actor).toBe("steve"); // owner(응답자)
+    expect(evs[0]!.target).toBe("bill"); // 원 요청자
+    expect(evs[0]!.request_message_id).toBe("orig1");
+    expect(evs[0]!.episode_id).toBe("t1:orig1"); // ★reply.id(r1) 아님 — 원요청 키★
+    expect(evs[0]!.event_id).toBe("ack:orig1:steve");
+  });
+
+  test("★request↔ack 같은 episode로 조인 (통일 핵심)★", () => {
+    const db = setup();
+    const r = acceptInbound(db, env() as never, { dedupeWindowSec: 60 }); // request.created(episode t1:S)
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const ackRes = applyAckClose(db, reply({ in_reply_to: r.stored.id, id: "reply-1" }));
+    expect(ackRes.applied).toBe(true);
+    const reqEp = byName(db, EVENT.request_created)[0]!.episode_id;
+    const ackEp = byName(db, EVENT.ack_observed)[0]!.episode_id;
+    expect(ackEp).toBe(reqEp); // 같은 episode → 요청→ack 조인 성립
+  });
+
+  test("이미 engaged(cur≠open) 전이 → ack.observed 무emit (분모 오염 방지)", () => {
+    const db = setup();
+    db.prepare(
+      `INSERT INTO message (id, thread_id, from_agent_id, to_agent_id, type, body, source)
+       VALUES ('orig2','t1','bill','steve','dm','x','agent')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO message_recipient (message_id, agent_id, delivery_state, recipient_state)
+       VALUES ('orig2','steve','wake_dispatched','acknowledged')`, // 이미 ack된 상태
+    ).run();
+    applyAckClose(db, reply({ in_reply_to: "orig2", body: "다 끝냈습니다 완료" }));
+    expect(byName(db, EVENT.ack_observed).length).toBe(0);
+  });
+
+  test("re-ack(같은 reply 재적용) → 두번째는 무emit (첫 전이만)", () => {
+    const db = setup();
+    mkOriginal(db, "orig1");
+    applyAckClose(db, reply({}));
+    applyAckClose(db, reply({})); // 이미 open 아님 → noop
+    expect(byName(db, EVENT.ack_observed).length).toBe(1);
+  });
+
+  test("activity-auto-ack(추론 ack) → ack.observed 무emit (spec §31)", () => {
+    const db = setup();
+    // 30초 grace 넘긴 open 행
+    db.prepare(
+      `INSERT INTO message (id, thread_id, from_agent_id, to_agent_id, type, body, source, created_at)
+       VALUES ('origold','t1','bill','steve','dm','x','agent', datetime('now','-120 seconds'))`,
+    ).run();
+    db.prepare(
+      `INSERT INTO message_recipient (message_id, agent_id, delivery_state, recipient_state)
+       VALUES ('origold','steve','wake_dispatched','open')`,
+    ).run();
+    const r = applyActivityAutoAck(db, "steve", "trigger-msg");
+    expect(r.acked).toBeGreaterThanOrEqual(1);
+    expect(byName(db, EVENT.ack_observed).length).toBe(0); // 추론 ack는 무emit
+  });
+});
+
+describe("emit③ best-effort (측정 실패가 라이브 기능 안 깸)", () => {
+  test("audit_event DROP → acceptInbound 여전히 ok:true·stored 커밋", () => {
+    const db = setup();
+    db.exec("DROP TABLE audit_event"); // emit(appendAudit INSERT) throw 유발
+    const r = acceptInbound(db, env() as never, { dedupeWindowSec: 60 });
+    expect(r.ok).toBe(true); // ★계측 실패해도 ingress 정상★
+    if (r.ok) expect(r.stored.id).toBeTruthy();
+  });
+
+  test("emit 경로 실패(origin SELECT의 message 소실) → applyAckClose 여전히 상태 전이 적용", () => {
+    // ★내 ack.observed 블록만 고립 실패시킴★: tier1(in_reply_to)은 message_recipient만 읽으므로
+    //   recipient 행을 별도 삽입 후 message 테이블을 비우면, 기존 audit/ack-close는 정상이고 내 origin SELECT만 throw.
+    const db = setup();
+    db.exec("PRAGMA foreign_keys=OFF"); // orphan recipient 삽입 허용(고립 실패 주입용)
+    db.prepare(
+      `INSERT INTO message_recipient (message_id, agent_id, delivery_state, recipient_state)
+       VALUES ('orig1','steve','wake_dispatched','open')`,
+    ).run();
+    db.exec("DROP TABLE message"); // 내 origin SELECT(from message)만 깨짐 — try/catch로 삼켜야 함
+    const res = applyAckClose(db, reply({}));
+    expect(res.applied).toBe(true); // ★측정 실패해도 ack-close 정상★
+  });
+});
+
+describe("emit③ makeEpisodeId 통일 (spec §32)", () => {
+  test("requestMessageId 우선(first-seen 고정) — task 붙어도 키 불변", () => {
+    expect(makeEpisodeId("t1", { requestMessageId: "m9", taskId: "task5" })).toBe("t1:m9");
+  });
+  test("회귀0: requestMessageId 없으면 taskId fallback(emit④ tasks 경로 불변)", () => {
+    expect(makeEpisodeId("task", { taskId: "task5" })).toBe("task:task5");
+  });
+  test("셋 다 없으면 '-'", () => {
+    expect(makeEpisodeId("t1", {})).toBe("t1:-");
+  });
+});

--- a/src/server/metrics/emit3.test.ts
+++ b/src/server/metrics/emit3.test.ts
@@ -89,16 +89,53 @@ describe("emit③ request.created (acceptInbound)", () => {
     expect(evs[0]!.event_id).toBe(`req:${r.stored.id}`);
   });
 
-  test("reply 인바운드(in_reply_to) → request.created 무emit", () => {
+  // ★리뷰(Bill 2026-07-27)로 계약이 바뀐 지점★ — 예전엔 `in_reply_to` 가 있으면 무조건 무emit 이었다.
+  //   그런데 우리 핵심룰이 버스 발신에 항상 `--in-reply-to` 를 붙이라고 해서, ★스레드 안에서 오는
+  //   새 위임(실제 요청의 대다수)이 통째로 배제★ 됐다. ack 쪽은 그 배제를 모르니 ack.observed 는 그대로 떠서
+  //   ★request 0 / ack 1 = 고아 ack + 분모 누락★ 이 됐다. 그래서 기준을 "ack 가능한 open 수신자 행을
+  //   만들었는가" 로 바꿨다. 아래 두 테스트가 그 계약을 못박는다.
+  test("★스레드 안 새 위임(in_reply_to 있음)도 request.created 1건★ — open 행을 만들면 요청이다", () => {
     const db = setup();
-    acceptInbound(db, env({ type: "reply", in_reply_to: "someorig" }) as never, { dedupeWindowSec: 60 });
+    const prev = acceptInbound(db, env({ body: "prev" }) as never, { dedupeWindowSec: 60 });
+    expect(prev.ok).toBe(true);
+    if (!prev.ok) return;
+    const before = byName(db, EVENT.request_created).length;
+
+    const r = acceptInbound(db, env({ body: "새 위임", in_reply_to: prev.stored.id }) as never, { dedupeWindowSec: 60 });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    // 이 메시지는 steve 에게 open 행을 만든다 = ack 이 날 수 있다 → request 로도 세어야 대칭이다
+    const openRows = db
+      .prepare(`SELECT COUNT(*) AS n FROM message_recipient WHERE message_id = ? AND recipient_state = 'open'`)
+      .get(r.stored.id) as { n: number };
+    expect(openRows.n).toBeGreaterThan(0);
+    expect(byName(db, EVENT.request_created).length).toBe(before + 1);
+  });
+
+  test("★ack 이 불가능한 것은 request 로도 안 센다★ — open 행이 없으면 무emit", () => {
+    const db = setup();
+    // broadcast 수신자 행은 'acknowledged'(broadcast_fyi)로 생성돼 애초에 open 이 아니다.
+    const r = acceptInbound(db, env({ to_agent_id: "broadcast" }) as never, { dedupeWindowSec: 60 });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const openRows = db
+      .prepare(`SELECT COUNT(*) AS n FROM message_recipient WHERE message_id = ? AND recipient_state = 'open'`)
+      .get(r.stored.id) as { n: number };
+    expect(openRows.n).toBe(0);
     expect(byName(db, EVENT.request_created).length).toBe(0);
   });
 
-  test("broadcast → request.created 무emit (per-recipient ack 대상 아님)", () => {
+  // ★Bill 권고★: broadcast 의 대칭을 request 쪽만 단언하면, 다른 모듈의 불변식(broadcast_fyi)이
+  //   바뀔 때 ★조용히 깨진다★. request 와 ack 을 ★한 테스트에서 함께★ 못박는다.
+  test("broadcast → request.created 0 ★그리고★ ack.observed 0 (대칭을 한 곳에서 고정)", () => {
     const db = setup();
-    acceptInbound(db, env({ to_agent_id: "broadcast" }) as never, { dedupeWindowSec: 60 });
+    const r = acceptInbound(db, env({ to_agent_id: "broadcast" }) as never, { dedupeWindowSec: 60 });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    // 수신자 전원이 이미 acknowledged 라 ack 전이가 일어날 수 없다
+    for (const who of ["steve", "demis"]) applyAckClose(db, { messageId: r.stored.id, agentId: who } as never);
     expect(byName(db, EVENT.request_created).length).toBe(0);
+    expect(byName(db, EVENT.ack_observed).length).toBe(0);
   });
 
   test("dedupe로 막힌 재inbound(ok:false)는 무emit", () => {

--- a/src/server/metrics/emit3.test.ts
+++ b/src/server/metrics/emit3.test.ts
@@ -180,6 +180,51 @@ describe("emit③ request.created (acceptInbound)", () => {
     expect(ev?.request_kind).toBe("delegation");
   });
 
+  // ★Codex 리뷰(2026-07-27) 회귀★ — 부모가 broadcast/다중수신이면 to_agent_id 가 'broadcast' 라
+  //   실제 수신자가 답해도 delegation 으로 오분류됐다. 수신 사실은 message_recipient 행이 정본이다.
+  test("★부모가 broadcast 여도 실제 수신자가 답하면 followup★ (to_agent_id 대리값 금지)", () => {
+    const db = setup();
+    const b = acceptInbound(db, env({ to_agent_id: "broadcast" }) as never, { dedupeWindowSec: 60 });
+    expect(b.ok).toBe(true);
+    if (!b.ok) return;
+    // 부모의 to_agent_id 는 'broadcast' 지만, steve 는 수신자 행을 갖는다 = 받았다
+    expect(
+      (db.prepare(`SELECT to_agent_id FROM message WHERE id = ?`).get(b.stored.id) as { to_agent_id: string })
+        .to_agent_id,
+    ).toBe("broadcast");
+    expect(
+      db.prepare(`SELECT 1 FROM message_recipient WHERE message_id = ? AND agent_id = 'steve'`).get(b.stored.id),
+    ).toBeTruthy();
+
+    const r = acceptInbound(
+      db,
+      env({ from_agent_id: "steve", to_agent_id: "bill", body: "공지 답", in_reply_to: b.stored.id }) as never,
+      { dedupeWindowSec: 60 },
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const ev = byName(db, EVENT.request_created).find((e) => e.request_message_id === r.stored.id);
+    expect(ev?.request_kind).toBe("followup");
+  });
+
+  test("★안 받은 사람이 그 부모를 인용해 보내면 delegation★ (수신 사실이 없으면 위임)", () => {
+    const db = setup();
+    // bill → steve 직접 (demis 는 수신자가 아니다)
+    const q = acceptInbound(db, env({ body: "질문" }) as never, { dedupeWindowSec: 60 });
+    expect(q.ok).toBe(true);
+    if (!q.ok) return;
+    // demis 가 그 메시지를 인용해 steve 에게 새 지시 → demis 는 부모 수신자가 아니므로 delegation
+    const r = acceptInbound(
+      db,
+      env({ from_agent_id: "demis", to_agent_id: "steve", body: "이거 이어서 해줘", in_reply_to: q.stored.id }) as never,
+      { dedupeWindowSec: 60 },
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const ev = byName(db, EVENT.request_created).find((e) => e.request_message_id === r.stored.id);
+    expect(ev?.request_kind).toBe("delegation");
+  });
+
   test("★라벨은 emit 여부를 바꾸지 않는다★ — 두 종류 다 정확히 1건씩 emit", () => {
     const db = setup();
     const q = acceptInbound(db, env({ body: "질문" }) as never, { dedupeWindowSec: 60 });

--- a/src/server/metrics/emit3.test.ts
+++ b/src/server/metrics/emit3.test.ts
@@ -138,6 +138,63 @@ describe("emit③ request.created (acceptInbound)", () => {
     expect(byName(db, EVENT.ack_observed).length).toBe(0);
   });
 
+  // ─── 라벨(request_kind) — ★emit 여부에는 쓰지 않는다★ (Bill 판정 2026-07-27) ───────────
+  //   "위임→응답" 과 "말 걸면 언제 답하나" 는 둘 다 볼 가치가 있지만 섞이면 둘 다 못 본다.
+  //   그래서 emit 은 open 행 하나로 결정하고, 성격은 라벨로만 남겨 분석에서 나눈다.
+  test("라벨: 선행 요청이 없으면 delegation", () => {
+    const db = setup();
+    const r = acceptInbound(db, env() as never, { dedupeWindowSec: 60 });
+    expect(r.ok).toBe(true);
+    expect(byName(db, EVENT.request_created)[0]!.request_kind).toBe("delegation");
+  });
+
+  test("★라벨: 내게 온 것에 답하면 followup★", () => {
+    const db = setup();
+    // bill → steve 질문
+    const q = acceptInbound(db, env({ body: "질문" }) as never, { dedupeWindowSec: 60 });
+    expect(q.ok).toBe(true);
+    if (!q.ok) return;
+    // steve → bill 답 (부모의 수신자가 steve = 나 → 내게 온 것에 답하는 것)
+    const a = acceptInbound(
+      db,
+      env({ from_agent_id: "steve", to_agent_id: "bill", body: "답", in_reply_to: q.stored.id }) as never,
+      { dedupeWindowSec: 60 },
+    );
+    expect(a.ok).toBe(true);
+    if (!a.ok) return;
+    const ev = byName(db, EVENT.request_created).find((e) => e.request_message_id === a.stored.id);
+    expect(ev?.request_kind).toBe("followup");
+  });
+
+  test("★라벨: 스레드 안 새 위임은 in_reply_to 가 있어도 delegation★ (이번 HIGH 의 그 케이스)", () => {
+    const db = setup();
+    // bill → steve 선행
+    const prev = acceptInbound(db, env({ body: "prev" }) as never, { dedupeWindowSec: 60 });
+    expect(prev.ok).toBe(true);
+    if (!prev.ok) return;
+    // bill → steve 새 위임 (부모의 수신자는 steve 인데 발신자는 bill = 내게 온 게 아니다)
+    const r = acceptInbound(db, env({ body: "새 위임", in_reply_to: prev.stored.id }) as never, { dedupeWindowSec: 60 });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const ev = byName(db, EVENT.request_created).find((e) => e.request_message_id === r.stored.id);
+    expect(ev?.request_kind).toBe("delegation");
+  });
+
+  test("★라벨은 emit 여부를 바꾸지 않는다★ — 두 종류 다 정확히 1건씩 emit", () => {
+    const db = setup();
+    const q = acceptInbound(db, env({ body: "질문" }) as never, { dedupeWindowSec: 60 });
+    expect(q.ok).toBe(true);
+    if (!q.ok) return;
+    acceptInbound(
+      db,
+      env({ from_agent_id: "steve", to_agent_id: "bill", body: "답", in_reply_to: q.stored.id }) as never,
+      { dedupeWindowSec: 60 },
+    );
+    const evs = byName(db, EVENT.request_created);
+    expect(evs.length).toBe(2); // 라벨이 달라도 둘 다 emit — 대칭은 open 행이 정한다
+    expect(evs.map((e) => e.request_kind).sort()).toEqual(["delegation", "followup"]);
+  });
+
   test("dedupe로 막힌 재inbound(ok:false)는 무emit", () => {
     const db = setup();
     acceptInbound(db, env() as never, { dedupeWindowSec: 60 });

--- a/src/server/metrics/loopEvent.ts
+++ b/src/server/metrics/loopEvent.ts
@@ -68,6 +68,13 @@ export interface LoopEvent {
   quiet_hours?: boolean;
   visible_surface?: string;
   metric_scope?: string;
+  // 요청 성격 라벨 (§측정 W1 · Bill 리뷰 2026-07-27)
+  //   ★emit 여부에는 절대 쓰지 않는다★ — emit 은 "ack 가능한 open 행이 생겼는가" 하나로만 결정한다.
+  //   이건 분석에서 차원을 나누기 위한 ★라벨★ 이다: "위임→응답" 과 "말 걸면 언제 답하나" 는
+  //   둘 다 볼 가치가 있지만 섞이면 둘 다 못 본다. 라벨로 두면 나중에 재계산이 된다(정보를 안 버린다).
+  //     delegation — 새 일을 맡기는 것(선행 요청이 없거나, 있어도 내게 온 게 아님)
+  //     followup   — 내게 온 것에 답하면서 상대에게 open 행을 남긴 것(대화 왕복)
+  request_kind?: "delegation" | "followup";
   // 결과
   outcome?: string;
   reason?: string;

--- a/src/server/metrics/loopEvent.ts
+++ b/src/server/metrics/loopEvent.ts
@@ -83,14 +83,17 @@ export interface LoopEvent {
 }
 
 /**
- * episode_id = thread_id : (task_id | proposal_id | request_message_id) (Lui 보강①).
- * ★'-' 금지: 카드 없는 요청도 request_message_id로 구분해 허수 방지.★ 셋 다 없을 때만 최후 '-'.
+ * episode_id = thread_id : (request_message_id | task_id | proposal_id) — origin·first-seen 고정.
+ * ★emit③ 결정(2026-07-11, spec §32):★ 키는 originating request_message_id 우선(first-seen). 카드 없이
+ * 시작한 뒤 task/proposal이 붙어도 키가 안 뒤집혀 같은 실episode가 2개로 분리되지 않는다. task_id/proposal_id는
+ * envelope 속성으로만 운반(키 승격 금지) — request_message_id가 없을 때만 fallback(회귀0: emit④ tasks는
+ * requestMessageId 미전달이라 기존대로 taskId 키 유지). ★'-' 금지★: 셋 다 없을 때만 최후 '-'.
  */
 export function makeEpisodeId(
   threadId: string,
   ids: { taskId?: string; proposalId?: string; requestMessageId?: string },
 ): string {
-  const key = ids.taskId || ids.proposalId || ids.requestMessageId || "-";
+  const key = ids.requestMessageId || ids.taskId || ids.proposalId || "-";
   return `${threadId}:${key}`;
 }
 


### PR DESCRIPTION
> ⚠ **머지 게이트: GD 승인 + emit⑤ 포함 여부 결정.** Bill `metrics-review` 는 **통과했다**(2026-07-27).
>
> 리뷰에서 HIGH 1건이 나와 두 번 고쳤다 — 아래 “리뷰 반영” 절이 최신 상태다.

## 왜 이제야 올라오나

설계·구현·검증은 **2026-07-11 에 끝났다** — Lui 공동리뷰 + Bill design-GO 4건 + GD 구현 승인. 그런데 그 뒤로 7일 밤 동안 `blocked` 였고, 원인은 리뷰 내용이 아니라 **리뷰할 수 있는 곳에 브랜치가 없었다**는 것이었다. 원본이 구 트리(`b3rys-team-collab`)에만 있었고, `team-os` 가 정본이 된 뒤에도 옮겨지지 않았다. 두 저장소는 **히스토리를 공유하지 않아**(team-os 는 2026-07-23 신규 init) cherry-pick 이 안 되고 패치 이식만 가능하다.

어제 야간 사이클에서 이식 가능성을 비파괴로 실측했고, 이 PR 이 그 이식본이다. **Bill 의 리뷰 게이트가 그동안 물리적으로 불가능했다는 점이 이 트랙이 멈춰 있던 진짜 이유다.**

## 무엇이 들어가나 (2026-07-09 확정 · 07-11 구현)

| 이벤트 | 발화 지점 |
|---|---|
| `request.created` | `acceptInbound` 의 `ok:true` + episode-first 에서만 |
| `ack.observed` | `applyAckClose` 의 **첫 open 전이에서만** (순수 발화는 무emit) |
| `episode_id` 통일 | origin·first-seen 기준 (`reqmsgid` 우선, task 는 속성) |
| `closeOrphanedDelivery` | **무emit** — 전송계층이라 의미 이벤트가 아니다 |

핫패스라 emit 은 best-effort(`emitLoopEventSafe`)이고, main 이 나중에 넣은 `metrics_emit` 게이트(기본 OFF)를 그대로 따른다 — 테스트가 `on` 으로 opt-in 한다.

## 범위 밖 (의도적)

**emit⑤(router native `routing.resolved`)** 는 넣지 않았다. 같이 넣으면 `projectAuditRow` 의 legacy 합성과 **이중 소스**가 되어 `recompute` 의 `routingCorrectness` 분모가 이중계수된다(2026-07-18 실측). 포함 여부는 GD 결정 사항이라 분리해 뒀다.

## 검증 (오늘 main `046eeea` 기준)

| 항목 | 결과 |
|---|---|
| `git apply` | **충돌 0** — emit③가 건드리는 4파일은 `cafcd2f` 이후 main 에서 **0커밋 변경** |
| `tsc --noEmit` | 0 |
| emit③ 스위트 | **38 pass / 0 fail** |
| 전체 게이트 (초기 53c97b5 기준) | 1641 pass / 5 skip / 0 fail (1646 tests) |
| 베이스라인(같은 main, 패치 없음) | 1627 / 5 / 0 (1632 tests) |
| 차이 | **+14 = emit③ 신규 테스트 수와 정확히 일치 · 회귀 0** |

**공개 push 전 유출 검사**(공개 repo 정리 때 쓴 절차 그대로): 라이브 `.env` 값 대조 0건 · 실이메일 0 · chat_id 0 · 내부 절대경로 0 · 토큰류 0.


---

## 리뷰 반영 (2026-07-27) — 최신 상태는 `3e56eb1`

### ★HIGH: request 분모가 대부분 비었다★ (Bill 발견 · 양쪽 독립 재현)

가드가 `type !== "reply" && !in_reply_to && to !== "broadcast"` 로 **ack 가능성을 간접 추정**했다. 그런데 우리 핵심룰은 버스 발신에 **항상 `--in-reply-to` 를 붙이라**고 한다 → **스레드 안에서 오는 새 위임(= 실제 요청의 대다수)이 통째로 배제**됐다.

문제는 ack 쪽이 그 배제를 모른다는 것이다. 수신자 행은 `open` 으로 생기고 답이 오면 `ack.observed` 가 그대로 뜬다:

```
request.created = 0  /  ack.observed = 1     ← 고아 ack + 분모 누락
```

**고친 방식 — 짝을 같은 사실에서 끌어낸다.** `insertMessage` 직후 **“ack 이 날 수 있는 `open` 수신자 행을 실제로 만들었는가”** 를 직접 본다. 추정이 아니라 사실이라 **정의상 어긋날 수 없다**. 특수 케이스가 조건 없이 따라온다:

- broadcast → 행이 `acknowledged`(broadcast_fyi) 라 `open` 아님 → 무emit (별도 조건 **삭제**)
- completed-on-insert(user source·비dispatch) → `open` 아님 → 무emit

### 같이 바뀐 의미 — 숨기지 않고 적는다

답장도 원 발신자에게 `open` 행을 만든다(실측). 그 행은 ack 이 날 수 있으므로 **이제 요청으로 센다**. 정의가 *“답장은 요청이 아니다”* → **“ack 을 기다리는 것은 전부 요청이다”** 로 바뀐다. 대칭이 우선이라는 판정(Bill): 되돌리면 고아 ack 이 돌아오고 그건 데이터 무결성 문제다.

### 그래서 `request_kind` 라벨을 추가했다 — **emit 여부에는 쓰지 않는다**

“위임→응답” 과 “말 걸면 언제 답하나” 는 둘 다 볼 가치가 있지만 섞이면 둘 다 못 본다. emit 은 `open` 행 하나로 결정하고, 성격은 **라벨로만** 남겨 분석에서 나눈다(정보를 버리는 대신 나눈다 → 나중에 재계산 가능).

**라벨 기준은 실측으로 정했다.** 처음 제안된 `type`·`in_reply_to` 는 버스 2000건에서 판별력이 없었다:

| 후보 | 실측 | 문제 |
|---|---|---|
| `type === "reply"` | 2건 (0.1%) | 우리 발신은 사실상 전부 `dm` |
| `in_reply_to` 유무 | 1143건 (57%) | **그 안에 ‘스레드 안 새 위임’ 이 섞여 있다** — 이번 HIGH 를 만든 바로 그 오분류를 라벨에서 반복하게 된다 |

→ 채택: **“부모 메시지가 내게 온 것이었는가”**

- 내게 온 것에 답하며 상대에게 `open` 행을 남겼다 → `followup`
- 선행 요청이 없거나, 있어도 내게 온 게 아니다 → `delegation`

실측 분포(directed 1879건): `followup` 1007 · `delegation` 857(부모없음 821 + **스레드 안 새 위임 36**) · 부모 조회 실패 15 → `delegation`(보수적 기본값).

### 검증

| 항목 | 결과 |
|---|---|
| emit③ 스위트 | **43 pass / 0 fail** |
| 전체 게이트 | **1646 pass / 5 skip / 0 fail** (1651) — 회귀 0 |
| `tsc --noEmit` · `bun run build` | 0 · 성공 |

**뮤턴트 3종 전부 KILLED**

| 뮤턴트 | 결과 |
|---|---|
| 옛 heuristic 가드로 복원 | 38 pass / **1 fail** |
| **라벨을 emit 조건에 섞기** | 41 pass / **2 fail** |
| 라벨 기준을 `in_reply_to` 로 되돌리기 | 42 pass / **1 fail** |

두 번째는 일부러 넣었다 — *“라벨은 라벨로만”* 이 말로만 남으면 나중에 누가 조건에 섞어도 아무도 모른다. **규약을 테스트로 만들었다.**

> 리뷰 과정에서 깨진 기존 테스트(`reply → 무emit`)는 **코드를 테스트에 맞추지 않고**, 실측으로 의미를 먼저 확인한 뒤 새 계약으로 다시 썼다.

