### PR TITLE
codex app-server 코드 정본 이식 (비활성 groundwork) — 구현됨/미구현 구분 명시, 활성화는 #106 이후

### DIFF
--- a/src/server/db/migrate.ts
+++ b/src/server/db/migrate.ts
@@ -267,6 +267,24 @@ export function migrateCodexRuntimeState(db: Database): void {
      )`,
   );
   db.exec("CREATE INDEX IF NOT EXISTS idx_codex_inflight_started ON codex_inflight(started_at)");
+  // Phase1 ③: 승인 팝업 ↔ app-server request 상관키 + CAS 상태(codex-owned, additive).
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS codex_approval_correlation (
+       request_id TEXT PRIMARY KEY,
+       agent_id TEXT NOT NULL REFERENCES agent(id) ON DELETE CASCADE,
+       server_request_id TEXT,
+       thread_id TEXT,
+       turn_id TEXT,
+       item_id TEXT,
+       operation_hash TEXT NOT NULL,
+       process_instance TEXT NOT NULL,
+       state TEXT NOT NULL DEFAULT 'pending' CHECK(state IN ('pending','decided','delivered','expired','orphaned')),
+       created_at TEXT NOT NULL DEFAULT (datetime('now')),
+       decided_at TEXT
+     )`,
+  );
+  db.exec("CREATE INDEX IF NOT EXISTS idx_codex_approval_corr_state ON codex_approval_correlation(state, created_at)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_codex_approval_corr_proc ON codex_approval_correlation(process_instance)");
 }
 
 export function migrateSchedulerState(db: Database): void {

--- a/src/server/db/schema.sql
+++ b/src/server/db/schema.sql
@@ -171,7 +171,7 @@ CREATE TABLE IF NOT EXISTS codex_approval_correlation (
   thread_id TEXT,
   turn_id TEXT,
   item_id TEXT,
-  operation_hash TEXT NOT NULL,             -- 전체(미절단) 작업 해시 — delivery 시 재검증(TOCTOU)
+  operation_hash TEXT NOT NULL,             -- 작업 지문(승인 전 캡처) — delivery 시 결정↔요청 1:1 대조용. grant scope에는 미반영(알려진 갭)
   process_instance TEXT NOT NULL,           -- 서버 프로세스 인스턴스 id(재시작 감지)
   state TEXT NOT NULL DEFAULT 'pending' CHECK(state IN ('pending','decided','delivered','expired','orphaned')),
   created_at TEXT NOT NULL DEFAULT (datetime('now')),

--- a/src/server/db/schema.sql
+++ b/src/server/db/schema.sql
@@ -163,7 +163,8 @@ CREATE INDEX IF NOT EXISTS idx_codex_inflight_started ON codex_inflight(started_
 
 -- codex app-server 승인 팝업 ↔ server-request 상관키 + CAS 상태(Phase1 ③).
 -- 팝업(permission_request.id)과 실제 app-server 승인 요청을 1:1로 묶어 TTL 늦은승인·서버재시작 orphan·
--- 중복·TOCTOU를 안전 처리. process_instance로 재시작을 감지해 옛 pending을 새 turn에 재결합 안 함.
+-- 중복 결정·요청 불일치를 안전 처리. process_instance로 재시작을 감지해 옛 pending을 새 turn에 재결합 안 함.
+-- ★operation_hash는 승인 전 캡처값이라 실행 직전 변경 검출이 아니고, 권한 grant scope에도 반영되지 않는다(알려진 갭 → 이슈 #106).★
 CREATE TABLE IF NOT EXISTS codex_approval_correlation (
   request_id TEXT PRIMARY KEY,              -- = permission_request.id (팝업)
   agent_id TEXT NOT NULL REFERENCES agent(id) ON DELETE CASCADE,

--- a/src/server/db/schema.sql
+++ b/src/server/db/schema.sql
@@ -161,6 +161,25 @@ CREATE TABLE IF NOT EXISTS codex_inflight (
 );
 CREATE INDEX IF NOT EXISTS idx_codex_inflight_started ON codex_inflight(started_at);
 
+-- codex app-server 승인 팝업 ↔ server-request 상관키 + CAS 상태(Phase1 ③).
+-- 팝업(permission_request.id)과 실제 app-server 승인 요청을 1:1로 묶어 TTL 늦은승인·서버재시작 orphan·
+-- 중복·TOCTOU를 안전 처리. process_instance로 재시작을 감지해 옛 pending을 새 turn에 재결합 안 함.
+CREATE TABLE IF NOT EXISTS codex_approval_correlation (
+  request_id TEXT PRIMARY KEY,              -- = permission_request.id (팝업)
+  agent_id TEXT NOT NULL REFERENCES agent(id) ON DELETE CASCADE,
+  server_request_id TEXT,                   -- app-server JSON-RPC request id
+  thread_id TEXT,
+  turn_id TEXT,
+  item_id TEXT,
+  operation_hash TEXT NOT NULL,             -- 전체(미절단) 작업 해시 — delivery 시 재검증(TOCTOU)
+  process_instance TEXT NOT NULL,           -- 서버 프로세스 인스턴스 id(재시작 감지)
+  state TEXT NOT NULL DEFAULT 'pending' CHECK(state IN ('pending','decided','delivered','expired','orphaned')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  decided_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_codex_approval_corr_state ON codex_approval_correlation(state, created_at);
+CREATE INDEX IF NOT EXISTS idx_codex_approval_corr_proc ON codex_approval_correlation(process_instance);
+
 CREATE TABLE IF NOT EXISTS scheduled_job (
   id TEXT PRIMARY KEY,
   kind TEXT NOT NULL CHECK(kind IN ('oneshot','recurring')),

--- a/src/server/runtimes/codex/adapter.test.ts
+++ b/src/server/runtimes/codex/adapter.test.ts
@@ -218,6 +218,27 @@ describe("codex adapter — 핵심 정확성", () => {
     expect(allMessages(db)).toEqual([]);                // 게시는 [B] 대로 0
   });
 
+  test("②-b in-flight 잠금은 ★agent 단위★: 같은 dex에 '다른 메시지'가 처리 중 와도 두 번째 턴이 안 뜬다 (동시성 회귀 가드)", async () => {
+    // Ames 교차검증(2026-07-24)이 짚은 버그: 잠금 키가 message_id별이면 같은 agent에 다른 메시지가
+    // 오면 동시 턴 2개가 떠 세션 resume/응답이 꼬인다. per-agent 키로 고쳤고 이 테스트가 회귀를 막는다.
+    const db = setup();
+    let release!: (r: CodexTurnResult) => void;
+    let calls = 0;
+    const blocking: CodexCaller = () => { calls += 1; return new Promise<CodexTurnResult>((res) => (release = res)); };
+    const adapter = makeCodexAdapter(db, agentsOf(db), { callCodex: blocking });
+    const r1 = await adapter.wake("cody", row({ message_id: "cc1" }), "");
+    expect(r1.detail).toBe("codex_dispatched");
+    // ★다른 message_id★ 로 같은 agent 재-wake — per-message 키였다면 여기서 동시 턴이 떴다.
+    const r2 = await adapter.wake("cody", row({ message_id: "cc2" }), "");
+    expect(r2.deferred, "다른 메시지라도 같은 agent 처리 중이면 defer돼야 한다").toBe(true);
+    expect(r2.detail).toBe("codex_in_flight");
+    expect(calls, "★같은 agent에 다른 메시지 = 동시 턴이 뜨면 안 됨★").toBe(1);
+    release(okResult("끝"));
+    await sleep(20);
+    expect(calls).toBe(1);                              // 완료 후에도 두 번째 턴 없음
+    expect(artifacts(db, "started").length).toBe(1);   // 턴은 정확히 하나만
+  });
+
   test("off 명단 멤버 → wake가 codex_agent_off(응답 차단, ok:true no-retry)", async () => {
     const db = setup();
     writeFileSync(OFF_FILE, "cody\n"); // cody를 off 명단에

--- a/src/server/runtimes/codex/adapter.ts
+++ b/src/server/runtimes/codex/adapter.ts
@@ -286,7 +286,14 @@ export function makeCodexAdapter(
       // ok:true(no-retry) — 정지는 정상 상태지 실패 아님.
       if (isAgentOff(targetAgentId)) return { ok: true, detail: "codex_agent_off" };
 
-      const key = `${row.message_id}:${targetAgentId}`;
+      // ★동시성(concurrency) 잠금 = 팀원(agent) 단위 — 메시지(message_id) 단위가 아니다.★
+      //   이유(Ames 교차검증 2026-07-24 + 코드 재검증): wake()는 아래서 runTurn을 detach(즉시 반환)하고,
+      //   2026-07-16 dispatchRow '턴 완료까지 블록' 직렬화(wakeDispatcher)는 hermes/openclaw/claude만 커버하고
+      //   ★codex는 빠져 있었다.★ 키가 message_id별이면 같은 agent에 '다른 메시지'가 오면 동시 턴 2개가 떠
+      //   같은 Codex 세션을 동시 resume/기록 → 답 섞임·맥락 꼬임·중복 발신이 난다.
+      //   → agent 단위 잠금으로 앞 턴이 끝날 때(아래 finally)까지 다음 턴을 defer(연기)해 '한 팀원=한 번에 한 턴'을 보장.
+      //   (다른 런타임과 동일 계약. 공용 RuntimeTurnCoordinator 리팩터는 shared 코드라 별도 과제로 분리.)
+      const key = targetAgentId;
       if (inFlight.has(key)) return { ok: true, deferred: true, detail: "codex_in_flight" };
       inFlight.add(key);
 

--- a/src/server/runtimes/codex/appServerClient.ts
+++ b/src/server/runtimes/codex/appServerClient.ts
@@ -10,6 +10,9 @@
  * ★이 모듈은 순수 프로토콜 클라이언트다 — 팀 버스/permissionGate/텔레그램 배선은 상위(adapter)가 한다.★
  */
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import {
+  classifyServerRequest, isApprovalKind, toInternalDecision, encodeApproval, failSafeNonApproval,
+} from "./serverRequestCodec";
 
 const CODEX_BIN = process.env.CODEX_BIN ?? "codex";
 const HANDSHAKE_TIMEOUT_MS = Number(process.env.B3OS_CODEX_APPSERVER_HANDSHAKE_MS ?? 45_000);
@@ -18,6 +21,7 @@ const HANDSHAKE_TIMEOUT_MS = Number(process.env.B3OS_CODEX_APPSERVER_HANDSHAKE_M
 export interface ApprovalRequest {
   method: string; // execCommandApproval | applyPatchApproval | item/permissions/requestApproval | item/tool/requestUserInput ...
   params: Record<string, unknown>;
+  serverRequestId?: string; // ★Phase1 ③: app-server JSON-RPC 요청 id — 팝업↔요청 1:1 상관키.★
 }
 /** 승인 결정. codex ReviewDecision: approved(=이번만) | approved_for_session(=계속) | denied(=거절/이번만거절) | abort. */
 export type ReviewDecision = "approved" | "approved_for_session" | "denied" | "abort";
@@ -122,6 +126,7 @@ export class CodexAppServerClient {
     this.currentTurnId = null;
     this.lastFinal = "";
     this.deltaBuf = ""; // ★턴 경계 버퍼 리셋(이전 턴 텍스트 누출 방지)★
+    this.approvalWaits = 0; // ★턴 시작 시 승인 대기 ref-count 리셋(이전 턴 누수 방지)★
     return new Promise<TurnResult>((resolve) => {
       let settled = false;
       const finish = (r: TurnResult) => { if (settled) return; settled = true; this.clearTurnTimer(); this.turnResolve = null; this.activeHandlers = null; resolve(r); };
@@ -139,10 +144,14 @@ export class CodexAppServerClient {
   }
 
   private clearTurnTimer(): void { if (this.turnTimer) { clearTimeout(this.turnTimer); this.turnTimer = null; } }
-  /** ★M5.3: 승인 팝업 대기 시작 — 턴 타이머 정지(사람 대기 중엔 타임아웃 안 되게).★ */
-  private pauseTurnTimer(): void { this.clearTurnTimer(); }
-  /** ★M5.3: 승인 응답 후 — 턴 타이머 재개(codex 활성 작업에만 타임아웃 적용).★ */
-  private resumeTurnTimer(): void { if (this.turnResolve && !this.turnTimer && this.armTurnTimer) this.turnTimer = this.armTurnTimer(); }
+  /** ★M5.3: 승인 팝업 대기 시작 — 턴 타이머 정지(사람 대기 중엔 타임아웃 안 되게). ref-count 증가(Phase1 ③).★ */
+  private pauseTurnTimer(): void { this.approvalWaits++; this.clearTurnTimer(); }
+  /** ★M5.3+③: 승인 응답 후 — ref-count 감소, ★모든★ 승인 대기가 끝나야 턴 타이머 재개.
+   *  (Ames ③ 지적: ref-count 없으면 동시 승인 2건 중 첫 응답이 두 번째 사람-대기 중에 타이머를 조기 재개해 오타임아웃.) */
+  private resumeTurnTimer(): void {
+    if (this.approvalWaits > 0) this.approvalWaits--;
+    if (this.approvalWaits === 0 && this.turnResolve && !this.turnTimer && this.armTurnTimer) this.turnTimer = this.armTurnTimer();
+  }
 
   /** 진행 중 턴을 새 지시로 전환(중간 steer). expectedTurnId 필수(실측). */
   async steer(text: string): Promise<void> {
@@ -214,6 +223,10 @@ export class CodexAppServerClient {
   private respond(id: number | string, result: unknown): void {
     this.send({ id, result });
   }
+  /** JSON-RPC error 응답 — 잘못 매핑된 {decision} 대신 pending을 즉시 해소(unknown/제공불가 요청용). */
+  private respondError(id: number | string, code: number, message: string): void {
+    this.send({ id, error: { code, message } });
+  }
   private failAll(err: Error): void {
     for (const [, p] of this.pending) p.reject(err);
     this.pending.clear();
@@ -256,16 +269,32 @@ export class CodexAppServerClient {
   }
 
   private async handleServerRequest(id: number | string, method: string, params: Record<string, unknown>): Promise<void> {
-    const handler = this.activeHandlers?.onApproval;
-    let decision: ReviewDecision = "denied"; // ★fail-closed 기본★
-    // ★M5.3: 승인 판정(팝업 대기 가능) 동안 턴 타이머 정지 → 사람이 폰으로 승인하는 시간이 turn timeout에 안 잡힘.★
-    this.pauseTurnTimer();
-    try {
-      if (handler) decision = await handler({ method, params });
-    } catch { decision = "denied"; }
-    // ★하네스 HIGH 4(a) 픽스: respond가 EPIPE 등으로 throw해도 resume이 스킵되어 턴이 hang하지 않게 finally로.★
-    try { this.respond(id, { decision }); }
-    finally { this.resumeTurnTimer(); } // codex가 결정 받고 작업 재개 → 턴 타이머 재개(예외에도 보장)
+    // ★Phase1 ②: 모든 요청에 {decision} 반환하던 것을 method별 분기로 교체(11종 중 승인 4종만 decision류).★
+    // 근거=serverRequestCodec(Ames 0.144.6 schema 검증). 잘못된 result는 Codex pending을 오류/폴백에 의존시키거나 hang.
+    const kind = classifyServerRequest(method);
+    if (kind === "unknown") { this.respondError(id, -32601, `unknown server request: ${method}`); return; }
+
+    if (isApprovalKind(kind)) {
+      // 승인성: onApproval(사람 팝업 가능)로 내부 결정 → method별 codec 인코딩.
+      const handler = this.activeHandlers?.onApproval;
+      let decision: ReturnType<typeof toInternalDecision> = "decline"; // ★fail-closed 기본★
+      // ★M5.3: 승인 대기(팝업) 동안 턴 타이머 정지 → 사람이 폰으로 승인하는 시간이 turn timeout에 안 잡힘.★
+      this.pauseTurnTimer();
+      try {
+        if (handler) decision = toInternalDecision(await handler({ method, params, serverRequestId: String(id) }));
+      } catch { decision = "decline"; }
+      finally { this.resumeTurnTimer(); } // 결정 받으면 즉시 재개(예외에도 보장)
+      const out = encodeApproval(kind, decision, params);
+      if (out.kind === "result") this.respond(id, out.result);
+      else this.respondError(id, out.code, out.message);
+      return;
+    }
+
+    // 비승인성(6종): 사람 대기 불필요 → 즉시 fail-safe result 또는 JSON-RPC error(진짜 값 필요한 auth/attestation).
+    // (요청 종류별 정상 응답을 만드는 전용 provider는 후속; 현재는 검증된 fail-safe로 pending을 안전 해소.)
+    const out = failSafeNonApproval(kind, Date.now() / 1000);
+    if (out.kind === "result") this.respond(id, out.result);
+    else this.respondError(id, out.code, out.message);
   }
 
   private handleNotification(method: string, params: any): void {
@@ -322,6 +351,7 @@ export class CodexAppServerClient {
   private deltaBuf = "";
   private stderrTail = "";
   private rateLimitTail = "";
+  private approvalWaits = 0; // 동시 승인 대기 ref-count(Phase1 ③) — 0일 때만 턴 타이머 재개.
   private turnTimer: ReturnType<typeof setTimeout> | null = null;
   private turnTimeoutMs = 0;
   private armTurnTimer: (() => ReturnType<typeof setTimeout>) | null = null;

--- a/src/server/runtimes/codex/appServerPopup.finalize.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.finalize.test.ts
@@ -1,0 +1,63 @@
+import { test, expect, describe, beforeEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { CodexApprovalCorrelationStore } from "./state";
+import { finalizeApprovalDelivery } from "./appServerPopup";
+
+// finalizeApprovalDelivery: 결정을 상관키 CAS로 마감(중복·TOCTOU·orphan 차단) — Phase1 ③.
+function setup() {
+  const db = new Database(":memory:");
+  db.exec(`CREATE TABLE codex_approval_correlation (
+    request_id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, server_request_id TEXT,
+    thread_id TEXT, turn_id TEXT, item_id TEXT, operation_hash TEXT NOT NULL,
+    process_instance TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending' CHECK(state IN ('pending','decided','delivered','expired','orphaned')),
+    created_at TEXT NOT NULL DEFAULT (datetime('now')), decided_at TEXT)`);
+  const store = new CodexApprovalCorrelationStore(db);
+  const rec = (id = "r1", hash = "H", proc = "P") =>
+    store.record({ requestId: id, agentId: "dex", operationHash: hash, processInstance: proc });
+  return { db, store, rec };
+}
+
+describe("finalizeApprovalDelivery — CAS 배달 게이트", () => {
+  let s: ReturnType<typeof setup>;
+  beforeEach(() => { s = setup(); });
+
+  test("정상: record→approved(hash·proc 일치) → approved + delivered", () => {
+    s.rec("r1", "H", "P");
+    expect(finalizeApprovalDelivery(s.store, "r1", "H", "approved", "P")).toBe("approved");
+    expect(s.store.get("r1")!.state).toBe("delivered");
+  });
+
+  test("★미기록 요청 → fail-closed denied★", () => {
+    expect(finalizeApprovalDelivery(s.store, "ghost", "H", "approved", "P")).toBe("denied");
+  });
+
+  test("★중복 버튼: 두 번째 approved → denied(exactly-once)★", () => {
+    s.rec("r1", "H", "P");
+    expect(finalizeApprovalDelivery(s.store, "r1", "H", "approved", "P")).toBe("approved");
+    expect(finalizeApprovalDelivery(s.store, "r1", "H", "approved", "P")).toBe("denied");
+  });
+
+  test("★TOCTOU: operation_hash 불일치 → denied★", () => {
+    s.rec("r1", "H", "P");
+    expect(finalizeApprovalDelivery(s.store, "r1", "WRONG", "approved", "P")).toBe("denied");
+    expect(s.store.get("r1")!.state).toBe("decided"); // decided까진 갔으나 delivered 거부
+  });
+
+  test("★재시작: process_instance 불일치 → denied★", () => {
+    s.rec("r1", "H", "Pold");
+    expect(finalizeApprovalDelivery(s.store, "r1", "H", "approved", "Pnew")).toBe("denied");
+  });
+
+  test("거절(denied): 그대로 denied + state expired(grant 없음)", () => {
+    s.rec("r1", "H", "P");
+    expect(finalizeApprovalDelivery(s.store, "r1", "H", "denied", "P")).toBe("denied");
+    expect(s.store.get("r1")!.state).toBe("expired");
+  });
+
+  test("approved_for_session도 게이트 통과", () => {
+    s.rec("r1", "H", "P");
+    expect(finalizeApprovalDelivery(s.store, "r1", "H", "approved_for_session", "P")).toBe("approved_for_session");
+    expect(s.store.get("r1")!.state).toBe("delivered");
+  });
+});

--- a/src/server/runtimes/codex/appServerPopup.finalize.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.finalize.test.ts
@@ -3,7 +3,7 @@ import { Database } from "bun:sqlite";
 import { CodexApprovalCorrelationStore } from "./state";
 import { finalizeApprovalDelivery } from "./appServerPopup";
 
-// finalizeApprovalDelivery: 결정을 상관키 CAS로 마감(중복·TOCTOU·orphan 차단) — Phase1 ③.
+// finalizeApprovalDelivery: 결정을 상관키 CAS로 마감(중복 결정·요청 불일치·orphan 거부) — Phase1 ③.
 function setup() {
   const db = new Database(":memory:");
   db.exec(`CREATE TABLE codex_approval_correlation (
@@ -38,7 +38,7 @@ describe("finalizeApprovalDelivery — CAS 배달 게이트", () => {
     expect(finalizeApprovalDelivery(s.store, "r1", "H", "approved", "P")).toBe("denied");
   });
 
-  test("★TOCTOU: operation_hash 불일치 → denied★", () => {
+  test("요청 지문 불일치(다른 요청의 결정) → denied", () => {
     s.rec("r1", "H", "P");
     expect(finalizeApprovalDelivery(s.store, "r1", "WRONG", "approved", "P")).toBe("denied");
     expect(s.store.get("r1")!.state).toBe("decided"); // decided까진 갔으나 delivered 거부

--- a/src/server/runtimes/codex/appServerPopup.opHash.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.opHash.test.ts
@@ -1,0 +1,33 @@
+import { test, expect, describe } from "bun:test";
+import { approvalOperationHash } from "./appServerPopup";
+import type { ApprovalRequest } from "./appServerClient";
+
+const cmd = (arr: string[]): ApprovalRequest => ({ method: "item/commandExecution/requestApproval", params: { command: arr } });
+
+describe("approvalOperationHash — TOCTOU/scope 하드닝(Phase1 ③)", () => {
+  test("결정적: 같은 작업 → 같은 해시", () => {
+    expect(approvalOperationHash(cmd(["ls", "-la"]))).toBe(approvalOperationHash(cmd(["ls", "-la"])));
+  });
+
+  test("★잘린 요약(2000자)이 같아도 전체가 다르면 해시가 다르다 — grant 재사용 차단★", () => {
+    const prefix = "x".repeat(2100); // 팝업 command 표시(slice 2000)는 동일하게 잘림
+    const a = cmd([prefix + "AAA"]);
+    const b = cmd([prefix + "BBB"]);
+    // 표시용 truncation은 같지만(앞 2000자 동일) 전체가 달라 해시는 달라야 한다.
+    expect(a.params.command).not.toEqual(b.params.command);
+    expect(approvalOperationHash(a)).not.toBe(approvalOperationHash(b));
+  });
+
+  test("command vs fileChanges vs method 구분", () => {
+    const fileReq: ApprovalRequest = { method: "item/fileChange/requestApproval", params: { fileChanges: { "a.ts": {}, "b.ts": {} } } };
+    expect(approvalOperationHash(cmd(["a.ts", "b.ts"]))).not.toBe(approvalOperationHash(fileReq));
+    // 파일집합 정렬 무관 동일
+    const f1: ApprovalRequest = { method: "item/fileChange/requestApproval", params: { fileChanges: { "a.ts": {}, "b.ts": {} } } };
+    const f2: ApprovalRequest = { method: "item/fileChange/requestApproval", params: { fileChanges: { "b.ts": {}, "a.ts": {} } } };
+    expect(approvalOperationHash(f1)).toBe(approvalOperationHash(f2));
+  });
+
+  test("16 hex 길이", () => {
+    expect(approvalOperationHash(cmd(["echo", "hi"]))).toMatch(/^[0-9a-f]{16}$/);
+  });
+});

--- a/src/server/runtimes/codex/appServerPopup.opHash.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.opHash.test.ts
@@ -1,15 +1,16 @@
 import { test, expect, describe } from "bun:test";
-import { approvalOperationHash } from "./appServerPopup";
+import { approvalOperationHash, buildOperationFromApproval } from "./appServerPopup";
+import { scopeKeyForOperation } from "../../lib/permissionGate";
 import type { ApprovalRequest } from "./appServerClient";
 
 const cmd = (arr: string[]): ApprovalRequest => ({ method: "item/commandExecution/requestApproval", params: { command: arr } });
 
-describe("approvalOperationHash — TOCTOU/scope 하드닝(Phase1 ③)", () => {
+describe("approvalOperationHash — 지문의 결정성·충돌저항(권한 결합은 미구현)", () => {
   test("결정적: 같은 작업 → 같은 해시", () => {
     expect(approvalOperationHash(cmd(["ls", "-la"]))).toBe(approvalOperationHash(cmd(["ls", "-la"])));
   });
 
-  test("★잘린 요약(2000자)이 같아도 전체가 다르면 해시가 다르다 — grant 재사용 차단★", () => {
+  test("잘린 요약(2000자)이 같아도 전체 command가 다르면 해시가 다르다 (해시 수준 구분만 — grant 재사용 차단 아님)", () => {
     const prefix = "x".repeat(2100); // 팝업 command 표시(slice 2000)는 동일하게 잘림
     const a = cmd([prefix + "AAA"]);
     const b = cmd([prefix + "BBB"]);
@@ -29,5 +30,42 @@ describe("approvalOperationHash — TOCTOU/scope 하드닝(Phase1 ③)", () => {
 
   test("16 hex 길이", () => {
     expect(approvalOperationHash(cmd(["echo", "hi"]))).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+/**
+ * ★알려진 갭을 코드로 못 박는다 (2026-07-28 Codex·Bill 리뷰).★
+ *
+ * 아래 테스트들은 ★현재 동작(=갭이 존재함)을 단언한다★. 말로만 남긴 갭은 사라지므로,
+ * 후속 작업(전체 canonical operation을 grant scope에 결합 + 실행 직전 재해시 + 파일 내용 해시)에서
+ * 이 갭이 실제로 닫히면 ★이 테스트들이 실패한다★. 그 실패가 후속 작업의 ★완료 판정★이다.
+ * 실패하면 테스트를 '갭이 닫혔다'는 단언으로 뒤집어 쓰면 된다.
+ *
+ * ★이 갭이 닫히기 전에는 B3OS_CODEX_APPSERVER를 켜지 않는다 — release blocker.★
+ */
+describe("알려진 갭 (후속 작업에서 닫히면 이 테스트가 실패해야 한다)", () => {
+  test("갭1: 240자 prefix가 같으면 전체가 달라도 ★같은 grant scope★로 취급된다", () => {
+    // permissionGate.targetForOperation이 target을 앞 240자만 쓴다 → 뒤가 갈라져도 scope가 같다.
+    const prefix = "y".repeat(240);
+    const safe = buildOperationFromApproval(cmd([prefix + "SAFE"]), "demis");
+    const evil = buildOperationFromApproval(cmd([prefix + "EVIL"]), "demis");
+
+    // 지문(해시)은 둘을 구분한다 —
+    expect(safe.provenance!.operation_hash).not.toBe(evil.provenance!.operation_hash);
+    // — 그런데 실제 권한 판단에 쓰이는 scope는 같다. ★이 한 줄이 갭의 본체다.★
+    expect(scopeKeyForOperation(safe)).toBe(scopeKeyForOperation(evil));
+  });
+
+  test("갭2: 파일 이름이 같으면 ★내용이 달라도★ 지문이 같다", () => {
+    // basis의 files가 Object.keys()라 이름만 담는다 → 승인과 실행 사이 내용 변경을 구분하지 못한다.
+    const before: ApprovalRequest = {
+      method: "item/fileChange/requestApproval",
+      params: { fileChanges: { "a.ts": { diff: "export const x = 1;" } } },
+    };
+    const after: ApprovalRequest = {
+      method: "item/fileChange/requestApproval",
+      params: { fileChanges: { "a.ts": { diff: "process.exit(1);" } } },
+    };
+    expect(approvalOperationHash(before)).toBe(approvalOperationHash(after));
   });
 });

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -7,9 +7,50 @@
  * 매핑: allowed_once→approved · allowed_always→approved_for_session · denied/expired/timeout→denied.
  * ★안전: Tier-D는 여기 도달 전 judgeApproval에서 이미 denied(팝업 안 뜸). fail-closed: 에러/무응답→denied.★
  */
+import { createHash, randomUUID } from "node:crypto";
 import type { Database } from "bun:sqlite";
 import { requestPermission, getPermissionRequest, type PermissionOperation } from "../../lib/permissionGate";
 import type { ApprovalRequest, ReviewDecision } from "./appServerClient";
+import { CodexApprovalCorrelationStore } from "./state";
+
+/** ★Phase1 ③: 이 서버 프로세스 인스턴스 id — 재시작 감지용(옛 팝업을 새 프로세스가 새 turn에 재결합 금지).★ */
+export const PROCESS_INSTANCE = randomUUID();
+
+/**
+ * ★Phase1 ③: 승인 결정을 상관키 스토어 CAS로 마감해 안전 배달 여부를 정한다(순수 로직·테스트 가능).
+ * - 거절류(denied/abort): decided+expire(중복 차단·grant 없음) 후 그대로 반환.
+ * - 승인류(approved/approved_for_session): CAS pending→decided(중복 버튼=exactly-once) → delivered(operation_hash+process_instance 일치 시만=TOCTOU·재시작 재결합 금지).
+ *   어느 단계든 실패=★fail-closed로 "denied"★(상관키 미기록·중복·불일치·orphan 전부 거부). */
+export function finalizeApprovalDelivery(
+  store: CodexApprovalCorrelationStore,
+  requestId: string,
+  operationHash: string,
+  decision: ReviewDecision,
+  processInstance: string = PROCESS_INSTANCE,
+): ReviewDecision {
+  if (decision === "denied" || decision === "abort") {
+    store.markDecided(requestId); // 중복 버튼 차단(CAS)
+    store.expire(requestId);      // 거절 = grant 없음 명시
+    return decision;
+  }
+  if (!store.markDecided(requestId)) return "denied";                              // 미기록/이미처리 → fail-closed
+  if (!store.markDelivered(requestId, operationHash, processInstance)) return "denied"; // TOCTOU/orphan/재시작 → 거부
+  return decision;
+}
+
+/** ★Phase1 ③(TOCTOU/scope): 팝업 표시용 command/path는 잘리지만(2000/500), grant·audit는 ★전체 미절단★ 작업에
+ *  묶여야 한다. 전체 command 배열 + 정렬 파일집합 + method로 sha256(16hex) → provenance.operation_hash.
+ *  이후 상관키 테이블/CAS(별도 슬라이스)가 이 해시로 결정↔요청을 1:1 검증한다(잘린 요약 충돌로 grant 재사용 차단). */
+export function approvalOperationHash(req: ApprovalRequest): string {
+  const p = req.params as Record<string, any>;
+  const basis = {
+    method: req.method,
+    command: Array.isArray(p.command) ? p.command : null,
+    files: p.fileChanges && typeof p.fileChanges === "object" ? Object.keys(p.fileChanges).sort() : null,
+    reason: typeof p.reason === "string" ? p.reason : null,
+  };
+  return createHash("sha256").update(JSON.stringify(basis)).digest("hex").slice(0, 16);
+}
 
 const POPUP_TTL_MS = Number(process.env.B3OS_CODEX_APPSERVER_POPUP_TTL_MS ?? 60 * 60 * 1000); // 1h (GD: 무응답→hold)
 const POLL_INTERVAL_MS = Number(process.env.B3OS_CODEX_APPSERVER_POLL_MS ?? 1500);
@@ -24,6 +65,8 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
     cwd: cwd ?? p.cwd ?? null,
     // ★provenance에 origin 표식(팝업 표시 하드닝·audit). taint 전체는 M3b 공용 layer로 확장.★
     input_origin: "codex_turn",
+    // ★Phase1 ③: 전체(미절단) 작업 해시 — 잘린 command/path 요약과 무관하게 정확한 작업에 grant/audit를 묶는 근거.★
+    operation_hash: approvalOperationHash(req),
   };
   if (Array.isArray(p.command)) {
     return { runtime: "codex", agent_id: agentId, action: "shell", command: p.command.join(" ").slice(0, 2000), requested_by: agentId, provenance };
@@ -65,19 +108,36 @@ export async function pollDecision(db: Database, requestId: string, ttlMs = POPU
  * ★반환 전까지 codex 턴이 대기하므로, 상위(runner)는 이 대기 동안 turn timeout을 연기해야 한다(M5.3 배선).★
  */
 export async function requestApprovalPopup(db: Database, req: ApprovalRequest, agentId: string, cwd?: string, ttlMs = POPUP_TTL_MS): Promise<ReviewDecision> {
+  const store = new CodexApprovalCorrelationStore(db);
+  const opHash = approvalOperationHash(req);
   let requestId: string | undefined;
   try {
     const op = buildOperationFromApproval(req, agentId, cwd);
     const res = requestPermission(db, op); // ★팝업 생성(telegramCapture가 렌더)★
     // requestPermission이 Tier-D면 deny로 즉시 반환(팝업 안 만듦) — 이중 안전.
     if (res.decision === "deny") return "denied";
-    if (res.decision === "allow") return "approved"; // 이미 grant 있으면 통과
+    if (res.decision === "allow") return "approved"; // 이미 grant 있으면 통과(기존 grant는 permissionGate가 벤팅)
     requestId = res.request?.id;
   } catch {
     return "denied"; // ★fail-closed: 팝업 생성 실패 → 거절★
   }
   if (!requestId) return "denied";
-  return pollDecision(db, requestId, ttlMs);
+  // ★Phase1 ③: 팝업↔app-server 요청 1:1 상관키 record(pending). best-effort — 미기록이면 finalize가 fail-closed.★
+  const p = req.params as Record<string, any>;
+  try {
+    store.record({
+      requestId, agentId,
+      serverRequestId: req.serverRequestId ?? null,
+      threadId: typeof p.threadId === "string" ? p.threadId : null,
+      turnId: typeof p.turnId === "string" ? p.turnId : null,
+      itemId: typeof p.itemId === "string" ? p.itemId : null,
+      operationHash: opHash,
+      processInstance: PROCESS_INSTANCE,
+    });
+  } catch { /* best-effort */ }
+  const decision = await pollDecision(db, requestId, ttlMs);
+  // ★결정을 CAS로 마감(중복·TOCTOU·orphan 차단) 후 반환.★
+  return finalizeApprovalDelivery(store, requestId, opHash, decision);
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -89,8 +89,9 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
     return { runtime: "codex", agent_id: agentId, action: "shell", command: p.command.join(" ").slice(0, 2000), requested_by: agentId, provenance };
   }
   if (p.fileChanges && typeof p.fileChanges === "object") {
-    // ★하네스 CRITICAL 1-B 픽스: scope_key(target)를 files[0]만이 아니라 '전체 파일집합(정렬)'으로 →
-    // [a.ts,b.ts] 승인이 [a.ts,evil.sh]로 재사용되는 grant 우회 차단(다른 파일집합=다른 scope).★
+    // scope_key(target)를 files[0]만이 아니라 '전체 파일집합(정렬)'으로 만든다 — 파일집합이 다르면 scope도 달라진다.
+    // ★단 일반 보장은 아니다★: target은 permissionGate에서 앞 240자만 쓰이므로(그리고 여기서도 500자로 자른다)
+    // 목록이 길면 서로 다른 파일집합이 같은 scope로 접힐 수 있다. 전체 결합은 미구현 — 이슈 #106.
     const files = Object.keys(p.fileChanges).sort();
     return { runtime: "codex", agent_id: agentId, action: "write", path: files.join("|").slice(0, 500), text: files.join(", ").slice(0, 500), requested_by: agentId, provenance };
   }

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -19,8 +19,12 @@ export const PROCESS_INSTANCE = randomUUID();
 /**
  * ★Phase1 ③: 승인 결정을 상관키 스토어 CAS로 마감해 안전 배달 여부를 정한다(순수 로직·테스트 가능).
  * - 거절류(denied/abort): decided+expire(중복 차단·grant 없음) 후 그대로 반환.
- * - 승인류(approved/approved_for_session): CAS pending→decided(중복 버튼=exactly-once) → delivered(operation_hash+process_instance 일치 시만=TOCTOU·재시작 재결합 금지).
- *   어느 단계든 실패=★fail-closed로 "denied"★(상관키 미기록·중복·불일치·orphan 전부 거부). */
+ * - 승인류(approved/approved_for_session): CAS pending→decided(중복 버튼=exactly-once) → delivered(operation_hash+process_instance 일치 시만).
+ *   어느 단계든 실패=★fail-closed로 "denied"★(상관키 미기록·중복·불일치·orphan 전부 거부).
+ *
+ * ★범위 주의★: 여기서 operation_hash 비교가 막는 것은 ★다른 요청의 결정이 이 슬롯에 배달되는 것★이다.
+ * 같은 요청의 작업이 승인 후 실행 직전에 바뀌는 것은 막지 못한다 — 비교 대상이 승인 ★전에 캡처한 같은 값★이기 때문.
+ * (approvalOperationHash 주석의 '알려진 갭' 참조) */
 export function finalizeApprovalDelivery(
   store: CodexApprovalCorrelationStore,
   requestId: string,
@@ -34,13 +38,25 @@ export function finalizeApprovalDelivery(
     return decision;
   }
   if (!store.markDecided(requestId)) return "denied";                              // 미기록/이미처리 → fail-closed
-  if (!store.markDelivered(requestId, operationHash, processInstance)) return "denied"; // TOCTOU/orphan/재시작 → 거부
+  if (!store.markDelivered(requestId, operationHash, processInstance)) return "denied"; // 요청 불일치/orphan/재시작 → 거부
   return decision;
 }
 
-/** ★Phase1 ③(TOCTOU/scope): 팝업 표시용 command/path는 잘리지만(2000/500), grant·audit는 ★전체 미절단★ 작업에
- *  묶여야 한다. 전체 command 배열 + 정렬 파일집합 + method로 sha256(16hex) → provenance.operation_hash.
- *  이후 상관키 테이블/CAS(별도 슬라이스)가 이 해시로 결정↔요청을 1:1 검증한다(잘린 요약 충돌로 grant 재사용 차단). */
+/** 승인 요청의 작업 지문(sha256 16hex) — 전체 command 배열 + 파일 ★이름★ 집합 + method + reason.
+ *  용도는 하나뿐이다: 상관키 테이블/CAS가 ★결정↔요청을 1:1로 맞추는 것★(다른 요청의 결정이 이 슬롯에 배달되는 것을 막는다).
+ *
+ *  ★이 해시가 하지 ★않는★ 것 — 알려진 갭(2026-07-28 Codex·Bill 리뷰에서 확인, 재현 테스트는 아래 파일 참조):★
+ *   1. ★권한 grant 재사용을 막지 못한다.★ grant scope는 permissionGate.scopeKeyForOperation이 따로 만들고
+ *      그 안에 이 해시가 들어가지 않는다(permissionGate.ts에 operation_hash 참조 0건). scope의 target은
+ *      ★앞 240자만★ 쓰므로(permissionGate.ts:216), 240자 prefix가 같고 뒤가 다른 두 작업은 ★같은 grant★로 취급된다.
+ *      게다가 이미 grant가 있으면 requestApprovalPopup이 조기 반환해 상관키·CAS·finalize를 ★전부 건너뛴다★.
+ *   2. ★승인 후 실행 직전의 변경을 잡지 못한다.★ 이 해시는 승인 ★전에 한 번★ 계산해 그 캡처값을 그대로
+ *      finalize에 넘긴다 — 실행 직전에 다시 계산해 비교하지 않는다.
+ *   3. ★같은 파일의 내용 변경을 구분하지 못한다.★ files는 Object.keys()라 ★이름만★ 담는다.
+ *      command 경로는 배열 전체가 들어가 구분되지만, fileChanges 경로는 이름 집합이 같으면 해시가 같다.
+ *
+ *  → 위 3건은 후속 작업에서 다룬다(전체 canonical operation을 grant scope에 결합 + 실행 직전 재해시 +
+ *     파일 내용 해시). ★그 전까지 B3OS_CODEX_APPSERVER를 켜지 않는다 — release blocker.★ */
 export function approvalOperationHash(req: ApprovalRequest): string {
   const p = req.params as Record<string, any>;
   const basis = {
@@ -65,7 +81,8 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
     cwd: cwd ?? p.cwd ?? null,
     // ★provenance에 origin 표식(팝업 표시 하드닝·audit). taint 전체는 M3b 공용 layer로 확장.★
     input_origin: "codex_turn",
-    // ★Phase1 ③: 전체(미절단) 작업 해시 — 잘린 command/path 요약과 무관하게 정확한 작업에 grant/audit를 묶는 근거.★
+    // 작업 지문 — ★audit/상관키 대조용으로만 기록된다.★ permissionGate는 이 값을 읽지 않으므로
+    // ★grant scope에는 반영되지 않는다★(알려진 갭 — approvalOperationHash 주석 참조).
     operation_hash: approvalOperationHash(req),
   };
   if (Array.isArray(p.command)) {
@@ -136,7 +153,7 @@ export async function requestApprovalPopup(db: Database, req: ApprovalRequest, a
     });
   } catch { /* best-effort */ }
   const decision = await pollDecision(db, requestId, ttlMs);
-  // ★결정을 CAS로 마감(중복·TOCTOU·orphan 차단) 후 반환.★
+  // ★결정을 CAS로 마감(중복 버튼·요청 불일치·orphan 거부) 후 반환. 실행 직전 변경 검출은 아님 — 위 갭 주석 참조.★
   return finalizeApprovalDelivery(store, requestId, opHash, decision);
 }
 

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -89,9 +89,9 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
     return { runtime: "codex", agent_id: agentId, action: "shell", command: p.command.join(" ").slice(0, 2000), requested_by: agentId, provenance };
   }
   if (p.fileChanges && typeof p.fileChanges === "object") {
-    // scope_key(target)를 files[0]만이 아니라 '전체 파일집합(정렬)'으로 만든다 — 파일집합이 다르면 scope도 달라진다.
-    // ★단 일반 보장은 아니다★: target은 permissionGate에서 앞 240자만 쓰이므로(그리고 여기서도 500자로 자른다)
-    // 목록이 길면 서로 다른 파일집합이 같은 scope로 접힐 수 있다. 전체 결합은 미구현 — 이슈 #106.
+    // scope_key(target)의 입력을 files[0]에서 '정렬된 전체 파일목록'으로 넓힌다.
+    // ★단 target 절단 전까지만 구분력이 늘어날 뿐, '서로 다른 파일집합 → 서로 다른 scope'를 일반 보장하지 않는다.★
+    // (여기서 500자, permissionGate.targetForOperation에서 240자로 잘린다.) 전체 결합은 미구현 — 이슈 #106.
     const files = Object.keys(p.fileChanges).sort();
     return { runtime: "codex", agent_id: agentId, action: "write", path: files.join("|").slice(0, 500), text: files.join(", ").slice(0, 500), requested_by: agentId, provenance };
   }

--- a/src/server/runtimes/codex/appServerRunner.ts
+++ b/src/server/runtimes/codex/appServerRunner.ts
@@ -8,7 +8,8 @@
 import type { Database } from "bun:sqlite";
 import { CodexAppServerClient, type ReviewDecision } from "./appServerClient";
 import { judgeApproval, resolveWithoutPopup, terminalGuidance } from "./appServerApproval";
-import { requestApprovalPopup } from "./appServerPopup";
+import { requestApprovalPopup, PROCESS_INSTANCE } from "./appServerPopup";
+import { CodexApprovalCorrelationStore } from "./state";
 import type { CodexCaller, CodexTurnResult, CodexTurnOptions } from "./runner";
 import type { PermissionAgent, PermissionContext } from "../../lib/permissionGate";
 
@@ -19,6 +20,9 @@ const TURN_TIMEOUT_MS = Number(process.env.B3OS_CODEX_APPSERVER_TIMEOUT_MS ?? 30
  * makeAppServerCaller(db)로 db 주입 = 팝업 경로. runCodexTurnViaAppServer = db 없는 안전 기본.
  */
 export function makeAppServerCaller(db: Database): CodexCaller {
+  // ★Phase1 ③: 부팅/모드 활성 시 1회 orphan sweep — 이전 프로세스의 pending/decided 팝업을 orphaned로
+  //   (재시작 후 옛 팝업이 새 turn에 재결합되지 않게). best-effort(스윕 실패가 caller 생성을 막지 않음).★
+  try { new CodexApprovalCorrelationStore(db).sweepOrphans(PROCESS_INSTANCE); } catch { /* best-effort */ }
   return (opts) => runViaAppServer(opts, db);
 }
 
@@ -73,6 +77,12 @@ async function runViaAppServer(opts: CodexTurnOptions, db?: Database): Promise<C
     const fresh = guidances.filter((g) => !r.finalText.includes(g.split("\n")[0]!));
     if (fresh.length) {
       r.finalText = r.finalText.trim() ? `${r.finalText}\n\n---\n${fresh.join("\n\n")}` : fresh.join("\n\n");
+    }
+    // ★Phase1 ③: 턴 종료 시 이 turn의 남은 pending/decided 팝업을 expire(cancel/interrupt/timeout 포함).
+    //   늦게 도착한 승인은 finalizeApprovalDelivery의 CAS가 expired 상태를 보고 이미 거부하지만, 여기서 상태를
+    //   확정 정리해 orphan 누적을 막는다. best-effort. (delivered/orphaned는 건드리지 않음.)★
+    if (db && threadId && r.turnId) {
+      try { new CodexApprovalCorrelationStore(db).expireTurn(threadId, r.turnId); } catch { /* best-effort */ }
     }
     const ok = r.status === "completed" && r.finalText.trim().length > 0;
     // ★#8 픽스: 실패면 detail에 실제 사유(에러 notification/stderr tail) 반영 — rate-limit 진단 가능.★

--- a/src/server/runtimes/codex/serverRequestCodec.test.ts
+++ b/src/server/runtimes/codex/serverRequestCodec.test.ts
@@ -1,0 +1,103 @@
+import { test, expect, describe } from "bun:test";
+import {
+  classifyServerRequest, isApprovalKind, toInternalDecision, encodeApproval, failSafeNonApproval,
+} from "./serverRequestCodec";
+
+// 근거: research/codex-appserver-0.144.6-server-request-codec.md (Ames, 0.144.6 schema PASS).
+
+describe("classifyServerRequest — 11종 + unknown", () => {
+  const cases: [string, string][] = [
+    ["item/commandExecution/requestApproval", "approval_command"],
+    ["item/fileChange/requestApproval", "approval_file"],
+    ["item/permissions/requestApproval", "approval_permissions"],
+    ["execCommandApproval", "approval_legacy"],
+    ["applyPatchApproval", "approval_legacy"],
+    ["item/tool/requestUserInput", "user_input"],
+    ["mcpServer/elicitation/request", "mcp_elicitation"],
+    ["item/tool/call", "dynamic_tool"],
+    ["account/chatgptAuthTokens/refresh", "auth_refresh"],
+    ["attestation/generate", "attestation"],
+    ["currentTime/read", "current_time"],
+    ["something/unheard", "unknown"],
+  ];
+  for (const [m, k] of cases) {
+    test(`${m} → ${k}`, () => { expect(classifyServerRequest(m)).toBe(k as any); });
+  }
+  test("승인성은 정확히 4종", () => {
+    const approval = cases.map(([m]) => classifyServerRequest(m)).filter(isApprovalKind);
+    expect(approval.length).toBe(5); // command,file,permissions,legacy(exec),legacy(apply)
+    expect(new Set(approval).size).toBe(4); // 종류는 4
+  });
+});
+
+describe("toInternalDecision (legacy ReviewDecision → 내부)", () => {
+  test.each([
+    ["approved", "once"], ["approved_for_session", "session"], ["abort", "cancel"],
+    ["denied", "decline"], ["timed_out", "decline"], ["whatever", "decline"],
+  ])("%s → %s", (inp, out) => { expect(toInternalDecision(inp)).toBe(out as any); });
+});
+
+describe("encodeApproval — method별 결정값 codec", () => {
+  test("신규 command: once→accept / session→acceptForSession / decline→decline / cancel→cancel", () => {
+    const p = {};
+    expect(encodeApproval("approval_command", "once", p)).toEqual({ kind: "result", result: { decision: "accept" } });
+    expect(encodeApproval("approval_command", "session", p)).toEqual({ kind: "result", result: { decision: "acceptForSession" } });
+    expect(encodeApproval("approval_command", "decline", p)).toEqual({ kind: "result", result: { decision: "decline" } });
+    expect(encodeApproval("approval_command", "cancel", p)).toEqual({ kind: "result", result: { decision: "cancel" } });
+  });
+  test("command availableDecisions 제약: 선호값 없으면 decline→cancel→error 폴백", () => {
+    // accept 불가, decline만 허용 → accept 요청이 decline로 강등
+    expect(encodeApproval("approval_command", "once", { availableDecisions: ["decline"] }))
+      .toEqual({ kind: "result", result: { decision: "decline" } });
+    // decline도 없고 cancel만 → cancel
+    expect(encodeApproval("approval_command", "decline", { availableDecisions: ["cancel"] }))
+      .toEqual({ kind: "result", result: { decision: "cancel" } });
+    // 둘 다 없음 → fail-closed error
+    expect(encodeApproval("approval_command", "decline", { availableDecisions: ["accept"] }).kind).toBe("error");
+  });
+  test("신규 file: decision류(availableDecisions 무관)", () => {
+    expect(encodeApproval("approval_file", "once", {})).toEqual({ kind: "result", result: { decision: "accept" } });
+    expect(encodeApproval("approval_file", "decline", {})).toEqual({ kind: "result", result: { decision: "decline" } });
+  });
+  test("legacy exec/apply: approved/approved_for_session/denied/abort", () => {
+    expect(encodeApproval("approval_legacy", "once", {})).toEqual({ kind: "result", result: { decision: "approved" } });
+    expect(encodeApproval("approval_legacy", "session", {})).toEqual({ kind: "result", result: { decision: "approved_for_session" } });
+    expect(encodeApproval("approval_legacy", "decline", {})).toEqual({ kind: "result", result: { decision: "denied" } });
+    expect(encodeApproval("approval_legacy", "cancel", {})).toEqual({ kind: "result", result: { decision: "abort" } });
+  });
+  test("permissions: decision 아님 — 거절=빈 grant(turn), 승인=요청 profile grant", () => {
+    expect(encodeApproval("approval_permissions", "decline", { permissions: { fs: true } }))
+      .toEqual({ kind: "result", result: { permissions: {}, scope: "turn", strictAutoReview: false } });
+    expect(encodeApproval("approval_permissions", "once", { permissions: { fs: true } }))
+      .toEqual({ kind: "result", result: { permissions: { fs: true }, scope: "turn", strictAutoReview: false } });
+    expect(encodeApproval("approval_permissions", "session", { permissions: { fs: true } }))
+      .toEqual({ kind: "result", result: { permissions: { fs: true }, scope: "session", strictAutoReview: false } });
+    // ★거절 시 요청 permissions echo 금지(= 승인돼버림) 회귀 가드★
+    const declined = encodeApproval("approval_permissions", "decline", { permissions: { fs: true } });
+    expect((declined as any).result.permissions).toEqual({});
+  });
+});
+
+describe("failSafeNonApproval — 비승인 6종", () => {
+  test("user_input → {answers:{}}", () => {
+    expect(failSafeNonApproval("user_input", 100)).toEqual({ kind: "result", result: { answers: {} } });
+  });
+  test("mcp_elicitation → {action:'decline'}", () => {
+    expect(failSafeNonApproval("mcp_elicitation", 100)).toEqual({ kind: "result", result: { action: "decline" } });
+  });
+  test("dynamic_tool → contentItems + success:false", () => {
+    expect(failSafeNonApproval("dynamic_tool", 100)).toEqual({
+      kind: "result", result: { contentItems: [{ type: "inputText", text: "client tool unavailable" }], success: false },
+    });
+  });
+  test("current_time → {currentTimeAt: Unix초(정수)}", () => {
+    const out = failSafeNonApproval("current_time", 1719999999.7);
+    expect(out).toEqual({ kind: "result", result: { currentTimeAt: 1719999999 } }); // floor, 밀리초/소수 금지
+  });
+  test("auth_refresh → JSON-RPC error (가짜 토큰 합성 금지)", () => {
+    expect(failSafeNonApproval("auth_refresh", 100).kind).toBe("error");
+  });
+  test("attestation → JSON-RPC error (opt-in 아님)", () => {
+    expect(failSafeNonApproval("attestation", 100).kind).toBe("error");
+  });
+});

--- a/src/server/runtimes/codex/serverRequestCodec.ts
+++ b/src/server/runtimes/codex/serverRequestCodec.ts
@@ -1,0 +1,160 @@
+/**
+ * codex app-server 0.144.6 ServerRequest 분류 + 응답 codec (Phase1 ②).
+ *
+ * 배경: appServerClient가 ★모든★ server→client 요청에 `{decision}`을 보내던 것을 고친다.
+ * generate-json-schema(0.144.6) 기준 ServerRequest는 11종이고, 그 중 승인성은 4종뿐,
+ * 나머지 6종(+unknown)은 각기 다른 result 또는 JSON-RPC error가 필요하다.
+ * 잘못된 result를 보내면 Codex 쪽 pending callback이 오류/폴백에 의존하거나 hang한다.
+ *
+ * 근거(Ames 교차검증·schema PASS 2026-07-24):
+ *   research/codex-appserver-0.144.6-server-request-codec.md (ames repo). 각 payload는 0.144.6 Response schema로 검증됨.
+ *
+ * ★이 모듈은 순수 함수다 — I/O·상태 없음(테스트 용이). appServerClient가 이걸 써서 respond/respondError 한다.★
+ */
+
+/** 승인 콜백의 내부 공통 결정(런타임 무관). wire codec에서 신규/legacy로 분리 인코딩. */
+export type InternalDecision = "once" | "session" | "decline" | "cancel";
+
+/** 기존 onApproval 반환(legacy 스타일 ReviewDecision) → 내부 결정으로 정규화. */
+export function toInternalDecision(d: string): InternalDecision {
+  switch (d) {
+    case "approved": return "once";
+    case "approved_for_session": return "session";
+    case "abort": return "cancel";
+    // denied·timed_out·기타 = 보수적으로 decline
+    default: return "decline";
+  }
+}
+
+export type ServerRequestKind =
+  | "approval_command"   // item/commandExecution/requestApproval (신규, availableDecisions 有)
+  | "approval_file"      // item/fileChange/requestApproval (신규)
+  | "approval_permissions" // item/permissions/requestApproval (별도 codec)
+  | "approval_legacy"    // execCommandApproval | applyPatchApproval (legacy)
+  | "user_input"         // item/tool/requestUserInput
+  | "mcp_elicitation"    // mcpServer/elicitation/request
+  | "dynamic_tool"       // item/tool/call
+  | "auth_refresh"       // account/chatgptAuthTokens/refresh
+  | "attestation"        // attestation/generate
+  | "current_time"       // currentTime/read
+  | "unknown";
+
+const APPROVAL_KINDS: ReadonlySet<ServerRequestKind> = new Set<ServerRequestKind>([
+  "approval_command", "approval_file", "approval_permissions", "approval_legacy",
+]);
+
+export function isApprovalKind(kind: ServerRequestKind): boolean {
+  return APPROVAL_KINDS.has(kind);
+}
+
+/** method 정확 매칭으로 분류. */
+export function classifyServerRequest(method: string): ServerRequestKind {
+  switch (method) {
+    case "item/commandExecution/requestApproval": return "approval_command";
+    case "item/fileChange/requestApproval": return "approval_file";
+    case "item/permissions/requestApproval": return "approval_permissions";
+    case "execCommandApproval":
+    case "applyPatchApproval": return "approval_legacy";
+    case "item/tool/requestUserInput": return "user_input";
+    case "mcpServer/elicitation/request": return "mcp_elicitation";
+    case "item/tool/call": return "dynamic_tool";
+    case "account/chatgptAuthTokens/refresh": return "auth_refresh";
+    case "attestation/generate": return "attestation";
+    case "currentTime/read": return "current_time";
+    default: return "unknown";
+  }
+}
+
+/** 신규(command/file) 결정값. */
+function newDecisionValue(d: InternalDecision): string {
+  switch (d) {
+    case "once": return "accept";
+    case "session": return "acceptForSession";
+    case "cancel": return "cancel";
+    case "decline": default: return "decline";
+  }
+}
+/** legacy(exec/apply) 결정값. */
+function legacyDecisionValue(d: InternalDecision): string {
+  switch (d) {
+    case "once": return "approved";
+    case "session": return "approved_for_session";
+    case "cancel": return "abort";
+    case "decline": default: return "denied";
+  }
+}
+
+/** 응답 인코딩 결과: result(성공) 또는 error(JSON-RPC error). */
+export type CodecOutcome =
+  | { kind: "result"; result: Record<string, unknown> }
+  | { kind: "error"; code: number; message: string };
+
+/**
+ * 승인성 요청 → 내부 결정을 method별 wire result로 인코딩.
+ * command의 availableDecisions(non-null)면 최종 문자열 결정이 그 배열에 있는지 검증(deep-equal는 문자열 한정).
+ * amendment 객체 결정은 이 경로에서 생성하지 않는다(팝업은 accept/decline/session/cancel만 노출).
+ */
+export function encodeApproval(
+  kind: ServerRequestKind,
+  decision: InternalDecision,
+  params: Record<string, unknown>,
+): CodecOutcome {
+  if (kind === "approval_command") {
+    let v = newDecisionValue(decision);
+    const avail = params?.availableDecisions;
+    if (Array.isArray(avail)) {
+      const strs = avail.filter((x) => typeof x === "string") as string[];
+      if (!strs.includes(v)) {
+        // 선호값이 허용목록에 없으면: decline→cancel→fail-closed(error)
+        if (strs.includes("decline")) v = "decline";
+        else if (strs.includes("cancel")) v = "cancel";
+        else return { kind: "error", code: -32001, message: "no acceptable decline/cancel in availableDecisions" };
+      }
+    }
+    return { kind: "result", result: { decision: v } };
+  }
+  if (kind === "approval_file") {
+    return { kind: "result", result: { decision: newDecisionValue(decision) } };
+  }
+  if (kind === "approval_legacy") {
+    return { kind: "result", result: { decision: legacyDecisionValue(decision) } };
+  }
+  if (kind === "approval_permissions") {
+    // permissions는 decision이 아니라 grant 프로필. 거절/타임아웃 = 빈 grant(turn).
+    // 승인(once/session) = 요청 profile을 grant(subset 정교화는 후속 과제 — 현재는 요청분 grant).
+    if (decision === "once" || decision === "session") {
+      const requested = (params?.permissions ?? {}) as Record<string, unknown>;
+      return {
+        kind: "result",
+        result: {
+          permissions: requested,
+          scope: decision === "session" ? "session" : "turn",
+          strictAutoReview: false,
+        },
+      };
+    }
+    return { kind: "result", result: { permissions: {}, scope: "turn", strictAutoReview: false } };
+  }
+  return { kind: "error", code: -32601, message: `not an approval kind: ${kind}` };
+}
+
+/**
+ * 비승인성 요청의 fail-safe 응답(핸들러 미제공/에러 시). 진짜 값이 필요한 것(auth/attestation)은 error.
+ * currentTime은 nowUnixSec 주입(테스트 결정성 위해 인자로).
+ */
+export function failSafeNonApproval(kind: ServerRequestKind, nowUnixSec: number): CodecOutcome {
+  switch (kind) {
+    case "user_input": return { kind: "result", result: { answers: {} } };
+    case "mcp_elicitation": return { kind: "result", result: { action: "decline" } };
+    case "dynamic_tool":
+      return { kind: "result", result: { contentItems: [{ type: "inputText", text: "client tool unavailable" }], success: false } };
+    case "current_time":
+      return { kind: "result", result: { currentTimeAt: Math.floor(nowUnixSec) } };
+    case "auth_refresh":
+      return { kind: "error", code: -32001, message: "no client-managed auth provider; cannot refresh" };
+    case "attestation":
+      return { kind: "error", code: -32001, message: "attestation not opted in (capabilities.requestAttestation=false)" };
+    default:
+      return { kind: "error", code: -32601, message: `unhandled non-approval kind: ${kind}` };
+  }
+}

--- a/src/server/runtimes/codex/state.approvalCorrelation.test.ts
+++ b/src/server/runtimes/codex/state.approvalCorrelation.test.ts
@@ -2,7 +2,7 @@ import { test, expect, describe, beforeEach } from "bun:test";
 import { Database } from "bun:sqlite";
 import { CodexApprovalCorrelationStore } from "./state";
 
-// codex_approval_correlation 스토어 CAS/TOCTOU/orphan 실증(Phase1 ③).
+// codex_approval_correlation 스토어 CAS/요청 불일치/orphan 실증(Phase1 ③).
 function setup(): { db: Database; store: CodexApprovalCorrelationStore } {
   const db = new Database(":memory:");
   db.exec(`CREATE TABLE codex_approval_correlation (

--- a/src/server/runtimes/codex/state.approvalCorrelation.test.ts
+++ b/src/server/runtimes/codex/state.approvalCorrelation.test.ts
@@ -1,0 +1,79 @@
+import { test, expect, describe, beforeEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { CodexApprovalCorrelationStore } from "./state";
+
+// codex_approval_correlation 스토어 CAS/TOCTOU/orphan 실증(Phase1 ③).
+function setup(): { db: Database; store: CodexApprovalCorrelationStore } {
+  const db = new Database(":memory:");
+  db.exec(`CREATE TABLE codex_approval_correlation (
+    request_id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, server_request_id TEXT,
+    thread_id TEXT, turn_id TEXT, item_id TEXT, operation_hash TEXT NOT NULL,
+    process_instance TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending' CHECK(state IN ('pending','decided','delivered','expired','orphaned')),
+    created_at TEXT NOT NULL DEFAULT (datetime('now')), decided_at TEXT)`);
+  return { db, store: new CodexApprovalCorrelationStore(db) };
+}
+const base = (over: Partial<Parameters<CodexApprovalCorrelationStore["record"]>[0]> = {}) => ({
+  requestId: "req1", agentId: "dex", operationHash: "hashAAA", processInstance: "proc1",
+  threadId: "th1", turnId: "tn1", itemId: "it1", serverRequestId: "srv1", ...over,
+});
+
+describe("CodexApprovalCorrelationStore — CAS/TOCTOU/orphan", () => {
+  let s: ReturnType<typeof setup>;
+  beforeEach(() => { s = setup(); });
+
+  test("record → pending, 중복 request_id는 무시(exactly-once)", () => {
+    s.store.record(base());
+    s.store.record(base({ operationHash: "DIFFERENT" })); // 같은 request_id 재기록 시도
+    const row = s.store.get("req1")!;
+    expect(row.state).toBe("pending");
+    expect(row.operation_hash).toBe("hashAAA"); // 최초 값 유지(IGNORE)
+  });
+
+  test("markDecided: pending→decided 정확히 1회(중복 버튼 차단)", () => {
+    s.store.record(base());
+    expect(s.store.markDecided("req1")).toBe(true);
+    expect(s.store.markDecided("req1")).toBe(false); // 두 번째=false
+    expect(s.store.get("req1")!.state).toBe("decided");
+  });
+
+  test("markDelivered: hash+proc 일치할 때만 성공(TOCTOU + 재시작 재결합 금지)", () => {
+    s.store.record(base()); s.store.markDecided("req1");
+    expect(s.store.markDelivered("req1", "WRONGHASH", "proc1")).toBe(false); // TOCTOU 불일치 거부
+    expect(s.store.get("req1")!.state).toBe("decided");
+    expect(s.store.markDelivered("req1", "hashAAA", "proc2")).toBe(false);   // 다른 프로세스(재시작) 거부
+    expect(s.store.markDelivered("req1", "hashAAA", "proc1")).toBe(true);    // 일치 → delivered
+    expect(s.store.get("req1")!.state).toBe("delivered");
+    expect(s.store.markDelivered("req1", "hashAAA", "proc1")).toBe(false);   // 재전달 차단
+  });
+
+  test("decided 아니면 delivered 불가(pending 직행 금지)", () => {
+    s.store.record(base());
+    expect(s.store.markDelivered("req1", "hashAAA", "proc1")).toBe(false);
+  });
+
+  test("expire: delivered 제외 임의 상태→expired", () => {
+    s.store.record(base()); s.store.expire("req1");
+    expect(s.store.get("req1")!.state).toBe("expired");
+  });
+
+  test("expireTurn: 그 turn의 pending/decided 전부 expire", () => {
+    s.store.record(base({ requestId: "a" }));
+    s.store.record(base({ requestId: "b" })); s.store.markDecided("b");
+    s.store.record(base({ requestId: "c", turnId: "OTHER" }));
+    const n = s.store.expireTurn("th1", "tn1");
+    expect(n).toBe(2);
+    expect(s.store.get("a")!.state).toBe("expired");
+    expect(s.store.get("b")!.state).toBe("expired");
+    expect(s.store.get("c")!.state).toBe("pending"); // 다른 turn은 유지
+  });
+
+  test("sweepOrphans: 다른 process_instance의 pending/decided→orphaned, 현재 proc은 유지", () => {
+    s.store.record(base({ requestId: "old", processInstance: "procOLD" }));
+    s.store.record(base({ requestId: "cur", processInstance: "procNEW" }));
+    const n = s.store.sweepOrphans("procNEW");
+    expect(n).toBe(1);
+    expect(s.store.get("old")!.state).toBe("orphaned");
+    expect(s.store.get("cur")!.state).toBe("pending");
+  });
+});

--- a/src/server/runtimes/codex/state.approvalCorrelation.test.ts
+++ b/src/server/runtimes/codex/state.approvalCorrelation.test.ts
@@ -18,7 +18,7 @@ const base = (over: Partial<Parameters<CodexApprovalCorrelationStore["record"]>[
   threadId: "th1", turnId: "tn1", itemId: "it1", serverRequestId: "srv1", ...over,
 });
 
-describe("CodexApprovalCorrelationStore — CAS/TOCTOU/orphan", () => {
+describe("CodexApprovalCorrelationStore — CAS/요청대조/orphan", () => {
   let s: ReturnType<typeof setup>;
   beforeEach(() => { s = setup(); });
 
@@ -37,9 +37,9 @@ describe("CodexApprovalCorrelationStore — CAS/TOCTOU/orphan", () => {
     expect(s.store.get("req1")!.state).toBe("decided");
   });
 
-  test("markDelivered: hash+proc 일치할 때만 성공(TOCTOU + 재시작 재결합 금지)", () => {
+  test("markDelivered: hash+proc 일치할 때만 성공(다른 요청의 결정 배달 거부 + 재시작 재결합 금지)", () => {
     s.store.record(base()); s.store.markDecided("req1");
-    expect(s.store.markDelivered("req1", "WRONGHASH", "proc1")).toBe(false); // TOCTOU 불일치 거부
+    expect(s.store.markDelivered("req1", "WRONGHASH", "proc1")).toBe(false); // 요청 불일치 거부
     expect(s.store.get("req1")!.state).toBe("decided");
     expect(s.store.markDelivered("req1", "hashAAA", "proc2")).toBe(false);   // 다른 프로세스(재시작) 거부
     expect(s.store.markDelivered("req1", "hashAAA", "proc1")).toBe(true);    // 일치 → delivered

--- a/src/server/runtimes/codex/state.ts
+++ b/src/server/runtimes/codex/state.ts
@@ -141,6 +141,117 @@ export class CodexInflightStore {
   }
 }
 
+export type CodexApprovalState = "pending" | "decided" | "delivered" | "expired" | "orphaned";
+
+export interface CodexApprovalCorrelationInput {
+  requestId: string; // = permission_request.id (팝업)
+  agentId: string;
+  serverRequestId?: string | null;
+  threadId?: string | null;
+  turnId?: string | null;
+  itemId?: string | null;
+  operationHash: string;
+  processInstance: string;
+}
+
+export interface CodexApprovalCorrelationRow {
+  request_id: string;
+  agent_id: string;
+  server_request_id: string | null;
+  thread_id: string | null;
+  turn_id: string | null;
+  item_id: string | null;
+  operation_hash: string;
+  process_instance: string;
+  state: CodexApprovalState;
+  created_at: string;
+  decided_at: string | null;
+}
+
+/**
+ * codex app-server 승인 팝업 ↔ server-request 상관키 + CAS 상태(Phase1 ③).
+ * 팝업(permission_request.id)과 실제 승인 요청을 1:1로 묶고, 상태전이를 CAS(원자적 UPDATE ... WHERE state=)로만 해
+ * 중복 버튼(exactly-once)·TTL 늦은승인·서버재시작 orphan·TOCTOU(operation_hash 재검증)를 안전 처리한다.
+ */
+export class CodexApprovalCorrelationStore {
+  constructor(private readonly db: Database) {}
+
+  /** 팝업 생성 시 pending 기록. 중복 request_id는 무시(INSERT OR IGNORE = exactly-once). */
+  record(input: CodexApprovalCorrelationInput): void {
+    this.db
+      .prepare(
+        `INSERT OR IGNORE INTO codex_approval_correlation
+           (request_id, agent_id, server_request_id, thread_id, turn_id, item_id, operation_hash, process_instance, state, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', datetime('now'))`,
+      )
+      .run(
+        input.requestId, input.agentId, input.serverRequestId ?? null,
+        input.threadId ?? null, input.turnId ?? null, input.itemId ?? null,
+        input.operationHash, input.processInstance,
+      );
+  }
+
+  get(requestId: string): CodexApprovalCorrelationRow | undefined {
+    return this.db
+      .prepare(`SELECT * FROM codex_approval_correlation WHERE request_id = ?`)
+      .get(requestId) as CodexApprovalCorrelationRow | undefined;
+  }
+
+  /** CAS pending→decided. 정확히 1회만 성공(true); 이미 decided/expired/orphaned면 false(중복/무효 차단). */
+  markDecided(requestId: string): boolean {
+    const r = this.db
+      .prepare(
+        `UPDATE codex_approval_correlation SET state='decided', decided_at=datetime('now')
+         WHERE request_id = ? AND state = 'pending'`,
+      )
+      .run(requestId);
+    return r.changes === 1;
+  }
+
+  /**
+   * delivery: decided→delivered. ★operation_hash 일치(TOCTOU) + process_instance 일치(재시작 재결합 금지)일 때만★ 성공.
+   * true면 codex에 승인 전달 허용. false면 거부(불일치/orphan/재시작/이미처리).
+   */
+  markDelivered(requestId: string, operationHash: string, processInstance: string): boolean {
+    const r = this.db
+      .prepare(
+        `UPDATE codex_approval_correlation SET state='delivered'
+         WHERE request_id = ? AND state = 'decided' AND operation_hash = ? AND process_instance = ?`,
+      )
+      .run(requestId, operationHash, processInstance);
+    return r.changes === 1;
+  }
+
+  /** 임의 상태(단 delivered 제외)→expired. TTL 늦은승인/무효화용. */
+  expire(requestId: string): void {
+    this.db
+      .prepare(`UPDATE codex_approval_correlation SET state='expired' WHERE request_id = ? AND state != 'delivered'`)
+      .run(requestId);
+  }
+
+  /** cancel/interrupt: 그 turn의 pending/decided 팝업 전부 expire. 반환=전이 수. */
+  expireTurn(threadId: string, turnId: string): number {
+    const r = this.db
+      .prepare(
+        `UPDATE codex_approval_correlation SET state='expired'
+         WHERE thread_id = ? AND turn_id = ? AND state IN ('pending','decided')`,
+      )
+      .run(threadId, turnId);
+    return r.changes;
+  }
+
+  /** 부팅 시: 다른 process_instance의 pending/decided를 orphaned로(재시작 → 옛 팝업을 새 turn에 재결합 금지). 반환=전이 수. */
+  sweepOrphans(currentProcessInstance: string): number {
+    const r = this.db
+      .prepare(
+        `UPDATE codex_approval_correlation SET state='orphaned'
+         WHERE process_instance != ? AND state IN ('pending','decided')`,
+      )
+      .run(currentProcessInstance);
+    return r.changes;
+  }
+}
+
 export function sha256Short(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 16);
 }

--- a/src/server/runtimes/codex/state.ts
+++ b/src/server/runtimes/codex/state.ts
@@ -171,7 +171,8 @@ export interface CodexApprovalCorrelationRow {
 /**
  * codex app-server 승인 팝업 ↔ server-request 상관키 + CAS 상태(Phase1 ③).
  * 팝업(permission_request.id)과 실제 승인 요청을 1:1로 묶고, 상태전이를 CAS(원자적 UPDATE ... WHERE state=)로만 해
- * 중복 버튼(exactly-once)·TTL 늦은승인·서버재시작 orphan·TOCTOU(operation_hash 재검증)를 안전 처리한다.
+ * 중복 버튼(exactly-once)·TTL 늦은승인·서버재시작 orphan·요청 불일치(operation_hash 대조)를 안전 처리한다.
+ * ★operation_hash는 승인 전 캡처값이라 실행 직전 변경 검출이 아니고, 권한 grant scope에도 들어가지 않는다(알려진 갭).★
  */
 export class CodexApprovalCorrelationStore {
   constructor(private readonly db: Database) {}
@@ -209,7 +210,7 @@ export class CodexApprovalCorrelationStore {
   }
 
   /**
-   * delivery: decided→delivered. ★operation_hash 일치(TOCTOU) + process_instance 일치(재시작 재결합 금지)일 때만★ 성공.
+   * delivery: decided→delivered. ★operation_hash 일치(요청 대조) + process_instance 일치(재시작 재결합 금지)일 때만★ 성공.
    * true면 codex에 승인 전달 허용. false면 거부(불일치/orphan/재시작/이미처리).
    */
   markDelivered(requestId: string, operationHash: string, processInstance: string): boolean {


### PR DESCRIPTION
> **이 PR은 기능 완성이 아니다.** 정본에 없던 codex app-server 코드를 **비활성 상태 그대로 회수**하는 이식 PR이다. 아래 "구현됨 / 미구현" 표를 먼저 읽어달라.

## 무엇을 왜

codex 런타임의 app-server 관련 코드가 정본에 없었다. 원본은 브랜치 `demis/codex-runtime-dev`에만 있었고, 그 브랜치가 main보다 **99커밋 뒤처져** 리뷰가 사실상 불가능했다. 코드 동작 변경 없이 최신 main 기준으로 옮긴다.

설계 배경: `/reports` → "Codex CLI 런타임 설계문서"(2026-07-25).

## ★구현됨 / 미구현 — 이 PR의 핵심 표★

| 영역 | 상태 | 근거 |
|---|---|---|
| 동시성 잠금 (message 단위 → agent 단위) | **구현됨** | 같은 팀원에게 턴이 겹쳐 들어와도 한 번에 하나 |
| server-request method별 dispatcher + 응답 codec | **구현됨** | 되묻기를 종류별로 처리, fail-safe 기본값 |
| 상관키·CAS 상태기계 | **구현됨** | 중복 버튼 exactly-once · 다른 요청의 결정이 이 슬롯에 배달되는 것 거부 · 재시작 후 재결합 금지 · 만료 시 fail-closed. Bill 리뷰에서 상태전이·게이트 순서 견고함 확인 |
| **작업↔권한 결합 (operation binding)** | **★미구현★** | 아래 |

### 미구현 상세 — `operationHash`가 하지 **못하는** 것

리뷰에서 Codex(P1)와 Bill이 각각 다른 각도로 발견했고, **내가 코드로 재현해 테스트로 고정했다**(`appServerPopup.opHash.test.ts` → `describe("알려진 갭 ...")`).

1. **권한 grant 재사용을 막지 못한다.** grant scope는 `permissionGate.scopeKeyForOperation`이 따로 만들고 그 안에 `operation_hash`가 들어가지 않는다(`permissionGate.ts`에 참조 **0건**). scope의 target은 **앞 240자만** 쓴다(`permissionGate.ts:216`) → 240자 prefix가 같고 뒤가 갈라지는 두 작업이 **같은 grant**가 된다.
2. **`allowed_always` 조기 반환이 안전장치를 통째로 건너뛴다.** 이미 grant가 있으면 `requestApprovalPopup`이 즉시 반환해 상관키·CAS·finalize가 전부 실행되지 않는다.
3. **실행 직전 변경을 잡지 못한다.** 해시는 승인 **전에 한 번** 계산해 그 캡처값을 그대로 넘긴다. 실행 직전 재해시가 없다 → **TOCTOU 방어가 아니다.**
4. **같은 파일의 내용 변경을 구분하지 못한다.** basis의 `files`가 이름만 담는다. `command` 경로는 전체가 들어가 구분되지만 `fileChanges` 경로는 이름 집합이 같으면 해시가 같다.

두 번째 커밋은 **이 사실에 맞게 주석·테스트명을 정정한 것**이다. 원래 주석은 "grant 재사용 차단", "TOCTOU 방어"라고 **없는 보호를 있다고** 적고 있었다. 코드 동작은 건드리지 않았다.

## ★release blocker★

**#106이 닫히기 전까지 `B3OS_CODEX_APPSERVER`를 켜지 않는다.** 플래그가 꺼져 있는 동안 이 경로는 실행되지 않으므로 현재 운영 영향은 없다. 플래그 활성화 자체도 팀 리드 승인 게이트다.

`describe("알려진 갭 ...")` 테스트는 **현재 동작(갭 존재)을 단언**한다. #106에서 갭이 닫히면 **이 테스트가 실패하며 완료를 알린다.**

## 검증

정본 `a98032c` 기준, 같은 커밋의 베이스라인과 대조했다.

```
검증 범위:  bun test 전체 게이트 · tsc --noEmit · vite build · codex 런타임 스위트
baseline:   1754 pass / 5 skip / 0 fail  (152 파일, 패치 없는 a98032c)
이 PR:      1805 pass / 5 skip / 0 fail  (156 파일)
증가분:     +51 pass / +4 파일
            = 신규 테스트 4파일 48건 + adapter.test 1건 + 알려진 갭 2건. 회귀 0
codex 스위트: 150 pass / 4 skip / 0 fail
tsc:        0
build:      성공
유출검사:    실이메일 0 · 식별자 0 · 절대경로 0 · 토큰 0 · 내부IP 0 · 라이브 .env 12항목 대조 0

미검증:     ★플래그를 켠 상태의 실환경 동작★ — 이 PR의 테스트는 전부 프로세스 내
            검증이고, 실제 codex app-server 프로세스와의 라이브 왕복은 범위 밖이다.
            ★승인 팝업의 사람 대면 동작★ — 팝업이 실제로 어떻게 보이는지 미확인.
            ★부팅 orphan sweep의 실환경 거동★ — 재시작 시나리오 미실행.
            ★fileChanges 값에 실제 diff가 실려오는지★ — 미확인. 안 실려온다면
            내용 해시는 이 계층이 아니라 codec 후속에서 다뤄야 한다.
            ★품질 시나리오 S4·S5·S6★ — app-server 모드 대상이라 플래그 OFF에서 미실행.
```

## 범위와 안전성

- codex 런타임 전용 + DB 스키마 **additive** 2파일. 공용 코드 무수정.
- **플래그를 켜지 않는 한 런타임 동작 변화 없음.**
- 라이브 트리 무수정. 격리 워크트리에서 작업.

## 리뷰

- **Codex**: P1 BLOCKING 제기 → 조건부 승인(A′) 4개 조건 제시 → 이 PR이 그 조건을 반영
- **Bill**: 상관키·CAS 상태전이 견고함 확인 + `fileChanges` 이름-only 갭 발견 + 재현 테스트 고정 요구

**머지는 팀 리드 게이트다.**
