### PR TITLE
fix(codex): 해석 못 한 승인 payload 가 넓은 권한 열쇠를 만들지 않게 (#106 S0)

### DIFF
--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -95,7 +95,56 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
     const files = Object.keys(p.fileChanges).sort();
     return { runtime: "codex", agent_id: agentId, action: "write", path: files.join("|").slice(0, 500), text: files.join(", ").slice(0, 500), requested_by: agentId, provenance };
   }
-  return { runtime: "codex", agent_id: agentId, action: req.method.slice(0, 64), text: typeof p.reason === "string" ? p.reason.slice(0, 500) : undefined, requested_by: agentId, provenance };
+  // ★S0(#106) — 여기까지 왔다는 것은 payload 를 해석하지 못했다는 뜻이다. 그 사실을 명시한다.★
+  //
+  //  예전에는 action 에 req.method 를, text 에 reason 만 넣었다. reason 이 없으면 targetForOperation 이
+  //  action 으로 떨어지므로 ★target = method 이름★ 이 되어 ★그 method 로 오는 모든 요청이 같은 scope★ 였다.
+  //  → 한 번 allowed_always 를 받으면 이후 ★내용이 전혀 다른 요청도 팝업 없이 통과★ 한다.
+  //  실측(2026-07-28): item/commandExecution/requestApproval 로 온 'rm -rf /tmp/x' 와 'cat ~/.ssh/id_rsa' 가
+  //  ★같은 scope_key★ 를 가졌다.
+  //
+  //  ★팀 리드 원칙(2026-07-28): "애매하면 통과가 아니고 ask 로."★
+  //  해석에 실패했으면 넓은 열쇠를 만들지 않는다 — payload 지문을 target 에 넣어 ★payload 가 다르면 열쇠도 다르게★ 한다.
+  //  저장된 grant 는 자기와 똑같은 payload 에만 적용되고, 조금이라도 다르면 다시 사람에게 묻는다.
+  //
+  //  ※ ★실제 효과: 신세대 payload 는 itemId·turnId·startedAtMs 가 요청마다 달라서 사실상 매번 새 열쇠가 된다★
+  //    = 해석 못 한 요청은 ★매번 묻는다★. 그게 이 단계가 노린 보수적 동작이다.
+  //  ※ reason 을 text 에 남기는 이유: permissionGate.operationText 가 text 도 Tier-D 스캔에 쓴다.
+  //    빼면 위험 문자열이 reason 에 있을 때 하드 차단이 약해진다.
+  const reason = typeof p.reason === "string" ? p.reason.slice(0, 300) : "";
+  return {
+    runtime: "codex",
+    agent_id: agentId,
+    action: "approval_unparsed",
+    text: `${req.method} #${unparsedPayloadDigest(req)}${reason ? ` ${reason}` : ""}`.slice(0, 500),
+    requested_by: agentId,
+    provenance,
+  };
+}
+
+/** 해석하지 못한 요청을 ★받은 payload 전체★ 로 묶는 지문(sha256 16hex).
+ *
+ *  approvalOperationHash 를 쓰지 않는 이유: 그 basis 는 {method, command(배열만), files, reason} 라
+ *  ★신세대 payload 를 하나도 담지 못한다★ — command 가 문자열이면 Array.isArray 가 false 라 null 이 되고,
+ *  fileChanges 는 신세대에 아예 없다. 그래서 서로 다른 두 명령이 ★같은 지문★ 을 갖는다(테스트로 고정해 뒀다).
+ *  해석에 실패한 마당에 '무엇이 중요한 필드인지' 를 고를 근거가 없으므로 ★전부★ 를 담는다.
+ *
+ *  키 순서에 흔들리지 않도록 재귀 정렬해 직렬화한다 — JSON.stringify 는 삽입 순서를 따르므로,
+ *  같은 내용이 다른 순서로 오면 지문이 달라져 ★같은 작업에 열쇠가 두 개★ 생긴다. */
+function unparsedPayloadDigest(req: ApprovalRequest): string {
+  const stable = (v: unknown): unknown => {
+    if (Array.isArray(v)) return v.map(stable);
+    if (v && typeof v === "object") {
+      return Object.keys(v as Record<string, unknown>)
+        .sort()
+        .reduce<Record<string, unknown>>((acc, k) => { acc[k] = stable((v as Record<string, unknown>)[k]); return acc; }, {});
+    }
+    return v;
+  };
+  return createHash("sha256")
+    .update(JSON.stringify(stable({ method: req.method, params: req.params ?? null })))
+    .digest("hex")
+    .slice(0, 16);
 }
 
 /** M5.2 — permission_request 상태를 폴링해 GD 결정을 ReviewDecision으로. 무응답 TTL→denied(hold). */

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -111,12 +111,15 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
   //    = 해석 못 한 요청은 ★매번 묻는다★. 그게 이 단계가 노린 보수적 동작이다.
   //  ※ reason 을 text 에 남기는 이유: permissionGate.operationText 가 text 도 Tier-D 스캔에 쓴다.
   //    빼면 위험 문자열이 reason 에 있을 때 하드 차단이 약해진다.
