### PR TITLE
docs(slack): 공개 문서가 지원하지 않는 방식을 안내하던 것

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,10 +173,13 @@ Slack은 **Socket Mode**로 붙습니다 — 공개 URL·웹훅 엔드포인트�
 
 1. 대시보드 **Settings → Slack** 위저드를 엽니다.
 2. 안내되는 **매니페스트로 앱 생성** (*From a manifest* — Socket Mode가 켜진 매니페스트) → 워크스페이스 선택.
-3. **App-Level Token** (`xapp-…`, scope `connections:write`)을 발급해 대시보드에 붙여넣습니다. *(메시지 전송용 봇 토큰 `xoxb-…`는 별도)*
-4. 봇을 대상 채널에 초대합니다.
+3. **Event Subscriptions** → `Enable Events` **ON** → `Subscribe to bot events` → `app_mention` 추가 → **Save Changes**. *(매니페스트에 이미 있어도 실제로 켜져 있는지 확인하세요 — 꺼져 있으면 봇이 멘션에 반응하지 않고 오류도 나지 않습니다)*
+4. **App-Level Token** (`xapp-…`, scope `connections:write`)을 발급해 대시보드에 붙여넣습니다. *(메시지 전송용 봇 토큰 `xoxb-…`는 별도)*
+5. 봇을 대상 채널에 초대합니다.
 
-> 🛠️ 공개 URL 방식을 선호하면 위저드에서 **Event URL** 모드로 바꿔 `/team/api/slack/events` 를 쓸 수도 있습니다(선택).
+> 🛠️ **`@멘션`이 없으면 봇에게 전달되지 않습니다.** 서버는 멘션 이벤트만 받습니다. 멘션 없이 쓴 글은 들어가지 않고 오류도 나지 않으니, 답이 없을 때는 "무시"가 아니라 "안 들어간 것"일 수 있습니다.
+>
+> 자세한 절차는 [docs/SLACK_SETUP.md](docs/SLACK_SETUP.md).
 
 채널은 텔레그램·슬랙 중 하나만 연결해도 됩니다.
 

--- a/docs/SLACK_SETUP.md
+++ b/docs/SLACK_SETUP.md
@@ -1,190 +1,40 @@
-# Slack 통합 셋업 (per agent)
+# Slack 통합 셋업
 
-AI team의 각 agent가 자기 Slack App + bot user를 갖는다. 모두 같은 채널에서 사용자가 `@team_<name>` 멘션하면 해당 agent만 트리거 → thread 댓글로 자동 응답.
+> **옛 방식(Event URL + 공개 도메인 + Cloudflare Access)을 설명하던 문서라 내용을 교체했습니다.**
+> **정본은 대시보드의 Slack 위저드입니다** — `Settings → 팀원 → Slack`.
 
-**예상 시간**: agent 당 ~3분 (팀원 수 × 3분 + 검증).
+## 지금 방식: Socket Mode
 
----
+Slack 연결은 **선택**입니다(텔레그램만으로 충분합니다).
 
-## 사전 조건 (워크스페이스 1회 셋업)
+붙일 때는 **Socket Mode** 를 씁니다. **공개 도메인도, 웹훅 엔드포인트도, Cloudflare 설정도 필요 없습니다.**
+대시보드 위저드가 매니페스트를 만들어 주고 각 단계를 안내합니다.
 
-1. **Slack workspace**: 대상 workspace
-2. **채널 생성**: `#team-ai` (private, AI team 전용)
-   - 새 채널 → Add bookmark `<dashboard-url>/team` (대시보드 빠른 진입)
-3. **Cloudflare Access Bypass** — Slack webhook 이 우리 endpoint 도달해야 함
-   - Zero Trust → Access → Applications → **Add an application** (Self-hosted)
-     - Name: `slack-webhook-bypass`
-     - Domain: `<dashboard-domain>`
-     - **Path**: `/team/api/slack/events`
-     - Policy: action **Bypass**, include Everyone
-   - 이거 안 하면 Slack 의 verification challenge 가 CF Access 로그인 페이지로 리다이렉트되어 fail
-4. **대표 App만 한 번** Event Subscriptions URL verify → 이후 모든 App은 같은 URL 그대로 즉시 통과
+1. 대시보드 **Settings → 팀원 → Slack** 위저드를 엽니다.
+2. 안내되는 **매니페스트로 앱 생성**(*From a manifest*, Socket Mode 켜진 상태) → 워크스페이스 선택.
+3. **Event Subscriptions** → `Enable Events` **ON** → 아래로 내려 `Subscribe to bot events`
+   → `Add Bot User Event` → `app_mention` 추가 → **Save Changes**.
+   매니페스트에 이미 들어 있어도 **실제로 켜져 있는지 확인하세요** — 꺼져 있으면
+   봇이 멘션에 반응하지 않고 **오류도 나지 않습니다.**
+4. **Install to Workspace** → 권한 승인.
+   필요한 scope: `app_mentions:read` · `chat:write` · `groups:history` · `channels:history`
+5. **App-Level Token**(`xapp-…`, scope `connections:write`)과
+   **Bot User OAuth Token**(`xoxb-…`)을 위저드에 붙여넣습니다.
+6. 봇을 대상 채널에 초대합니다: `/invite @봇이름`
 
