### PR TITLE
fix(test): 영입 테스트가 실제 머신의 런타임 설치 여부를 탐침하던 것 [CI 0단계]

### DIFF
--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -34,6 +34,15 @@ const AGENTS = [
   { id: "steve", display_name: "Steve", nicknames: ["steve"], role: "fullstack", runtime: "claude_channel", status_provider: "claude_tmux", avatar_emoji: "🧑‍💻", moderator_eligible: false },
 ];
 
+// ★런타임 인증 검사 기본 스텁 — 테스트가 실제 머신을 탐침하지 않게 한다.★
+//   publicRuntimeGate(settings.ts) 가 openclaw/hermes 영입 때 checkRuntimeAuth 를 부르는데,
+//   주입이 없으면 ★실 머신의 openclaw 바이너리·~/.hermes 프로필을 찾는다.★
+//   그래서 그 런타임이 깔린 기기에서만 통과하는 ★환경결합 테스트★ 가 됐다 —
+//   fresh clone(=CI·외부 기여자 조건)에서 10건이 400 으로 떨어졌다(2026-07-27 실측).
+//   archiveWorkspace=noop · skipRuntimeCleanup=true 와 같은 이유의 격리다: 테스트는 이 기기 상태를 읽지 않는다.
+//   ★미준비 상태를 검증하는 테스트는 각자 notReady 를 주입한다★ — 그쪽이 의도적으로 덮어쓴다.
+const readyAuth = async (runtime: string) => ({ runtime, loggedIn: true, detail: "테스트 스텁(준비됨)", fixHint: "" });
+
 function setup(agents: any[] = AGENTS, overrides: Partial<Parameters<typeof createSettingsApp>[0]> = {}) {
   const db = new Database(":memory:");
   migrate(db);
@@ -55,7 +64,7 @@ function setup(agents: any[] = AGENTS, overrides: Partial<Parameters<typeof crea
   syncRegistry(db, registryPath);
   // ⚠️ archiveWorkspace=noop 주입: 퇴사(DELETE) 테스트가 실제 ~/Development/<id>를 mv하지 않게 격리.
   // (이게 빠지면 full suite 실행 시 라이브 멤버 워크스페이스가 진짜 archive로 날아감 — high-sev 회귀)
-  const app = createSettingsApp({ db, registryPath, teamOsPath, appendAudit, onRegistryChanged: () => syncRegistry(db, registryPath), archiveWorkspace: () => null, skipRuntimeCleanup: true, ...overrides });
+  const app = createSettingsApp({ db, registryPath, teamOsPath, appendAudit, onRegistryChanged: () => syncRegistry(db, registryPath), archiveWorkspace: () => null, skipRuntimeCleanup: true, checkRuntimeAuth: readyAuth, ...overrides });
   return { app, teamOsPath, registryPath, dir, db };
 }
 /** 팀 세팅이 '완료'된 상태 — 영입(recruit)은 setupComplete() 를 통과해야 열린다.


### PR DESCRIPTION
## 문제

**깨끗한 클론에서 10건이 실패한다.**

```
이 맥        1759 pass / 0 fail     ← 아무도 몰랐다
fresh clone  1744 pass / ★10 fail★  ← CI·외부 기여자가 보는 조건
```

이 맥은 openclaw·hermes 가 깔려 있어서 초록이었다.

**원인**: `publicRuntimeGate`(settings.ts:320)가 openclaw/hermes 영입 때 `checkRuntimeAuth` 를 부르는데, 그 테스트들이 **주입을 안 해서 실제 머신을 탐침했다** — openclaw 바이너리 존재 여부, `~/.hermes` 프로필. 런타임이 없는 기기에서는 400 이 나고 영입·OT 테스트가 전부 깨진다.

## 수정 — 제품 코드는 안 건드렸다

**주입 자리(`deps.checkRuntimeAuth`)가 이미 있었다.** 테스트만 안 쓰고 있었다.
`setup()` 기본값으로 "준비됨" 스텁을 넣는다 — 기존 `archiveWorkspace: noop` · `skipRuntimeCleanup: true` 와 **같은 계열의 격리**다. *테스트는 이 기기 상태를 읽지 않는다.*

미준비 상태를 검증하는 테스트는 각자 `notReady` 를 주입하므로 **그대로 동작한다**(overrides 가 뒤에 온다).

## 검증

| | 결과 |
|---|---|
| **fresh clone + 격리 HOME** | **10 fail → 0 fail** |
| **변이 검증** (스텁 제거) | **정확히 그 10건 재실패** |
| 이 맥 (런타임 설치됨) | 1759 pass / 0 fail — 회귀 없음 |
| `tsc --noEmit` | 통과 |

**판정을 fresh clone 기준으로 한 이유**: 이 맥 초록은 근거가 안 된다. 같은 문제를 두고 이 맥에서 6건, fresh clone 에서 10건이 나왔고, **그 차이 자체가 환경 결합의 증거**였다.

## 후속

이걸로 **CI·pre-push 훅의 선행조건이 풀린다.** Steve 의 CI PR(훅 + workflow + .github 템플릿)이 이 머지를 대기 중이다.