### PR TITLE
feat(reports): add custom multi-tag organization

### DIFF
--- a/src/server/db/reports.ts
+++ b/src/server/db/reports.ts
@@ -18,10 +18,17 @@ export interface ReportMeta {
   summary: string | null;
   category: string | null; // '보고서' | '교육자료' | '리서치' | ... (/research 통합)
   is_important: boolean;
+  tags: ReportTag[];
   forms: PortalForm[];
   project: string | null;
   created_at: string;
   updated_at: string;
+}
+export interface ReportTag {
+  id: string;
+  name: string;
+  color: string;
+  report_count?: number;
 }
 
 export interface ReportListPage {
@@ -31,6 +38,7 @@ export interface ReportListPage {
   total: number;
   important_count: number;
   category_counts: Record<string, number>;
+  tags: ReportTag[];
 }
 
 export interface ReportListOptions {
@@ -39,6 +47,7 @@ export interface ReportListOptions {
   category?: string | null;
   important?: boolean;
   q?: string | null;
+  tagIds?: string[];
 }
 
 interface ReportRow {
@@ -60,13 +69,75 @@ function rowToReport(r: ReportRow): ReportMeta {
     const p = JSON.parse(r.forms_json);
     if (Array.isArray(p)) forms = p;
   } catch {}
-  return { id: r.id, title: r.title, author: r.author, summary: r.summary, category: r.category ?? null, is_important: Boolean(r.is_important), forms, project: r.project, created_at: r.created_at, updated_at: r.updated_at };
+  return { id: r.id, title: r.title, author: r.author, summary: r.summary, category: r.category ?? null, is_important: Boolean(r.is_important), tags: [], forms, project: r.project, created_at: r.created_at, updated_at: r.updated_at };
+}
+
+function attachTags(db: Database, reports: ReportMeta[]): ReportMeta[] {
+  if (!reports.length) return reports;
+  const byId = new Map(reports.map((r) => [r.id, r]));
+  const marks = reports.map(() => "?").join(",");
+  const rows = db.query(
+    `SELECT m.report_id, t.id, t.name, t.color
+       FROM report_tag_map m JOIN report_tag t ON t.id = m.tag_id
+      WHERE m.report_id IN (${marks})
+      ORDER BY t.name COLLATE NOCASE`,
+  ).all(...reports.map((r) => r.id)) as Array<{ report_id: string } & ReportTag>;
+  for (const row of rows) byId.get(row.report_id)?.tags.push({ id: row.id, name: row.name, color: row.color });
+  return reports;
+}
+
+export function listReportTags(db: Database): ReportTag[] {
+  return db.query(
+    `SELECT t.id, t.name, t.color, COUNT(m.report_id) AS report_count
+       FROM report_tag t LEFT JOIN report_tag_map m ON m.tag_id = t.id
+      GROUP BY t.id ORDER BY t.name COLLATE NOCASE`,
+  ).all() as ReportTag[];
+}
+
+export function createReportTag(db: Database, input: { name: string; color?: string }): ReportTag {
+  const name = input.name.trim();
+  if (!name || name.length > 40) throw new Error("tag name must be 1-40 characters");
+  const id = nanoid(12);
+  db.query("INSERT INTO report_tag (id, name, color) VALUES (?, ?, ?)").run(id, name, input.color || "blue");
+  return db.query("SELECT id, name, color FROM report_tag WHERE id = ?").get(id) as ReportTag;
+}
+
+export function updateReportTag(db: Database, id: string, input: { name?: string; color?: string }): ReportTag | null {
+  const current = db.query("SELECT id, name, color FROM report_tag WHERE id = ?").get(id) as ReportTag | null;
+  if (!current) return null;
+  const name = input.name == null ? current.name : input.name.trim();
+  if (!name || name.length > 40) throw new Error("tag name must be 1-40 characters");
+  db.query("UPDATE report_tag SET name = ?, color = ?, updated_at = datetime('now') WHERE id = ?")
+    .run(name, input.color ?? current.color, id);
+  return db.query("SELECT id, name, color FROM report_tag WHERE id = ?").get(id) as ReportTag;
+}
+
+export function deleteReportTag(db: Database, id: string): boolean {
+  return db.query("DELETE FROM report_tag WHERE id = ?").run(id).changes > 0;
+}
+
+export function setReportTags(db: Database, reportId: string, tagIds: string[]): ReportMeta | null {
+  if (!getReport(db, reportId)) return null;
+  const unique = [...new Set(tagIds)];
+  if (unique.length > 20) throw new Error("a report can have at most 20 tags");
+  if (unique.length) {
+    const marks = unique.map(() => "?").join(",");
+    const count = (db.query(`SELECT COUNT(*) AS c FROM report_tag WHERE id IN (${marks})`).get(...unique) as { c: number }).c;
+    if (count !== unique.length) throw new Error("unknown tag");
+  }
+  db.transaction(() => {
+    db.query("DELETE FROM report_tag_map WHERE report_id = ?").run(reportId);
+    const insert = db.query("INSERT INTO report_tag_map (report_id, tag_id) VALUES (?, ?)");
+    for (const tagId of unique) insert.run(reportId, tagId);
+    db.query("UPDATE report SET updated_at = datetime('now') WHERE id = ?").run(reportId);
+  })();
+  return getReport(db, reportId);
 }
 
 // ── report (/reports) ────────────────────────────────────────────────
 export function listReports(db: Database): ReportMeta[] {
   const rows = db.query("SELECT * FROM report ORDER BY created_at DESC, id DESC").all() as ReportRow[];
-  return rows.map(rowToReport);
+  return attachTags(db, rows.map(rowToReport));
 }
 
 const DEFAULT_REPORT_CATEGORY = "보고서";
@@ -121,6 +192,13 @@ export function listReportsPage(db: Database, options: ReportListOptions = {}): 
   if (options.important === true) {
     where.push("is_important = 1");
   }
+  const tagIds = [...new Set((options.tagIds ?? []).map((id) => id.trim()).filter(Boolean))];
+  if (tagIds.length > 20) throw new Error("too many tag filters");
+  if (tagIds.length) {
+    const marks = tagIds.map(() => "?").join(",");
+    where.push(`report.id IN (SELECT DISTINCT tm.report_id FROM report_tag_map tm WHERE tm.tag_id IN (${marks}))`);
+    args.push(...tagIds);
+  }
   const totalWhereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
   const total = countScalar(db, totalWhereSql, args);
 
@@ -135,7 +213,7 @@ export function listReportsPage(db: Database, options: ReportListOptions = {}): 
      ORDER BY created_at DESC, id DESC
      LIMIT ?`,
   ).all(...args, limit + 1) as ReportRow[];
-  const pageRows = rows.slice(0, limit).map(rowToReport);
+  const pageRows = attachTags(db, rows.slice(0, limit).map(rowToReport));
   const hasMore = rows.length > limit;
 
   const categoryRows = db.query(
@@ -155,12 +233,13 @@ export function listReportsPage(db: Database, options: ReportListOptions = {}): 
     total,
     important_count: importantCount,
     category_counts: categoryCounts,
+    tags: listReportTags(db),
   };
 }
 
 export function getReport(db: Database, id: string): ReportMeta | null {
   const row = db.query("SELECT * FROM report WHERE id = ?").get(id) as ReportRow | null;
-  return row ? rowToReport(row) : null;
+  return row ? attachTags(db, [rowToReport(row)])[0]! : null;
 }
 
 export function setReportImportant(db: Database, id: string, important: boolean): ReportMeta | null {

--- a/src/server/db/schema.sql
+++ b/src/server/db/schema.sql
@@ -245,6 +245,22 @@ CREATE TABLE IF NOT EXISTS report (
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_report_created ON report(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_report_created_id ON report(created_at DESC, id DESC);
+
+CREATE TABLE IF NOT EXISTS report_tag (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+  color TEXT NOT NULL DEFAULT 'blue',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS report_tag_map (
+  report_id TEXT NOT NULL REFERENCES report(id) ON DELETE CASCADE,
+  tag_id TEXT NOT NULL REFERENCES report_tag(id) ON DELETE CASCADE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (report_id, tag_id)
+);
+CREATE INDEX IF NOT EXISTS idx_report_tag_map_tag ON report_tag_map(tag_id, report_id);
 
 -- 팀 셀프 커스터마이즈 설정 (key-value). 팀명/태그라인 등. Mission·팀원은 파일이 정본.
 CREATE TABLE IF NOT EXISTS setting (

--- a/src/server/routes/portal.test.ts
+++ b/src/server/routes/portal.test.ts
@@ -20,6 +20,7 @@ function setup() {
 }
 const json = (b: unknown) => ({ method: "POST", body: JSON.stringify(b), headers: { "content-type": "application/json" } });
 const patchJson = (b: unknown) => ({ method: "PATCH", body: JSON.stringify(b), headers: { "content-type": "application/json" } });
+const putJson = (b: unknown) => ({ method: "PUT", body: JSON.stringify(b), headers: { "content-type": "application/json" } });
 
 describe("portal 리포트 요청 — 접수회신 플로우", () => {
   test("요청 제출 → {ok, assignee, thread_id} 반환 (대시보드 인라인 확인 근거)", async () => {
@@ -107,5 +108,40 @@ describe("portal 리포트 요청 — 접수회신 플로우", () => {
     const searched = await app.request(`/api/list?limit=10&q=${encodeURIComponent("중요 릴리즈")}`);
     const searchedJson = (await searched.json()) as { reports: { id: string }[] };
     expect(searchedJson.reports.map((r) => r.id)).toEqual(["star1"]);
+  });
+
+  test("태그 CRUD, 복수 태깅, OR 필터와 삭제 연결 해제", async () => {
+    const { app, db } = setup();
+    upsertReport(db, { id: "rep2", title: "두 번째", forms: [] } as never);
+    const a = await app.request("/api/tags", json({ name: "AI", color: "violet" }));
+    const b = await app.request("/api/tags", json({ name: "전략" }));
+    const tagA = ((await a.json()) as any).tag;
+    const tagB = ((await b.json()) as any).tag;
+    expect(a.status).toBe(201);
+
+    const marked = await app.request("/api/rep1/tags", putJson({ tag_ids: [tagA.id, tagB.id] }));
+    expect(marked.status).toBe(200);
+    expect(((await marked.json()) as any).report.tags.map((t: any) => t.name)).toEqual(["AI", "전략"]);
+    await app.request("/api/rep2/tags", putJson({ tag_ids: [tagB.id] }));
+
+    const filtered = await app.request(`/api/list?limit=10&tags=${tagA.id},${tagB.id}`);
+    expect(((await filtered.json()) as any).reports.map((r: any) => r.id).sort()).toEqual(["rep1", "rep2"]);
+
+    const renamed = await app.request(`/api/tags/${tagA.id}`, patchJson({ name: "에이전트" }));
+    expect(((await renamed.json()) as any).tag.name).toBe("에이전트");
+    await app.request(`/api/tags/${tagA.id}`, { method: "DELETE" });
+    const afterDelete = await app.request("/api/rep1");
+    expect(((await afterDelete.json()) as any).tags.map((t: any) => t.name)).toEqual(["전략"]);
+  });
+
+  test("태그 필터·보고서 태깅은 20개를 상한으로 제한한다", async () => {
+    const { app } = setup();
+    const ids = Array.from({ length: 21 }, (_, i) => `tag-${i}`);
+    const list = await app.request(`/api/list?limit=10&tags=${ids.join(",")}`);
+    expect(list.status).toBe(400);
+    const put = await app.request("/api/rep1/tags", putJson({ tag_ids: ids }));
+    expect(put.status).toBe(400);
+    const report = await app.request("/api/rep1");
+    expect(((await report.json()) as any).tags).toEqual([]);
   });
 });

--- a/src/server/routes/portal.ts
+++ b/src/server/routes/portal.ts
@@ -4,12 +4,14 @@ import { existsSync, realpathSync } from "node:fs";
 import { join, isAbsolute, resolve, extname } from "node:path";
 import {
   listReports, listReportsPage, getReport, upsertReport, deleteReport, setReportImportant,
+  listReportTags, createReportTag, updateReportTag, deleteReportTag, setReportTags,
   listResearch, getResearch, upsertResearch,
   type PortalForm,
 } from "../db/reports";
 import { ensureThread, insertMessage } from "../db/inbox/messages";
 import { createTask } from "../db/taskQueries";
 import { leadActorId, trustedActorFromRequest } from "../lib/opAuth";
+import { appendAudit } from "../db/queries";
 
 // 팀 결과물 포털 라우트 — rootApp 에 /reports, /research 로 마운트(BASE_PATH /team 형제).
 // 메타=DB, 본문=디스크 파일. report=Bill, research=Demis. 허브 next.config.ts rewrite 로 your-team.example.com 노출.
@@ -77,18 +79,65 @@ export function createReportsApp(deps: PortalDeps): Hono {
       c.req.query("cursor") != null ||
       c.req.query("category") != null ||
       c.req.query("important") != null ||
+      c.req.query("tags") != null ||
       c.req.query("q") != null;
     if (!hasPageQuery) return c.json({ reports: listReports(deps.db) });
     const limitRaw = Number(c.req.query("limit") ?? 30);
     const limit = Number.isFinite(limitRaw) ? limitRaw : 30;
     const importantRaw = c.req.query("important");
+    const tagIds = (c.req.query("tags") ?? "").split(",").filter(Boolean);
+    if (tagIds.length > 20) return c.json({ error: "at most 20 tag filters are allowed" }, 400);
     return c.json(listReportsPage(deps.db, {
       limit,
       cursor: c.req.query("cursor") ?? null,
       category: c.req.query("category") ?? null,
       important: importantRaw === "1" || importantRaw === "true",
       q: c.req.query("q") ?? null,
+      tagIds,
     }));
+  });
+
+  r.get("/api/tags", (c) => c.json({ tags: listReportTags(deps.db) }));
+  r.post("/api/tags", async (c) => {
+    try {
+      const auth = requireActor(c.req.raw);
+      if (!auth.ok || !auth.actor) return c.json({ error: auth.error }, (auth.status ?? 401) as 401);
+      const body = await c.req.json();
+      const tag = deps.db.transaction(() => {
+        const created = createReportTag(deps.db, { name: String(body?.name ?? ""), color: body?.color });
+        appendAudit(deps.db, auth.actor!.actor, "report_tag_created", created.id, { name: created.name, color: created.color });
+        return created;
+      })();
+      return c.json({ ok: true, tag }, 201);
+    } catch (e) {
+      return c.json({ error: (e as Error).message }, 400);
+    }
+  });
+  r.patch("/api/tags/:tagId", async (c) => {
+    try {
+      const auth = requireActor(c.req.raw);
+      if (!auth.ok || !auth.actor) return c.json({ error: auth.error }, (auth.status ?? 401) as 401);
+      const body = await c.req.json();
+      const tag = deps.db.transaction(() => {
+        const updated = updateReportTag(deps.db, c.req.param("tagId"), body ?? {});
+        if (updated) appendAudit(deps.db, auth.actor!.actor, "report_tag_updated", updated.id, { name: updated.name, color: updated.color });
+        return updated;
+      })();
+      return tag ? c.json({ ok: true, tag }) : c.json({ error: "tag not found" }, 404);
+    } catch (e) {
+      return c.json({ error: (e as Error).message }, 400);
+    }
+  });
+  r.delete("/api/tags/:tagId", (c) => {
+    const auth = requireActor(c.req.raw);
+    if (!auth.ok || !auth.actor) return c.json({ error: auth.error }, (auth.status ?? 401) as 401);
+    const id = c.req.param("tagId");
+    const ok = deps.db.transaction(() => {
+      const deleted = deleteReportTag(deps.db, id);
+      if (deleted) appendAudit(deps.db, auth.actor!.actor, "report_tag_deleted", id, {});
+      return deleted;
+    })();
+    return ok ? c.json({ ok: true }) : c.json({ error: "tag not found" }, 404);
   });
 
   r.get("/api/:id", (c) => {
@@ -139,6 +188,22 @@ export function createReportsApp(deps: PortalDeps): Hono {
     if (typeof body?.important !== "boolean") return c.json({ error: "important boolean required" }, 400);
     const rep = setReportImportant(deps.db, c.req.param("id"), body.important);
     return rep ? c.json({ ok: true, report: rep }) : c.json({ error: "report not found" }, 404);
+  });
+  r.put("/api/:id/tags", async (c) => {
+    try {
+      const auth = requireActor(c.req.raw);
+      if (!auth.ok || !auth.actor) return c.json({ error: auth.error }, (auth.status ?? 401) as 401);
+      const body = await c.req.json();
+      if (!Array.isArray(body?.tag_ids)) return c.json({ error: "tag_ids array required" }, 400);
+      const rep = deps.db.transaction(() => {
+        const updated = setReportTags(deps.db, c.req.param("id"), body.tag_ids.map(String));
+        if (updated) appendAudit(deps.db, auth.actor!.actor, "report_tags_updated", updated.id, { tag_ids: updated.tags.map((t) => t.id) });
+        return updated;
+      })();
+      return rep ? c.json({ ok: true, report: rep }) : c.json({ error: "report not found" }, 404);
+    } catch (e) {
+      return c.json({ error: (e as Error).message }, 400);
+    }
   });
 
   // 요청 버튼: 보고서 + 요청내용을 담당자(기본=author)에게 버스로 directed 전달(깨움) + 추적 task.

--- a/src/web/components/Reports.ts
+++ b/src/web/components/Reports.ts
@@ -23,6 +23,12 @@ interface ReportForm {
   type: string;
   path?: string;
 }
+interface ReportTag {
+  id: string;
+  name: string;
+  color: string;
+  report_count?: number;
+}
 interface Report {
   id: string;
   title: string;
@@ -30,6 +36,7 @@ interface Report {
   summary?: string | null;
   category?: string | null;
   is_important?: boolean | number | null;
+  tags?: ReportTag[];
   created_at?: string | null;
   forms?: (string | ReportForm)[];
 }
@@ -40,6 +47,7 @@ interface ReportListPage {
   total?: number;
   important_count?: number;
   category_counts?: Record<string, number>;
+  tags?: ReportTag[];
 }
 
 // 컴포넌트 로컬 상태 (대시보드는 store.mainView 기반, Reports 내부 list↔detail 은 자체 상태)
@@ -53,6 +61,8 @@ let _nextCursor: string | null = null;
 let _totalCount = 0;
 let _importantCount = 0;
 let _categoryCounts: Record<string, number> = {};
+let _tags: ReportTag[] = [];
+let _selectedTagIds = new Set<string>();
 let _view: "list" | "detail" = "list";
 let _curId: string | null = null;
 let _curType: string | null = null;
@@ -109,10 +119,11 @@ function asPage(res: unknown): ReportListPage {
       total: typeof page.total === "number" ? page.total : page.reports.length,
       important_count: typeof page.important_count === "number" ? page.important_count : page.reports.filter(isImportant).length,
       category_counts: page.category_counts ?? {},
+      tags: page.tags ?? [],
     };
   }
   const reports = asList(res);
-  return { reports, next_cursor: null, has_more: false, total: reports.length, important_count: reports.filter(isImportant).length, category_counts: {} };
+  return { reports, next_cursor: null, has_more: false, total: reports.length, important_count: reports.filter(isImportant).length, category_counts: {}, tags: [] };
 }
 // 정렬은 같은 방향으로 어긋나면 순서가 살아남지만, ★DB 형식과 ISO 가 섞이면 9시간짜리 오정렬이 난다.★
 // 같은 파서를 쓰면 그 위험 자체가 없어진다.
@@ -225,6 +236,7 @@ function pageQuery(reset: boolean): string {
   if (_cat === IMPORTANT_FILTER) params.set("important", "1");
   else if (_cat !== ALL_FILTER) params.set("category", _cat);
   if (_query.trim()) params.set("q", _query.trim());
+  if (_selectedTagIds.size) params.set("tags", [..._selectedTagIds].join(","));
   return "/api/list?" + params.toString();
 }
 async function loadReportsPage(reset: boolean): Promise<void> {
@@ -245,6 +257,9 @@ async function loadReportsPage(reset: boolean): Promise<void> {
     _totalCount = page.total ?? _all.length;
     _importantCount = page.important_count ?? _all.filter(isImportant).length;
     _categoryCounts = page.category_counts ?? {};
+    _tags = page.tags ?? _tags;
+    const availableTagIds = new Set(_tags.map((t) => t.id));
+    _selectedTagIds = new Set([..._selectedTagIds].filter((id) => availableTagIds.has(id)));
     _loaded = true;
     _loadError = null;
   } catch (err) {
@@ -256,6 +271,7 @@ async function loadReportsPage(reset: boolean): Promise<void> {
       _totalCount = 0;
       _importantCount = 0;
       _categoryCounts = {};
+      _tags = [];
       _loaded = true;
       _loadError = (err as Error).message || "load failed";
     }
@@ -301,6 +317,57 @@ async function setReportImportant(id: string, important: boolean): Promise<Repor
   if (!report) throw new Error("missing report");
   _all = _all.map((rep) => (rep.id === id ? { ...rep, is_important: report.is_important } : rep));
   return report;
+}
+async function mutateJson(path: string, method: string, body?: unknown): Promise<any> {
+  const r = await fetch(REPORTS_BASE + path, {
+    method,
+    headers: { accept: "application/json", "content-type": "application/json" },
+    body: body == null ? undefined : JSON.stringify(body),
+  });
+  const j = await r.json().catch(() => ({}));
+  if (!r.ok || j?.ok === false) throw new Error(j?.error || "HTTP " + r.status);
+  return j;
+}
+async function editReportTags(report: Report): Promise<void> {
+  const current = (report.tags ?? []).map((t) => t.name).join(", ");
+  const raw = prompt(pick("태그 이름을 쉼표로 구분해 입력하세요. 비우면 모두 해제됩니다.", "Enter tag names separated by commas. Leave empty to clear."), current);
+  if (raw == null) return;
+  const names = [...new Set(raw.split(",").map((s) => s.trim()).filter(Boolean))];
+  const known = new Map(_tags.map((t) => [t.name.toLocaleLowerCase(), t]));
+  for (const name of names) {
+    if (!known.has(name.toLocaleLowerCase())) {
+      const created = (await mutateJson("/api/tags", "POST", { name })).tag as ReportTag;
+      _tags.push(created);
+      known.set(created.name.toLocaleLowerCase(), created);
+    }
+  }
+  await mutateJson(`/api/${encodeURIComponent(report.id)}/tags`, "PUT", {
+    tag_ids: names.map((name) => known.get(name.toLocaleLowerCase())!.id),
+  });
+}
+async function manageTags(): Promise<void> {
+  const action = prompt(pick("새 태그 이름 / ‘기존이름 → 새이름’ / 삭제는 ‘-태그이름’을 입력하세요.", "Enter a new name / 'old → new' / '-name' to delete."));
+  if (!action?.trim()) return;
+  const value = action.trim();
+  if (value.startsWith("-")) {
+    const tag = _tags.find((t) => t.name.toLocaleLowerCase() === value.slice(1).trim().toLocaleLowerCase());
+    if (!tag) throw new Error(pick("태그를 찾을 수 없습니다.", "Tag not found."));
+    if (!confirm(pick(`‘${tag.name}’ 태그를 삭제할까요? 보고서는 삭제되지 않습니다.`, `Delete '${tag.name}'? Reports remain.`))) return;
+    await mutateJson(`/api/tags/${encodeURIComponent(tag.id)}`, "DELETE");
+    _selectedTagIds.delete(tag.id);
+  } else if (value.includes("→")) {
+    const [from = "", to = ""] = value.split("→", 2).map((s) => s.trim());
+    const tag = _tags.find((t) => t.name.toLocaleLowerCase() === from.toLocaleLowerCase());
+    if (!tag || !to) throw new Error(pick("‘기존이름 → 새이름’ 형식으로 입력하세요.", "Use 'old → new'."));
+    await mutateJson(`/api/tags/${encodeURIComponent(tag.id)}`, "PATCH", { name: to });
+  } else {
+    await mutateJson("/api/tags", "POST", { name: value });
+  }
+  await reloadList();
+}
+function tagBadge(tag: ReportTag, interactive = false): string {
+  const tagName = interactive ? "button" : "span";
+  return `<${tagName} class="${interactive ? "reports-tag-filter " : ""}inline-flex px-2 py-0.5 rounded-full text-[10px] font-semibold border border-blue-400/25 bg-blue-400/10 text-txt-blue" data-tag-id="${escape(tag.id)}">#${escape(tag.name)}</${tagName}>`;
 }
 function fileUrl(id: string, type: string): string {
   return `${REPORTS_BASE}/file/${encodeURIComponent(id)}/${encodeURIComponent(type)}`;
@@ -435,6 +502,9 @@ function renderList(): void {
     `<button class="${pillCls(_cat === ALL_FILTER)}" data-cat="${ALL_FILTER}">${pick("전체", "All")}<span class="ml-1.5 text-[11px] text-slate-500" data-reports-all-count>${allCount}</span></button>` +
     `<button class="${pillCls(_cat === IMPORTANT_FILTER)}" data-cat="${IMPORTANT_FILTER}" title="${pick("중요 표시만 보기", "Show important only")}" aria-label="${pick("중요 표시만 보기", "Show important only")}"><span class="inline-flex items-center gap-1.5" title="${pick("중요 표시", "Important")}">${starIcon(true)}<span class="text-[11px] text-slate-500" data-reports-important-count>${_importantCount}</span></span></button>` +
     cats.map((c) => `<button class="${pillCls(_cat === c)}" data-cat="${escape(c)}">${escape(c)}<span class="ml-1.5 text-[11px] text-slate-500" data-reports-category-count="${escape(c)}">${counts[c]}</span></button>`).join("");
+  const tagPills = _tags.map((t) =>
+    `<button class="${pillCls(_selectedTagIds.has(t.id))} reports-tag-pill" data-tag-id="${escape(t.id)}">#${escape(t.name)}<span class="ml-1.5 text-[11px] text-slate-500">${t.report_count ?? 0}</span></button>`
+  ).join("");
 
   const items = _all.slice().sort(byNewest);
 
@@ -457,6 +527,7 @@ function renderList(): void {
         </div>
         <div class="flex items-center gap-2 flex-wrap text-xs text-slate-500 mt-1"><span class="text-accent-greenSoft font-medium">${escape(r.author || "—")}</span><span>·</span><span>${fmtDate(r.created_at)}</span></div>
         ${r.summary ? `<div class="text-[13px] text-slate-400 leading-relaxed mt-1.5 line-clamp-1">${escape(r.summary)}</div>` : ""}
+        ${(r.tags ?? []).length ? `<div class="flex gap-1.5 flex-wrap mt-2">${(r.tags ?? []).map((t) => tagBadge(t, true)).join("")}</div>` : ""}
         ${badges ? `<div class="flex gap-1.5 flex-wrap mt-2">${badges}</div>` : ""}
       </div>`;
   }).join("");
@@ -477,6 +548,10 @@ function renderList(): void {
       <div class="max-w-3xl mx-auto px-4 md:px-6 py-5 pb-20">
         <div class="text-sm text-slate-500 mb-4">${pick("b3rys 팀 보고서 — 클릭하면 본문을 봅니다.", "b3rys team reports — click to read the full text.")}</div>
         <div class="flex gap-2 flex-wrap mb-3">${pills}</div>
+        <div class="flex items-center gap-2 flex-wrap mb-3">
+          ${tagPills || `<span class="text-xs text-slate-600">${pick("등록된 태그 없음", "No tags yet")}</span>`}
+          <button id="reports-manage-tags" class="ml-auto px-3 py-1.5 rounded-full text-xs font-semibold border border-surface-3 bg-surface-2 text-slate-400 hover:text-slate-200">＋ ${pick("태그 관리", "Manage tags")}</button>
+        </div>
         <div class="relative mb-4">
           <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
           <input id="reports-q" type="search" placeholder="${pick("제목·작성자·요약 검색", "Search title · author · summary")}" value="${escape(_query)}"
@@ -488,8 +563,25 @@ function renderList(): void {
   const scroller = _root.querySelector<HTMLElement>("[data-reports-list-scroll]");
   if (scroller) scroller.scrollTop = _listScrollTop;
 
-  _root.querySelectorAll<HTMLButtonElement>(".reports-pill").forEach((el) => {
+  _root.querySelectorAll<HTMLButtonElement>(".reports-pill:not(.reports-tag-pill)").forEach((el) => {
     el.addEventListener("click", () => { _cat = el.dataset.cat || ALL_FILTER; void reloadList(); });
+  });
+  _root.querySelectorAll<HTMLButtonElement>(".reports-tag-pill").forEach((el) => {
+    el.addEventListener("click", () => {
+      const id = el.dataset.tagId || "";
+      if (_selectedTagIds.has(id)) _selectedTagIds.delete(id); else _selectedTagIds.add(id);
+      void reloadList();
+    });
+  });
+  _root.querySelectorAll<HTMLButtonElement>(".reports-tag-filter").forEach((el) => {
+    el.addEventListener("click", (e) => {
+      e.preventDefault(); e.stopPropagation();
+      _selectedTagIds = new Set([el.dataset.tagId || ""]);
+      void reloadList();
+    });
+  });
+  _root.querySelector<HTMLButtonElement>("#reports-manage-tags")?.addEventListener("click", () => {
+    void manageTags().catch((err) => alert(pick(`태그 관리 실패: ${err.message}`, `Tag management failed: ${err.message}`)));
   });
   _root.querySelectorAll<HTMLElement>(".reports-card").forEach((el) => {
     el.addEventListener("click", () => { rememberListScroll(); _curId = el.dataset.id || null; if (_curId) setDetailHash(_curId); _curType = null; _view = "detail"; renderDetail(); });
@@ -600,7 +692,7 @@ async function renderDetail(): Promise<void> {
     _root.querySelector("#reports-back")?.addEventListener("click", goList);
     return;
   }
-  _all = _all.map((r) => (r.id === meta!.id ? { ...r, is_important: meta!.is_important } : r));
+  _all = _all.map((r) => (r.id === meta!.id ? { ...r, is_important: meta!.is_important, tags: meta!.tags } : r));
 
   const forms = (meta.forms || []).map(formType);
   const activeType = preferredFormType(forms);
@@ -631,6 +723,10 @@ async function renderDetail(): Promise<void> {
           <span class="inline-block mb-2 px-2 py-0.5 rounded text-[10px] font-semibold border text-txt-green border-accent-green/30 bg-accent-green/10">${escape(catOf(meta))}</span>
           <div class="flex items-center gap-2 flex-wrap text-[13px] text-slate-500"><span class="text-accent-greenSoft font-medium">${escape(author)}</span><span>·</span><span>${fmtDate(meta.created_at)}</span></div>
           ${meta.summary ? `<div class="text-sm text-slate-400 leading-relaxed mt-3 pl-3 border-l-2 border-surface-3">${escape(meta.summary)}</div>` : ""}
+          <div class="flex items-center gap-2 flex-wrap mt-3">
+            ${(meta.tags ?? []).map((t) => tagBadge(t)).join("")}
+            <button id="reports-edit-tags" class="px-2.5 py-1 rounded-full text-[11px] font-semibold border border-surface-3 text-slate-400 hover:text-slate-200">＋ ${pick("태그 편집", "Edit tags")}</button>
+          </div>
 
           <div class="reports-reqbox mt-5">
             <button id="reports-reqtoggle" class="inline-flex items-center gap-2 text-[13px] font-semibold px-4 py-2 rounded-lg border border-accent-green/35 text-accent-green bg-accent-green/10 hover:bg-accent-green/20 transition-colors">${pick("✉ 요청하기", "✉ Request")}</button>
@@ -666,6 +762,15 @@ async function renderDetail(): Promise<void> {
     } catch (err) {
       await showAlert(pick(`중요 표시 변경 실패: ${(err as Error).message}`, `Failed to update important mark: ${(err as Error).message}`));
       btn.disabled = false;
+    }
+  });
+  _root.querySelector<HTMLButtonElement>("#reports-edit-tags")?.addEventListener("click", async () => {
+    try {
+      await editReportTags(meta);
+      await loadReportsPage(true);
+      void renderDetail();
+    } catch (err) {
+      await showAlert(pick(`태그 변경 실패: ${(err as Error).message}`, `Failed to update tags: ${(err as Error).message}`));
     }
   });
   _root.querySelector<HTMLButtonElement>("#reports-delete-detail")?.addEventListener("click", async () => {


### PR DESCRIPTION
## 변경
- report_tag/report_tag_map 스키마와 cascade·인덱스 추가
- 태그 CRUD, 복수 태깅, OR 필터 API 및 감사 로그 추가
- Reports 태그 필터·관리 UI와 portal 통합 테스트 추가
- category/important/search 조합 필터와 클릭당 단일 reload 보장

## 검증
- portal.test 8/8
- tsc --noEmit
- production build
- release preflight 및 변경 diff secret scan
- Bill·Devon 재리뷰: blocker 없음

## 이번 MVP 범위 아님
- prompt 기반 모바일 관리 UX를 bottom sheet/chip UI로 개선
- 태그 생성 후 mapping 실패 시 orphan tag 자동 복구/transaction
- color picker·표시·허용값 검증
- 대용량 실DB latency 및 실제 iPhone 수동 UX 검증

## 롤백
- 배포 스크립트가 실패 시 배포 전 origin/main 커밋으로 자동 롤백