----
+## 알아둘 것
 
-## Agent 당 등록 절차 (반복)
+- **`@멘션` 이 없으면 봇에게 전달되지 않습니다.** 서버는 `app_mention` 이벤트만 받습니다.
+  멘션 없이 쓴 글은 아예 안 들어가고 오류도 나지 않으므로, 답이 없을 때는
+  "무시" 가 아니라 **"안 들어간 것"** 일 수 있습니다.
+  부를 때는 Slack 의 멘션 자동완성을 쓰세요 — 이름을 글자로 적는 건 멘션이 아닙니다.
+- 토큰은 채팅·로그에 평문으로 남기지 마세요. 위저드에 붙여넣으면 서버가 권한 0600 파일로 보관합니다.
+- 팀원이 Slack 에 글을 올릴 때는 `skills/b3os-team-inbox` 의 `scripts/slack-post.sh` 를 씁니다.
 
-`<NAME>` = 소문자 agent id (agent-a / coordinator / ...)
-`<Name>` = 표시명 (Agent A / Coordinator / ...)
+## 왜 내용을 바꿨나
 
-### ① App 생성
-- https://api.slack.com/apps → **Create New App** → **From scratch**
-- App Name: `Team <Name>`
-- Workspace: 대상 workspace
+예전에는 Event URL 방식(공개 HTTPS 주소 + Cloudflare Access Bypass + Event Subscriptions Request URL)을
+설명했습니다. 지금은 **Socket Mode 가 정본**이고 서버도 Socket 매니페스트만 내보냅니다.
 
