### PR TITLE
fix(web): b3os.app 다운로드 404 — latest 대신 자산이 있는 태그 고정

### DIFF
--- a/src/web/components/MetricsBar.ts
+++ b/src/web/components/MetricsBar.ts
@@ -19,9 +19,15 @@ function isMacClient(): boolean {
 // b3os.app 배포처 = GitHub Releases.
 // ★서명된 .app 을 저장소에 커밋하지 않는 이유★: 서명·공증 바이너리에는 서명 주체(Developer ID·Team ID)가
 //   박혀 있어, 저장소에 올리면 개발자 신원이 공개 이력에 영구히 남는다. 자산은 Releases 로만 배포한다.
-// `releases/latest/download/` 는 최신 릴리스로 자동 해석되므로 버전을 올려도 이 링크는 그대로다.
-const MAC_APP_DOWNLOAD_URL =
-  "https://github.com/b3rys/b3rys-team-os/releases/latest/download/b3os.app.zip";
+// ★`latest` 를 쓰지 않고 태그를 고정한다★ — 2026-07-28 라이브 404 의 원인이었다.
+//   `releases/latest/download/` 는 URL 은 그대로 두지만 ★가리키는 릴리스에 자산이 없으면 조용히 404★ 가 된다.
+//   실제로 v0.5.1 태그가 앱 자산 없이 올라가면서(07-27 12:07) latest 가 빈 릴리스를 가리켰고,
+//   외부 사용자가 신고할 때까지 ★하루 동안 아무 경고도 없었다.★
+//   그래서 ★자산이 실제로 붙어 있는 태그★ 를 가리킨다. 앱을 새로 공증해 릴리스에 첨부할 때 이 값을 올린다.
+//   (release-preflight 에 'latest 에 b3os.app.zip 이 있는가' 가드를 넣기 전까지는 latest 로 되돌리지 않는다)
+export const MAC_APP_DOWNLOAD_TAG = "v0.5.0";
+export const MAC_APP_DOWNLOAD_URL =
+  `https://github.com/b3rys/b3rys-team-os/releases/download/${MAC_APP_DOWNLOAD_TAG}/b3os.app.zip`;
 
 let alertsOpen = false;
 let tasksMenuOpen = false;

--- a/src/web/components/macAppDownloadUrl.test.ts
+++ b/src/web/components/macAppDownloadUrl.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import { MAC_APP_DOWNLOAD_TAG, MAC_APP_DOWNLOAD_URL } from "./MetricsBar";
+
+// 2026-07-28 라이브 장애의 회귀 가드.
+// 대시보드 상단 b3os.app 링크가 `releases/latest/download/` 였고, v0.5.1 태그가 앱 자산 없이
+// 올라가면서 latest 가 빈 릴리스를 가리켜 404 가 됐다. URL 은 멀쩡해 보였고 아무 경고도 없었다.
+// 외부 사용자가 신고할 때까지 하루가 걸렸다.
+describe("b3os.app 다운로드 링크", () => {
+  it("`latest` 를 쓰지 않는다 — 자산 없는 릴리스를 가리키면 조용히 404 가 된다", () => {
+    expect(MAC_APP_DOWNLOAD_URL).not.toContain("/releases/latest/");
+  });
+
+  it("자산이 붙어 있는 태그를 고정해서 가리킨다", () => {
+    expect(MAC_APP_DOWNLOAD_TAG).toMatch(/^v\d+\.\d+\.\d+$/);
+    expect(MAC_APP_DOWNLOAD_URL).toBe(
+      `https://github.com/b3rys/b3rys-team-os/releases/download/${MAC_APP_DOWNLOAD_TAG}/b3os.app.zip`,
+    );
+  });
+});


### PR DESCRIPTION
외부 사용자가 신고한 ★라이브 장애★ 입니다. GD 팀장님 지시로 Bill 과 조율해 ①(즉시 조치)로 진행합니다.

## 증상
대시보드 상단 `b3os.app` 다운로드 아이콘 → GitHub **not found**

## 원인 (실측)

| 태그 | 게시 | 자산 |
|---|---|---|
| `v0.5.1` (= latest) | 07-27 12:07 | **0개** |
| `v0.5.0` | 07-26 09:05 | `b3os.app.zip` |

링크가 `releases/**latest**/download/b3os.app.zip` 이라 latest = 빈 릴리스 → **302 → 404**.

**URL 은 멀쩡해 보였고 아무 경고도 없었습니다.** 태그는 어제 올라갔고 신고는 오늘입니다.

## 기존 주석이 이 사고를 예고했습니다

`MetricsBar.ts:22` — "`releases/latest/download/` 는 최신 릴리스로 자동 해석되므로 **버전을 올려도 이 링크는 그대로다**"

맞는 말이지만 **"가리키는 릴리스에 자산이 없으면 조용히 깨진다"** 가 빠졌습니다. **가정만 적고 그 가정이 깨지는 조건을 안 적은 것**이 원인입니다.

## 변경

- `MAC_APP_DOWNLOAD_TAG = "v0.5.0"` — **자산이 실제로 붙어 있는 태그**를 고정
- **왜 고정했는지를 주석에 같이 박았습니다** (Bill 요청) — 안 적으면 다음 사람이 "latest 가 낫잖아" 하고 되돌립니다
- **회귀 가드 테스트 추가** `macAppDownloadUrl.test.ts` — `/releases/latest/` 로 되돌아가면 실패합니다

## 검증

- `bunx tsc --noEmit` 통과
- `bun test src/web` → **54 pass / 0 fail** (신규 2건 포함)
- `v0.5.0` 자산 실측: **200, 431,315 bytes**
- 그 자산 **공증 확인**: `codesign --verify --deep --strict` 통과 · `stapler validate` 통과 · `spctl` → **`source=Notarized Developer ID`**
  - ⚠️ `unzip` 으로 풀면 `sealed resource is missing` 로 **잘못 나옵니다**. `ditto` 로 풀어야 합니다. (저도 처음에 그렇게 나와서 다시 쟀습니다)

## 미검증 / 남는 것

- **앱 0.5.0 / 서버 0.5.1 불일치** — 실제 상태 그대로라 유지합니다. 404 보다 정직합니다.
- **0.5.1 앱 빌드 + 공증** = 별건(Devon). Bill 이 팀장님께 보고합니다.
- **릴리스 가드** = 별건(제가 가져갑니다). Bill 제안대로 "latest 에 자산이 있는가" 가 아니라 **"대시보드가 실제로 거는 그 URL 이 200 인가"** 를 검사합니다 — 고정 URL 로 바꾸면 전자는 우리가 쓰는 링크를 안 보기 때문입니다.

## 롤백

이 커밋 revert 하면 즉시 원복됩니다(코드 3줄 + 테스트 1파일).

배포는 Bill 이 합니다 — 이 URL 은 `dist/web/assets/` 에 구워지고 서버가 요청마다 디스크에서 읽으므로 **재빌드만 하면 반영되고 서버 재시작은 불필요**합니다(Bill 확인).