### PR TITLE
chore(release): 0.5.1 + 버전 동기화 가드

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team-collab",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/src/web/components/LiveBadge.test.ts
+++ b/src/web/components/LiveBadge.test.ts
@@ -1,10 +1,24 @@
 import { describe, expect, test } from "bun:test";
-import { shouldShowLiveBadge } from "./LiveBadge";
+import { shouldShowLiveBadge, APP_VERSION } from "./LiveBadge";
 
 describe("LiveBadge host gating", () => {
   test("shows only on the private live dashboard", () => {
     expect(shouldShowLiveBadge("dev.b3rys.com")).toBe(true);
     expect(shouldShowLiveBadge("studio.b3rys.com")).toBe(false);
     expect(shouldShowLiveBadge("localhost")).toBe(false);
+  });
+});
+
+/* ★버전이 두 곳에 손으로 적혀 있다★ — package.json 과 여기. 주석에 "맞춰 관리" 라고만 돼 있고
+ * 어긋나도 아무것도 안 잡았다. 배지가 옛 버전을 표시해도 테스트는 초록이다.
+ * 릴리즈마다 사람이 두 번 고쳐야 하는 구조라, 한 번 빠지면 조용히 어긋난 채로 배포된다. */
+describe("APP_VERSION — package.json 과 어긋나면 실패한다", () => {
+  test("★대시보드 배지 버전 = package.json 버전★", async () => {
+    const pkg = await Bun.file(`${import.meta.dir}/../../../package.json`).json();
+    expect(APP_VERSION).toBe(pkg.version);
+  });
+
+  test("버전 형식은 x.y.z 다", () => {
+    expect(APP_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
   });
 });

--- a/src/web/components/LiveBadge.ts
+++ b/src/web/components/LiveBadge.ts
@@ -5,7 +5,7 @@
 
 const LIVE_HOSTS = new Set(["dev.b3rys.com"]);
 // b3os 제품 버전. package.json version과 맞춰 관리.
-const APP_VERSION = "0.5.0";
+export const APP_VERSION = "0.5.1";
 
 export function shouldShowLiveBadge(hostname: string): boolean {
   return LIVE_HOSTS.has(hostname);


### PR DESCRIPTION
## 0.5.1 (패치)

`v0.5.0` 이후 **35커밋**. 전부 수정·문서이고 호환성 깨짐 없음.

주요: 슬랙 Socket 통일(#93) · 마법사 이벤트 구독 단계(#92) · 재시작 poller 자동복구(#94) · 세션 저장소 오염(#82) · 홉 이중증가(#86) · 체인 8(#90) · openclaw 경로(#83) · 팀원 지시문 절대경로(#89) · 슬랙 통신 문서화(#95)

## 같이 넣은 것 — 버전 동기화 가드

버전이 **두 곳에 손으로** 적혀 있었다(`package.json` · `LiveBadge.APP_VERSION`). 주석에 "맞춰 관리" 라고만 돼 있고 **어긋나도 아무것도 안 잡았다** — 배지가 옛 버전을 표시해도 테스트는 초록이다.

→ 두 값이 어긋나면 **실패하는 테스트**를 넣었다. **변이 검증**: 배지만 되돌리면 1건 실패.

## 검증
tsc 통과 · 전체 **1,759 pass / 0 fail**

## 부수 확인
이 PR 의 머지 커밋 author 이메일로 **`Keep my email addresses private` 설정이 실제로 걸렸는지** 검증한다.