-### ② Bot 권한
-(좌측 메뉴) **OAuth & Permissions**
-- Scopes → Bot Token Scopes → Add OAuth Scope:
-  - `app_mentions:read` (멘션 수신)
-  - `chat:write` (thread 댓글 / channel post)
-  - `groups:history` (private 채널 메시지 읽기)
-- 페이지 상단 → **Install to workspace** → 권한 승인
-
-### ③ Event Subscriptions
-(좌측 메뉴) **Event Subscriptions**
-- Enable Events: **ON**
-- Request URL: `<dashboard-url>/team/api/slack/events`
-- "Subscribe to bot events" → **Add Bot User Event** → `app_mention`
-- **Save Changes** (필수)
-
-### ④ 토큰 두 개 추출
-| 항목 | 위치 | 형태 |
-|---|---|---|
-| **Bot User OAuth Token** | OAuth & Permissions 상단 | `xoxb-숫자-숫자-문자열` |
-| **Signing Secret** | Basic Information → "App Credentials" → Show | 32자 16진수 |
-
-**무시할 토큰** (Slack UI 에 같이 보이지만 우리 안 씀):
-- *Verification Token* — 2018 deprecated, Signing Secret 으로 대체됨
-- *App-Level Token* (`xapp-...`) — Socket Mode 용, 우리는 public webhook 쓰니 불필요
-
-→ 두 값을 아래 형식으로 안전한 곳에 기록해 둡니다(다음 "서버 측 처리" 단계에서 `slack-tokens/<name>.env` 로 저장). 토큰은 채팅·로그에 평문으로 남기지 마세요:
-```
-<NAME> token: xoxb-...
-<NAME> secret: ...
-```
-
-### ⑤ 아이콘 업로드
-- **Basic Information** → "Display Information" → App Icon
-- `assets/slack-avatars/<name>.png` (repo 루트 기준) 업로드
-- (Optional) Background color: `#0F172A` (대시보드 surface-2 와 일치)
-- Short Description / Long Description: persona 한 줄 요약
-
-### ⑥ 채널 초대
-- Slack `#team-ai` 입력창:
-  ```
-  /invite @team_<name>
-  ```
-
-### ⑦ 첫 멘션 테스트
-- 채널에:
-  ```
-  @team_<name> 안녕!
-  ```
-- 봇이 같은 thread 에 댓글로 응답 → 성공
-- 동시에 대시보드 `<dashboard-url>/team` THREADS 패널에 새 thread 표시
-
----
-
-## 서버 측 처리 (④ 에서 기록한 토큰으로 호스트에서 진행)
-
-호스트에서 직접(또는 담당 agent 세션에서) 아래를 수행합니다:
-
-1. `slack-tokens/<name>.env` 작성 (Write 도구, chmod 600) — `SLACK_BOT_TOKEN=xoxb-...` / `SLACK_SIGNING_SECRET=...`
-2. **토큰 검증** — Slack `auth.test` API 로 team / bot_user_id 확인 (토큰은 stdout 에 노출하지 않고 파일에서 주입):
-   ```bash
-   # slack-tokens/<name>.env 를 로드해 Bearer 로만 넘긴다. 토큰 값은 출력하지 않는다.
-   set -a; . slack-tokens/<name>.env; set +a
-   curl -sS -H "Authorization: Bearer $SLACK_BOT_TOKEN" https://slack.com/api/auth.test \
-     | python3 -c 'import sys,json; d=json.load(sys.stdin); print("ok=",d.get("ok"),"team=",d.get("team"),"bot_user_id=",d.get("user_id"))'
-   unset SLACK_BOT_TOKEN SLACK_SIGNING_SECRET
-   ```
-   `ok= True` 와 함께 team / bot_user_id 가 나오면 성공. `ok= False` 면 `error` 필드(`invalid_auth` 등) 확인.
-3. `agents.json` 에 `slack_bot_user_id` 필드 추가 (위 `bot_user_id` 값)
-4. registry watch (`fs.watch`) 가 자동 reload → in-memory agents 갱신
-5. 이어서 ⑤⑥⑦ (아이콘 업로드 · 채널 초대 · 첫 멘션 테스트) 를 진행
-
----
-
-## 전체 흐름 (멘션 → 자동 응답)
-
-```
-사용자: "@team_agent_a 안녕"
-   │
-   ▼
-Slack Events API
-   │
-   ▼
-CF Tunnel → CF Access Bypass(/team/api/slack/events) → localhost:7878
-   │
-   ▼
-POST /api/slack/events
-   ├─ Signing Secret 으로 HMAC 검증 (위조 차단)
-   ├─ payload.api_app_id 로 어느 agent 의 webhook 인지 식별
-   ├─ event.text 안의 <@U...> → registry 의 slack_bot_user_id 매칭 → target = agent-a
-   ├─ envelope 저장 (DB message + meta.slack = {channel, thread_ts})
-   ├─ WS broadcast (대시보드 실시간 갱신)
-   └─ tmux send-keys 로 claude-agent-a 세션에 <external_message> wrapper 주입
-   │
-   ▼
-claude-agent-a 의 Claude Code 세션
-   ├─ wrapper 보고 외부 메시지로 인식
-   ├─ 응답 작성
-   └─ skills/b3os-team-inbox/scripts/send.sh --to user --thread X --in-reply-to Y --body "..."
-   │
-   ▼
-POST /api/inbox
-   ├─ envelope 저장
-   ├─ thread 의 첫 메시지 meta_json 에서 slack 정보 추출
-   ├─ slack-tokens/agent-a.env 의 bot token 으로 chat.postMessage(thread_ts) 호출
-   └─ audit: slack_relay_sent {ok:true, ts:...}
-   │
-   ▼
-Slack thread 에 agent A 답글 표시
-```
-
----
-
-## 자발적 channel post (멘션 없이)
-
-스킬 헬퍼:
-```bash
-skills/b3os-team-inbox/scripts/slack-post.sh \
-  --channel <channel-id> \
-  --text "공지 내용"
-```
-
-- `<channel-id>` = 대상 Slack 채널 id (채널 이름 우클릭 → "채널 세부정보 보기" 하단, 또는 채널 URL 끝 `C...` 문자열)
-- `--thread <ts>` 있으면 thread 댓글, 없으면 채널 최상위 글
-- `--as <agent>` 명시 안 하면 tmux 세션명에서 자동 감지
-
-활용:
-- 주간 미팅 안건 던지기 ("@channel 이번 주 진행상황 thread 댓글 부탁")
-- 시스템 알림
-- briefing agent 일일 뉴스 요약
-
----
-
-## 트러블슈팅
-
-| 증상 | 원인 | 해결 |
-|---|---|---|
-| "Your URL didn't respond with the value of the challenge parameter" | CF Access 가 Slack webhook 차단 (Email OTP 로그인 페이지로 리다이렉트) | 사전 조건 #3 (Bypass app) 추가 |
-| 멘션해도 봇 응답 없음 | (1) 채널에 봇 초대 안 됨 (2) Event Subscriptions Save 안 함 (3) `app_mention` scope 누락 | 위 ② ③ ⑥ 재확인 |
-| signature mismatch 로그 | Signing Secret 잘못 저장 | 위 "토큰 검증"(`auth.test`) 으로 bot token 확인 + `slack-tokens/<name>.env` 의 `SLACK_SIGNING_SECRET` 이 Basic Information 값과 일치하는지 대조, 안 되면 Slack 에서 Regenerate |
-| bot 끼리 무한 응답 | echo prevention bug | `routes/slack.ts` 의 `if (ev.bot_id) return;` 확인 (현재 적용됨) |
-| token leak 우려 | 메시지/로그 검색 | BotFather/Slack 에서 Revoke → 새 토큰 → `slack-tokens/<name>.env` 갱신 → LaunchAgent kickstart |
-
----
-
-## 보안
-
-- `slack-tokens/` 디렉토리: chmod 700, `.env` 파일: chmod 600
-- `.gitignore` 에 `slack-tokens/` 포함 (커밋 금지)
-- 토큰을 stdout 으로 echo 금지 (Claude Code .jsonl 세션 로그에 영구 기록 위험)
-- 검증은 위 "토큰 검증"(`auth.test`) 처럼 `.env` 에서 Bearer 로만 주입해 team/user_id 만 출력하고, 끝나면 `unset` — 토큰 값 자체는 절대 출력하지 않는다
-
----
-
-## 향후 (사이드 목표)
-
-`team-collab-skill` (외부 공개용 playbook) 의 일부로 이 절차 그대로 가져감. 다른 조직이 fork 해서 자기 팀 구성할 때 동일하게 적용 가능.
+옛 설명을 남겨두면 **도메인을 사고 Cloudflare 를 설정해도 끝나지 않는 막다른 길**로 사용자를 보내게 됩니다.
+그래서 지웠습니다.


