### PR TITLE
fix(runtime): 재시작에도 텔레그램 poller 자동복구 — 영입에만 있던 안전장치

### DIFF
--- a/src/server/lib/activation.ts
+++ b/src/server/lib/activation.ts
@@ -19,6 +19,7 @@ import { HERMES_BASE_PROFILE, MANUALS_DIR, runtimeCwdForAgent } from "./paths";
 import { isHermesMemberProtected, isHermesProfileProtected } from "./hermesBaseProfile";
 import { appendAuditFile } from "./auditFile";
 import { codexBridgePaths, placeCodexToken, writeCodexBridgeFiles, removeCodexBridgeFiles, resolveOwnerDmId } from "../runtimes/codex/launcher";
+import { ensureClaudePollerUp } from "../runtimes/claude/pollerHealth";
 import { placeClaudeToken, writeClaudeBridgeFiles, seedClaudeTrust, seedClaudeAccess, killClaudeTmux, reconnectClaudeTelegram, claudeBridgePaths, installReplyGuardHook, installOutboundHook, installProgressHook, uninstallOutboundHook, uninstallReplyGuardHook, uninstallRecoveryHook, removeClaudeBridgeFiles } from "../runtimes/claude/launcher";
 import { isTier2Outbound, isTier2Shadow } from "../runtimes/claude/tier2Flag";
 import { setAgentEnabled, clearAgentOff, isAgentOff } from "./agentControl";
@@ -349,44 +350,9 @@ function placeToken(tokenFile: string, token: string): void {
   chmodSync(tokenFile, 0o600);
 }
 
