### PR TITLE
feat(bus): 체인 한도 6→8 (GD 결정)

### DIFF
--- a/src/server/bus/antiPingpong.ts
+++ b/src/server/bus/antiPingpong.ts
@@ -3,7 +3,7 @@
  *
  * Prevents bot↔bot infinite loops by counting automatic agent rounds in a
  * message chain (via parent_message_id) and blocking dispatch when the count
- * exceeds BUS_MAX_AUTO_ROUNDS (default 6).
+ * exceeds BUS_MAX_AUTO_ROUNDS (default 8).
  *
  * 2026-06-04: default 2→6. max=2 는 1 round-trip(Q→A) 후 후속을 막아서,
  * GD 가 지시한 정당한 다단계 기술 협의(질문→답→재질문→답…)까지 dispatch_blocked
@@ -19,7 +19,12 @@ import type { Database } from "bun:sqlite";
 import type { PendingDispatchRow } from "./types";
 import { countAutoRounds } from "../db/inboxQueries";
 
-export const MAX_AUTO_ROUNDS = Number(process.env.BUS_MAX_AUTO_ROUNDS ?? 6);
+// 2026-07-27: 기본 6→8 (GD 결정). ★홉 이중증가 수정(#86)이 배포된 뒤에 올렸다★ —
+//   그 전엔 홉이 메시지당 2씩 올라 실효 한도가 8메시지였고, 체인을 먼저 올리면 ★홉이 먼저 걸려★
+//   체인 상향이 아무 효과가 없었다. 순서를 지켜야 계산이 맞는다.
+//   실측 근거: 어제 스티브의 정당한 리뷰 왕복이 6에서 끊겼다(dispatch_blocked).
+//   8 = 4 round-trip. 진짜 runaway 는 여전히 8에서 bounded 다.
+export const MAX_AUTO_ROUNDS = Number(process.env.BUS_MAX_AUTO_ROUNDS ?? 8);
 
 // Agents registered in agents.json at runtime (passed in by dispatcher)
 export type AgentRoster = ReadonlySet<string>;

--- a/src/server/bus/blockNotice.test.ts
+++ b/src/server/bus/blockNotice.test.ts
@@ -17,7 +17,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { migrate } from "../db/migrate";
 import { insertMessage } from "../db/inboxQueries";
-import { checkPingpong } from "./antiPingpong";
+import { checkPingpong, MAX_AUTO_ROUNDS } from "./antiPingpong";
 import { notifySenderOfBlock } from "./wakeDispatcher";
 import type { PendingDispatchRow } from "./types";
 import type { AgentRecord } from "../types";
