### PR TITLE
fix(web): Slack 마법사에 이벤트 구독 켜는 단계 추가 (안내에 아예 없었다)

### DIFF
--- a/src/web/components/AgentSlack.test.ts
+++ b/src/web/components/AgentSlack.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { socketManifest, webhookBlockedNotice } from "./AgentSlack";
+import { socketManifest, webhookBlockedNotice, wizardSteps } from "./AgentSlack";
 
 /* 2026-07-26: 공개 URL 이 없을 때 서버가 event_subscriptions 를 통째로 빼도록 고쳤더니, Socket 매니페스트에
  * ★app_mention 구독이 사라졌다.★ 그러면 사용자는 앱을 만들 수는 있는데 ★봇이 멘션에 반응하지 않는다.★
@@ -92,5 +92,84 @@ describe("webhookBlockedNotice — 실행 가능한 행동만 안내한다", () 
   test("Socket 모드는 공개 URL 과 무관하게 막지 않는다", () => {
     expect(webhookBlockedNotice("socket", null)).toBeNull();
     expect(webhookBlockedNotice("socket", "https://x.test/e")).toBeNull();
+  });
+});
+
+/* ★안내에서 '이벤트 구독 켜기' 단계가 통째로 빠져 있었다★ (2026-07-27 GD 실측 — 리사 앱을 만들다 헤맸다).
+ * 매니페스트에는 app_mention 이 들어 있다. 그런데 ★매니페스트에 있다는 것과 그 앱에서 켜져 있다는 것은 다르다★ —
+ * GD 는 Slack 화면에서 직접 Enable Events 토글을 올려야 했다. 꺼져 있으면 ★봇이 멘션을 무시하고 오류도 안 난다.★
+ * 오늘 하루 반복된 형태 그대로다: 있는데 도달하지 못한다. 그래서 ★안내 문구 자체를 회귀로 고정한다.★ */
+describe("wizardSteps — 이벤트 구독 켜는 단계가 반드시 있다", () => {
+  const opts = { appLink: "<a>apps</a>", scopes: "app_mentions:read, chat:write", channel: "#team", eventUrl: "https://x.test/team/api/slack/events" };
+  const joined = (isSocket: boolean) => wizardSteps({ ...opts, isSocket }).join("\n");
+
+  for (const isSocket of [true, false]) {
+    const label = isSocket ? "Socket Mode" : "Event URL";
+
+    test(`★${label}: Enable Events → app_mention → Save 순서가 안내된다★`, () => {
+      const s = joined(isSocket);
+      expect(s).toContain("Enable Events");          // ← 토글을 켜라는 말이 없으면 사용자는 못 찾는다
+      expect(s).toContain("Subscribe to bot events");
+      expect(s).toContain("app_mention");
+      expect(s).toContain("Save Changes");           // ← 저장 안 하면 위를 다 해도 적용 안 된다
+    });
+
+    test(`${label}: 단계는 앱 생성 → 이벤트 구독 순서다 (앱이 없으면 켤 화면이 없다)`, () => {
+      const steps = wizardSteps({ ...opts, isSocket });
+      const created = steps.findIndex((x) => x.includes("From a manifest"));
+      const events = steps.findIndex((x) => x.includes("Enable Events"));
+      expect(created).toBeGreaterThanOrEqual(0);
+      expect(events).toBeGreaterThan(created);
+    });
+
+    test(`${label}: 채널 초대·토큰 복사 단계는 그대로 남아 있다 (단계 추가가 기존 안내를 밀어내지 않는다)`, () => {
+      const s = joined(isSocket);
+      expect(s).toContain("/invite");
+      expect(s).toContain("xoxb");
+    });
+  }
+
+  test("Socket 방식만 App-Level Token(xapp) 단계를 안내한다", () => {
+    expect(joined(true)).toContain("xapp");
+    expect(joined(false)).not.toContain("xapp");
+  });
+
+  test("Event URL 방식은 Request URL 등록 단계를 유지한다", () => {
+    expect(joined(false)).toContain("Request URL");
+  });
+});
+
+/* ★단계를 추가하면서 순서를 틀릴 뻔했다★ — 처음엔 'Enable Events' 를 2번, 'Request URL 등록' 을 마지막 6번에
+ * 뒀다. 그런데 Event URL 방식은 Enable Events 를 켜는 순간 Slack 이 ★Request URL 검증부터★ 요구한다.
+ * 그 순서면 사용자는 2번에서 저장을 못 하고 막힌 채 6번을 못 본다 — ★고치려던 것과 똑같은 막다른 안내★ 다.
+ * 그래서 한 단계로 합쳤고, 여기서 그걸 고정한다. */
+describe("wizardSteps — Event URL 방식은 URL 검증이 구독 저장보다 먼저다", () => {
+  const base = { appLink: "<a>apps</a>", scopes: "chat:write", channel: "#team" };
+  const url = "https://x.test/team/api/slack/events";
+
+  test("★Enable Events 와 Request URL 은 같은 단계다★ (쪼개면 저장에서 막힌다)", () => {
+    const steps = wizardSteps({ ...base, isSocket: false, eventUrl: url });
+    const step = steps.find((s) => s.includes("Enable Events"));
+    expect(step).toBeTruthy();
+    expect(step).toContain("Request URL");
+    expect(step).toContain(url);                       // 값까지 그 자리에 있어야 복붙으로 끝난다
+    expect(step!.indexOf("Request URL")).toBeLessThan(step!.indexOf("Save Changes"));
+  });
+
+  test("Request URL 안내는 한 번만 나온다 (중복 단계가 남아 있지 않다)", () => {
+    const steps = wizardSteps({ ...base, isSocket: false, eventUrl: url });
+    expect(steps.filter((s) => s.includes("Request URL")).length).toBe(1);
+  });
+
+  test("공개 URL 이 아직 없으면 값 대신 어디서 찾는지 안내한다", () => {
+    const step = wizardSteps({ ...base, isSocket: false, eventUrl: null }).find((s) => s.includes("Enable Events"));
+    expect(step).toContain("Event URL");
+    expect(step).not.toContain("null");                 // ★빈 값을 그대로 그리지 않는다★
+  });
+
+  test("★Socket 방식엔 Request URL 이 아예 안 나온다★ (없는 걸 시키면 막다른 안내다)", () => {
+    const steps = wizardSteps({ ...base, isSocket: true, eventUrl: url });
+    expect(steps.join("\n")).toContain("Enable Events");
+    expect(steps.join("\n")).not.toContain("Request URL");
   });
 });

