### PR TITLE
fix(slack): 슬랙 정본을 Socket Mode 로 통일 — 서버가 Event URL 매니페스트를 내던 것

### DIFF
--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -1304,40 +1304,35 @@ describe("slack reinstall-info", () => {
     }
   };
 
-  test("★공개 URL 이 없어도 완전한 매니페스트를 준다★ (Socket Mode 는 그것 없이 되어야 한다)", withBase(undefined, async () => {
+  /* ★서버는 언제나 Socket 매니페스트를 낸다★ (GD 2026-07-27 — 슬랙 정본 = Socket Mode).
+   * 예전엔 공개 URL 이 있으면 request_url + socket_mode_enabled:false 를 내보냈다. 화면에서는
+   * 클라이언트 socketManifest() 가 Socket 으로 바꿔줘 멀쩡해 보였지만, ★그건 화면을 거칠 때만★ 이다.
+   * 이 엔드포인트를 직접 받아가면 ★지원하지 않는 Event URL 앱을 만드는 매니페스트★ 가 그대로 나갔다.
+   * 그래서 ★공개 URL 유무와 무관하게 같은 Socket 매니페스트★ 가 나오는 것을 고정한다. */
+  const expectSocketManifest = (b: any) => {
+    expect(b.manifest?.settings?.socket_mode_enabled).toBe(true);
+    expect(b.manifest?.settings?.event_subscriptions?.bot_events).toEqual(["app_mention"]);
+    // ★request_url 이 있으면 Event URL 앱이 만들어진다★ — 공개 URL 이 설정돼 있어도 넣지 않는다
+    expect(b.manifest?.settings?.event_subscriptions?.request_url).toBeUndefined();
+  };
+
+  test("★공개 URL 이 없어도 Socket 매니페스트를 완전하게 준다★", withBase(undefined, async () => {
     const { app } = setup();
     const res = await app.request("/members/bill/slack/reinstall-info");
     expect(res.status).toBe(200);
     const b = await res.json() as any;
     expect(b.ok).toBe(true);
-    // ★scope 가 비면 권한 없는 앱이 만들어진다★ — 이게 이번 사고의 핵심이라 개수까지 고정한다
+    // ★scope 가 비면 권한 없는 앱이 만들어진다★ — 이게 이전 사고의 핵심이라 개수까지 고정한다
     expect(b.needed_scopes).toEqual(["app_mentions:read", "chat:write", "groups:history", "channels:history"]);
     expect(b.manifest?.oauth_config?.scopes?.bot).toEqual(b.needed_scopes);
     expect(b.manifest?.display_information?.name).toBeTruthy();
-    expect(b.event_request_url).toBeNull();
-    // ★event_subscriptions 블록 자체가 없어야 한다★ (2026-07-27 Steve 리뷰).
-    //   이 응답은 webhook 매니페스트(socket_mode_enabled=false)다. Slack 규격상 이 블록이 있으면
-    //   request_url 또는 socket_mode_enabled 중 하나가 필수라, 공개 URL 없이 블록을 넣으면
-    //   ★Slack 이 거부하는 매니페스트를 사용자에게 내주게 된다.★
-    //   앞선 판(#74)은 "구독이 없으면 멘션을 못 받는다" 를 이유로 무조건 넣었는데, 그건
-    //   ★Socket 매니페스트가 풀 문제를 webhook 매니페스트에서 풀려 한 것★ 이었다.
-    //   Socket 쪽 구독은 클라이언트 socketManifest() 가 주입한다(AgentSlack.test.ts 에서 고정).
-    expect(b.manifest?.settings?.event_subscriptions).toBeUndefined();
-    expect(b.public_base_missing).toBe(true);
-    expect(typeof b.public_base_hint).toBe("string");
+    expectSocketManifest(b);
   }));
 
-  test("공개 URL 이 있으면 request_url 과 ★bot_events 둘 다★ 포함한다", withBase("https://example.test/", async () => {
+  test("★공개 URL 이 있어도 request_url 을 넣지 않는다★ (Event URL 방식은 지원하지 않는다)", withBase("https://example.test/", async () => {
     const { app } = setup();
     const b = await (await app.request("/members/bill/slack/reinstall-info")).json() as any;
-    expect(b.event_request_url).toBe("https://example.test/team/api/slack/events");
-    expect(b.manifest?.settings?.event_subscriptions?.request_url).toBe("https://example.test/team/api/slack/events");
-    // ★이 줄이 없어서 기본 경로가 무방비였다★ — 마법사 기본 모드가 webhook 이라 '공개 URL 있음' 이
-    //   대부분 사용자의 경로다. 그런데 여기 bot_events 단언이 없어서, event_subscriptions 를 삼항으로
-    //   갈라 URL 있을 때 bot_events 를 빼도 ★전 테스트가 통과했다★(하네스 검증에서 변이로 실증).
-    //   #73 과 똑같은 피해가 다시 통과될 수 있었다.
-    expect(b.manifest?.settings?.event_subscriptions?.bot_events).toEqual(["app_mention"]);
-    expect(b.public_base_missing).toBe(false);
+    expectSocketManifest(b);
   }));
 
   /* ★서버 산출물 → 클라이언트 변환★ 접합부. 양쪽을 따로만 검사하면, 서버가 모양을 바꿔도 클라이언트

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1035,20 +1035,15 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
         display_information: { name: appName },
         features: { bot_user: { display_name: agent.slack_app_name || `gd_${id}`, always_online: true } },
         oauth_config: { scopes: { bot: scopes } },
-        // ★event_subscriptions 는 request_url 이 있을 때만 넣는다.★
-        //   Slack 규격: 이 블록이 있으면 request_url 또는 socket_mode_enabled 중 하나가 반드시 있어야 한다
-        //   ("Event Subscription requires either Request URL or Socket Mode Enabled").
-        //   이 응답은 ★webhook 방식 매니페스트★ 이고 socket_mode_enabled=false 다. 그러므로 공개 URL 이
-        //   없는데 블록을 넣으면 ★Slack 이 거부하는 매니페스트★ 를 사용자에게 그대로 내주게 된다.
-        //   (2026-07-27 Steve 리뷰. 직전 판(#74)은 bot_events 를 살리려고 무조건 넣었는데,
-        //    그 주석이 "Socket Mode 는 request_url 없이 된다" 고 적어놓고 ★정작 여기서 false 를 내보냈다★ —
-        //    주석은 의도를, 코드는 다른 것을 말하고 있었다.)
-        //   ★Socket 쪽 bot_events 는 클라이언트 socketManifest() 가 주입한다★ — 서버가 안 내보내도 안전하다.
-        //   공개 URL 이 없는 webhook 사용자에겐 webhookBlockedNotice() 가 이미 안내한다.
+        // ★슬랙 정본은 Socket Mode 다 — Event URL(request_url) 방식은 지원하지 않는다★ (GD 2026-07-27).
+        //   예전엔 공개 URL 이 있으면 request_url + socket_mode_enabled:false 를 내보냈다. 화면에서는
+        //   클라이언트 socketManifest() 가 Socket 으로 바꿔줘서 멀쩡해 보였지만, ★그건 화면을 거칠 때만★ 이다.
+        //   이 엔드포인트를 직접 받아가면 ★지원하지 않는 Event URL 앱을 만드는 매니페스트★ 가 그대로 나갔다.
+        //   서버가 처음부터 옳은 것을 낸다. 클라이언트 변환은 이제 안전망일 뿐이다.
         settings: {
-          ...(eventUrl ? { event_subscriptions: { request_url: eventUrl, bot_events: ["app_mention"] } } : {}),
+          event_subscriptions: { bot_events: ["app_mention"] },  // request_url 없음 — Socket 에는 필요없다
           org_deploy_enabled: false,
-          socket_mode_enabled: false,
+          socket_mode_enabled: true,
         },
       },
     });

--- a/src/web/components/AgentSlack.test.ts
+++ b/src/web/components/AgentSlack.test.ts
@@ -101,13 +101,13 @@ describe("webhookBlockedNotice — 실행 가능한 행동만 안내한다", () 
  * 오늘 하루 반복된 형태 그대로다: 있는데 도달하지 못한다. 그래서 ★안내 문구 자체를 회귀로 고정한다.★ */
 describe("wizardSteps — 이벤트 구독 켜는 단계가 반드시 있다", () => {
   const opts = { appLink: "<a>apps</a>", scopes: "app_mentions:read, chat:write", channel: "#team" };
-  const joined = (isSocket: boolean) => wizardSteps({ ...opts, isSocket }).join("\n");
+  const joined = () => wizardSteps(opts).join("\n");
 
   for (const isSocket of [true, false]) {
     const label = isSocket ? "Socket Mode" : "Event URL";
 
     test(`★${label}: Enable Events → app_mention → Save 순서가 안내된다★`, () => {
-      const s = joined(isSocket);
+      const s = joined();
       expect(s).toContain("Enable Events");          // ← 토글을 켜라는 말이 없으면 사용자는 못 찾는다
       expect(s).toContain("Subscribe to bot events");
       expect(s).toContain("app_mention");
@@ -115,7 +115,7 @@ describe("wizardSteps — 이벤트 구독 켜는 단계가 반드시 있다", (
     });
 
     test(`${label}: 단계는 앱 생성 → 이벤트 구독 순서다 (앱이 없으면 켤 화면이 없다)`, () => {
-      const steps = wizardSteps({ ...opts, isSocket });
+      const steps = wizardSteps(opts);
       const created = steps.findIndex((x) => x.includes("From a manifest"));
       const events = steps.findIndex((x) => x.includes("Enable Events"));
       expect(created).toBeGreaterThanOrEqual(0);
@@ -123,19 +123,19 @@ describe("wizardSteps — 이벤트 구독 켜는 단계가 반드시 있다", (
     });
 
     test(`${label}: 채널 초대·토큰 복사 단계는 그대로 남아 있다 (단계 추가가 기존 안내를 밀어내지 않는다)`, () => {
-      const s = joined(isSocket);
+      const s = joined();
       expect(s).toContain("/invite");
       expect(s).toContain("xoxb");
     });
   }
 
-  test("Socket 방식만 App-Level Token(xapp) 단계를 안내한다", () => {
-    expect(joined(true)).toContain("xapp");
-    expect(joined(false)).not.toContain("xapp");
+  test("★App-Level Token(xapp) 단계를 안내한다★ — Socket Mode 에 필수다", () => {
+    expect(joined()).toContain("xapp");
   });
 
-  test("Event URL 방식은 Request URL 등록 단계를 유지한다", () => {
-    expect(joined(false)).toContain("Request URL");
+  test("★Request URL·Signing Secret 은 안내하지 않는다★ (Event URL 방식은 지원하지 않는다)", () => {
+    expect(joined()).not.toContain("Request URL");
+    expect(joined()).not.toContain("Signing Secret");
   });
 });
 
@@ -146,14 +146,14 @@ describe("Socket Mode 가 정본 — 안내에 Event URL 을 섞지 않는다", 
   const base = { appLink: "<a>apps</a>", scopes: "chat:write", channel: "#team" };
 
   test("★Socket 안내에는 Request URL·Signing Secret 이 나오지 않는다★", () => {
-    const s = wizardSteps({ ...base, isSocket: true }).join("\n");
+    const s = wizardSteps(base).join("\n");
     expect(s).not.toContain("Request URL");
     expect(s).not.toContain("Signing Secret");
     expect(s).toContain("xapp");                    // Socket 은 App-Level Token 을 쓴다
   });
 
   test("이벤트 구독 단계는 GD 가 준 4단계 그대로다 (덧붙이지 않는다)", () => {
-    const step = wizardSteps({ ...base, isSocket: true }).find((x) => x.includes("Enable Events"))!;
+    const step = wizardSteps(base).find((x) => x.includes("Enable Events"))!;
     const order = ["Enable Events", "Subscribe to bot events", "Add Bot User Event", "app_mention", "Save Changes"];
     let at = -1;
     for (const token of order) {

--- a/src/web/components/AgentSlack.ts
+++ b/src/web/components/AgentSlack.ts
@@ -109,8 +109,8 @@ export function enableEventsStep(): string {
 
 /** 마법사의 사람 단계 목록. 렌더에서 분리해 ★안내 내용 자체를 테스트할 수 있게★ 한다
  *  (빠진 단계는 화면을 봐야만 드러났다 — 그래서 회귀로 고정한다). */
-export function wizardSteps(opts: { isSocket: boolean; appLink: string; scopes: string; channel: string }): string[] {
-  const { isSocket, appLink, scopes, channel } = opts;
+export function wizardSteps(opts: { appLink: string; scopes: string; channel: string }): string[] {
+  const { appLink, scopes, channel } = opts;
   const inviteStep = pick(
     `봇을 <b>${channel ? esc(channel) : pick("사용할 채널", "your channel")}</b>에 초대: <code>/invite @봇이름</code>.${channel ? "" : pick(" <span class=\"text-slate-500\">(채널이 아직 설정되지 않았습니다 — 아래 채널 칸에 입력하세요)</span>", "")}`,
     `Invite the bot to <b>${channel ? esc(channel) : "your channel"}</b>: <code>/invite @botname</code>.${channel ? "" : " <span class=\"text-slate-500\">(no channel configured yet — set it in the Channel field below)</span>"}`);
@@ -118,37 +118,21 @@ export function wizardSteps(opts: { isSocket: boolean; appLink: string; scopes: 
     `<b>Install to Workspace</b> → Allow (권한 승인). 필요 scope: <code>${esc(scopes || "—")}</code>.`,
     `<b>Install to Workspace</b> → Allow (approve permissions). Scopes needed: <code>${esc(scopes || "—")}</code>.`);
 
-  return isSocket
-    ? [
-        pick(
-          `Slack 앱 생성: ${appLink} → <b>From a manifest</b> → 워크스페이스 선택 → 아래 <b>매니페스트</b> 붙여넣기. <span class="text-slate-500">(Socket Mode 켜진 매니페스트 — 공개 URL 불필요)</span>`,
-          `Create the Slack app: ${appLink} → <b>From a manifest</b> → select a workspace → paste the <b>manifest</b> below. <span class="text-slate-500">(manifest with Socket Mode on — no public URL needed)</span>`),
-        enableEventsStep(),
-        installStep,
-        pick(
-          `<b>Basic Information</b> → <b>App-Level Tokens</b> → Generate Token → scope <code>connections:write</code> 추가 → <b>App-Level Token</b>(<code>xapp-…</code>) 복사.`,
-          `<b>Basic Information</b> → <b>App-Level Tokens</b> → Generate Token → add scope <code>connections:write</code> → copy the <b>App-Level Token</b>(<code>xapp-…</code>).`),
-        pick(
-          `<b>OAuth & Permissions</b> → <b>Bot User OAuth Token</b>(<code>xoxb-…</code>) 복사 → 아래 폼에 <b>xoxb</b>·<b>xapp</b> 붙여넣기.`,
-          `<b>OAuth & Permissions</b> → copy the <b>Bot User OAuth Token</b>(<code>xoxb-…</code>) → paste <b>xoxb</b> and <b>xapp</b> into the form below.`),
-        inviteStep,
-      ]
-    : [
-        pick(
-          `Slack 앱 생성: ${appLink} → <b>From a manifest</b> → 워크스페이스 선택 → 아래 <b>매니페스트</b> 붙여넣기.`,
-          `Create the Slack app: ${appLink} → <b>From a manifest</b> → select a workspace → paste the <b>manifest</b> below.`),
-        enableEventsStep(),
-        installStep,
-        pick(
-          `<b>Bot User OAuth Token</b>(<code>xoxb-…</code>)과 <b>Signing Secret</b> 복사 → 아래 폼에 붙여넣기.`,
-          `Copy the <b>Bot User OAuth Token</b>(<code>xoxb-…</code>) and <b>Signing Secret</b> → paste into the form below.`),
-        inviteStep,
-        // 이 분기는 ★기존에 Event URL 로 붙어 있는 멤버를 위해 남아 있을 뿐★ 이다(슬랙 정본 = Socket Mode).
-        // 그래서 여기는 손대지 않는다 — 새로 설계하거나 확장하지 않고 기존 문구 그대로 둔다.
-        pick(
-          `Event Subscriptions Request URL = 아래 값 등록 + <code>app_mention</code> 구독 (URL은 우리 서버 고정 주소 — 매니페스트에 이미 포함, 붙여넣으면 바로 Verified).`,
-          `Event Subscriptions Request URL = register the value below + subscribe to <code>app_mention</code> (the URL is our server's fixed address — already in the manifest, so it turns Verified as soon as you paste it).`),
-      ];
+  // ★Event URL 분기를 없앤다★ — 지원하지 않는 경로가 화면에 남아 있으면 사용자는 그걸 선택지로 읽는다.
+  return [
+    pick(
+      `Slack 앱 생성: ${appLink} → <b>From a manifest</b> → 워크스페이스 선택 → 아래 <b>매니페스트</b> 붙여넣기. <span class="text-slate-500">(Socket Mode 켜진 매니페스트 — 공개 URL 불필요)</span>`,
+      `Create the Slack app: ${appLink} → <b>From a manifest</b> → select a workspace → paste the <b>manifest</b> below. <span class="text-slate-500">(manifest with Socket Mode on — no public URL needed)</span>`),
+    enableEventsStep(),
+    installStep,
+    pick(
+      `<b>Basic Information</b> → <b>App-Level Tokens</b> → Generate Token → scope <code>connections:write</code> 추가 → <b>App-Level Token</b>(<code>xapp-…</code>) 복사.`,
+      `<b>Basic Information</b> → <b>App-Level Tokens</b> → Generate Token → add scope <code>connections:write</code> → copy the <b>App-Level Token</b>(<code>xapp-…</code>).`),
+    pick(
+      `<b>OAuth & Permissions</b> → <b>Bot User OAuth Token</b>(<code>xoxb-…</code>) 복사 → 아래 폼에 <b>xoxb</b>·<b>xapp</b> 붙여넣기.`,
+      `<b>OAuth & Permissions</b> → copy the <b>Bot User OAuth Token</b>(<code>xoxb-…</code>) → paste <b>xoxb</b> and <b>xapp</b> into the form below.`),
+    inviteStep,
+  ];
 }
 
 export function renderAgentSlack(host: HTMLElement, agentId: string, _displayName: string): void {
@@ -212,7 +196,7 @@ export function renderAgentSlack(host: HTMLElement, agentId: string, _displayNam
     const blockedNotice = webhookBlockedNotice(wizardMode, info.event_request_url);
     const appLink = `<a class="text-accent-greenSoft underline" href="https://api.slack.com/apps?new_app=1" target="_blank" rel="noopener">api.slack.com/apps</a>`;
 
-    const steps = wizardSteps({ isSocket, appLink, scopes, channel });
+    const steps = wizardSteps({ appLink, scopes, channel });
 
     // Event URL 방식은 공개 HTTPS 주소가 있어야 한다. 없으면 "—" 만 띄우지 말고 ★무엇을 하면 되는지★ 알린다
     // (Socket Mode 는 이 값 없이도 되므로 그쪽으로 안내). 예전엔 이 조건에서 화면 전체가 못 뜨고 있었다.
@@ -337,12 +321,11 @@ export function renderAgentSlack(host: HTMLElement, agentId: string, _displayNam
 
     host.querySelector<HTMLButtonElement>("#sl-open")?.addEventListener("click", () => {
       open = !open;
-      // 열 때 방식 초기화: 신규 연결은 Socket 기본(권장 — 공개 URL 불필요), 기존 연결은 현 방식 유지(working webhook 안 깨뜨림).
-      if (open) {
-        wizardMode = me?.state === "not_connected"
-          ? "socket"
-          : (me?.slack_connection_mode === "socket" ? "socket" : "webhook");
-      }
+      // ★슬랙 정본은 Socket Mode 뿐이다★ (GD 2026-07-27). 예전엔 기존 멤버의 저장된 방식을 따라가서
+      //   ★지원하지 않는 Event URL 안내가 계속 떴다.★ 저장값은 과거 잔재이지 현재 정책이 아니다.
+      //   기존 멤버의 ★런타임 수신 동작은 그대로다★ — 서버 경로는 안 건드린다. 앱을 다시 만들 때만 Socket 이 된다.
+      //   (이 값이 항상 "socket" 이므로 아래 isSocket 분기·webhookBlockedNotice 는 자연히 Socket 쪽만 탄다.)
+      if (open) wizardMode = "socket";
       if (open && !info) { render(); loadInfo(); } else render();
     });
     host.querySelector<HTMLButtonElement>("#sl-cancel")?.addEventListener("click", () => { open = false; render(); });


### PR DESCRIPTION
## 무엇이 문제였나

**슬랙 정본은 Socket Mode 이고 Event URL(`request_url`) 방식은 지원하지 않는다.** 그런데 서버는 공개 URL 이 설정돼 있으면 이렇게 내보내고 있었다:

```json
"settings": {
  "event_subscriptions": { "request_url": "https://…/team/api/slack/events", "bot_events": ["app_mention"] },
  "socket_mode_enabled": false      ← Event URL 앱이 만들어진다
}
```

화면에서는 클라이언트 `socketManifest()` 가 Socket 으로 바꿔줘서 **멀쩡해 보였다.** 하지만 **그건 화면을 거칠 때만**이고, 이 엔드포인트를 직접 받아가면 **지원하지 않는 방식의 앱을 만드는 매니페스트**가 그대로 나갔다.

또 마법사는 **기존 멤버의 저장된 방식을 그대로 따라가서**, 이미 Event URL 로 붙어 있는 멤버 화면에 지원하지 않는 방식의 안내(6번 `Request URL` 등록)가 계속 떴다. **저장값은 과거 잔재이지 현재 정책이 아니다.**

## 무엇을 고쳤나

**서버** — 공개 URL 유무와 무관하게 Socket 매니페스트:
```json
"settings": {
  "event_subscriptions": { "bot_events": ["app_mention"] },
  "socket_mode_enabled": true
}
```

**마법사** — 언제나 Socket 안내. Event URL 단계·분기 삭제.
`isSocket` 분기와 `webhookBlockedNotice` 는 모드가 항상 `socket` 이라 자연히 Socket 쪽만 탄다 — **구조는 건드리지 않았다.**

## 범위 밖 — 의도적으로 안 건드린 것

**기존 Event URL 멤버의 런타임 수신 경로**(`routes/slack.ts`). 지금 붙어 있는 멤버는 **그대로 동작한다.** 바뀌는 것은 **앱을 다시 만들 때 어떤 매니페스트를 쓰는가** 뿐이다.

## 검증

- 옛 Event URL 계약을 검증하던 테스트 **4건을 새 계약으로 교체**
- **변이 검증**: 서버를 Event URL 로 되돌리면 **3건 실패** → 테스트가 실제로 잡는다
- `tsc --noEmit` 통과
- 전체 **1,746 pass / 0 fail** (151 파일)

## 롤백

4개 파일(서버 라우트 1 · 웹 컴포넌트 1 · 각 테스트). revert 하면 끝. DB·설정·런타임 변경 없음.