@@ -65,9 +65,11 @@ function row(over: Partial<PendingDispatchRow>): PendingDispatchRow {
 }
 
 describe("★차단 통보 — 실제로 막히고, 실제로 통보가 나가고, 그 통보는 안 막힌다★", () => {
-  test("① 6왕복 넘으면 실제로 차단된다 (전제 확인)", () => {
+  // ★한도를 하드코딩하지 않는다★ — 6 을 박아뒀더니 기본값이 8 로 바뀔 때 이 테스트가 깨졌다(2026-07-27).
+  //   검증하려는 건 "한도를 넘으면 막힌다" 이지 "6에서 막힌다" 가 아니다. 상수를 따라가게 한다.
+  test(`① 한도(${MAX_AUTO_ROUNDS})를 넘으면 실제로 차단된다 (전제 확인)`, () => {
     const db = freshDb();
-    const parent = buildChain(db, 6);
+    const parent = buildChain(db, MAX_AUTO_ROUNDS);
     const v = checkPingpong(db, row({ parent_message_id: parent }), ROSTER);
     expect(v.allowed).toBe(false);
     expect(v.reason).toContain("pingpong_limit_exceeded");
@@ -75,9 +77,9 @@ describe("★차단 통보 — 실제로 막히고, 실제로 통보가 나가�
 
   test("② 차단되면 ★발신자에게★ 통보가 실제로 들어간다", () => {
     const db = freshDb();
-    const parent = buildChain(db, 6);
+    const parent = buildChain(db, MAX_AUTO_ROUNDS);
     const blocked = row({ parent_message_id: parent, message_id: "m-blocked" });
-    notifySenderOfBlock(db, blocked, AGENTS, "pingpong_limit_exceeded:rounds=6,max=6");
+    notifySenderOfBlock(db, blocked, AGENTS, `pingpong_limit_exceeded:rounds=${MAX_AUTO_ROUNDS},max=${MAX_AUTO_ROUNDS}`);
 
     const n = db.query("SELECT * FROM message WHERE from_agent_id='system' ORDER BY rowid DESC LIMIT 1").get() as any;
     expect(n).toBeTruthy();
@@ -89,8 +91,8 @@ describe("★차단 통보 — 실제로 막히고, 실제로 통보가 나가�
 
   test("③ ★그 통보 자체는 같은 가드에 안 걸린다★ — 이게 핵심이다", () => {
     const db = freshDb();
-    const parent = buildChain(db, 6);
-    notifySenderOfBlock(db, row({ parent_message_id: parent }), AGENTS, "pingpong_limit_exceeded:rounds=6,max=6");
+    const parent = buildChain(db, MAX_AUTO_ROUNDS);
+    notifySenderOfBlock(db, row({ parent_message_id: parent }), AGENTS, `pingpong_limit_exceeded:rounds=${MAX_AUTO_ROUNDS},max=${MAX_AUTO_ROUNDS}`);
     const n = db.query("SELECT * FROM message WHERE from_agent_id='system' ORDER BY rowid DESC LIMIT 1").get() as any;
 
     // ★체인 밖★ — parent 가 없어야 한다. 있으면 통보가 통보를 막는다.
@@ -114,10 +116,10 @@ describe("★차단 통보 — 실제로 막히고, 실제로 통보가 나가�
 
   test("⑤ 같은 차단으로 두 번 알리지 않는다 (dedupe)", () => {
     const db = freshDb();
-    const parent = buildChain(db, 6);
+    const parent = buildChain(db, MAX_AUTO_ROUNDS);
     const r = row({ parent_message_id: parent, message_id: "m-dup" });
-    notifySenderOfBlock(db, r, AGENTS, "pingpong_limit_exceeded:rounds=6,max=6");
-    notifySenderOfBlock(db, r, AGENTS, "pingpong_limit_exceeded:rounds=6,max=6");
+    notifySenderOfBlock(db, r, AGENTS, `pingpong_limit_exceeded:rounds=${MAX_AUTO_ROUNDS},max=${MAX_AUTO_ROUNDS}`);
+    notifySenderOfBlock(db, r, AGENTS, `pingpong_limit_exceeded:rounds=${MAX_AUTO_ROUNDS},max=${MAX_AUTO_ROUNDS}`);
     const cnt = db.query("SELECT COUNT(*) c FROM message WHERE from_agent_id='system'").get() as any;
     expect(cnt.c).toBe(1);
   });


### PR DESCRIPTION
■ 배경
어제 스티브의 ★정당한 리뷰 왕복이 6에서 끊겼다★(dispatch_blocked). 8 = 4 round-trip 허용.
진짜 runaway 는 여전히 8에서 bounded 다.

■ ★순서를 지켰다★
홉 이중증가 수정(#86)이 ★배포·실측된 뒤★ 에 올린다.
그 전엔 홉이 메시지당 2씩 올라 실효 한도가 8메시지였고, ★체인을 먼저 올리면 홉이 먼저 걸려★
체인 상향이 아무 효과가 없었다. #86 배포 후 실측(0→1) 으로 홉이 1씩 오르는 것을 확인했다.

■ 같이 고친 것 — ★내 테스트가 한도를 하드코딩하고 있었다★
`blockNotice.test.ts`(내가 #75 에서 쓴 것)가 `buildChain(db, 6)` 처럼 ★6 을 박아뒀다.★
기본값을 8로 올리자 그 전제가 깨져 실패했다. ★검증하려는 건 "한도를 넘으면 막힌다" 이지
"6에서 막힌다" 가 아니다.★ MAX_AUTO_ROUNDS 를 따라가게 바꿨다 — 다음에 또 조정해도 안 깨진다.

■ 검증
· 1708 pass / 0 fail · tsc 0
· 환경변수 override(BUS_MAX_AUTO_ROUNDS)는 그대로 — 기본값만 바뀐다

■ 미검증
라이브에서 7~8왕복이 실제로 통과하는지는 ★배포 후 확인★ 이다. 지금은 유닛까지다.