### PR TITLE
feat(hermes): allow member runtime cwd configuration

### DIFF
--- a/src/server/db/migrate.b3osnative.test.ts
+++ b/src/server/db/migrate.b3osnative.test.ts
@@ -16,6 +16,7 @@ function oldHermesWidenedDb(): Database {
     tmux_session TEXT,
     telegram_bot_username TEXT,
     workspace_path TEXT NOT NULL,
+    runtime_cwd TEXT,
     persona_file TEXT NOT NULL,
     moderator_eligible INTEGER NOT NULL DEFAULT 0,
     avatar_emoji TEXT NOT NULL DEFAULT '🤖',
@@ -26,16 +27,16 @@ function oldHermesWidenedDb(): Database {
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
   )`);
   db.prepare(
-    `INSERT INTO agent (id, display_name, role, runtime, status_provider, workspace_path, persona_file,
+    `INSERT INTO agent (id, display_name, role, runtime, status_provider, workspace_path, runtime_cwd, persona_file,
        hermes_profile, hermes_alias, gateway_service, icon)
-     VALUES ('herm','Herm','cso','hermes_agent','hermes_gateway','/tmp','p.md',
+     VALUES ('herm','Herm','cso','hermes_agent','hermes_gateway','/tmp/ws','/tmp/runtime','p.md',
        'b3hermes','헤르메스','com.x.hermes','hexagon')`,
   ).run();
   return db;
 }
 
 describe("b3os_native CHECK 위든 마이그레이션", () => {
-  test("★데이터 보존: 재빌드 후 hermes_profile·alias·gateway·icon 데이터 살아있음", () => {
+  test("★데이터 보존: 재빌드 후 hermes_profile·alias·gateway·icon·runtime_cwd 데이터 살아있음", () => {
     const db = oldHermesWidenedDb();
     widenAgentRuntimeChecks(db); // b3os_native 위해 1회 재빌드 발생
     const herm = db.prepare(`SELECT * FROM agent WHERE id='herm'`).get() as Record<string, unknown>;
@@ -43,6 +44,7 @@ describe("b3os_native CHECK 위든 마이그레이션", () => {
     expect(herm.hermes_alias).toBe("헤르메스");
     expect(herm.gateway_service).toBe("com.x.hermes");
     expect(herm.icon).toBe("hexagon"); // ← 하네스가 잡은 손실 컬럼들
+    expect(herm.runtime_cwd).toBe("/tmp/runtime");
   });
 
   test("재빌드 후 b3os_native / b3os_native_runner INSERT 가능", () => {

--- a/src/server/db/migrate.ts
+++ b/src/server/db/migrate.ts
@@ -622,6 +622,7 @@ export function widenAgentRuntimeChecks(db: Database): void {
         tmux_session TEXT,
         telegram_bot_username TEXT,
         workspace_path TEXT NOT NULL,
+        runtime_cwd TEXT,
         persona_file TEXT NOT NULL,
         moderator_eligible INTEGER NOT NULL DEFAULT 0,
         avatar_emoji TEXT NOT NULL DEFAULT '🤖',
@@ -633,7 +634,7 @@ export function widenAgentRuntimeChecks(db: Database): void {
       )`,
     );
     // ★ 데이터 보존(하네스 리뷰 발견): 고정 컬럼 목록으로 복사하면 나중에 추가된 컬럼(icon·hermes_profile·
-    // hermes_alias·gateway_service)이 재빌드 때 날아간다. 소스∩신규 '공통 컬럼'만 동적으로 복사해 드리프트 안전하게.
+    // hermes_alias·gateway_service·runtime_cwd)이 재빌드 때 날아간다. 소스∩신규 '공통 컬럼'만 동적으로 복사해 드리프트 안전하게.
     const srcCols = (db.prepare("PRAGMA table_info('agent')").all() as { name: string }[]).map((c) => c.name);
     const newCols = new Set(
       (db.prepare("PRAGMA table_info('agent_new')").all() as { name: string }[]).map((c) => c.name),

--- a/src/server/db/migrate.ts
+++ b/src/server/db/migrate.ts
@@ -32,6 +32,12 @@ export function migrate(db: Database): void {
   } catch {
     /* 이미 존재 */
   }
+  // Gateway runtime 실행 CWD(예: Hermes terminal.cwd). 없으면 workspace_path를 쓴다.
+  try {
+    db.exec("ALTER TABLE agent ADD COLUMN runtime_cwd TEXT");
+  } catch {
+    /* 이미 존재 */
+  }
   // 그룹 owner 영속화(2026-06-05 GD): 재시작에도 owner 유지. 단일 작은 행(thread_id='group').
   db.exec(
     `CREATE TABLE IF NOT EXISTS group_owner (

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -12,8 +12,8 @@ const MAX_METRIC_ROWS = 720;
 
 export function upsertAgent(db: Database, a: AgentRecord): void {
   db.prepare(
-    `INSERT INTO agent (id, display_name, role, runtime, status_provider, tmux_session, telegram_bot_username, workspace_path, persona_file, moderator_eligible, avatar_emoji, icon, hermes_profile, hermes_alias, gateway_service)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `INSERT INTO agent (id, display_name, role, runtime, status_provider, tmux_session, telegram_bot_username, workspace_path, runtime_cwd, persona_file, moderator_eligible, avatar_emoji, icon, hermes_profile, hermes_alias, gateway_service)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(id) DO UPDATE SET
        display_name=excluded.display_name,
        role=excluded.role,
@@ -22,6 +22,7 @@ export function upsertAgent(db: Database, a: AgentRecord): void {
        tmux_session=excluded.tmux_session,
        telegram_bot_username=excluded.telegram_bot_username,
        workspace_path=excluded.workspace_path,
+       runtime_cwd=excluded.runtime_cwd,
        persona_file=excluded.persona_file,
        moderator_eligible=excluded.moderator_eligible,
        avatar_emoji=excluded.avatar_emoji,
@@ -38,6 +39,7 @@ export function upsertAgent(db: Database, a: AgentRecord): void {
     a.tmux_session,
     a.telegram_bot_username,
     a.workspace_path,
+    a.runtime_cwd ?? null,
     a.persona_file,
     a.moderator_eligible ? 1 : 0,
     a.avatar_emoji,
@@ -60,7 +62,7 @@ export function deleteAgentsNotIn(db: Database, ids: string[]): void {
 export function listAgents(db: Database): AgentRecord[] {
   const rows = db
     .prepare(
-      `SELECT id, display_name, role, runtime, status_provider, tmux_session, telegram_bot_username, workspace_path, persona_file, moderator_eligible, avatar_emoji, icon, hermes_profile, hermes_alias, gateway_service FROM agent ORDER BY id`,
+      `SELECT id, display_name, role, runtime, status_provider, tmux_session, telegram_bot_username, workspace_path, runtime_cwd, persona_file, moderator_eligible, avatar_emoji, icon, hermes_profile, hermes_alias, gateway_service FROM agent ORDER BY id`,
     )
     .all() as Array<Omit<AgentRecord, "moderator_eligible"> & { moderator_eligible: number }>;
   return rows.map((r) => ({ ...r, moderator_eligible: r.moderator_eligible === 1 }));

--- a/src/server/db/schema.sql
+++ b/src/server/db/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE IF NOT EXISTS agent (
   tmux_session TEXT,
   telegram_bot_username TEXT,
   workspace_path TEXT NOT NULL,
+  runtime_cwd TEXT,
   persona_file TEXT NOT NULL,
   moderator_eligible INTEGER NOT NULL DEFAULT 0,
   avatar_emoji TEXT NOT NULL DEFAULT '🤖',

--- a/src/server/lib/activation.test.ts
+++ b/src/server/lib/activation.test.ts
@@ -306,18 +306,18 @@ describe("activation: Hermes runtime CWD resolution", () => {
     expect(resolveActivationRuntimeCwd(
       "herm",
       undefined,
-      { workspace_path: "/Users/gd452/b3os/members/herm", runtime_cwd: null },
-      "/Users/gd452/Development/herm",
-    )).toBe("/Users/gd452/b3os/members/herm");
+      { workspace_path: "/home/tester/b3os/members/herm", runtime_cwd: null },
+      "/home/tester/Development/herm",
+    )).toBe("/home/tester/b3os/members/herm");
   });
 
   test("명시 runtime_cwd는 agents.json workspace_path보다 우선한다", () => {
     expect(resolveActivationRuntimeCwd(
       "herm",
-      "/Users/gd452/custom/herm",
-      { workspace_path: "/Users/gd452/b3os/members/herm", runtime_cwd: null },
-      "/Users/gd452/Development/herm",
-    )).toBe("/Users/gd452/custom/herm");
+      "/home/tester/custom/herm",
+      { workspace_path: "/home/tester/b3os/members/herm", runtime_cwd: null },
+      "/home/tester/Development/herm",
+    )).toBe("/home/tester/custom/herm");
   });
 });
 

--- a/src/server/lib/activation.test.ts
+++ b/src/server/lib/activation.test.ts
@@ -21,7 +21,7 @@ import { buildPersona, buildAgentsMd } from "./personaTemplates";
 import {
   waitForClaudePoller, waitForCodexPoller, waitForHermesGateway,
   activateMember, teardownRuntime, swapRuntime, RUNTIMES, STATUS_BY_RUNTIME,
-  classifyEssentials, CLAUDE_ESSENTIAL_TOLERANCE,
+  classifyEssentials, CLAUDE_ESSENTIAL_TOLERANCE, resolveActivationRuntimeCwd,
   type ActivateResult, type SwapDeps,
 } from "./activation";
 import { HERMES_BASE_PROFILE } from "./paths";
@@ -298,6 +298,26 @@ describe("activation: teardownRuntime (Phase1 offboard 4-branch 추출)", () => 
     expect(calls.some((c) => c.includes("telegram-lui-token.txt"))).toBe(true);
     expect(calls.some((c) => c.includes("telegram-lui-allowFrom.json"))).toBe(true);
     expect(calls.some((c) => c.includes("/agents/lui") && c.includes('"recursive":true'))).toBe(true);
+  });
+});
+
+describe("activation: Hermes runtime CWD resolution", () => {
+  test("runtime_cwd 미설정이면 canonical fallback 전에 agents.json workspace_path를 쓴다", () => {
+    expect(resolveActivationRuntimeCwd(
+      "herm",
+      undefined,
+      { workspace_path: "/Users/gd452/b3os/members/herm", runtime_cwd: null },
+      "/Users/gd452/Development/herm",
+    )).toBe("/Users/gd452/b3os/members/herm");
+  });
+
+  test("명시 runtime_cwd는 agents.json workspace_path보다 우선한다", () => {
+    expect(resolveActivationRuntimeCwd(
+      "herm",
+      "/Users/gd452/custom/herm",
+      { workspace_path: "/Users/gd452/b3os/members/herm", runtime_cwd: null },
+      "/Users/gd452/Development/herm",
+    )).toBe("/Users/gd452/custom/herm");
   });
 });
 

--- a/src/server/lib/activation.ts
+++ b/src/server/lib/activation.ts
@@ -329,6 +329,19 @@ function runtimeScript(id: string, runtime: string, runtimeCwd?: string): { scri
   return null; // claude_channel 은 별도 런타임 활성화 없음(CLAUDE.md + tmux/LaunchAgent)
 }
 
+export function resolveActivationRuntimeCwd(
+  id: string,
+  inputRuntimeCwd: string | null | undefined,
+  configured: { workspace_path?: string | null; runtime_cwd?: string | null } | undefined,
+  fallbackWorkspacePath: string,
+): string {
+  return runtimeCwdForAgent({
+    id,
+    workspace_path: configured?.workspace_path ?? fallbackWorkspacePath,
+    runtime_cwd: inputRuntimeCwd ?? configured?.runtime_cwd ?? null,
+  });
+}
+
 /** 토큰을 스크립트가 기대하는 파일에 0600 저장(stdout 노출 없음). */
 function placeToken(tokenFile: string, token: string): void {
   mkdirSync(dirname(tokenFile), { recursive: true });
@@ -564,11 +577,7 @@ export async function activateMember(db: Database, input: ActivateInput): Promis
   try { clearAgentOff(id); } catch { /* best-effort */ }
   const paths = memberPaths(id, runtime);
   const configured = activationAgents.find((a: any) => a.id === id);
-  const runtimeCwd = runtimeCwdForAgent({
-    id,
-    workspace_path: paths.workspace_path,
-    runtime_cwd: input.runtime_cwd ?? configured?.runtime_cwd ?? null,
-  });
+  const runtimeCwd = resolveActivationRuntimeCwd(id, input.runtime_cwd, configured, paths.workspace_path);
   // 라이브 생성 경로 → 핵심룰의 {{OWNER}}/{{TEAM}} 을 setting owner_name(="GD")/team_name(="b3rys")으로 치환. 미설정이면 undefined → 플레이스홀더 유지.
   const ownerRow = db.query("SELECT value FROM setting WHERE key = 'owner_name'").get() as { value: string } | null;
   const owner_name = ownerRow?.value || undefined;

--- a/src/server/lib/activation.ts
+++ b/src/server/lib/activation.ts
@@ -15,7 +15,7 @@ import { existsSync, mkdirSync, writeFileSync, chmodSync, readFileSync, renameSy
 import { dirname } from "node:path";
 import { memberPaths, MEMBERS_ROOT, personaTargetsForRuntime, assertNotLiveMemberFsUnderTest } from "./personaTemplates";
 import { writeMemberPersona, savePersonaFile } from "./writeMemberPersona";
-import { HERMES_BASE_PROFILE, MANUALS_DIR } from "./paths";
+import { HERMES_BASE_PROFILE, MANUALS_DIR, runtimeCwdForAgent } from "./paths";
 import { isHermesMemberProtected, isHermesProfileProtected } from "./hermesBaseProfile";
 import { appendAuditFile } from "./auditFile";
 import { codexBridgePaths, placeCodexToken, writeCodexBridgeFiles, removeCodexBridgeFiles, resolveOwnerDmId } from "../runtimes/codex/launcher";
@@ -169,6 +169,8 @@ export interface ActivateInput {
   display_name: string;
   role: string;
   runtime: string;
+  /** Optional machine-local CWD for gateway runtimes; defaults to workspace_path. */
+  runtime_cwd?: string | null;
   bot_username?: string;
   persona?: string; // 능력/강점(영입 입력)
   bot_token: string; // provisioning 에서 받은 BotFather 토큰
@@ -304,7 +306,7 @@ export function withInitialLeadCapabilities<T extends Record<string, unknown>>(
 }
 
 /** 런타임 활성화 스크립트 경로 + 토큰 파일 경로(스크립트가 기대하는 위치). */
-function runtimeScript(id: string, runtime: string): { script: string; tokenFile: string; env: Record<string, string> } | null {
+function runtimeScript(id: string, runtime: string, runtimeCwd?: string): { script: string; tokenFile: string; env: Record<string, string> } | null {
   // ★WS=MEMBERS_ROOT/id 명시 주입 — 스크립트 default(WS=~/Development/id)는 퍼블릭 모드(MEMBERS_ROOT=$B3RYS_HOME/members)서 persona/AGENTS.md 위치와 어긋남(claude WORKDIR과 같은 계열, 하네스 HIGH). 스크립트가 WS env 이미 존중. GD 2026-07-02.
   const ws = `${MEMBERS_ROOT}/${id}`;
   if (runtime === "openclaw") {
@@ -321,7 +323,7 @@ function runtimeScript(id: string, runtime: string): { script: string; tokenFile
     return {
       script: `${MANUALS_DIR}/hermes/activate-hermes-agent.sh`,
       tokenFile: `${HOME}/.hermes/credentials/${id}-token.txt`,
-      env: { AGENT_ID: id, WS: ws, HERMES_BASE_PROFILE, ...(ownerDm ? { OWNER_CHAT_ID: ownerDm } : {}) },
+      env: { AGENT_ID: id, WS: ws, HERMES_CWD: runtimeCwd || ws, HERMES_BASE_PROFILE, ...(ownerDm ? { OWNER_CHAT_ID: ownerDm } : {}) },
     };
   }
   return null; // claude_channel 은 별도 런타임 활성화 없음(CLAUDE.md + tmux/LaunchAgent)
@@ -561,6 +563,12 @@ export async function activateMember(db: Database, input: ActivateInput): Promis
   // ★재영입 belt-and-suspenders: off-list에서 제거 — openclaw/hermes는 setAgentEnabled(true) 경로를 안 타서, 이거 없으면 재영입해도 stale off로 버스 suppress(하네스 #1). GD 2026-07-01.
   try { clearAgentOff(id); } catch { /* best-effort */ }
   const paths = memberPaths(id, runtime);
+  const configured = activationAgents.find((a: any) => a.id === id);
+  const runtimeCwd = runtimeCwdForAgent({
+    id,
+    workspace_path: paths.workspace_path,
+    runtime_cwd: input.runtime_cwd ?? configured?.runtime_cwd ?? null,
+  });
   // 라이브 생성 경로 → 핵심룰의 {{OWNER}}/{{TEAM}} 을 setting owner_name(="GD")/team_name(="b3rys")으로 치환. 미설정이면 undefined → 플레이스홀더 유지.
   const ownerRow = db.query("SELECT value FROM setting WHERE key = 'owner_name'").get() as { value: string } | null;
   const owner_name = ownerRow?.value || undefined;
@@ -727,7 +735,7 @@ export async function activateMember(db: Database, input: ActivateInput): Promis
       needsPairing: pairingPending,
     };
   }
-  const rs = runtimeScript(id, runtime);
+  const rs = runtimeScript(id, runtime, runtimeCwd);
   if (rs) {
     if (process.env.APPROVAL_EXECUTION_ENABLED !== "1") {
       steps.push({ step: "runtime", ok: false, detail: "실행 OFF(APPROVAL_EXECUTION_ENABLED≠1) — 런타임 활성화 건너뜀" });
@@ -873,6 +881,7 @@ async function rollbackSwap(db: Database, ctx: RollbackCtx): Promise<{ steps: Sw
       const heal = await ctx.doActivateMember(db, {
         id: ctx.id, display_name: ctx.target.display_name, role: ctx.target.role,
         runtime: ctx.oldRuntime, bot_username: ctx.target.telegram_bot_username,
+        runtime_cwd: ctx.target.runtime_cwd ?? null,
         bot_token: token, // ★persona 미전달: SOUL.md 는 STEP1 백업에서 복원된다(아래 copyFileSync). purpose 는 제거됨(cfe8bf7)
         registryPath: ctx.registryPath,
       });
@@ -1115,6 +1124,7 @@ export async function swapRuntime(db: Database, input: SwapInput, deps: SwapDeps
     role: target.role,
     runtime: targetRuntime,
     bot_username: target.telegram_bot_username,
+    runtime_cwd: updatedEntry.runtime_cwd ?? null,
     // ★persona 를 전달하지 않는다 — SOUL.md 는 이미 제자리에 있다(위에서 경로가 바뀌면 옮겼다).★
     //   purpose 필드는 제거됐고(cfe8bf7) persona 값의 유일한 집은 SOUL.md 다.
     //   전달하면 savePersonaFile 이 같은 내용을 다시 써서 무의미한 .bak 만 남는다.

--- a/src/server/lib/hermesBridge.ts
+++ b/src/server/lib/hermesBridge.ts
@@ -12,7 +12,7 @@ import { pick, type Locale } from "./i18n";
 import { teamContextLabel } from "../channels/registry";
 import { isRuntimeFailureOutput, readTurnFailure } from "./runtimeFailureOutput";
 import { appendAuditFile } from "./auditFile";
-import { hermesBinary, HERMES_ROOT, MEMBERS_ROOT } from "./paths";
+import { hermesBinary, HERMES_ROOT, runtimeCwdForAgent } from "./paths";
 
 export interface HermesTurnOptions {
   agent: AgentRecord;
@@ -227,6 +227,7 @@ export const HERMES_TURN_TIMEOUT_MS = Number(process.env.HERMES_TURN_TIMEOUT_MS 
 export async function runHermesTeamTurn(opts: HermesTurnOptions): Promise<string> {
   const cmd = hermesCommand(opts.agent);
   const prompt = buildPrompt(opts);
+  const runtimeCwd = runtimeCwdForAgent(opts.agent);
   // ★턴 상한은 ★한 곳★ 에서만 정한다.★ (GD 2026-07-15: "턴 상한도 한 군데서 수정하게")
   //   예전엔 호출부마다 따로 넘겨서 ★슬랙만 이 기본값(150s)이 그대로 적용★됐다 — 버스·단톡방은
   //   HERMES_TURN_TIMEOUT_MS(300s)를 명시했는데 슬랙(routes/slack.ts)은 안 넘겨서 ★절반★ 이었다.
@@ -242,7 +243,7 @@ export async function runHermesTeamTurn(opts: HermesTurnOptions): Promise<string
   const usagePath = join(tmpdir(), `hermes-usage-${opts.agent.id}-${opts.messageId}-${process.pid}.json`);
   return new Promise((resolve, reject) => {
     const proc = spawn(cmd, ["-z", prompt, "--usage-file", usagePath], {
-      cwd: opts.agent.workspace_path || `${MEMBERS_ROOT}/hermes`,
+      cwd: runtimeCwd,
       // ★팀원의 정체를 ★명시적으로★ 알려준다 — 추측하게 두지 않는다.★ (2026-07-13 실측 사고)
       //
       // ═══ 무슨 일이 있었나 ═══
@@ -259,6 +260,8 @@ export async function runHermesTeamTurn(opts: HermesTurnOptions): Promise<string
         ...process.env,
         GD_AGENT_ID: opts.agent.id,          // 나는 누구인가 (스크립트가 tmux 세션으로 추측하지 않게)
         TEAM_DB_PATH: process.env.TEAM_DB_PATH ?? DB_PATH_FOR_SCRIPTS,
+        TERMINAL_CWD: runtimeCwd,
+        MESSAGING_CWD: runtimeCwd,
       },
     });
     let stdout = "";

--- a/src/server/lib/paths.ts
+++ b/src/server/lib/paths.ts
@@ -49,6 +49,21 @@ export function hermesBinary(agent: Pick<AgentRecord, "id" | "hermes_profile">):
   return agent.hermes_profile ? `${LOCAL_BIN}/${agent.hermes_profile}` : `${LOCAL_BIN}/b3rys${agent.id}`;
 }
 
+/** Expand a machine-local path stored in agents.json/runtime config. */
+export function expandHomePath(path: string): string {
+  if (path === "~") return HOME;
+  if (path.startsWith("~/")) return `${HOME}${path.slice(1)}`;
+  return path;
+}
+
+/** Gateway/CLI working directory for a member. Defaults to workspace_path for backward compatibility. */
+export function runtimeCwdForAgent(agent: Pick<AgentRecord, "id" | "workspace_path" | "runtime_cwd">): string {
+  const configured = agent.runtime_cwd?.trim();
+  if (configured) return expandHomePath(configured);
+  if (agent.workspace_path) return expandHomePath(agent.workspace_path);
+  return `${MEMBERS_ROOT}/${agent.id}`;
+}
+
 /** 공유 openclaw env 파일 경로. OPENCLAW_ENV env override, 기본 = ~/.openclaw/openclaw.env. */
 export function openclawEnvPath(): string {
   return process.env.OPENCLAW_ENV ?? `${OPENCLAW_ROOT}/openclaw.env`;

--- a/src/server/lib/registry.ts
+++ b/src/server/lib/registry.ts
@@ -37,6 +37,7 @@ export function loadRegistry(path: string): AgentRecord[] {
     tmux_session: a.tmux_session ?? null,
     telegram_bot_username: a.telegram_bot_username ?? null,
     workspace_path: String(a.workspace_path),
+    runtime_cwd: typeof a.runtime_cwd === "string" && a.runtime_cwd.trim() ? String(a.runtime_cwd) : null,
     persona_file: String(a.persona_file),
     moderator_eligible: Boolean(a.moderator_eligible),
     avatar_emoji: a.avatar_emoji ?? "🤖",

--- a/src/server/lib/runtimeActivationSafety.test.ts
+++ b/src/server/lib/runtimeActivationSafety.test.ts
@@ -53,4 +53,21 @@ describe("runtime activation safety", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test("Hermes activation expands HERMES_CWD=~/path under bash and zsh", () => {
+    const snippet = [
+      'HOME="/Users/gdmini"',
+      'HERMES_CWD="~/foo"',
+      'case "$HERMES_CWD" in',
+      '  "~/"*) HERMES_CWD="$HOME/${HERMES_CWD#\\~/}" ;;',
+      '  "~") HERMES_CWD="$HOME" ;;',
+      'esac',
+      'printf "%s" "$HERMES_CWD"',
+    ].join("\n");
+    for (const shell of ["bash", "zsh"]) {
+      const run = spawnSync(shell, ["-c", snippet], { encoding: "utf-8" });
+      expect(run.status, `${shell}: ${run.stderr || run.stdout}`).toBe(0);
+      expect(run.stdout).toBe("/Users/gdmini/foo");
+    }
+  });
 });

--- a/src/server/lib/runtimeActivationSafety.test.ts
+++ b/src/server/lib/runtimeActivationSafety.test.ts
@@ -55,19 +55,22 @@ describe("runtime activation safety", () => {
   });
 
   test("Hermes activation expands HERMES_CWD=~/path under bash and zsh", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../runtimes/hermes/activate-hermes-agent.sh"),
+      "utf-8",
+    );
+    const caseBlock = source.match(/case "\$HERMES_CWD" in[\s\S]*?\nesac/)?.[0];
+    expect(caseBlock).toBeDefined();
     const snippet = [
-      'HOME="/Users/gdmini"',
+      'HOME="/home/tester"',
       'HERMES_CWD="~/foo"',
-      'case "$HERMES_CWD" in',
-      '  "~/"*) HERMES_CWD="$HOME/${HERMES_CWD#\\~/}" ;;',
-      '  "~") HERMES_CWD="$HOME" ;;',
-      'esac',
+      caseBlock!,
       'printf "%s" "$HERMES_CWD"',
     ].join("\n");
     for (const shell of ["bash", "zsh"]) {
       const run = spawnSync(shell, ["-c", snippet], { encoding: "utf-8" });
       expect(run.status, `${shell}: ${run.stderr || run.stdout}`).toBe(0);
-      expect(run.stdout).toBe("/Users/gdmini/foo");
+      expect(run.stdout).toBe("/home/tester/foo");
     }
   });
 });

--- a/src/server/lib/runtimeActivationSafety.test.ts
+++ b/src/server/lib/runtimeActivationSafety.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
 
 describe("runtime activation safety", () => {
   test("Hermes reactivation force-corrects stale false TELEGRAM_REQUIRE_MENTION", () => {
@@ -16,5 +18,39 @@ describe("runtime activation safety", () => {
     const source = readFileSync(join(import.meta.dir, "runtimeAuth.ts"), "utf-8");
     expect(source).toContain("openclaw 인증 확인됨(전역 openclaw.json auth.profiles 또는 per-agent auth-profiles.json)");
     expect(source).toContain("openclaw 미인증(전역 openclaw.json auth.profiles가 비어 있고 per-agent auth-profiles.json도 없음)");
+  });
+
+  test("Hermes activation updates terminal.cwd even when backend is between terminal and cwd", () => {
+    const script = readFileSync(
+      join(import.meta.dir, "../runtimes/hermes/activate-hermes-agent.sh"),
+      "utf-8",
+    );
+    const match = script.match(/def _set_terminal_cwd\(src, cwd\):[\s\S]*?\nnew, n = _set_terminal_cwd\(txt, hermes_cwd\)/);
+    expect(match).not.toBeNull();
+
+    const dir = mkdtempSync(join(tmpdir(), "b3os-hermes-cwd-"));
+    try {
+      const input = join(dir, "input.yaml");
+      const output = join(dir, "output.yaml");
+      writeFileSync(
+        input,
+        ["terminal:", "  backend: local", "  cwd: .", "  timeout: 180", "messaging:", "  transport: telegram", ""].join("\n"),
+      );
+      const py = [
+        "import pathlib, re, sys",
+        "txt = pathlib.Path(sys.argv[1]).read_text()",
+        "hermes_cwd = sys.argv[3]",
+        match![0],
+        "assert n == 1, n",
+        "pathlib.Path(sys.argv[2]).write_text(new)",
+      ].join("\n");
+      const run = spawnSync("python3", ["-c", py, input, output, "/Users/gdmini/Development/hermes"], { encoding: "utf-8" });
+      expect(run.status, run.stderr || run.stdout).toBe(0);
+      expect(readFileSync(output, "utf-8")).toBe(
+        ["terminal:", "  backend: local", "  cwd: /Users/gdmini/Development/hermes", "  timeout: 180", "messaging:", "  transport: telegram", ""].join("\n"),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -628,6 +628,23 @@ describe("settings: 팀원 추가/퇴사", () => {
     expect((await app.request("/members/steve", patch({ nicknames: [] }))).status).toBe(200);
     expect(read("steve").nicknames).toBeUndefined();
   });
+  test("PATCH runtime_cwd — Hermes 시작 CWD를 멤버별로 저장·초기화한다", async () => {
+    const { app, registryPath, db } = setup([
+      ...AGENTS,
+      { id: "mes", display_name: "Mes", nicknames: ["mes"], role: "strategy", runtime: "hermes_agent", status_provider: "hermes_gateway", avatar_emoji: "✦", moderator_eligible: false, workspace_path: "/tmp/mes", persona_file: "/tmp/mes/SOUL.md" },
+    ]);
+    const read = () => JSON.parse(readFileSync(registryPath, "utf-8")).find((a: any) => a.id === "mes");
+
+    const saved = await app.request("/members/mes", patch({ runtime_cwd: "~/b3os/members/mes" }));
+    expect(saved.status).toBe(200);
+    expect(read().runtime_cwd).toBe("~/b3os/members/mes");
+    syncRegistry(db, registryPath);
+    expect(listAgents(db).find((a) => a.id === "mes")?.runtime_cwd).toBe("~/b3os/members/mes");
+
+    expect((await app.request("/members/mes", patch({ runtime_cwd: "bad\0path" }))).status).toBe(400);
+    expect((await app.request("/members/mes", patch({ runtime_cwd: null }))).status).toBe(200);
+    expect(read().runtime_cwd).toBeNull();
+  });
   test("중복 id 409", async () => {
     const { app } = setup();
     expect((await app.request("/members", json({ id: "bill", display_name: "X", role: "r" }))).status).toBe(409);

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -128,6 +128,7 @@ const SLACK_APP_ID_RE = /^A[A-Z0-9]{8,}$/;
 const SLACK_BOT_TOKEN_RE = /^xoxb-[A-Za-z0-9-]+$/;
 const SLACK_APP_TOKEN_RE = /^xapp-[A-Za-z0-9-]+$/;
 const SLACK_SECRET_RE = /^[A-Za-z0-9]{24,}$/;
+const RUNTIME_CWD_MAX = 1024;
 // §1 Mission 블록: 헤더 다음부터 "## 2." 직전까지(lookahead 로 다음 절은 소비 안 함).
 // 제목 텍스트는 무관하게 "## 1." 만 매칭 — 운영판("Mission & Identity")·공개 템플릿("정체성 (팀마다 채움)") 양쪽 동작.
 const MISSION_RE = /(## 1\.[^\n]*\n)([\s\S]*?)(?=\n## 2\.)/;
@@ -141,6 +142,17 @@ function setSetting(db: Database, key: string, value: string) {
     "INSERT INTO setting (key, value, updated_at) VALUES (?, ?, datetime('now')) " +
       "ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')",
   ).run(key, value);
+}
+
+function parseRuntimeCwd(value: unknown): { ok: true; value: string | null } | { ok: false; error: string; hint: string } {
+  if (value === null || value === "") return { ok: true, value: null };
+  if (typeof value !== "string") return { ok: false, error: "runtime_cwd_invalid", hint: "문자열 경로여야 합니다" };
+  const path = value.trim();
+  if (!path) return { ok: true, value: null };
+  if (path.length > RUNTIME_CWD_MAX || path.includes("\0")) {
+    return { ok: false, error: "runtime_cwd_invalid", hint: `경로는 ${RUNTIME_CWD_MAX}자 이하이고 NUL 문자를 포함할 수 없습니다` };
+  }
+  return { ok: true, value: path };
 }
 
 // 전체 핵심룰 재적용 롤백 가능 시간(6시간). 지나면 롤백 버튼/엔드포인트가 거부.
@@ -601,10 +613,10 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     return c.json({ ok: true, member: { id, display_name, role, runtime, icon: entry.icon }, note: "봇·tmux·slack 연결은 lifecycle 스킬로 별도 설정" });
   });
 
-  // 아이콘 교체: SVG icon(ICONS 키) 그리고/또는 icon_color(팔레트 키) 갱신(본인 Settings 페이지에서 클릭→선택).
+  // 아이콘/별칭/런타임 CWD 교체: 가벼운 agents.json 필드 업데이트.
   app.patch("/members/:id", async (c) => {
     const id = c.req.param("id");
-    let body: { icon?: unknown; icon_color?: unknown; nicknames?: unknown };
+    let body: { icon?: unknown; icon_color?: unknown; nicknames?: unknown; runtime_cwd?: unknown };
     try {
       body = await c.req.json();
     } catch {
@@ -613,7 +625,8 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     const hasIcon = body.icon !== undefined;
     const hasColor = body.icon_color !== undefined;
     const hasNicks = body.nicknames !== undefined;
-    if (!hasIcon && !hasColor && !hasNicks) return c.json({ error: "no_change" }, 400);
+    const hasRuntimeCwd = body.runtime_cwd !== undefined;
+    if (!hasIcon && !hasColor && !hasNicks && !hasRuntimeCwd) return c.json({ error: "no_change" }, 400);
 
     const icon = typeof body.icon === "string" ? body.icon.trim() : "";
     if (hasIcon && !ICON_RE.test(icon)) return c.json({ error: "icon_invalid" }, 400);
@@ -633,6 +646,9 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
       if (nicknames.length > 8) return c.json({ error: "nicknames_invalid", hint: "최대 8개" }, 400);
     }
 
+    const runtimeCwd = hasRuntimeCwd ? parseRuntimeCwd(body.runtime_cwd) : null;
+    if (runtimeCwd?.ok === false) return c.json({ error: runtimeCwd.error, hint: runtimeCwd.hint }, 400);
+
     let list: any[];
     try {
       list = readAgents();
@@ -644,13 +660,14 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     if (hasIcon) target.icon = icon;
     if (hasColor) target.icon_color = iconColor;
     if (hasNicks) target.nicknames = nicknames.length ? nicknames : undefined;
+    if (runtimeCwd?.ok) target.runtime_cwd = runtimeCwd.value;
     try {
       writeAgents(list);
     } catch (e) {
       return c.json({ error: "write_failed", detail: e instanceof Error ? e.message : String(e) }, 500);
     }
-    appendAudit(db, "user", "member_icon_updated", id, { ...(hasIcon ? { icon } : {}), ...(hasColor ? { icon_color: iconColor } : {}), ...(hasNicks ? { nicknames } : {}) });
-    return c.json({ ok: true, id, ...(hasIcon ? { icon } : {}), ...(hasColor ? { icon_color: iconColor } : {}), ...(hasNicks ? { nicknames } : {}) });
+    appendAudit(db, "user", "member_config_updated", id, { ...(hasIcon ? { icon } : {}), ...(hasColor ? { icon_color: iconColor } : {}), ...(hasNicks ? { nicknames } : {}), ...(runtimeCwd?.ok ? { runtime_cwd: runtimeCwd.value } : {}) });
+    return c.json({ ok: true, id, ...(hasIcon ? { icon } : {}), ...(hasColor ? { icon_color: iconColor } : {}), ...(hasNicks ? { nicknames } : {}), ...(runtimeCwd?.ok ? { runtime_cwd: runtimeCwd.value } : {}) });
   });
 
   // 퇴사: confirm_name 이 display_name 과 정확히 일치해야 진행(오발 방지).

--- a/src/server/runtimes/hermes/activate-hermes-agent.sh
+++ b/src/server/runtimes/hermes/activate-hermes-agent.sh
@@ -183,8 +183,46 @@ if not os.path.exists(cfgp):
 txt = open(cfgp).read()
 changes = []
 # config.yaml 은 한글을 \uXXXX 로 저장 → 영문 리터럴을 타겟해야 escape 무관하게 매칭됨(2026-06-11).
-# (a) cwd → 이 에이전트 workspace
-new, n = re.subn(r"(terminal:\s*\n\s*cwd:\s*).*", r"\g<1>" + hermes_cwd, txt, count=1)
+# (a) cwd → Hermes 실행 CWD. terminal: 바로 아래에 cwd가 있다는 인접 가정은 금지한다
+#     (예: backend/timeout 이 사이에 있으면 기존 정규식은 n=0 이었다).
+def _set_terminal_cwd(src, cwd):
+    lines = src.splitlines()
+    keep_newline = src.endswith("\n")
+
+    def indent_of(line):
+        return len(line) - len(line.lstrip(" "))
+
+    terminal_idx = None
+    terminal_indent = 0
+    for i, line in enumerate(lines):
+        m = re.match(r"^(\s*)terminal:\s*(?:#.*)?$", line)
+        if m:
+            terminal_idx = i
+            terminal_indent = len(m.group(1))
+            break
+    if terminal_idx is None:
+        return src, 0
+
+    end = len(lines)
+    for i in range(terminal_idx + 1, len(lines)):
+        stripped = lines[i].strip()
+        if stripped and not stripped.startswith("#") and indent_of(lines[i]) <= terminal_indent:
+            end = i
+            break
+
+    child_indent = " " * (terminal_indent + 2)
+    for i in range(terminal_idx + 1, end):
+        m = re.match(r"^(\s*)cwd:\s*.*$", lines[i])
+        if m and len(m.group(1)) > terminal_indent:
+            lines[i] = f"{m.group(1)}cwd: {cwd}"
+            out = "\n".join(lines) + ("\n" if keep_newline else "")
+            return out, 1
+
+    lines.insert(terminal_idx + 1, f"{child_indent}cwd: {cwd}")
+    out = "\n".join(lines) + ("\n" if keep_newline else "")
+    return out, 1
+
+new, n = _set_terminal_cwd(txt, hermes_cwd)
 if n: txt = new; changes.append("cwd")
 # (b) 자기 멘션: @(?:<원본이름>|hermes) → @(?:ko|aid)  자기 이름에만 응답
 new, n = re.subn(r"@\(\?:[^)]*\|hermes\)", f"@(?:{ko}|{aid})", txt)

--- a/src/server/runtimes/hermes/activate-hermes-agent.sh
+++ b/src/server/runtimes/hermes/activate-hermes-agent.sh
@@ -16,6 +16,11 @@ DISPLAY="${DISPLAY:-$(echo "$AGENT_ID" | tr '[:lower:]' '[:upper:]')}"   # ${var
 KO="${KO:-$AGENT_ID}"                     # 한글 멘션 별칭 (예: 별칭)
 DESC="${DESC:-b3rys 팀원 ($AGENT_ID)}"
 WS="${WS:-$HOME/Development/$AGENT_ID}"
+HERMES_CWD="${HERMES_CWD:-$WS}"
+case "$HERMES_CWD" in
+  "~/"*) HERMES_CWD="$HOME/${HERMES_CWD#~/}" ;;
+  "~") HERMES_CWD="$HOME" ;;
+esac
 TOKEN_FILE="${TOKEN_FILE:-$HOME/.hermes/credentials/$AGENT_ID-token.txt}"
 PROF_DIR="$HOME/.hermes/profiles/$AGENT_ID"
 HERMES_BASE_PROFILE="${HERMES_BASE_PROFILE:-b3os}"
@@ -162,9 +167,9 @@ say "■ 3) config.yaml — 멘션 별칭(=$KO/$AGENT_ID) + cwd + Telegram UX �
 #   팀마다 다르므로 env HERMES_EXCLUDE_ANCHOR 로 지정(예: 마지막 멤버 id). 미지정이면 (c) 스킵 —
 #   (b)에서 이미 멘션 패턴을 자기 이름으로 좁히므로 안전(제외 목록은 belt-and-suspenders).
 HERMES_EXCLUDE_ANCHOR="${HERMES_EXCLUDE_ANCHOR:-}"
-python3 - "$PROF_DIR" "$AGENT_ID" "$KO" "$WS" "$HERMES_EXCLUDE_ANCHOR" <<'PY'
+python3 - "$PROF_DIR" "$AGENT_ID" "$KO" "$WS" "$HERMES_CWD" "$HERMES_EXCLUDE_ANCHOR" <<'PY'
 import sys, os, re
-prof, aid, ko, ws, anchor = sys.argv[1:6]
+prof, aid, ko, ws, hermes_cwd, anchor = sys.argv[1:7]
 # ★hermes 버전드리프트(BUG8b, OWNER 2026-07-03): v0.17.0은 프로필별 config.yaml, v0.18.0+는 profile.yaml 을 쓴다.
 #   config.yaml 있으면(구버전) 그걸, 없으면 profile.yaml(신버전) 을 편집 = 두 버전 커버(라이브 v0.17.0 동작 불변).
 #   둘 다 없으면 예전엔 여기서 FileNotFoundError→exit1 로 activate 전체가 죽었다 → graceful skip 으로 바꿔 활성화는 계속.
@@ -179,7 +184,7 @@ txt = open(cfgp).read()
 changes = []
 # config.yaml 은 한글을 \uXXXX 로 저장 → 영문 리터럴을 타겟해야 escape 무관하게 매칭됨(2026-06-11).
 # (a) cwd → 이 에이전트 workspace
-new, n = re.subn(r"(terminal:\s*\n\s*cwd:\s*).*", r"\g<1>" + ws, txt, count=1)
+new, n = re.subn(r"(terminal:\s*\n\s*cwd:\s*).*", r"\g<1>" + hermes_cwd, txt, count=1)
 if n: txt = new; changes.append("cwd")
 # (b) 자기 멘션: @(?:<원본이름>|hermes) → @(?:ko|aid)  자기 이름에만 응답
 new, n = re.subn(r"@\(\?:[^)]*\|hermes\)", f"@(?:{ko}|{aid})", txt)

--- a/src/server/runtimes/hermes/activate-hermes-agent.sh
+++ b/src/server/runtimes/hermes/activate-hermes-agent.sh
@@ -18,7 +18,7 @@ DESC="${DESC:-b3rys 팀원 ($AGENT_ID)}"
 WS="${WS:-$HOME/Development/$AGENT_ID}"
 HERMES_CWD="${HERMES_CWD:-$WS}"
 case "$HERMES_CWD" in
-  "~/"*) HERMES_CWD="$HOME/${HERMES_CWD#~/}" ;;
+  "~/"*) HERMES_CWD="$HOME/${HERMES_CWD#\~/}" ;;
   "~") HERMES_CWD="$HOME" ;;
 esac
 TOKEN_FILE="${TOKEN_FILE:-$HOME/.hermes/credentials/$AGENT_ID-token.txt}"

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -29,6 +29,8 @@ export interface AgentRecord {
   tmux_session: string | null;
   telegram_bot_username: string | null;
   workspace_path: string;
+  /** Optional machine-local runtime launch CWD. Defaults to workspace_path. */
+  runtime_cwd?: string | null;
   persona_file: string;
   moderator_eligible: boolean;
   avatar_emoji: string;

--- a/src/web/components/AgentConfig.ts
+++ b/src/web/components/AgentConfig.ts
@@ -25,6 +25,7 @@ interface ConfigResponse {
     slack_bot_user_id?: string | null;
     slack_app_name?: string | null;
     openclaw_agent_id?: string | null;
+    runtime_cwd?: string | null;
   };
   persona: { path: string; content: string | null; exists: boolean; bytes: number };
   custom_persona?: string | null; // 편집기 pre-fill용 커스텀 블록(룰 섹션 제거·추출) — 파일 통짜 대신 이걸 편집
@@ -91,6 +92,7 @@ const REGISTRY_FIELDS: Array<[string, (a: ConfigResponse["agent"]) => string]> =
   ["tmux_session", (a) => a.tmux_session ?? "—"],
   ["telegram_bot", (a) => a.telegram_bot_username ?? "—"],
   ["workspace_path", (a) => a.workspace_path],
+  ["runtime_cwd", (a) => a.runtime_cwd ?? "—"],
   ["persona_file", (a) => a.persona_file],
   ["slack_bot_user_id", (a) => a.slack_bot_user_id ?? "—"],
   ["openclaw_agent_id", (a) => a.openclaw_agent_id ?? "—"],
@@ -170,6 +172,18 @@ function renderInto(root: HTMLElement, data: ConfigResponse, reload: () => void,
       </tr>`;
 
   const personaContent = persona.content ?? "";
+  const runtimeCwdSection = agent.runtime === "hermes_agent" ? `
+        <div class="mt-6 mb-6 rounded-lg border border-txt-blue/25 bg-txt-blue/5 p-3">
+          <div class="text-xs font-semibold uppercase tracking-widest text-txt-blue/80 mb-2">${pick("Hermes CWD", "Hermes CWD")}</div>
+          <div class="text-[12px] text-slate-400 mb-2">${pick("Hermes가 시작/응답할 작업 폴더입니다. 비우면 workspace_path를 씁니다. AGENTS.md를 읽게 하려면 팀원 폴더로 맞추세요.", "Working directory for Hermes startup/turns. Empty uses workspace_path. Set it to the member folder so AGENTS.md is loaded.")}</div>
+          <div class="flex items-center gap-2 flex-wrap">
+            <input id="cfg-runtime-cwd" value="${escape(agent.runtime_cwd ?? "")}" spellcheck="false" autocomplete="off"
+              class="flex-1 min-w-[260px] bg-surface-0 border border-surface-3 rounded-md px-3 py-2 text-sm text-slate-100 focus:outline-none focus:border-txt-blue/50 font-mono"
+              placeholder="${escape(agent.workspace_path)}" />
+            <button id="cfg-runtime-cwd-save" class="inline-flex items-center gap-1.5 px-3 py-2 rounded-md border border-slate-400/40 bg-surface-3 text-txt-blue text-sm font-medium hover:bg-surface-0 hover:border-txt-blue/50">${renderIcon("save", { size: 13, className: "shrink-0" })}${pick("CWD 저장", "Save CWD")}</button>
+          </div>
+          <div id="cfg-runtime-cwd-msg" class="text-[11px] text-slate-500 mt-1.5"></div>
+        </div>` : "";
   // 런타임 교체 select 옵션 — 서버 화이트리스트(SWAP_TARGETS)와 교집합 + 현재 런타임 제외 + 공개빌드 b3os_native 숨김.
   // 공개빌드에선 아래 '런타임 교체' 섹션 전체를 렌더하지 않는다(LIVE_ONLY_OPS=false) — 공개판은 UI에서만 swap 숨김(GD 0721). 서버 엔드포인트는 유지되며 codex target·미준비는 publicRuntimeGate/runtime_not_ready 가 막는다.
   const swapTargetOptions = runtimeOptions
@@ -188,6 +202,7 @@ function renderInto(root: HTMLElement, data: ConfigResponse, reload: () => void,
       <div class="p-4">
         <div class="text-xs font-semibold uppercase tracking-widest text-slate-500 mb-2">${pick("레지스트리 (agents.json · icon만 변경 가능)", "Registry (agents.json · icon only)")}</div>
         <table class="w-full text-xs mb-6"><tbody>${rows}${iconRow}</tbody></table>
+        ${runtimeCwdSection}
 
         <div class="flex items-center justify-between mb-2">
           <div class="text-xs font-semibold uppercase tracking-widest text-slate-500">${pick("역할 · 페르소나 (agents.json)", "Role · Persona (agents.json)")}</div>
@@ -302,11 +317,40 @@ function renderInto(root: HTMLElement, data: ConfigResponse, reload: () => void,
   const resetBtn = root.querySelector<HTMLButtonElement>("#cfg-reset");
   const statusEl = root.querySelector<HTMLElement>("#cfg-save-status");
   const originalProfile = { role: agent.role ?? "", persona: customPersona };
+  const runtimeCwdInput = root.querySelector<HTMLInputElement>("#cfg-runtime-cwd");
+  const runtimeCwdSave = root.querySelector<HTMLButtonElement>("#cfg-runtime-cwd-save");
+  const runtimeCwdMsg = root.querySelector<HTMLElement>("#cfg-runtime-cwd-msg");
   const updateLocalIcon = (patch: { icon?: string | null; icon_color?: string | null }) => {
     Object.assign(agent, patch);
     const st = store.getState();
     st.setAgents(st.agents.map((a) => (a.id === agent.id ? { ...a, ...patch } : a)));
   };
+
+  runtimeCwdSave?.addEventListener("click", async () => {
+    const value = runtimeCwdInput?.value.trim() ?? "";
+    const _busy = setBtnBusy(runtimeCwdSave, pick("저장 중…", "Saving…"));
+    if (runtimeCwdMsg) { runtimeCwdMsg.textContent = pick("CWD 저장 중…", "Saving CWD…"); runtimeCwdMsg.className = "text-[11px] text-slate-400 mt-1.5"; }
+    try {
+      const res = await fetch(`${apiBase()}/api/members/${encodeURIComponent(agent.id)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ runtime_cwd: value || null }),
+      });
+      const j = (await res.json().catch(() => ({}))) as { ok?: boolean; runtime_cwd?: string | null; error?: string; hint?: string };
+      if (!res.ok || !j.ok) {
+        if (runtimeCwdMsg) { runtimeCwdMsg.textContent = `✗ ${j.hint ?? j.error ?? res.status}`; runtimeCwdMsg.className = "text-[11px] text-status-blocked mt-1.5"; }
+        return;
+      }
+      agent.runtime_cwd = j.runtime_cwd ?? null;
+      const st = store.getState();
+      st.setAgents(st.agents.map((a) => (a.id === agent.id ? { ...a, runtime_cwd: agent.runtime_cwd } : a)));
+      if (runtimeCwdMsg) { runtimeCwdMsg.textContent = pick("✓ 저장됨 — 다음 Hermes 재시작/턴부터 적용", "✓ Saved — applies from the next Hermes restart/turn"); runtimeCwdMsg.className = "text-[11px] text-accent-greenSoft mt-1.5"; }
+    } catch (e) {
+      if (runtimeCwdMsg) { runtimeCwdMsg.textContent = pick("실패: ", "Failed: ") + (e as Error).message; runtimeCwdMsg.className = "text-[11px] text-status-blocked mt-1.5"; }
+    } finally {
+      _busy();
+    }
+  });
 
   resetBtn?.addEventListener("click", () => {
     if (roleInput) roleInput.value = originalProfile.role;

--- a/src/web/store.ts
+++ b/src/web/store.ts
@@ -15,6 +15,7 @@ export interface Agent {
   tmux_session: string | null;
   telegram_bot_username: string | null;
   workspace_path: string;
+  runtime_cwd?: string | null;
   persona_file: string;
   moderator_eligible: boolean;
   avatar_emoji: string;


### PR DESCRIPTION
## Summary
- Add per-member runtime_cwd for Hermes runtime CWD with workspace_path fallback.
- Add Settings UI control for Hermes members to save/reset runtime_cwd.
- Pass HERMES_CWD into Hermes activation and spawn paths.
- Fix activation config rewrite to update terminal.cwd by terminal block scope, not adjacent regex, so layouts like terminal.backend before cwd are handled.

## Test Plan
- bun test src/server/lib/runtimeActivationSafety.test.ts
- bun test src/server/routes/settings.test.ts
- bun run typecheck
- bun test (1695 pass / 5 skip / 6 fail; failures are pre-existing/unrelated in uninstallLaunchdSafety.test.ts and teamRouter.test.ts broadcast marker expectations, outside this diff)

## Notes / unverified scope
- Existing Hermes profiles need reactivation before profile config cwd changes on disk.
- runtime_cwd is Hermes-scoped in UI; runtime_cwd empty/null falls back to workspace_path.
- Existing DB migration path is covered by idempotent ALTER TABLE agent ADD COLUMN runtime_cwd in migrate.ts, but not yet validated on every live machine.
