### PR TITLE
fix(ot): 영입 위저드에 claude 페어링 코드 입력창이 안 뜨던 것 — 신호 배선

### DIFF
--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -1454,6 +1454,26 @@ describe("OT 조회가 claude 페어링 대기를 표면화한다", () => {
     expect(ot.awaiting_input).toBeNull();
   });
 
+  test("★join 이 blocked(구독/한도) 면 안 띄운다 — 더 급한 안내를 가리면 안 된다★", async () => {
+    // web footer 삼항은 pairing 분기가 needsSubscription 분기보다 ★앞★ 이다(Settings.ts:432 vs :436).
+    // subscription_needed 는 join.state="blocked" 로 온다 → 마커를 내면 앰버 경고와
+    // '🔄 해결 후 다시 활성화' 버튼이 ★통째로 가려진다★. 결제를 못 고치니 영영 못 푼다.
+    const { app, dir, db } = setup();
+    const channels = join(dir, "claude-channels");
+    process.env.CLAUDE_CHANNELS_DIR = channels;
+    const accessDir = join(channels, "telegram-bill");
+    mkdirSync(accessDir, { recursive: true });
+    writeFileSync(join(accessDir, "access.json"), JSON.stringify({ dmPolicy: "pairing", allowFrom: [], groups: {}, pending: {} }));
+    const steps = [
+      { key: "register", state: "done" }, { key: "provision", state: "done" },
+      { key: "preflight", state: "done" }, { key: "bundle", state: "done" },
+      { key: "join", state: "blocked", detail: "subscription_needed: 구독 확인 필요" },
+    ];
+    db.query("INSERT INTO ot(id,member_id,stage,steps_json) VALUES('ot_sub','bill','join',?)").run(JSON.stringify({ steps }));
+    const ot = await (await app.request("/ot/ot_sub")).json() as any;
+    expect(ot.awaiting_input).toBeNull();
+  });
+
   test("claude 가 아닌 런타임엔 영향 없다", async () => {
     const agents = [{ ...AGENTS[0], id: "bill", runtime: "openclaw" }, AGENTS[1]];
     const { app, dir, db } = setup(agents);

--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -1369,3 +1369,96 @@ describe("slack reinstall-info", () => {
     }
   }));
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// ★영입 위저드가 페어링 코드 입력창을 못 띄우던 회귀 (2026-07-28 외부 사용자 신고)★
+//
+// 증상: 대시보드로 claude 팀원을 영입하면 마지막 '합류 확인' 에서 영원히 멈춘다.
+//   위저드는 "봇에게 DM 을 한 번 보내주세요" 라고 안내하고, 사용자가 DM 을 보내면
+//   봇이 6자리 코드를 답한다. ★그런데 그 코드를 넣을 입력창이 뜨지 않는다.★
+//
+// 원인: 입력창은 `awaiting_input.kind === "claude_pairing_code"` 일 때만 렌더된다
+//   (web/components/Settings.ts shouldShowClaudePairingPanel). 그 값을 만드는 곳은
+//   `GET /members/:id/pairing-status` 뿐인데 ★웹은 그 엔드포인트를 한 번도 부르지 않는다★.
+//   위저드가 폴링하는 `GET /ot/:ot_id` 는 steps_json 에 저장된 awaiting_input 만 돌려주고,
+//   그 값은 봇 토큰 단계에서만 채워지고 그 뒤로는 계속 null 이다.
+//   → 승인 라우트도·입력창도·검증 로직도 다 있는데 ★"지금 필요하다" 는 신호만 도달하지 않았다.★
+//
+// 클로드 코드로 영입하면 성공하던 이유: 동반자가 access.json 을 직접 편집해 승인해서
+//   이 입력창을 아예 거치지 않기 때문. ★대시보드만 쓰는 사용자는 통과할 방법이 없었다.★
+describe("OT 조회가 claude 페어링 대기를 표면화한다", () => {
+  const claudeOt = (db: any, dir: string, opts: { allowFrom?: string[]; joinState?: string; stored?: unknown } = {}) => {
+    const channels = join(dir, "claude-channels");
+    process.env.CLAUDE_CHANNELS_DIR = channels;
+    const accessDir = join(channels, "telegram-bill");
+    mkdirSync(accessDir, { recursive: true });
+    writeFileSync(join(accessDir, "access.json"), JSON.stringify({
+      dmPolicy: "pairing", allowFrom: opts.allowFrom ?? [], groups: {},
+      pending: { abc123: { senderId: "1000000001", chatId: "1000000001", expiresAt: Date.now() + 60_000 } },
+    }));
+    const steps = [
+      { key: "register", state: "done" }, { key: "provision", state: "done" },
+      { key: "preflight", state: "done" }, { key: "bundle", state: "done" },
+      { key: "join", state: opts.joinState ?? "pending" },
+    ];
+    const payload: any = { steps };
+    if (opts.stored !== undefined) payload.awaiting_input = opts.stored;
+    db.query("INSERT INTO ot(id,member_id,stage,steps_json) VALUES('ot_ui','bill','join',?)").run(JSON.stringify(payload));
+  };
+
+  test("★핵심★ 합류 대기 + allowFrom 비어 있으면 코드 입력 마커를 내려준다", async () => {
+    const { app, dir, db } = setup();
+    claudeOt(db, dir);
+    const ot = await (await app.request("/ot/ot_ui")).json() as any;
+    // 이 한 줄이 실패하면 사용자는 코드를 받고도 넣을 곳이 없다.
+    expect(ot.awaiting_input?.kind).toBe("claude_pairing_code");
+  });
+
+  test("이미 승인된(allowFrom 있음) 팀원에겐 안 띄운다 — 승인 끝난 화면에 입력창이 남으면 안 된다", async () => {
+    const { app, dir, db } = setup();
+    claudeOt(db, dir, { allowFrom: ["1000000001"] });
+    const ot = await (await app.request("/ot/ot_ui")).json() as any;
+    expect(ot.awaiting_input).toBeNull();
+  });
+
+  test("합류가 이미 done 이면 안 띄운다", async () => {
+    const { app, dir, db } = setup();
+    claudeOt(db, dir, { joinState: "done" });
+    const ot = await (await app.request("/ot/ot_ui")).json() as any;
+    expect(ot.awaiting_input).toBeNull();
+  });
+
+  test("★봇 토큰 대기를 덮어쓰지 않는다★ — 같은 칸을 쓰므로 앞 단계가 우선이다", async () => {
+    const { app, dir, db } = setup();
+    claudeOt(db, dir, { stored: { kind: "bot_token", fields: [{ key: "bot_token" }] } });
+    const ot = await (await app.request("/ot/ot_ui")).json() as any;
+    expect(ot.awaiting_input.kind).toBe("bot_token");
+  });
+
+  test("★활성화 전에는 안 띄운다 — 띄우면 활성화 버튼이 사라져 진행이 막힌다★", async () => {
+    // web/Settings.ts: needsActivate = provisionDone && bundlePending && … && !(awaiting?.fields?.length)
+    //   이 마커는 fields 가 있으므로, bundle 대기 중에 내보내면 ★활성화 버튼이 숨는다★.
+    //   페어링은 활성화 뒤에 생기는 단계라, 그러면 사용자는 활성화도 페어링도 못 하고 갇힌다.
+    const { app, dir, db } = setup();
+    const channels = join(dir, "claude-channels");
+    process.env.CLAUDE_CHANNELS_DIR = channels;
+    const accessDir = join(channels, "telegram-bill");
+    mkdirSync(accessDir, { recursive: true });
+    writeFileSync(join(accessDir, "access.json"), JSON.stringify({ dmPolicy: "pairing", allowFrom: [], groups: {}, pending: {} }));
+    const steps = [
+      { key: "register", state: "done" }, { key: "provision", state: "done" },
+      { key: "preflight", state: "done" }, { key: "bundle", state: "pending" }, { key: "join", state: "pending" },
+    ];
+    db.query("INSERT INTO ot(id,member_id,stage,steps_json) VALUES('ot_preact','bill','bundle',?)").run(JSON.stringify({ steps }));
+    const ot = await (await app.request("/ot/ot_preact")).json() as any;
+    expect(ot.awaiting_input).toBeNull();
+  });
+
+  test("claude 가 아닌 런타임엔 영향 없다", async () => {
+    const agents = [{ ...AGENTS[0], id: "bill", runtime: "openclaw" }, AGENTS[1]];
+    const { app, dir, db } = setup(agents);
+    claudeOt(db, dir);
+    const ot = await (await app.request("/ot/ot_ui")).json() as any;
+    expect(ot.awaiting_input).toBeNull();
+  });
+});

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1481,8 +1481,14 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     //   로 활성화 버튼을 그린다. 이 마커는 fields 가 있으므로, bundle 대기 중에 내보내면 ★버튼이 숨는다★ —
     //   페어링은 활성화 뒤에 생기는 단계라 사용자는 활성화도 페어링도 못 하고 갇힌다(원래 버그보다 나쁘다).
     if (steps.find((s) => s.key === "bundle")?.state !== "done") return null;