--- a/src/web/components/AgentSlack.ts
+++ b/src/web/components/AgentSlack.ts
@@ -95,6 +95,66 @@ export function webhookBlockedNotice(mode: "webhook" | "socket", eventRequestUrl
   );
 }
 
+// ★이벤트 구독을 켜는 단계가 안내에 아예 없었다★ (2026-07-27 GD 실측 — 리사 앱을 만들다 여기서 헤맸다).
+// 매니페스트에는 event_subscriptions.bot_events=["app_mention"] 이 들어 있다. 그런데 ★그게 들어 있다는 것과
+// 그 앱에서 실제로 켜져 있다는 것은 다르다★ — 실제로 GD 는 Slack 화면에서 직접 토글을 올려야 했다.
+// 이게 꺼져 있으면 ★봇은 멘션에 아무 반응을 하지 않는다. 오류도 안 난다.★ 사용자는 "봇이 무시한다" 로만 본다.
+// 그래서 매니페스트를 믿지 말고 ★눈으로 확인하는 단계★ 를 안내에 넣는다(양쪽 방식 공통).
+//
+// ★단, 두 방식의 순서가 다르다.★ Event URL 방식은 Enable Events 를 켜는 순간 Slack 이 ★Request URL 검증부터★
+// 요구한다 — URL 등록을 별도 단계로 뒤에 두면 사용자는 여기서 저장을 못 하고 막힌다. Socket 은 URL 자체가 없다.
+// 그래서 한 단계 안에서 방식에 맞는 순서로 안내한다(쪼개지 않는다).
+export function enableEventsStep(isSocket: boolean, eventUrl: string | null): string {
+  const urlPart = isSocket
+    ? ""
+    : pick(
+        ` → <b>Request URL</b> 에 ${eventUrl ? `<code>${esc(eventUrl)}</code>` : pick("아래 Event URL 값", "the Event URL below")} 입력 → <b>Verified</b> 확인`,
+        ` → set <b>Request URL</b> to ${eventUrl ? `<code>${esc(eventUrl)}</code>` : "the Event URL below"} → wait for <b>Verified</b>`);
+  return pick(
+    `<b>Event Subscriptions</b> → <b>Enable Events</b> 토글 <b>ON</b>${urlPart} → 아래로 내려 <b>Subscribe to bot events</b> → <b>Add Bot User Event</b> → <code>app_mention</code> 추가 → <b>Save Changes</b>. <span class="text-slate-500">(매니페스트에 이미 있어도 실제로 켜져 있는지 확인하세요 — 꺼져 있으면 봇이 멘션에 반응하지 않고 오류도 나지 않습니다)</span>`,
+    `<b>Event Subscriptions</b> → turn <b>Enable Events</b> <b>ON</b>${urlPart} → scroll down to <b>Subscribe to bot events</b> → <b>Add Bot User Event</b> → add <code>app_mention</code> → <b>Save Changes</b>. <span class="text-slate-500">(it is already in the manifest, but confirm it is actually on — if it is off the bot ignores mentions and no error is shown)</span>`,
+  );
+}
+
+/** 마법사의 사람 단계 목록. 렌더에서 분리해 ★안내 내용 자체를 테스트할 수 있게★ 한다
+ *  (빠진 단계는 화면을 봐야만 드러났다 — 그래서 회귀로 고정한다). */
+export function wizardSteps(opts: { isSocket: boolean; appLink: string; scopes: string; channel: string; eventUrl: string | null }): string[] {
+  const { isSocket, appLink, scopes, channel, eventUrl } = opts;
+  const inviteStep = pick(
+    `봇을 <b>${channel ? esc(channel) : pick("사용할 채널", "your channel")}</b>에 초대: <code>/invite @봇이름</code>.${channel ? "" : pick(" <span class=\"text-slate-500\">(채널이 아직 설정되지 않았습니다 — 아래 채널 칸에 입력하세요)</span>", "")}`,
+    `Invite the bot to <b>${channel ? esc(channel) : "your channel"}</b>: <code>/invite @botname</code>.${channel ? "" : " <span class=\"text-slate-500\">(no channel configured yet — set it in the Channel field below)</span>"}`);
+  const installStep = pick(
+    `<b>Install to Workspace</b> → Allow (권한 승인). 필요 scope: <code>${esc(scopes || "—")}</code>.`,
+    `<b>Install to Workspace</b> → Allow (approve permissions). Scopes needed: <code>${esc(scopes || "—")}</code>.`);
+
+  return isSocket
+    ? [
+        pick(
+          `Slack 앱 생성: ${appLink} → <b>From a manifest</b> → 워크스페이스 선택 → 아래 <b>매니페스트</b> 붙여넣기. <span class="text-slate-500">(Socket Mode 켜진 매니페스트 — 공개 URL 불필요)</span>`,
+          `Create the Slack app: ${appLink} → <b>From a manifest</b> → select a workspace → paste the <b>manifest</b> below. <span class="text-slate-500">(manifest with Socket Mode on — no public URL needed)</span>`),
+        enableEventsStep(isSocket, eventUrl),
+        installStep,
+        pick(
+          `<b>Basic Information</b> → <b>App-Level Tokens</b> → Generate Token → scope <code>connections:write</code> 추가 → <b>App-Level Token</b>(<code>xapp-…</code>) 복사.`,
+          `<b>Basic Information</b> → <b>App-Level Tokens</b> → Generate Token → add scope <code>connections:write</code> → copy the <b>App-Level Token</b>(<code>xapp-…</code>).`),
+        pick(
+          `<b>OAuth & Permissions</b> → <b>Bot User OAuth Token</b>(<code>xoxb-…</code>) 복사 → 아래 폼에 <b>xoxb</b>·<b>xapp</b> 붙여넣기.`,
+          `<b>OAuth & Permissions</b> → copy the <b>Bot User OAuth Token</b>(<code>xoxb-…</code>) → paste <b>xoxb</b> and <b>xapp</b> into the form below.`),
+        inviteStep,
+      ]
+    : [
+        pick(
+          `Slack 앱 생성: ${appLink} → <b>From a manifest</b> → 워크스페이스 선택 → 아래 <b>매니페스트</b> 붙여넣기.`,
+          `Create the Slack app: ${appLink} → <b>From a manifest</b> → select a workspace → paste the <b>manifest</b> below.`),
+        enableEventsStep(isSocket, eventUrl),
+        installStep,
+        pick(
+          `<b>Bot User OAuth Token</b>(<code>xoxb-…</code>)과 <b>Signing Secret</b> 복사 → 아래 폼에 붙여넣기.`,
+          `Copy the <b>Bot User OAuth Token</b>(<code>xoxb-…</code>) and <b>Signing Secret</b> → paste into the form below.`),
+        inviteStep,
+      ];
+}
+
 export function renderAgentSlack(host: HTMLElement, agentId: string, _displayName: string): void {
   let open = false;
   let me: SlackMember | null = null;
@@ -156,41 +216,7 @@ export function renderAgentSlack(host: HTMLElement, agentId: string, _displayNam
     const blockedNotice = webhookBlockedNotice(wizardMode, info.event_request_url);
     const appLink = `<a class="text-accent-greenSoft underline" href="https://api.slack.com/apps?new_app=1" target="_blank" rel="noopener">api.slack.com/apps</a>`;
 
-    const steps = isSocket
-      ? [
-          pick(
-            `Slack 앱 생성: ${appLink} → <b>From a manifest</b> → 워크스페이스 선택 → 아래 <b>매니페스트</b> 붙여넣기. <span class="text-slate-500">(Socket Mode 켜진 매니페스트 — 공개 URL 불필요)</span>`,
-            `Create the Slack app: ${appLink} → <b>From a manifest</b> → select a workspace → paste the <b>manifest</b> below. <span class="text-slate-500">(manifest with Socket Mode on — no public URL needed)</span>`),
-          pick(
-            `<b>Install to Workspace</b> → Allow (권한 승인). 필요 scope: <code>${esc(scopes || "—")}</code>.`,
-            `<b>Install to Workspace</b> → Allow (approve permissions). Scopes needed: <code>${esc(scopes || "—")}</code>.`),
-          pick(
-            `<b>Basic Information</b> → <b>App-Level Tokens</b> → Generate Token → scope <code>connections:write</code> 추가 → <b>App-Level Token</b>(<code>xapp-…</code>) 복사.`,
-            `<b>Basic Information</b> → <b>App-Level Tokens</b> → Generate Token → add scope <code>connections:write</code> → copy the <b>App-Level Token</b>(<code>xapp-…</code>).`),
-          pick(
-            `<b>OAuth & Permissions</b> → <b>Bot User OAuth Token</b>(<code>xoxb-…</code>) 복사 → 아래 폼에 <b>xoxb</b>·<b>xapp</b> 붙여넣기.`,
-            `<b>OAuth & Permissions</b> → copy the <b>Bot User OAuth Token</b>(<code>xoxb-…</code>) → paste <b>xoxb</b> and <b>xapp</b> into the form below.`),
-          pick(
-            `봇을 <b>${channel ? esc(channel) : pick("사용할 채널", "your channel")}</b>에 초대: <code>/invite @봇이름</code>.${channel ? "" : pick(" <span class=\"text-slate-500\">(채널이 아직 설정되지 않았습니다 — 아래 채널 칸에 입력하세요)</span>", "")}`,
-            `Invite the bot to <b>${channel ? esc(channel) : "your channel"}</b>: <code>/invite @botname</code>.${channel ? "" : " <span class=\"text-slate-500\">(no channel configured yet — set it in the Channel field below)</span>"}`),
-        ]
-      : [
-          pick(
-            `Slack 앱 생성: ${appLink} → <b>From a manifest</b> → 워크스페이스 선택 → 아래 <b>매니페스트</b> 붙여넣기.`,
-            `Create the Slack app: ${appLink} → <b>From a manifest</b> → select a workspace → paste the <b>manifest</b> below.`),
-          pick(
-            `<b>Install to Workspace</b> → Allow (권한 승인). 필요 scope: <code>${esc(scopes || "—")}</code>.`,
-            `<b>Install to Workspace</b> → Allow (approve permissions). Scopes needed: <code>${esc(scopes || "—")}</code>.`),
-          pick(
-            `<b>Bot User OAuth Token</b>(<code>xoxb-…</code>)과 <b>Signing Secret</b> 복사 → 아래 폼에 붙여넣기.`,
-            `Copy the <b>Bot User OAuth Token</b>(<code>xoxb-…</code>) and <b>Signing Secret</b> → paste into the form below.`),
-          pick(
-            `봇을 <b>${channel ? esc(channel) : pick("사용할 채널", "your channel")}</b>에 초대: <code>/invite @봇이름</code>.${channel ? "" : pick(" <span class=\"text-slate-500\">(채널이 아직 설정되지 않았습니다 — 아래 채널 칸에 입력하세요)</span>", "")}`,
-            `Invite the bot to <b>${channel ? esc(channel) : "your channel"}</b>: <code>/invite @botname</code>.${channel ? "" : " <span class=\"text-slate-500\">(no channel configured yet — set it in the Channel field below)</span>"}`),
-          pick(
-            `Event Subscriptions Request URL = 아래 값 등록 + <code>app_mention</code> 구독 (URL은 우리 서버 고정 주소 — 매니페스트에 이미 포함, 붙여넣으면 바로 Verified).`,
-            `Event Subscriptions Request URL = register the value below + subscribe to <code>app_mention</code> (the URL is our server's fixed address — already in the manifest, so it turns Verified as soon as you paste it).`),
-        ];
+    const steps = wizardSteps({ isSocket, appLink, scopes, channel, eventUrl: info.event_request_url });
 
     // Event URL 방식은 공개 HTTPS 주소가 있어야 한다. 없으면 "—" 만 띄우지 말고 ★무엇을 하면 되는지★ 알린다
     // (Socket Mode 는 이 값 없이도 되므로 그쪽으로 안내). 예전엔 이 조건에서 화면 전체가 못 뜨고 있었다.


### PR DESCRIPTION
## 무엇이 문제였나

Slack 앱을 만든 뒤 **이벤트 구독을 켜는 단계가 마법사 안내에 아예 없었다.**

매니페스트에는 `event_subscriptions.bot_events=["app_mention"]` 이 들어 있다.
그런데 **매니페스트에 있다는 것과 그 앱에서 실제로 켜져 있다는 것은 다르다** — 실사용에서 Slack 화면의 `Enable Events` 토글을 직접 올려야 했다.

**꺼져 있으면 봇은 멘션에 아무 반응을 하지 않는다. 오류도 안 난다.** 사용자에게는 "봇이 무시한다" 로만 보인다.

오늘 반복해서 만난 형태 그대로다 — 기능은 있는데 그 기능에 도달하는 경로가 없다.

## 무엇을 고쳤나

**① 빠진 단계를 넣었다** (`enableEventsStep`)
`Event Subscriptions` → `Enable Events` ON → `Subscribe to bot events` → `Add Bot User Event` → `app_mention` → `Save Changes`

**② 두 방식의 순서가 다르다는 것을 반영했다**
Event URL 방식은 `Enable Events` 를 켜는 순간 Slack 이 **Request URL 검증부터** 요구한다.
처음엔 URL 등록을 별도 단계로 뒤에 뒀는데, 그러면 사용자는 **거기서 저장을 못 하고 막힌 채** 뒷 단계를 못 본다 — 고치려던 것과 똑같은 막다른 안내가 된다.
그래서 **한 단계로 합치고 URL 값을 그 자리에** 넣었다. 중복 단계는 제거. Socket 방식엔 URL 이 아예 안 나온다.

**③ 안내를 테스트 가능하게 만들었다** (`wizardSteps` export)
빠진 단계는 **화면을 봐야만** 드러났다. 렌더에서 분리해 회귀로 고정한다.

## 실제 출력

**Socket Mode**
```
1. Slack 앱 생성 → From a manifest → 매니페스트 붙여넣기
2. Event Subscriptions → Enable Events 토글 ON → Subscribe to bot events →
   Add Bot User Event → app_mention 추가 → Save Changes        ← 추가된 단계
3. Install to Workspace → Allow
4. Basic Information → App-Level Tokens → connections:write → xapp 복사
5. OAuth & Permissions → xoxb 복사
6. 봇을 채널에 초대
```

**Event URL**
```
2. Event Subscriptions → Enable Events 토글 ON →
   Request URL 에 https://…/team/api/slack/events 입력 → Verified 확인 →
   Subscribe to bot events → Add Bot User Event → app_mention → Save Changes
```

## 검증

- 회귀 테스트 **10건 추가** — 단계 존재 · 앱생성보다 뒤 · 중복 없음 · 방식별 차이 · 빈 URL 처리
- **변이 검증**: 추가한 단계를 도로 빼면 **4건 실패** → 테스트가 실제로 잡는다
- 렌더 출력 **육안 확인** (양쪽 방식) — 템플릿이 조용히 깨지는 걸 tsc 는 못 잡는다
- `tsc --noEmit` 통과
- 전체 **1,720 pass / 0 fail** (148 파일)

## 검증 안 된 범위

- **Slack 실제 앱 생성 플로우는 재현하지 않았다.** 남의 워크스페이스 앱 설정을 건드리는 일이라 하지 않았다. 이 PR 은 **안내 문구** 수정이고, 근거는 실사용에서 토글을 직접 올려야 했다는 실측이다.
- 매니페스트가 왜 토글까지 켜주지 않는지는 **Slack 쪽 동작이라 확인 불가**. 그래서 "매니페스트를 믿지 말고 눈으로 확인하라" 로 안내한다.

## 롤백

`src/web/components/AgentSlack.ts` · `AgentSlack.test.ts` 두 파일뿐. revert 하면 끝. 서버·DB·설정 변경 없음.