-/** claude 텔레그램 채널 poller 기동 대기 — 플러그인 MCP(server.ts)가 토큰 확인 통과 후에만 bot.pid를 쓴다(server.ts:69).
- *  bot.pid 출현 = poller 실제 폴링 시작 = '진짜 대화됨'. 미출현 = 죽은 봇(귀머거리). timeoutMs 안에 file 확인. 슬러그 가드.
- *  opts = 테스트 격리용(실 HOME/~/.claude·라이브 봇 미접촉): homeDir로 base 경로를 tmp로 돌리고 intervalMs로 짧은 폴 간격.
- *  production은 opts 없이 호출 → HOME + 1500ms 그대로(동작 불변). */
-export async function waitForClaudePoller(
-  id: string,
-  timeoutMs: number,
-  opts?: { homeDir?: string; intervalMs?: number; pidAlive?: (pid: number) => boolean },
-): Promise<boolean> {
-  if (!/^[a-z0-9_-]+$/i.test(id)) return false;
-  const home = opts?.homeDir ?? process.env.HOME ?? "";
-  const intervalMs = opts?.intervalMs ?? 1500;
-  const pidFile = `${home}/.claude/channels/telegram-${id}/bot.pid`;
-  const pidAlive = opts?.pidAlive ?? ((pid: number) => {
-    try { process.kill(pid, 0); return true; } catch { return false; }
-  });
-  const markerAlive = (): boolean => {
-    try {
-      if (!existsSync(pidFile)) return false;
-      const raw = readFileSync(pidFile, "utf-8").trim();
-      let pid = Number(raw);
-      let agentId: string | undefined;
-      if (!Number.isInteger(pid)) {
-        const parsed = JSON.parse(raw) as { pid?: unknown; agentId?: unknown };
-        pid = Number(parsed.pid);
-        agentId = typeof parsed.agentId === "string" ? parsed.agentId : undefined;
-      }
-      if (agentId && agentId !== id) return false;
-      return Number.isInteger(pid) && pid > 0 && pidAlive(pid);
-    } catch { return false; }
-  };
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (markerAlive()) return true;
-    await new Promise((r) => setTimeout(r, intervalMs));
-  }
-  return markerAlive();
-}
+// claude poller 대기·자동복구는 ★runtimes/claude/pollerHealth.ts★ 가 정본이다(재시작 경로와 공유).
+// 기존 import 경로를 깨지 않도록 여기서 재-export 한다.
+export { waitForClaudePoller } from "../runtimes/claude/pollerHealth";
 
 /** codex per-member bridge 헬스게이트 — 첫 getUpdates 성공 후 bridge.ts가 쓰는 pid marker를 기다린다. */
 export async function waitForCodexPoller(
@@ -703,18 +669,10 @@ export async function activateMember(db: Database, input: ActivateInput): Promis
       //   pre-warm·버전락·30s 게이트 늘리기는 "타임아웃"을 겨냥한 헛수고였다(Starting connection 0건이 반증).
       const rawWait = process.env.TEAMOS_POLLER_WAIT_MS;
       const pollerWaitMs = rawWait !== undefined && Number.isFinite(Number(rawWait)) ? Number(rawWait) : 30000;
-      let pollerOk = await waitForClaudePoller(id, pollerWaitMs);
-      // ★auto-reconnect(하네스 확정 fix)★: 첫 부팅 열거 누락 시 b3os 가 세션에 `/mcp reconnect` 를 자동 주입(최대 2회, 각 12s 재확인).
-      //   사용자가 tmux 에 직접 들어가 reconnect 하던 걸 서버가 대신 = 공개 사용자는 아무것도 안 만짐. reconnect 는 항상 붙는다(실측).
-      let reconnected = false;
-      for (let attempt = 0; !pollerOk && attempt < 2; attempt++) {
-        if (!reconnectClaudeTelegram(id)) break; // tmux 세션 부재(스폰 실패)면 중단
-        pollerOk = await waitForClaudePoller(id, 12000);
-        reconnected = pollerOk;
-      }
-      steps.push({ step: "poller", ok: pollerOk, detail: pollerOk
-        ? (reconnected ? "텔레그램 채널 poller 기동(auto-reconnect 로 복구)" : "텔레그램 채널 poller 기동 확인(bot.pid)")
-        : "poller 미기동 → needs_reconnect(auto-reconnect 2회 시도했으나 미복구; 세션·토큰·scope 정상). 세션에서 /mcp reconnect 재시도 가능" });
+      // ★영입과 재시작이 같은 복구를 쓴다★(pollerHealth) — 한쪽에만 있는 안전장치는 없는 것과 같다.
+      const pollerRes = await ensureClaudePollerUp(id, { waitMs: pollerWaitMs });
+      const pollerOk = pollerRes.ok;
+      steps.push({ step: "poller", ok: pollerOk, detail: pollerRes.detail });
       // ★early-return 제거 + degraded 완결(2026-07-25)★: poller 실패해도 essentials 를 tolerate(poller:) 로 통과시켜
       //   아래 recall·bus-wake·degraded 반환까지 진행한다(그렇지 않으면 :620 essentials 하드실패가 746f6b3 의 degraded 를 무효화).
       //   token·allowFrom·채널 등 진짜 필수설정이 빠지면 종전대로 하드실패.

--- a/src/server/lib/agentControl.ts
+++ b/src/server/lib/agentControl.ts
@@ -16,6 +16,7 @@ import { dirname } from "node:path";
 import { codexBridgeLaunchdLabel, writeCodexBridgeFiles } from "../runtimes/codex/launcher";
 import { REPO_ROOT } from "./personaTemplates";
 import { ambientAgents } from "./registry";
+import { ensureClaudePollerUp } from "../runtimes/claude/pollerHealth";
 
 const HOME = process.env.HOME ?? "";
 function execOn(): boolean { return process.env.APPROVAL_EXECUTION_ENABLED === "1"; }
@@ -187,6 +188,24 @@ export async function setAgentEnabled(agentId: string, runtime: string, enabled:
 //   런타임별: claude=restart-agent.sh --resume(컨텍스트 유지+새 CLAUDE.md) / openclaw·hermes=게이트웨이 in-place kickstart.
 const OPENCLAW_LABEL = "ai.openclaw.gateway";
 
+/**
+ * ★재시작 뒤 텔레그램 poller 가 실제로 붙었는지 확인하고, 안 붙었으면 자동 복구한다.★
+ *
+ * 이게 없어서 ★재시작 후 안 붙으면 아무도 안 고쳤다★(2026-07-27 GD 지적). 프로세스는 살아 있고
+ * 대시보드도 정상으로 보이는데 메시지만 안 들어온다 — 오류가 없으니 사람이 눈치챌 때까지 방치된다.
+ * 영입(activation)에는 같은 복구가 이미 있었다. ★한쪽에만 있는 안전장치는 없는 것과 같다.★
+ *
+ * 복구에 실패해도 ★재시작 자체는 성공★ 으로 보고한다(프로세스는 떴다). 대신 detail 에 미기동을
+ * 명시해 사람이 볼 수 있게 한다 — 조용히 성공이라고 말하지 않는 것이 이 수정의 핵심이다.
+ */
+async function withPollerRecovery(agentId: string, baseDetail: string): Promise<ControlResult> {
+  const raw = process.env.TEAMOS_RESTART_POLLER_WAIT_MS;
+  const waitMs = raw !== undefined && Number.isFinite(Number(raw)) ? Number(raw) : 30000;
+  const res = await ensureClaudePollerUp(agentId, { waitMs });
+  return { ok: true, detail: `${baseDetail} · ${res.detail}` };
+}
+
+
 /** 팀원 1명 재시작. off 상태는 거부(기동은 🟢). bill 도 가능 — claude_channel 이라 --resume(컨텍스트 유지)이고,
  *  재시작 실행 주체는 team-collab 서버(executor)지 bill 세션이 아니라서 bill 재시작이 작업을 끊지 않는다. */
 export async function restartAgent(agentId: string, runtime: string, fresh = false): Promise<ControlResult> {
@@ -206,7 +225,8 @@ export async function restartAgent(agentId: string, runtime: string, fresh = fal
       const opsScript = `${REPO_ROOT}/scripts/restart-agent.sh`;
       if (existsSync(opsScript)) {
         const r = await run(["bash", opsScript, agentId, flag]);
-        return { ok: r.code === 0, detail: r.code === 0 ? `claude ${agentId} 재시작(${mode})` : `재시작 실패: ${r.out.slice(-150)}` };
+        if (r.code !== 0) return { ok: false, detail: `재시작 실패: ${r.out.slice(-150)}` };
+        return withPollerRecovery(agentId, `claude ${agentId} 재시작(${mode})`);
       }
 
       // vendoring 경로(공개 설치본): repo 내 기동 스크립트로 재기동.
@@ -221,7 +241,8 @@ export async function restartAgent(agentId: string, runtime: string, fresh = fal
       try { await run(["tmux", "kill-session", "-t", `claude-${agentId}`]); } catch { /* 없으면 그만 */ }
       const args = fresh ? [agentId] : [agentId, "--resume"];
       const r = await run(["bash", starter, ...args]);
-      return { ok: r.code === 0, detail: r.code === 0 ? `claude ${agentId} 재시작(${mode})` : `재시작 실패: ${r.out.slice(-150)}` };
+      if (r.code !== 0) return { ok: false, detail: `재시작 실패: ${r.out.slice(-150)}` };
+      return withPollerRecovery(agentId, `claude ${agentId} 재시작(${mode})`);
     }
     // openclaw/hermes 는 게이트웨이 in-place 재시작이라 '새 세션' 개념이 claude 처럼 없음 — fresh 무시.
     if (runtime === "openclaw") {

--- a/src/server/runtimes/claude/launcher.ts
+++ b/src/server/runtimes/claude/launcher.ts
@@ -277,20 +277,10 @@ export function killClaudeTmux(id: string): void {
   try { spawnSync("tmux", ["kill-session", "-t", `claude-${id}`], { stdio: "ignore" }); } catch { /* best-effort */ }
 }
 
-/** ★auto-reconnect(2026-07-25 하네스 4-way 확정 + 실측)★: CC fresh 세션 부팅서 telegram MCP 가 부팅 MCP "열거"에서
- *  빠지는 경우(실패 세션 로그 `Starting connection` 0건 = 타임아웃 아니라 스폰 자체 없음)를 런타임에 복구한다.
- *  슬래시 명령 `/mcp reconnect plugin:telegram:telegram` 을 세션에 주입하면 (조용해진 상태서) 재열거돼 즉시 붙는다
- *  (steve 실측: "Successfully reconnected to plugin:telegram:telegram"). 메뉴 네비가 아니라 슬래시 명령이라
- *  커서 위치/항목 순서에 무관 = 로버스트. b3os 가 tmux 세션을 소유하므로 사용자가 tmux 에 들어갈 필요 없다.
- *  세션이 없으면(스폰 실패) false. */
-export function reconnectClaudeTelegram(id: string): boolean {
-  assertId(id);
-  try {
-    if (spawnSync("tmux", ["has-session", "-t", `claude-${id}`], { stdio: "ignore" }).status !== 0) return false;
-    spawnSync("tmux", ["send-keys", "-t", `claude-${id}`, "/mcp reconnect plugin:telegram:telegram", "Enter"], { stdio: "ignore" });
-    return true;
-  } catch { return false; }
-}
+// auto-reconnect 구현은 ★pollerHealth.ts★ 로 옮겼다 — 재시작 경로(agentControl)도 같은 복구를 써야 하는데
+// launcher 는 agentControl 을 import 하고 있어서 반대 방향 import 가 순환이 된다. 여기서는 재-export 만 한다.
+export { reconnectClaudeTelegram } from "./pollerHealth";
+
 
 /** 퇴사 정리 — tmux 세션 kill + plist + (removeToken 시) 채널 상태 dir 전체 + ~/.claude.json projects 항목.
  *  ★재영입 clean: 채널 dir(.env·access.json·inbox 등)·trust 항목이 남으면 재영입 시 stale 설정 잔재(GD 2026-07-01 4런타임 잔재 감사). launchctl bootout은 호출자가 먼저. */

--- a/src/server/runtimes/claude/pollerHealth.test.ts
+++ b/src/server/runtimes/claude/pollerHealth.test.ts
@@ -1,0 +1,78 @@
+/* ★재시작에는 자동복구가 없었다★ (2026-07-27 GD 지적, "매우 중요한 기능").
+ * 영입(activation)에는 poller 확인 + auto-reconnect 가 있었는데 재시작(agentControl)에는 ★아예 없었다★ —
+ * 기동 스크립트만 돌리고 붙었는지 확인조차 안 했다. 그래서 재시작 후 안 붙으면 아무도 안 고쳤고,
+ * 팀원은 ★프로세스는 살아 있는데 메시지만 안 들어오는★ 상태로 방치됐다(오류도 안 남).
+ *
+ * 여기서는 ensureClaudePollerUp 의 계약을 고정한다. tmux·HOME 을 건드리지 않도록 wait/reconnect 를 주입한다. */
+import { describe, expect, test } from "bun:test";
+import { ensureClaudePollerUp } from "./pollerHealth";
+
+/** 호출 n번째까지 false, 그 뒤 true 를 주는 wait 스텁 + 호출 기록. */
+function stubs(opts: { upAfterReconnects: number | null; sessionAlive?: boolean }) {
+  const calls = { wait: [] as number[], reconnect: 0 };
+  let reconnects = 0;
+  return {
+    calls,
+    wait: async (_id: string, ms: number) => {
+      calls.wait.push(ms);
+      if (opts.upAfterReconnects === null) return false;      // 영영 안 붙는 경우
+      return reconnects >= opts.upAfterReconnects;
+    },
+    reconnect: (_id: string) => {
+      if (opts.sessionAlive === false) return false;          // tmux 세션 부재 = 살릴 수단 없음
+      reconnects++; calls.reconnect++; return true;
+    },
+  };
+}
+
+describe("ensureClaudePollerUp — 재시작 뒤 poller 자동복구", () => {
+  test("이미 붙어 있으면 reconnect 를 쏘지 않는다 (멀쩡한 세션에 슬래시 명령 주입 금지)", async () => {
+    const s = stubs({ upAfterReconnects: 0 });
+    const r = await ensureClaudePollerUp("bill", { waitMs: 100, wait: s.wait, reconnect: s.reconnect });
+    expect(r.ok).toBe(true);
+    expect(r.recovered).toBe(false);
+    expect(s.calls.reconnect).toBe(0);      // ★중요★ — 정상 세션에 명령을 던지면 그게 사고다
+    expect(r.detail).toContain("기동 확인");
+  });
+
+  test("★안 붙어 있으면 reconnect 를 주입해 살린다★ (이 기능의 존재 이유)", async () => {
+    const s = stubs({ upAfterReconnects: 1 });
+    const r = await ensureClaudePollerUp("bill", { waitMs: 100, recheckMs: 10, wait: s.wait, reconnect: s.reconnect });
+    expect(r.ok).toBe(true);
+    expect(r.recovered).toBe(true);
+    expect(r.attempts).toBe(1);
+    expect(r.detail).toContain("복구");
+  });
+
+  test("한 번으로 안 되면 다시 시도한다 (기본 2회)", async () => {
+    const s = stubs({ upAfterReconnects: 2 });
+    const r = await ensureClaudePollerUp("bill", { waitMs: 100, recheckMs: 10, wait: s.wait, reconnect: s.reconnect });
+    expect(r.ok).toBe(true);
+    expect(r.attempts).toBe(2);
+  });
+
+  test("★무한 재시도하지 않는다★ — 한도를 넘으면 멈추고 실패를 말한다", async () => {
+    const s = stubs({ upAfterReconnects: null });
+    const r = await ensureClaudePollerUp("bill", { waitMs: 100, recheckMs: 10, wait: s.wait, reconnect: s.reconnect });
+    expect(r.ok).toBe(false);
+    expect(r.attempts).toBe(2);                 // 기본 한도에서 멈춘다
+    expect(s.calls.reconnect).toBe(2);
+    // ★조용히 성공이라고 말하지 않는다★ — 오늘 하루 계속 나온 '있는데 작동 안 하는' 형태를 막는 부분
+    expect(r.detail).toContain("미기동");
+  });
+
+  test("★tmux 세션이 없으면 즉시 멈춘다★ (살릴 수단이 없는데 헛돌면 재시작이 30초씩 늘어진다)", async () => {
+    const s = stubs({ upAfterReconnects: null, sessionAlive: false });
+    const r = await ensureClaudePollerUp("bill", { waitMs: 100, recheckMs: 10, wait: s.wait, reconnect: s.reconnect });
+    expect(r.ok).toBe(false);
+    expect(r.attempts).toBe(0);
+    expect(s.calls.wait.length).toBe(1);        // 첫 확인 1회로 끝 — 재확인 대기를 반복하지 않는다
+  });
+
+  test("첫 대기와 재확인 대기는 서로 다른 값을 쓴다 (재확인은 짧게)", async () => {
+    const s = stubs({ upAfterReconnects: 1 });
+    await ensureClaudePollerUp("bill", { waitMs: 777, recheckMs: 11, wait: s.wait, reconnect: s.reconnect });
+    expect(s.calls.wait[0]).toBe(777);
+    expect(s.calls.wait[1]).toBe(11);
+  });
+});

--- a/src/server/runtimes/claude/pollerHealth.ts
+++ b/src/server/runtimes/claude/pollerHealth.ts
@@ -1,0 +1,120 @@
+// claude_channel 텔레그램 poller 헬스 + 자동복구.
+//
+// ★왜 별도 모듈인가★ — 이 로직이 필요한 곳이 둘인데(영입=activation, 재시작=agentControl),
+//   기존 위치(activation.ts / launcher.ts)는 서로·agentControl 과 이미 얽혀 있어 어느 방향으로 import 해도
+//   순환이 생긴다. 의존이 없는 자리로 내려 양쪽이 함께 쓴다(fs/process/tmux 만 씀).
+//
+// ★이게 왜 중요한가★ — poller 가 안 붙으면 팀원은 ★조용히 귀머거리★ 가 된다. 프로세스는 살아 있고
+//   대시보드도 정상으로 보이는데 메시지만 안 들어온다. 오류도 안 난다. 사람이 눈치챌 때까지 방치된다.
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const SAFE_ID = /^[a-z0-9_-]+$/i;
+
+/** claude 텔레그램 채널 poller 기동 대기 — 플러그인 MCP(server.ts)가 토큰 확인 통과 후에만 bot.pid를 쓴다.
+ *  bot.pid 출현 = poller 실제 폴링 시작 = '진짜 대화됨'. 미출현 = 죽은 봇(귀머거리). timeoutMs 안에 확인. 슬러그 가드.
+ *  opts = 테스트 격리용(실 HOME/~/.claude·라이브 봇 미접촉): homeDir로 base 경로를 tmp로 돌리고 intervalMs로 짧은 폴 간격.
+ *  production은 opts 없이 호출 → HOME + 1500ms 그대로(동작 불변). */
+export async function waitForClaudePoller(
+  id: string,
+  timeoutMs: number,
+  opts?: { homeDir?: string; intervalMs?: number; pidAlive?: (pid: number) => boolean },
+): Promise<boolean> {
+  if (!SAFE_ID.test(id)) return false;
+  const home = opts?.homeDir ?? process.env.HOME ?? "";
+  const intervalMs = opts?.intervalMs ?? 1500;
+  const pidFile = `${home}/.claude/channels/telegram-${id}/bot.pid`;
+  const pidAlive = opts?.pidAlive ?? ((pid: number) => {
+    try { process.kill(pid, 0); return true; } catch { return false; }
+  });
+  const markerAlive = (): boolean => {
+    try {
+      if (!existsSync(pidFile)) return false;
+      const raw = readFileSync(pidFile, "utf-8").trim();
+      let pid = Number(raw);
+      let agentId: string | undefined;
+      if (!Number.isInteger(pid)) {
+        const parsed = JSON.parse(raw) as { pid?: unknown; agentId?: unknown };
+        pid = Number(parsed.pid);
+        agentId = typeof parsed.agentId === "string" ? parsed.agentId : undefined;
+      }
+      if (agentId && agentId !== id) return false;
+      return Number.isInteger(pid) && pid > 0 && pidAlive(pid);
+    } catch { return false; }
+  };
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (markerAlive()) return true;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return markerAlive();
+}
+
+/** ★auto-reconnect★: CC fresh 세션 부팅서 telegram MCP 가 부팅 MCP "열거"에서 빠지는 경우
+ *  (실패 세션 로그 `Starting connection` 0건 = 타임아웃 아니라 스폰 자체 없음)를 런타임에 복구한다.
+ *  슬래시 명령 `/mcp reconnect plugin:telegram:telegram` 을 세션에 주입하면 재열거돼 즉시 붙는다(실측).
+ *  메뉴 네비가 아니라 슬래시 명령이라 커서 위치/항목 순서에 무관 = 로버스트.
+ *  b3os 가 tmux 세션을 소유하므로 사용자가 tmux 에 들어갈 필요 없다. 세션이 없으면(스폰 실패) false. */
+export function reconnectClaudeTelegram(id: string): boolean {
+  if (!SAFE_ID.test(id)) throw new Error(`unsafe agent id: ${id}`);
+  try {
+    if (spawnSync("tmux", ["has-session", "-t", `claude-${id}`], { stdio: "ignore" }).status !== 0) return false;
+    spawnSync("tmux", ["send-keys", "-t", `claude-${id}`, "/mcp reconnect plugin:telegram:telegram", "Enter"], { stdio: "ignore" });
+    return true;
+  } catch { return false; }
+}
+
+export interface PollerUpResult {
+  /** poller 가 최종적으로 붙었는가 */
+  ok: boolean;
+  /** auto-reconnect 로 살려낸 것인가(첫 확인에 이미 붙어 있었으면 false) */
+  recovered: boolean;
+  /** 주입한 reconnect 횟수 */
+  attempts: number;
+  /** 사람이 읽는 한 줄(재시작 응답·활성화 step 에 그대로 쓴다) */
+  detail: string;
+}
+
+/**
+ * poller 가 붙을 때까지 기다리고, 안 붙으면 `/mcp reconnect` 를 주입해 되살린다.
+ *
+ * ★영입에는 있었지만 재시작에는 없던 것★(2026-07-27 GD 지적) — 재시작 경로는 기동 스크립트만 돌리고
+ *   붙었는지 확인조차 안 했다. 그래서 ★재시작 후 안 붙으면 아무도 복구하지 않았다.★ 팀원은 조용히
+ *   귀머거리가 되고, 팀장이 눈치챌 때까지 방치된다. 같은 복구를 양쪽에서 쓰게 여기로 모은다.
+ */
+export async function ensureClaudePollerUp(
+  id: string,
+  opts?: {
+    waitMs?: number;
+    reconnectAttempts?: number;
+    recheckMs?: number;
+    /** 테스트 주입 — 실제 tmux/HOME 을 건드리지 않는다 */
+    wait?: (id: string, ms: number) => Promise<boolean>;
+    reconnect?: (id: string) => boolean;
+  },
+): Promise<PollerUpResult> {
+  const waitMs = opts?.waitMs ?? 30000;
+  const maxAttempts = opts?.reconnectAttempts ?? 2;
+  const recheckMs = opts?.recheckMs ?? 12000;
+  const wait = opts?.wait ?? ((i, ms) => waitForClaudePoller(i, ms));
+  const reconnect = opts?.reconnect ?? reconnectClaudeTelegram;
+
+  let ok = await wait(id, waitMs);
+  if (ok) return { ok: true, recovered: false, attempts: 0, detail: "텔레그램 poller 기동 확인" };
+
+  let attempts = 0;
+  for (; !ok && attempts < maxAttempts; ) {
+    // 세션 자체가 없으면(스폰 실패) reconnect 로 살릴 수 없다 — 헛도는 대신 즉시 중단한다.
+    if (!reconnect(id)) break;
+    attempts++;
+    ok = await wait(id, recheckMs);
+  }
+  return {
+    ok,
+    recovered: ok && attempts > 0,
+    attempts,
+    detail: ok
+      ? `텔레그램 poller 복구(auto-reconnect ${attempts}회)`
+      : `★텔레그램 poller 미기동★ — auto-reconnect ${attempts}회 시도했으나 미복구. 세션에서 /mcp reconnect 재시도 가능`,
+  };
+}


### PR DESCRIPTION
## 무엇이 문제였나

**재시작하면 텔레그램 통로가 안 붙는 경우가 있는데, 재시작 경로에는 복구가 없었다.**

`restartAgent` 는 기동 스크립트만 돌리고 **poller 가 실제로 붙었는지 확인조차 하지 않았다.**

그래서 재시작 후 안 붙으면:
- 프로세스는 살아 있다
- 대시보드도 정상으로 보인다
- **메시지만 안 들어온다. 오류도 안 난다.**
- 사람이 눈치챌 때까지 그 팀원은 **조용히 귀머거리**로 방치된다

**같은 복구가 영입(`activation`)에는 이미 있었다.** 한쪽에만 있는 안전장치는 없는 것과 같다.

## 무엇을 고쳤나

**새 모듈 `runtimes/claude/pollerHealth.ts`**
- `waitForClaudePoller` · `reconnectClaudeTelegram` (기존 구현 이동)
- `ensureClaudePollerUp` — 대기 → 실패 시 `/mcp reconnect` 주입 → 재확인, **한도 2회**

**왜 별도 모듈인가** — 이 로직이 필요한 곳이 `activation`·`agentControl` 둘인데, 기존 위치(`activation.ts`/`launcher.ts`)는 `agentControl` 과 이미 얽혀 있어 **어느 방향으로 import 해도 순환**이 된다. 의존이 없는 자리로 내렸다. 기존 위치는 **재-export** 로 남겨 import 경로와 동작을 보존한다.

**`restartAgent`(claude_channel)** — 재시작 성공 후 `ensureClaudePollerUp` 호출.
복구에 실패해도 **재시작 자체는 성공**으로 보고하되(프로세스는 떴다) `detail` 에 미기동을 명시한다. **조용히 성공이라고 말하지 않는 것이 이 수정의 핵심이다.**

## 설계 판단

- **이미 붙어 있으면 reconnect 를 쏘지 않는다** — 멀쩡한 세션에 슬래시 명령을 주입하는 게 더 위험하다
- **tmux 세션이 없으면 즉시 중단** — 살릴 수단이 없는데 헛돌면 재시작이 30초씩 늘어진다
- **무한 재시도 없음** — 한도 2회에서 멈추고 실패를 말한다
- 대기시간은 `TEAMOS_RESTART_POLLER_WAIT_MS` 로 조정 가능(기본 30s)

## 검증

- 회귀 테스트 **6건**: 이미 붙어있으면 주입 안 함 · 안 붙으면 복구 · 재시도 · 한도 · 세션부재 즉시중단 · 첫대기/재확인 값 분리
- **변이 검증 2종**: 복구 로직 제거 → **4건 실패** / 세션부재 가드 제거 → **1건 실패**
- `tsc --noEmit` 통과
- 전체 **1,752 pass / 0 fail** (152 파일)
- **배포 후 라이브 실기 테스트 예정** (정상 재시작 + 실패 시 복구 양쪽)

## 롤백

5개 파일. 새 모듈 삭제 + 3개 파일 revert. DB·설정 변경 없음. 기존 import 경로는 재-export 라 되돌려도 안전.