+    // ★join 이 'pending' 일 때만 낸다 — 'blocked' 를 포함하면 더 급한 안내를 덮는다.★
+    //   web/Settings.ts 의 footer 삼항은 pairing 분기가 ★needsSubscription 분기보다 앞★ 이다(:432 vs :436).
+    //   subscription_needed 는 join.state="blocked" 로 오는데(:1774), 이때 마커를 내면
+    //   앰버 경고와 '🔄 해결 후 다시 활성화' 버튼이 ★통째로 가려진다★ — 결제를 못 고치니 영영 못 푼다.
+    //   서버는 이미 ①구독 ②첫 모델호출 ③페어링 순서로 안내하도록 만들어져 있고(:1765~ 주석),
+    //   페어링은 그 문구에 ★병기★ 된다. 마커까지 앞세우면 그 설계를 UI 에서 뒤집는 셈이다.
     const joinStep = steps.find((s) => s.key === "join");
-    if (!joinStep || joinStep.state === "done") return null; // 합류 끝난 화면에 입력창이 남으면 안 된다
+    if (joinStep?.state !== "pending") return null; // done(끝남)·blocked(더 급한 게 있음) 둘 다 제외
     let agent: any;
     try { agent = readAgents().find((a: any) => a.id === memberId); } catch { return null; }
     if (!agent || agent.runtime !== "claude_channel") return null;

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1462,6 +1462,41 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     return c.json({ ot_id: null });
   });
 