### PR DESCRIPTION
## 문제

**`docs/SLACK_SETUP.md` 가 정본과 정면으로 반대였다.**

| | 문서가 요구 | 실제(Socket Mode) |
|---|---|---|
| 공개 도메인 | 필요 | **불필요** |
| Cloudflare Zero Trust Bypass | 필요 | **불필요** |
| Event Subscriptions URL | 필요 | **불필요** |
| App-Level Token | `우리 안 씀` 이라고 명시 | **필수** |

이 문서를 따라간 사용자는 **도메인을 사고 Cloudflare 를 설정해도 끝나지 않는다.** 막다른 길이다.

또 README 에 `위저드에서 Event URL 모드로 바꿀 수 있다` 가 남아 있었다. **오늘 #93 으로 그 토글을 없앴으므로 없는 기능을 약속하고 있었다** — 내 변경의 뒷정리다.

## 수정

- `SLACK_SETUP.md` → Socket Mode 절차로 교체(183줄 삭제). **왜 바꿨는지 문서에 남겼다** — 안 적으면 누군가 옛 방식으로 되돌린다.
- README → Event URL 안내 제거, 이벤트 구독 켜는 단계 추가, SLACK_SETUP 링크 연결
- 양쪽에 **`@멘션` 없으면 전달 안 됨** 명시. 오늘 실제로 이것 때문에 팀원 통신이 어긋났다(멘션 없는 답이 서버에 안 들어와 '침묵'으로 보였다).

## 검증

문서 변경만, 코드 무변경. 전체 **1,759 pass / 0 fail**. 링크 대상 실재 확인.