-  const reason = typeof p.reason === "string" ? p.reason.slice(0, 300) : "";
+  // reason 은 ★기존과 같은 500자★ 를 유지한다 — 여기서 줄이면 Tier-D 스캔 범위가 좁아진다(Codex 리뷰).
+  // 합친 문자열을 다시 자르지도 않는다: method 는 프로토콜 상수(방어적으로 64자), 지문은 16자라
+  // 전체가 유계이고, 자르면 그만큼 reason 끝이 스캔에서 빠진다.
+  const reason = typeof p.reason === "string" ? p.reason.slice(0, 500) : "";
   return {
     runtime: "codex",
     agent_id: agentId,
     action: "approval_unparsed",
-    text: `${req.method} #${unparsedPayloadDigest(req)}${reason ? ` ${reason}` : ""}`.slice(0, 500),
+    text: `${req.method.slice(0, 64)} #${unparsedPayloadDigest(req)}${reason ? ` ${reason}` : ""}`,
     requested_by: agentId,
     provenance,
   };
@@ -135,9 +138,16 @@ function unparsedPayloadDigest(req: ApprovalRequest): string {
   const stable = (v: unknown): unknown => {
     if (Array.isArray(v)) return v.map(stable);
     if (v && typeof v === "object") {
-      return Object.keys(v as Record<string, unknown>)
-        .sort()
-        .reduce<Record<string, unknown>>((acc, k) => { acc[k] = stable((v as Record<string, unknown>)[k]); return acc; }, {});
+      // ★Object.fromEntries 를 쓴다 — 일반 객체에 acc["__proto__"]=... 로 대입하면 ★프로토타입이 바뀔 뿐
+      //  own property 가 되지 않아 JSON.stringify 에서 통째로 사라진다.★ 그러면 "__proto__" 값만 다른 두
+      //  payload 가 ★같은 지문·같은 열쇠★ 가 된다(Codex 리뷰에서 지적, 재현 확인: 둘 다 #5353b5b6…).
+      //  JSON-RPC payload 에 그 키가 오는 것은 유효하므로, ★해석 실패 경로에서 이건 우회 통로★ 가 된다.
+      //  fromEntries 는 CreateDataProperty 라 "__proto__" 도 평범한 키로 보존한다.
+      return Object.fromEntries(
+        Object.keys(v as Record<string, unknown>)
+          .sort()
+          .map((k) => [k, stable((v as Record<string, unknown>)[k])] as const),
+      );
     }
     return v;
   };

--- a/src/server/runtimes/codex/appServerPopup.unparsed.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.unparsed.test.ts
@@ -1,0 +1,86 @@
+import { test, expect, describe } from "bun:test";
+import { buildOperationFromApproval, approvalOperationHash } from "./appServerPopup";
+import { scopeKeyForOperation, targetForOperation } from "../../lib/permissionGate";
+import type { ApprovalRequest } from "./appServerClient";
+
+/**
+ * ★S0(#106) — 해석하지 못한 승인 payload 가 넓은 권한 열쇠를 만들지 않는다★
+ *
+ * 배경: 승인 요청 payload 는 두 세대다(2026-07-28 벤더 스키마 실측, codex-cli 0.144.6).
+ *   구세대 execCommandApproval   → command 가 ★배열★
+ *   신세대 item/commandExecution/requestApproval → command 가 ★문자열★
+ *   신세대 item/fileChange/requestApproval       → ★fileChanges 필드 자체가 없다★
+ * buildOperationFromApproval 은 Array.isArray(p.command) / p.fileChanges 로만 분기하므로
+ * ★신세대는 전부 마지막 분기로 떨어진다.★
+ *
+ * 예전 마지막 분기는 action=req.method, text=reason 이었다. reason 이 없으면 target 이 action 으로
+ * 떨어져 ★target = method 이름★ 이 된다 → 그 method 로 오는 ★모든 요청이 같은 scope_key★.
+ * 즉 한 번 allowed_always 를 주면 이후 내용이 전혀 다른 요청도 팝업 없이 통과한다.
+ *
+ * 팀 리드 원칙(2026-07-28): ★"애매하면 통과가 아니고 ask 로."★
+ * 아래 테스트들이 그 원칙을 코드에 고정한다.
+ */
+describe("S0 — 해석 실패 payload 의 권한 열쇠", () => {
+  const newGenCmd = (command: string): ApprovalRequest => ({
+    method: "item/commandExecution/requestApproval",
+    params: { command, cwd: "/tmp", itemId: "i1", turnId: "t1", threadId: "th1", startedAtMs: 1 },
+  });
+
+  test("★서로 다른 명령은 서로 다른 열쇠를 갖는다★ — 하나를 '항상 허용' 해도 다른 하나는 다시 묻는다", () => {
+    const safe = buildOperationFromApproval(newGenCmd("rm -rf /tmp/x"), "dex");
+    const evil = buildOperationFromApproval(newGenCmd("cat ~/.ssh/id_rsa"), "dex");
+
+    // 이 단언이 S0 의 본체다. 수정 전에는 두 값이 ★같았다★.
+    expect(scopeKeyForOperation(safe)).not.toBe(scopeKeyForOperation(evil));
+  });
+
+  test("target 이 더 이상 method 이름이 아니다", () => {
+    const op = buildOperationFromApproval(newGenCmd("ls -la"), "dex");
+    expect(targetForOperation(op)).not.toBe("item/commandExecution/requestApproval");
+    expect(op.action).toBe("approval_unparsed"); // 해석 실패를 이름으로 밝힌다
+  });
+
+  test("payload 지문이 target 안에 살아남는다 (240자 절단 뒤에도)", () => {
+    const op = buildOperationFromApproval(newGenCmd("echo hi"), "dex");
+    // 지문이 절단에 잘려나가면 열쇠가 다시 뭉개진다. 그래서 method 바로 뒤에 둔다.
+    expect(targetForOperation(op)).toMatch(/#[0-9a-f]{16}/);
+  });
+
+  test("같은 payload 는 같은 열쇠 — 결정적이다", () => {
+    const a = buildOperationFromApproval(newGenCmd("git status"), "dex");
+    const b = buildOperationFromApproval(newGenCmd("git status"), "dex");
+    expect(scopeKeyForOperation(a)).toBe(scopeKeyForOperation(b));
+  });
+
+  test("★키 순서가 달라도 같은 열쇠★ — 같은 작업에 두 개의 열쇠가 생기면 안 된다", () => {
+    const a: ApprovalRequest = { method: "item/tool/requestUserInput", params: { a: 1, b: { x: 1, y: 2 } } };
+    const b: ApprovalRequest = { method: "item/tool/requestUserInput", params: { b: { y: 2, x: 1 }, a: 1 } };
+    expect(scopeKeyForOperation(buildOperationFromApproval(a, "dex")))
+      .toBe(scopeKeyForOperation(buildOperationFromApproval(b, "dex")));
+  });
+
+  test("★approvalOperationHash 로는 못 가른다★ — 왜 payload 전체 지문이 필요한지의 근거", () => {
+    // 신세대는 command 가 문자열이라 basis 의 Array.isArray 가 false → command:null.
+    // fileChanges 도 reason 도 없으니 basis 가 {method, null, null, null} 로 같아진다.
+    // ★즉 기존 지문을 그대로 썼다면 위 첫 테스트가 통과하지 못한다.★ (실제로 처음에 그렇게 짰다가 잡혔다)
+    expect(approvalOperationHash(newGenCmd("rm -rf /tmp/x")))
+      .toBe(approvalOperationHash(newGenCmd("cat ~/.ssh/id_rsa")));
+  });
+
+  test("★reason 은 text 에 남는다★ — permissionGate 가 text 를 Tier-D 스캔에 쓰기 때문", () => {
+    const req: ApprovalRequest = {
+      method: "item/permissions/requestApproval",
+      params: { reason: "needs network egress to example.com", itemId: "i9" },
+    };
+    const op = buildOperationFromApproval(req, "dex");
+    expect(op.text).toContain("needs network egress to example.com");
+  });
+
+  test("해석되는 구세대 경로는 건드리지 않는다 — 회귀 가드", () => {
+    const oldGen: ApprovalRequest = { method: "execCommandApproval", params: { command: ["rm", "-rf", "/tmp/x"], cwd: "/tmp" } };
+    const op = buildOperationFromApproval(oldGen, "dex");
+    expect(op.action).toBe("shell");
+    expect(op.command).toBe("rm -rf /tmp/x");
+    expect(targetForOperation(op)).toBe("rm -rf /tmp/x");
+  });
+});

--- a/src/server/runtimes/codex/appServerPopup.unparsed.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.unparsed.test.ts
@@ -59,6 +59,28 @@ describe("S0 — 해석 실패 payload 의 권한 열쇠", () => {
       .toBe(scopeKeyForOperation(buildOperationFromApproval(b, "dex")));
   });
 
+  test("★'__proto__' 키만 다른 payload 도 갈린다★ — 해석 실패 경로의 우회 통로였다", () => {
+    // Codex 리뷰(2026-07-29)에서 잡힌 실제 충돌. 일반 객체에 acc["__proto__"]=... 로 대입하면
+    // ★프로토타입이 바뀔 뿐 own property 가 되지 않아 JSON.stringify 에서 통째로 사라진다.★
+    // → "__proto__" 값만 다른 두 payload 가 ★같은 지문·같은 열쇠★ 였다(재현: 둘 다 #5353b5b6…).
+    // JSON-RPC payload 에 이 키가 오는 것은 유효하므로 ★해석 실패 경로에서 우회 통로★ 가 된다.
+    // JSON.parse 로 만들어야 실제 수신 경로와 같다(리터럴로 쓰면 파서가 프로토타입으로 처리한다).
+    const a = { method: "item/tool/requestUserInput", params: JSON.parse('{"x":1,"__proto__":{"a":1}}') } as ApprovalRequest;
+    const b = { method: "item/tool/requestUserInput", params: JSON.parse('{"x":1,"__proto__":{"a":2}}') } as ApprovalRequest;
+    expect(scopeKeyForOperation(buildOperationFromApproval(a, "dex")))
+      .not.toBe(scopeKeyForOperation(buildOperationFromApproval(b, "dex")));
+  });
+
+  test("reason 은 500자까지 text 에 남는다 — Tier-D 스캔 범위를 줄이지 않는다", () => {
+    const long = "x".repeat(600);
+    const op = buildOperationFromApproval(
+      { method: "item/permissions/requestApproval", params: { reason: long, itemId: "i1" } } as ApprovalRequest,
+      "dex",
+    );
+    // 합친 문자열을 다시 자르면 reason 끝이 스캔에서 빠진다. 500자는 온전히 남아야 한다.
+    expect(op.text).toContain("x".repeat(500));
+  });
+
   test("★approvalOperationHash 로는 못 가른다★ — 왜 payload 전체 지문이 필요한지의 근거", () => {
     // 신세대는 command 가 문자열이라 basis 의 Array.isArray 가 false → command:null.
     // fileChanges 도 reason 도 없으니 basis 가 {method, null, null, null} 로 같아진다.


### PR DESCRIPTION
> #106 의 **S0** 단계. 계획서: `demis/research/codex-approval-staged-plan-20260729.md`
> 팀 리드 지시대로 **한 번에 한 단계**만 한다. 이 PR 에는 S1~S5 가 들어있지 않다.

## 무엇이 문제였나

승인 요청 payload 는 **두 세대**다 (codex-cli 0.144.6 벤더 스키마 실측 — `codex app-server generate-json-schema`).

| method | 세대 | `command` | `fileChanges` |
|---|---|---|---|
| `execCommandApproval` | 구 | **배열** | — |
| `applyPatchApproval` | 구 | — | **있음** |
| `item/commandExecution/requestApproval` | 신 | **문자열** | — |
| `item/fileChange/requestApproval` | 신 | — | **없음** |

`buildOperationFromApproval` 은 `Array.isArray(p.command)` / `p.fileChanges` 로만 분기한다. **신세대는 전부 마지막 분기로 떨어진다.** 그 분기가 `action = req.method`, `text = reason` 이었는데, `reason` 이 없으면 `targetForOperation` 이 `action` 으로 떨어지므로 **target 이 method 이름**이 된다.

**결과: 그 method 로 오는 모든 요청이 같은 `scope_key` 를 갖는다.** 한 번 `allowed_always` 를 주면 이후 **내용이 전혀 다른 요청도 팝업 없이 통과**한다.

실측(2026-07-28):

```
item/commandExecution/requestApproval + "rm -rf /tmp/x"
item/commandExecution/requestApproval + "cat ~/.ssh/id_rsa"
→ scopeKeyForOperation 이 ★같음★
```

## 고친 방식

팀 리드 원칙(2026-07-28): **"승인 필요한 경우는 해석을 보수적으로. 애매하면 통과가 아니고 ask 로."**

해석에 실패했으면 **넓은 열쇠를 만들지 않는다.**

- `action` → `approval_unparsed` (해석하지 못했다는 사실을 이름으로 밝힌다)
- `text` → `<method> #<payload 전체 지문> <reason>` → **payload 가 다르면 열쇠도 다르다**

**실제 효과**: 신세대 payload 는 `itemId`·`turnId`·`startedAtMs` 가 요청마다 달라서 사실상 **매번 새 열쇠**가 된다 = 해석 못 한 요청은 **매번 묻는다.** 이 단계가 노린 보수적 동작이다.

### 기존 `approvalOperationHash` 를 쓰지 않은 이유

그 basis 는 `{method, command(배열만), files, reason}` 이라 **신세대 payload 를 하나도 담지 못한다** — `command` 가 문자열이면 `Array.isArray` 가 false 라 `null`, `fileChanges` 는 신세대에 없음.

**처음엔 그걸 썼다가 핵심 테스트가 빨강이 나서 잡았다.** 그 사실 자체를 테스트로 고정해 뒀다 (`★approvalOperationHash 로는 못 가른다★`) — 나중에 누가 "이미 지문이 있는데 왜 또 만들었나" 라고 물을 때의 답이다.

### `reason` 을 `text` 에 남긴 이유

`permissionGate.operationText` 가 `text` 도 **Tier-D 스캔 대상**으로 쓴다. 빼면 위험 문자열이 `reason` 에 있을 때 하드 차단이 약해진다.

## 검증

```
검증 범위:  bun test 전체 게이트 · tsc --noEmit · 뮤턴트 3종
baseline:   1824 pass / 5 skip / 0 fail  (157 파일, 같은 커밋 536329f)
이 PR:      1832 pass / 5 skip / 0 fail  (158 파일)
증가분:     +8 pass / +1 파일 → 신규 테스트 수와 정확히 일치 = 회귀 0
tsc:        0

mutation (되돌리면 테스트가 빨강이 되는가):
  1. 옛 분기 복원(action=method, text=reason)        → 3 fail
  2. 지문을 approvalOperationHash 로 교체            → 1 fail
  3. 지문 직렬화에서 키 정렬 제거                     → 1 fail
  → 셋 다 잡힌다. 원복 후 워킹트리 청결 확인.

미검증:     ★플래그를 켠 상태의 실환경 동작★ — B3OS_CODEX_APPSERVER 는 여전히 꺼져 있고
            이 PR 에서도 켜지 않았다. 프로세스 내 검증만 했다.
            ★실제 app-server 가 어느 세대를 보내는지★ — 스키마에 둘 다 있고 실제 전송 세대는
            버전·협상에 달렸다. 확인하려면 플래그를 켜야 한다.
            ★팝업 표시 문구★ — 이 PR 은 열쇠만 고친다. 사람에게 무엇을 보여줄지는 S3.
```

## 범위와 정지 조건

- **codex 전용.** 공용 `src/server/lib/` **무수정** — 팀 리드 지시("공용에 손이 가는 순간이 정지 신호") 준수.
- 이 PR 로 **런타임 동작 변화 없음** — 플래그가 꺼져 있어 이 경로가 실행되지 않는다.
- **`B3OS_CODEX_APPSERVER` 활성화는 #106 이 닫힌 뒤 + 팀 리드 승인.** 이 PR 은 그 조건을 바꾸지 않는다.

## 남은 단계 (이 PR 에 없음)

| | | |
|---|---|---|
| S1 | 신세대 `command`(문자열) **해석** | 다음 사이클 |
| S2 | 파일 변경 내용을 `itemId` 로 조회, 실패하면 ask | |
| S3 | **팝업이 사람에게 실제 명령·변경 요약을 보여줌** | |
| S4 | 지문 basis 에 파일 내용 해시 | |
| S5 | 작업을 **권한 scope 에 결합** | **착수 금지 — 공용 코드, 팀 리드 승인 사항** |

**머지는 팀 리드 게이트다.**

### 계획서 정정 1건

계획서의 S0 완료 판정은 *"신세대 모양을 넣었을 때 일반 분기로 떨어지지 않는다"* 였는데, **그건 S1 의 결과**다. S0 에서는 신세대가 여전히 해석되지 않아 마지막 분기로 떨어지는 게 맞고, **그 분기가 안전해지는 것**이 S0 이다. 판정 기준을 *"해석 실패 payload 가 서로 다른 열쇠를 갖는다"* 로 바로잡아 테스트에 반영했다.