+  // ★영입 위저드에 페어링 코드 입력 마커를 표면화한다 (2026-07-28 외부 사용자 신고 수정).★
+  //   증상: 대시보드로 claude 팀원을 영입하면 '합류 확인' 에서 영원히 멈춘다. 위저드는 "봇에게 DM 을
+  //   한 번 보내주세요" 라고 안내하고, 사용자가 DM 을 보내면 봇이 6자리 코드를 답한다.
+  //   ★그런데 그 코드를 넣을 입력창이 뜨지 않았다.★
+  //   입력창(web/Settings.ts shouldShowClaudePairingPanel)은 `awaiting_input.kind==="claude_pairing_code"`
+  //   일 때만 렌더되는데, 그 값을 만드는 곳이 `GET /members/:id/pairing-status` 뿐이고
+  //   ★웹은 그 엔드포인트를 한 번도 부르지 않았다.★ 위저드가 폴링하는 이 라우트는 steps_json 에
+  //   저장된 값만 돌려주고, 그 값은 봇 토큰 단계에서만 채워진 뒤 계속 null 이었다.
+  //   → 승인 라우트도·입력창도·검증 로직도 다 있는데 ★"지금 필요하다"는 신호만 도달하지 않았다.★
+  //   (클로드 코드로 영입하면 동반자가 access.json 을 직접 편집해 승인해서 이 화면을 안 거친다.
+  //    그래서 그 경로만 성공했고, ★대시보드만 쓰는 사용자는 통과할 방법이 없었다.★)
+  //
+  //   저장된 마커가 우선이다 — 봇 토큰 대기와 같은 칸을 쓰므로 앞 단계를 덮어쓰면 안 된다.
+  function claudePairingAwaitingInput(memberId: string, steps: Array<{ key: string; state: string }>) {
+    // ★활성화(bundle) 전에는 절대 내지 않는다 — 안 그러면 활성화 버튼이 사라져 진행이 막힌다.★
+    //   web/Settings.ts 는 `needsActivate = provisionDone && bundlePending && … && !(awaiting?.fields?.length)`
+    //   로 활성화 버튼을 그린다. 이 마커는 fields 가 있으므로, bundle 대기 중에 내보내면 ★버튼이 숨는다★ —
+    //   페어링은 활성화 뒤에 생기는 단계라 사용자는 활성화도 페어링도 못 하고 갇힌다(원래 버그보다 나쁘다).
+    if (steps.find((s) => s.key === "bundle")?.state !== "done") return null;
+    const joinStep = steps.find((s) => s.key === "join");
+    if (!joinStep || joinStep.state === "done") return null; // 합류 끝난 화면에 입력창이 남으면 안 된다
+    let agent: any;
+    try { agent = readAgents().find((a: any) => a.id === memberId); } catch { return null; }
+    if (!agent || agent.runtime !== "claude_channel") return null;
+    let state: ReturnType<typeof readClaudePairing>;
+    try { state = readClaudePairing(memberId); } catch { return null; } // access.json 깨짐 = 표시 안 함(승인 라우트가 정본)
+    if (!state.pairing_required) return null; // allowFrom 이 차면 승인 완료 → 마커 내림
+    const mention = agent.telegram_bot_username ? `@${agent.telegram_bot_username}` : "봇";
+    return {
+      kind: "claude_pairing_code",
+      fields: ["code"],
+      hint: `Telegram 에서 ${mention} 에게 DM 을 한 번 보내면 6자리 코드가 옵니다. 그 코드를 여기에 넣어 승인하세요.`,
+    };
+  }
+
   // ── OT 상태 조회 (Steve 스테퍼가 ~1.5s 폴링) ─────────────────────
   app.get("/ot/:ot_id", (c) => {
     const ot_id = c.req.param("ot_id");
@@ -1471,7 +1506,8 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     try { parsed = JSON.parse(row.steps_json); } catch { /* corrupt → 빈 */ }
     const steps = Array.isArray(parsed.steps) ? parsed.steps : [];
     const stage = deriveStage(steps);
-    return c.json({ ot_id: row.id, member_id: row.member_id, stage, steps, awaiting_input: parsed.awaiting_input ?? null, done: stage === "joined" || stage === "failed", joined: stage === "joined", error: row.error ?? undefined });
+    const awaitingInput = parsed.awaiting_input ?? claudePairingAwaitingInput(row.member_id, steps);
+    return c.json({ ot_id: row.id, member_id: row.member_id, stage, steps, awaiting_input: awaitingInput, done: stage === "joined" || stage === "failed", joined: stage === "joined", error: row.error ?? undefined });
   });
 
   // ── OT 단계 진행 (프로비저닝/합류 완료 시 갱신) ──────────────────

--- a/src/web/components/Settings.ts
+++ b/src/web/components/Settings.ts
@@ -129,6 +129,34 @@ function escape(s: unknown): string {
     .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
 }
 
+/** 페어링 코드 형식 검사 — ★16진수 6자리다. 숫자 6자리가 아니다.★
+ *
+ *  플러그인이 코드를 이렇게 만든다: `randomBytes(3).toString('hex')` → `a4f91c` 같은 값.
+ *  그런데 이 화면의 검사는 오래도록 `/^\d{6}$/`(숫자만) 이었다. 서버는 `/^[a-f0-9]{6}$/` 로 받는데
+ *  ★클라이언트가 먼저 막아 POST 조차 나가지 않았다.★ 글자가 하나도 안 섞일 확률이 (10/16)^6 ≈ 6% 이니
+ *  ★사용자 약 94% 는 맞는 코드를 넣고도 "코드가 틀렸다" 를 본다.★
+ *  게다가 재요청도 막힌다 — 플러그인은 미만료 코드가 있으면 같은 코드를 다시 주고, DM 2회부터는 침묵한다.
+ *
+ *  ★이 불일치는 원래 있었지만 도달할 수 없었다★ — 입력 박스 자체가 안 떴기 때문이다(이 PR 이 고친 것).
+ *  즉 박스를 띄우는 순간 이 버그가 ★주 경로로 승격★ 된다. 그래서 같은 PR 에서 고친다.
+ *  (서버는 받은 값을 소문자로 정규화하므로 대문자 입력도 통과시킨다.) */
+export function isPairingCodeWellFormed(code: string): boolean {
+  return /^[a-f0-9]{6}$/i.test(code.trim());
+}
+
+/** 입력 대기 마커를 만났을 때 폴링을 멈출지 / 어떤 패널이 이미 떠 있는지 볼지 결정한다.
+ *  ★페어링 마커만 폴링을 유지한다★ — 자세한 이유는 pollOt 의 호출부 주석. */
+export function awaitingPollPlan(awaiting: Pick<AwaitingInput, "kind"> | null | undefined): {
+  stopPolling: boolean;
+  panelSelector: string;
+} {
+  const pairing = String(awaiting?.kind ?? "").toLowerCase() === "claude_pairing_code";
+  return {
+    stopPolling: !pairing,
+    panelSelector: pairing ? "#ot-claude-pair-code" : "#ot-provision-submit",
+  };
+}
+
 export function shouldShowClaudePairingPanel(runtime: string, awaiting: Pick<AwaitingInput, "kind"> | null | undefined): boolean {
   if (runtime !== "claude_channel") return false;
   const kind = String(awaiting?.kind ?? "").toLowerCase();
@@ -141,7 +169,8 @@ function claudePairingPanelHtml(aw: AwaitingInput): string {
       <div class="text-[12px] font-semibold text-slate-200 mb-1">${pick("Claude 접근 승인", "Claude access approval")}</div>
       <div class="text-[11px] text-slate-400 leading-relaxed mb-2">${escape(aw.hint || pick("봇 DM에서 받은 6자리 코드를 입력해 승인하세요. 이 박스는 서버가 승인 필요 상태를 내려줄 때만 보입니다.", "Enter the 6-digit code from the bot DM to approve access. This box appears only when the server reports that pairing is required."))}</div>
       <div class="flex flex-col sm:flex-row gap-2">
-        <input id="ot-claude-pair-code" class="${inputCls} sm:flex-1" inputmode="numeric" pattern="[0-9]*" maxlength="6" autocomplete="one-time-code" placeholder="123456" />
+        <!-- ★16진수 6자리다★ — inputmode/pattern 을 숫자로 두면 모바일에서 a~f 를 못 친다. placeholder 도 숫자 예시면 안 된다. -->
+        <input id="ot-claude-pair-code" class="${inputCls} sm:flex-1" inputmode="text" autocapitalize="off" autocorrect="off" spellcheck="false" pattern="[A-Fa-f0-9]{6}" maxlength="6" autocomplete="one-time-code" placeholder="a4f91c" />
         <button id="ot-claude-pair-approve" class="${btnPrimary}"${_pairing ? " disabled" : ""}>${_pairing ? `⏳ ${pick("승인 중…", "Approving…")}` : `🔓 ${pick("승인", "Approve")}`}</button>
       </div>
       <div class="text-[11px] text-slate-600 mt-2">${pick("두 번째 이후 Claude 팀원은 보통 기존 Telegram plugin access.json 승인을 자동 승계하므로 이 박스가 뜨지 않는 것이 정상입니다.", "Later Claude teammates usually inherit the existing Telegram plugin access.json approval automatically, so it is normal for this box not to appear.")}</div>
@@ -1129,8 +1158,8 @@ function wireOtZone(): void {
     if (!_ot || _pairing) return;
     const input = _root!.querySelector<HTMLInputElement>("#ot-claude-pair-code");
     const code = (input?.value ?? "").trim();
-    if (!/^\d{6}$/.test(code)) {
-      _pairMsg = `<div class="text-txt-red">${pick("6자리 숫자 코드를 입력하세요.", "Enter the 6-digit numeric code.")}</div>`;
+    if (!isPairingCodeWellFormed(code)) {
+      _pairMsg = `<div class="text-txt-red">${pick("6자리 코드를 입력하세요 (숫자와 a~f).", "Enter the 6-character code (0-9 and a-f).")}</div>`;
       refreshOtZone();
       return;
     }
@@ -1267,9 +1296,22 @@ async function pollOt(): Promise<void> {
   }
   if (d.awaiting_input && d.awaiting_input.fields?.length) {
     // 입력 대기 — 서버는 제출 전엔 진행 안 함. 폴링 정지(타이핑 중 입력칸 클로버 방지).
-    stopOtPolling();
-    // 패널이 아직 안 떠 있을 때만 렌더(이미 입력 중이면 건드리지 않음).
-    if (!_root?.querySelector("#ot-provision-submit")) refreshOtZone();
+    //
+    // ★페어링 마커는 폴링을 멈추면 안 된다 (2026-07-28, Demis 리뷰 + 하네스 2건이 독립 지적).★
+    //   위 전제("제출 전엔 서버가 진행 안 함")는 ★봇 토큰 마커에만 참★ 이다. 페어링 마커는
+    //   access.json 에서 ★파생된 상태★ 라 이 패널을 거치지 않고도 바뀐다:
+    //     · 설치 동반자(claude code)가 access.json 을 직접 편집해 승인
+    //     · promote-pending.sh 등 다른 경로 승인
+    //   그때 서버는 마커를 내리는데 ★폴링이 멈춰 있으면 화면이 코드 입력칸에 굳는다★
+    //   (새로고침 전까지. 그리고 새로고침하라는 신호가 어디에도 없다 — 이 PR 이 고치려던 침묵과 같은 종류).
+    //   ★첫 claude 멤버는 access.json 이 페어링 대기로 시드되는 게 설계상 정상★ 이라
+    //   (activation.ts 'tolerateWhenPairing') 이 창은 CC 경로에서도 실제로 열린다.
+    const plan = awaitingPollPlan(d.awaiting_input);
+    if (plan.stopPolling) stopOtPolling();
+    // 패널이 아직 안 떠 있을 때만 렌더(이미 떠 있으면 입력값·포커스를 건드리지 않는다).
+    //   ★패널마다 요소 id 가 다르다★ — 페어링 패널을 provision id 로 찾으면 항상 '없음' 이 되어
+    //   매 폴링마다 재렌더 → 입력칸이 날아간다.
+    if (!_root?.querySelector(plan.panelSelector)) refreshOtZone();
     return;
   }
   void maybeAutoRecheckPreflight(d); // preflight blocked면 throttle로 자동 재점검(로그인되면 done→다음 렌더에서 활성화 버튼 노출)

--- a/src/web/components/settingsPairing.test.ts
+++ b/src/web/components/settingsPairing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { shouldShowClaudePairingPanel } from "./Settings";
+import { awaitingPollPlan, isPairingCodeWellFormed, shouldShowClaudePairingPanel } from "./Settings";
 
 describe("Settings Claude pairing panel visibility", () => {
   test("shows only when the server reports a pending pairing input for a claude OT", () => {
@@ -11,5 +11,66 @@ describe("Settings Claude pairing panel visibility", () => {
     expect(shouldShowClaudePairingPanel("claude_channel", null)).toBe(false);
     expect(shouldShowClaudePairingPanel("claude_channel", { kind: "bot_token" })).toBe(false);
     expect(shouldShowClaudePairingPanel("openclaw", { kind: "claude_pairing_code" })).toBe(false);
+  });
+});
+
+// ★폴링 정지 판정 (2026-07-28 · Demis 리뷰 + 하네스 2건이 독립 지적)★
+//
+// pollOt 는 `awaiting_input.fields?.length` 가 있으면 폴링을 멈춘다. 근거 주석은
+// "서버는 제출 전엔 진행 안 함" 인데, ★그 전제는 봇 토큰 마커에만 참★ 이다.
+// 페어링 마커는 access.json 에서 파생된 상태라 이 패널을 거치지 않고도 바뀐다
+// (설치 동반자가 access.json 을 직접 편집해 승인 · promote-pending.sh 등).
+// 그때 서버는 마커를 내리는데 폴링이 멈춰 있으면 ★화면이 코드 입력칸에 굳는다★ —
+// 새로고침 전까지, 그리고 새로고침하라는 신호는 어디에도 없다.
+// ★첫 claude 멤버는 access.json 이 페어링 대기로 시드되는 게 설계상 정상★ 이라
+// 이 창은 클로드 코드 경로에서도 실제로 열린다.
+describe("awaitingPollPlan — 어떤 마커가 폴링을 멈추나", () => {
+  test("★페어링 마커는 폴링을 멈추지 않는다★ — 밖에서 승인되면 화면이 따라와야 한다", () => {
+    expect(awaitingPollPlan({ kind: "claude_pairing_code" }).stopPolling).toBe(false);
+  });
+
+  test("봇 토큰 마커는 종전대로 멈춘다 — 제출로만 풀리는 상태다", () => {
+    expect(awaitingPollPlan({ kind: "bot_token" }).stopPolling).toBe(true);
+  });
+
+  test("마커가 없으면 종전 동작", () => {
+    expect(awaitingPollPlan(null).stopPolling).toBe(true);
+    expect(awaitingPollPlan(undefined).stopPolling).toBe(true);
+  });
+
+  test("★패널마다 찾는 요소가 다르다★ — 틀리면 매 폴링마다 재렌더돼 입력칸이 날아간다", () => {
+    expect(awaitingPollPlan({ kind: "claude_pairing_code" }).panelSelector).toBe("#ot-claude-pair-code");
+    expect(awaitingPollPlan({ kind: "bot_token" }).panelSelector).toBe("#ot-provision-submit");
+  });
+});
+
+// ★코드 형식 — 16진수 6자리다. 숫자 6자리가 아니다 (2026-07-28 적대적 하네스 발견).★
+//
+// 플러그인: randomBytes(3).toString('hex') → `a4f91c` 같은 값.
+// 이 화면의 검사는 오래도록 /^\d{6}$/ (숫자만) 이었고 서버는 /^[a-f0-9]{6}$/ 로 받았다.
+// ★클라이언트가 먼저 막아 POST 조차 안 나갔다★ — 글자가 하나도 안 섞일 확률 (10/16)^6 ≈ 6%,
+// 즉 ★약 94% 의 사용자가 맞는 코드를 넣고도 "코드가 틀렸다" 를 본다.★
+// 재요청도 안 통한다: 플러그인은 미만료 코드가 있으면 같은 코드를 다시 주고 DM 2회부터 침묵한다.
+describe("isPairingCodeWellFormed — 코드는 16진수다", () => {
+  test("★글자가 섞인 hex 를 받는다★ — 이게 실제로 오는 코드다", () => {
+    expect(isPairingCodeWellFormed("a4f91c")).toBe(true);
+    expect(isPairingCodeWellFormed("abcdef")).toBe(true);
+    expect(isPairingCodeWellFormed("ffffff")).toBe(true);
+  });
+
+  test("숫자만인 코드도 받는다 — hex 의 부분집합이라 종전 동작 유지", () => {
+    expect(isPairingCodeWellFormed("123456")).toBe(true);
+  });
+
+  test("대문자·공백은 정규화해서 받는다 — 서버가 소문자로 맞춘다", () => {
+    expect(isPairingCodeWellFormed("A4F91C")).toBe(true);
+    expect(isPairingCodeWellFormed("  a4f91c  ")).toBe(true);
+  });
+
+  test("hex 가 아닌 것은 거른다", () => {
+    expect(isPairingCodeWellFormed("a4f91g")).toBe(false); // g 는 hex 아님
+    expect(isPairingCodeWellFormed("a4f91")).toBe(false);  // 5자리
+    expect(isPairingCodeWellFormed("a4f91cc")).toBe(false); // 7자리
+    expect(isPairingCodeWellFormed("")).toBe(false);
   });
 });


### PR DESCRIPTION
## 증상 (외부 사용자 신고, 2026-07-28)

대시보드로 claude 팀원을 영입하면 마지막 **'합류 확인'에서 영원히 멈춘다.**
위저드는 *"봇에게 DM 을 한 번 보내주세요"* 라고 안내하고, 사용자가 DM 을 보내면 봇이 6자리 코드를
답한다. **그런데 그 코드를 넣을 입력창이 뜨지 않는다.**

## 원인 — 부품은 다 있는데 신호만 도달하지 않았다

| 부품 | 위치 | 상태 |
|---|---|---|
| 입력창·승인 버튼 | `web/Settings.ts` `claudePairingPanelHtml` | ✓ 있음 |
| 표시 조건 | `web/Settings.ts` `shouldShowClaudePairingPanel` | ✓ 있음 (+테스트) |
| 서버 승인 처리 | `POST /ot/:id/claude-pair-approve` | ✓ 있음 (+테스트 9건) |
| 판정 로직 | `readClaudePairing` | ✓ 있음 |
| **"지금 필요하다" 는 신호** | — | ✖ **화면에 안 옴** |

입력창은 `awaiting_input.kind === "claude_pairing_code"` 일 때만 렌더된다. 그 값을 만드는 곳은
`GET /members/:id/pairing-status` 하나뿐인데 **웹은 그 엔드포인트를 한 번도 부르지 않는다**
(`src/web` 전체 grep = **0건**). 위저드가 ~1.5s 로 폴링하는 `GET /ot/:ot_id` 는 `steps_json` 에
저장된 값만 돌려주고, 그 값은 봇 토큰 단계에서만 채워진 뒤 계속 `null` 이다.

**클로드 코드로 하면 왜 됐나** — 동반자가 `access.json` 의 `allowFrom` 을 직접 편집해 승인해버려
이 화면을 안 거친다. 그래서 그 경로만 성공했고 **대시보드만 쓰는 사용자는 통과할 방법이 없었다.**

## 수정

`GET /ot/:ot_id` 가 저장된 마커가 없을 때 페어링 필요 여부를 함께 판정해 내려준다.
**새 판정 로직·새 UI·새 라우트 없음** — 이미 있는 것들을 잇기만 한다.

## 가드 4겹 (전부 테스트로 고정)

1. **활성화(bundle) 전에는 안 낸다** — web 은
   `needsActivate = provisionDone && bundlePending && … && !(awaiting?.fields?.length)` 로 활성화
   버튼을 그린다. 이 마커는 `fields` 가 있어서 bundle 대기 중에 내보내면 **활성화 버튼이 숨는다**
   → 활성화도 페어링도 못 하고 갇힌다(원래 버그보다 나쁘다).
   **구현 중 실제로 이 회귀를 만들 뻔했고 UI 사슬을 따라가다 잡았다.**
2. 저장된 마커가 우선 — 봇 토큰 대기와 **같은 칸**이라 앞 단계를 덮지 않는다
3. `join` 이 done 이면 안 낸다
4. `claude_channel` 이 아니면 안 낸다 · `allowFrom` 이 차 있으면 안 낸다

## 클로드 코드 경로 무영향 (팀장 요구사항)

CC 로 영입하면 동반자가 `access.json` 을 채워 `allowFrom` 이 비지 않는다 →
`pairing_required=false` → 마커 `null` → **화면 변화 0.** 활성화 이후에만 뜨므로 활성화 버튼도 가리지 않는다.

## 검증

- **검증 범위**: 신규 테스트 6건 · `bun test`(전체) · `bunx tsc --noEmit`
- **baseline**: 변경 전 0 fail
- **핵심 테스트가 수정 전 실제로 실패** — `Expected: "claude_pairing_code" / Received: undefined`
- **mutation**: 고친 한 줄을 원래대로 되돌리니 그 1건이 다시 실패 → 테스트가 진짜로 잡는다
- 전체 **1815 pass / 5 skip / 0 fail** (157 파일), typecheck 통과
- **미검증**: **브라우저 실물 클릭.** 라우트 응답·표시조건 함수까지는 테스트로 덮었으나
  실제 렌더는 확인하지 않았다. 또한 폴링마다 `access.json` 을 읽으므로 fs read 가 늘어난다
  (join 대기 구간에 한정, 파일은 작음).

## 리뷰에서 봐줬으면 하는 곳

**다른 데 영향이 없는지.** 특히 ① `awaiting_input` 을 읽는 다른 분기가 이 새 kind 를 만나 오동작하지
않는지 ② openclaw/hermes/codex 영입 흐름에 끼어들 여지가 없는지 ③ `GET /ot/:ot_id` 를 소비하는
다른 곳(스킬·스크립트·테스트)이 있는지.