### PR TITLE
fix(bus): codex 팀원의 팀장 보고가 도달하지 않던 것 — 봇 토큰 경로 런타임 불일치

### DIFF
--- a/src/server/channels/telegram.ts
+++ b/src/server/channels/telegram.ts
@@ -23,7 +23,7 @@ export const telegramChannel: ChannelAdapter = {
     //   ★완성된 보고(서귀포 날씨)가 팀장께 안 갔다.★ telegram_send_failed 로만 남고 끝.
     //   ★"팀원이 직접 보낸다" 로 바꿨으면 ★모든 런타임이 실제로 보낼 수 있어야 한다.★★
     //   → ★자기 봇 토큰이 있으면 Bot API 로 직접 보낸다★ (런타임 무관, 가장 확실한 경로).
-    if (canSendAsBot(req.agent.id)) {
+    if (canSendAsBot(req.agent)) {
       const r = await sendAsAgentBot(req.agent, req.target, req.text);
       if (r.ok) return { ok: true };
       // 토큰은 있는데 실패 → ★조용히 묻지 않는다.★ 이유를 올려보낸다(토큰 값은 안 실린다).

--- a/src/server/lib/telegramBotSend.test.ts
+++ b/src/server/lib/telegramBotSend.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { canSendAsBot } from "./telegramBotSend";
+
+/**
+ * ★런타임마다 봇 토큰을 두는 자리가 다르다★ — 2026-07-29 Demis S7 이 잡은 라이브 결함.
+ *
+ * codex 팀원(dex)은 토큰이 <repo>/var/secrets/<id>.bot-token 에 있는데
+ * botTokenFor 는 claude 규약(~/.claude/channels/telegram-<id>/.env)만 봤다.
+ * → canSendAsBot=false → hermes CLI 폴백 → ★dex 는 hermes 가 아니라 실패★
+ * → ★dex 의 팀장 보고가 도달하지 않았다.★ 파일 머리말이 2026-07-14 에 예고한 그 패턴이다.
+ *
+ * ※ 이 테스트는 ★실제 홈 디렉토리를 읽지 않는다★ — claude 경로가 없는 상태를 전제로
+ *   codex 경로만 검증한다(테스트가 이 기계 상태를 타면 안 된다).
+ */
+describe("botTokenFor — 런타임별 토큰 경로", () => {
+  let repo: string;
+  let prev: string | undefined;
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), "tokenfix-"));
+    mkdirSync(join(repo, "var", "secrets"), { recursive: true });
+    prev = process.env.TEAM_COLLAB_ROOT;
+    process.env.TEAM_COLLAB_ROOT = repo;
+  });
+  afterEach(() => {
+    if (prev === undefined) delete process.env.TEAM_COLLAB_ROOT; else process.env.TEAM_COLLAB_ROOT = prev;
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  test("★codex 는 var/secrets 의 raw 토큰을 찾는다★ (이게 없으면 dex 보고가 유실된다)", () => {
+    writeFileSync(join(repo, "var", "secrets", "zz-codex.bot-token"), "123:ABC\n");
+    expect(canSendAsBot({ id: "zz-codex", runtime: "codex" })).toBe(true);
+  });
+
+  test("★hermes 는 일부러 안 본다★ — 지금 CLI 경로로 정상 동작 중인 걸 건드리지 않는다", () => {
+    writeFileSync(join(repo, "var", "secrets", "zz-hermes.bot-token"), "123:ABC\n");
+    expect(canSendAsBot({ id: "zz-hermes", runtime: "hermes_agent" })).toBe(false);
+  });
+
+  test("runtime 을 안 주면 claude 규약만 본다 (기존 동작 유지)", () => {
+    writeFileSync(join(repo, "var", "secrets", "zz-none.bot-token"), "123:ABC\n");
+    expect(canSendAsBot({ id: "zz-none" })).toBe(false);
+  });
+
+  test("파일이 없으면 false — 조용히 true 가 되면 안 된다", () => {
+    expect(canSendAsBot({ id: "zz-missing", runtime: "codex" })).toBe(false);
+  });
+
+  test("★빈 파일은 토큰 없음으로 친다★ — 빈 문자열로 Bot API 를 부르면 이유 모를 실패가 된다", () => {
+    writeFileSync(join(repo, "var", "secrets", "zz-empty.bot-token"), "   \n");
+    expect(canSendAsBot({ id: "zz-empty", runtime: "codex" })).toBe(false);
+  });
+});

--- a/src/server/lib/telegramBotSend.test.ts
+++ b/src/server/lib/telegramBotSend.test.ts
@@ -12,45 +12,42 @@ import { canSendAsBot } from "./telegramBotSend";
  * → canSendAsBot=false → hermes CLI 폴백 → ★dex 는 hermes 가 아니라 실패★
  * → ★dex 의 팀장 보고가 도달하지 않았다.★ 파일 머리말이 2026-07-14 에 예고한 그 패턴이다.
  *
- * ※ 이 테스트는 ★실제 홈 디렉토리를 읽지 않는다★ — claude 경로가 없는 상태를 전제로
+ * ※ 이 테스트는 ★실제 홈 디렉토리를 읽지 않고, env 도 안 건드린다★ — 루트를 인자로 준다.
+ *  — claude 경로가 없는 상태를 전제로
  *   codex 경로만 검증한다(테스트가 이 기계 상태를 타면 안 된다).
  */
 describe("botTokenFor — 런타임별 토큰 경로", () => {
   let repo: string;
-  let prev: string | undefined;
 
   beforeEach(() => {
     repo = mkdtempSync(join(tmpdir(), "tokenfix-"));
     mkdirSync(join(repo, "var", "secrets"), { recursive: true });
-    prev = process.env.TEAM_COLLAB_ROOT;
-    process.env.TEAM_COLLAB_ROOT = repo;
   });
   afterEach(() => {
-    if (prev === undefined) delete process.env.TEAM_COLLAB_ROOT; else process.env.TEAM_COLLAB_ROOT = prev;
     rmSync(repo, { recursive: true, force: true });
   });
 
   test("★codex 는 var/secrets 의 raw 토큰을 찾는다★ (이게 없으면 dex 보고가 유실된다)", () => {
     writeFileSync(join(repo, "var", "secrets", "zz-codex.bot-token"), "123:ABC\n");
-    expect(canSendAsBot({ id: "zz-codex", runtime: "codex" })).toBe(true);
+    expect(canSendAsBot({ id: "zz-codex", runtime: "codex" }, repo)).toBe(true);
   });
 
   test("★hermes 는 일부러 안 본다★ — 지금 CLI 경로로 정상 동작 중인 걸 건드리지 않는다", () => {
     writeFileSync(join(repo, "var", "secrets", "zz-hermes.bot-token"), "123:ABC\n");
-    expect(canSendAsBot({ id: "zz-hermes", runtime: "hermes_agent" })).toBe(false);
+    expect(canSendAsBot({ id: "zz-hermes", runtime: "hermes_agent" }, repo)).toBe(false);
   });
 
   test("runtime 을 안 주면 claude 규약만 본다 (기존 동작 유지)", () => {
     writeFileSync(join(repo, "var", "secrets", "zz-none.bot-token"), "123:ABC\n");
-    expect(canSendAsBot({ id: "zz-none" })).toBe(false);
+    expect(canSendAsBot({ id: "zz-none" }, repo)).toBe(false);
   });
 
   test("파일이 없으면 false — 조용히 true 가 되면 안 된다", () => {
-    expect(canSendAsBot({ id: "zz-missing", runtime: "codex" })).toBe(false);
+    expect(canSendAsBot({ id: "zz-missing", runtime: "codex" }, repo)).toBe(false);
   });
 
   test("★빈 파일은 토큰 없음으로 친다★ — 빈 문자열로 Bot API 를 부르면 이유 모를 실패가 된다", () => {
     writeFileSync(join(repo, "var", "secrets", "zz-empty.bot-token"), "   \n");
-    expect(canSendAsBot({ id: "zz-empty", runtime: "codex" })).toBe(false);
+    expect(canSendAsBot({ id: "zz-empty", runtime: "codex" }, repo)).toBe(false);
   });
 });

--- a/src/server/lib/telegramBotSend.ts
+++ b/src/server/lib/telegramBotSend.ts
@@ -11,15 +11,34 @@
  *   claude 팀원에게 릴레이를 시켜놓고 ★보낼 수단을 안 준 것★ — 오늘도 그 패턴이다.
  *
  * ═══ 어떻게 ═══
- *   각 봇 토큰은 ★파일에만★ 있다 (~/.claude/channels/telegram-<id>/.env).
+ *   각 봇 토큰은 ★파일에만★ 있다. ★그런데 런타임마다 두는 자리가 다르다★:
+ *     claude_channel : ~/.claude/channels/telegram-<id>/.env  의 TELEGRAM_BOT_TOKEN=...
+ *     codex          : <repo>/var/secrets/<id>.bot-token      ★raw 토큰 한 줄★ (0600)
  *   ★값을 로그·에러메시지에 절대 싣지 않는다★ — 세션 로그에 영구 기록된다(팀 보안룰).
+ *
+ * ═══ 2026-07-29 — ★같은 사고가 codex 차례로 왔다★ (Demis S7 이 잡음) ═══
+ *   위 머리말이 "모든 런타임이 실제로 보낼 수 있어야 한다" 고 적어놨는데,
+ *   ★정작 이 함수는 claude 경로 하나만 봤다.★ codex 팀원(dex)은 토큰이 var/secrets 에 있어
+ *   botTokenFor 가 null → hermes CLI 폴백 → ★dex 는 hermes 가 아니라 실패★ → telegram_send_failed.
+ *   ★dex 가 아무리 좋은 결과를 내도 팀장 화면에는 안 떴다.★ 2026-07-14 과 ★같은 문장, 다른 런타임★ 이다.
+ *
+ *   ★hermes 계열은 일부러 그대로 둔다★ — forin·ames 는 var/secrets 에 토큰이 있지만
+ *   지금 hermes CLI 경로로 ★정상 동작 중★ 이다. 여기서 폴백을 열면 그 둘이 조용히 Bot API 로
+ *   갈아탄다. ★고장 안 난 것을 이 수정으로 건드리지 않는다.★ (열려면 별건으로 검증하고 연다)
  */
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import type { AgentRecord } from "../types";
+import { REPO_ROOT } from "./personaTemplates";
 
-/** ~/.claude/channels/telegram-<id>/.env 의 TELEGRAM_BOT_TOKEN. 없으면 null. ★값은 반환만 하고 절대 로깅하지 않는다.★ */
-function botTokenFor(agentId: string): string | null {
+/** 토큰을 찾을 때 필요한 최소 정보. AgentRecord 전체를 요구하지 않는다(테스트가 쉬워진다). */
+export interface BotTokenLookup {
+  id: string;
+  runtime?: string;
+}
+
+/** claude 규약: ~/.claude/channels/telegram-<id>/.env 의 TELEGRAM_BOT_TOKEN. */
+function claudeChannelToken(agentId: string): string | null {
   const envPath = `${homedir()}/.claude/channels/telegram-${agentId}/.env`;
   if (!existsSync(envPath)) return null;
   try {
@@ -31,9 +50,37 @@ function botTokenFor(agentId: string): string | null {
   return null;
 }
 
+/** codex 규약: <repo>/var/secrets/<id>.bot-token — ★raw 토큰 한 줄★ (launcher.ts:233 이 그렇게 쓴다).
+ *
+ *  ★경로는 반드시 쓰는 쪽과 같은 출처로 구한다★ — codexBridgePaths 가 personaTemplates 의 REPO_ROOT 로
+ *  이 파일을 쓰므로, 읽는 쪽도 같은 REPO_ROOT 를 쓴다. 여기서 cwd 나 다른 env 로 따로 구하면
+ *  ★서버가 다른 디렉토리에서 뜨는 순간 조용히 어긋난다★ — 오늘 아침 launchd plist 가 코드 기본값을
+ *  덮어 '체인 8' 이 안 먹던 것과 같은 계열의 사고다(설정처가 둘이면 언젠가 갈린다). */
+function codexSecretToken(agentId: string): string | null {
+  // ★같은 env 변수를 호출 시점에 읽는다★ — REPO_ROOT 는 import 시점 상수라
+  //   테스트가 격리된 루트를 주입할 수 없다. 출처는 ★그대로 하나★(TEAM_COLLAB_ROOT)이고,
+  //   미설정이면 정본 REPO_ROOT 로 떨어지므로 ★운영 동작은 동일★ 하다.
+  const root = process.env.TEAM_COLLAB_ROOT ?? REPO_ROOT;
+  const p = `${root}/var/secrets/${agentId}.bot-token`;
+  if (!existsSync(p)) return null;
+  try {
+    const raw = readFileSync(p, "utf8").trim();
+    return raw.length > 0 ? raw : null;
+  } catch { /* 읽기 실패 = 토큰 없음으로 취급 */ }
+  return null;
+}
+
+/** 이 팀원의 봇 토큰. 없으면 null. ★값은 반환만 하고 절대 로깅하지 않는다.★
+ *  ★런타임별로 두는 자리가 다르다★ — claude 경로를 먼저 보고, codex 런타임일 때만 var/secrets 를 본다.
+ *  hermes 계열을 여기 넣지 않는 이유는 파일 머리말 참고(지금 CLI 경로로 정상 동작 중이라 안 건드린다). */
+function botTokenFor(agent: BotTokenLookup): string | null {
+  return claudeChannelToken(agent.id)
+    ?? (agent.runtime === "codex" ? codexSecretToken(agent.id) : null);
+}
+
 /** 이 팀원이 자기 봇으로 보낼 수 있나 (토큰이 있나). */
-export function canSendAsBot(agentId: string): boolean {
-  return botTokenFor(agentId) !== null;
+export function canSendAsBot(agent: BotTokenLookup): boolean {
+  return botTokenFor(agent) !== null;
 }
 
 /**
@@ -45,7 +92,7 @@ export async function sendAsAgentBot(
   chatId: string,
   text: string,
 ): Promise<{ ok: boolean; error?: string }> {
-  const token = botTokenFor(agent.id);
+  const token = botTokenFor(agent);
   if (!token) return { ok: false, error: "no_bot_token" };
   try {
     const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {

--- a/src/server/lib/telegramBotSend.ts
+++ b/src/server/lib/telegramBotSend.ts
@@ -52,15 +52,18 @@ function claudeChannelToken(agentId: string): string | null {
 
 /** codex 규약: <repo>/var/secrets/<id>.bot-token — ★raw 토큰 한 줄★ (launcher.ts:233 이 그렇게 쓴다).
  *
+ *  ★루트를 인자로 받는다 — 여기서 process.env 를 다시 읽지 않는다.★
+ *  lib/paths.ts 머리말이 "★process.env 는 여기서 한 번만 읽는다(단일 출처)★" 를 못박고,
+ *  REPO_ROOT 를 재정의 없이 personaTemplates 것으로 re-export 한다(divergence 방지).
+ *  호출부에서 env 를 또 읽으면 ★값은 같아도 규약 밖★ 이고, 다음 사람이 "여기서도 읽어도 되는구나"
+ *  로 따라 하는 순간 갈린다. 테스트는 root 를 직접 주고, 운영은 정본 상수 기본값을 쓴다.
+ *  (Demis 리뷰 2026-07-29 — 내가 처음에 없는 이름 B3OS_REPO_ROOT 를 만들어 쓴 것과 같은 계열이다)
+ *
  *  ★경로는 반드시 쓰는 쪽과 같은 출처로 구한다★ — codexBridgePaths 가 personaTemplates 의 REPO_ROOT 로
  *  이 파일을 쓰므로, 읽는 쪽도 같은 REPO_ROOT 를 쓴다. 여기서 cwd 나 다른 env 로 따로 구하면
  *  ★서버가 다른 디렉토리에서 뜨는 순간 조용히 어긋난다★ — 오늘 아침 launchd plist 가 코드 기본값을
  *  덮어 '체인 8' 이 안 먹던 것과 같은 계열의 사고다(설정처가 둘이면 언젠가 갈린다). */
-function codexSecretToken(agentId: string): string | null {
-  // ★같은 env 변수를 호출 시점에 읽는다★ — REPO_ROOT 는 import 시점 상수라
-  //   테스트가 격리된 루트를 주입할 수 없다. 출처는 ★그대로 하나★(TEAM_COLLAB_ROOT)이고,
-  //   미설정이면 정본 REPO_ROOT 로 떨어지므로 ★운영 동작은 동일★ 하다.
-  const root = process.env.TEAM_COLLAB_ROOT ?? REPO_ROOT;
+function codexSecretToken(agentId: string, root: string = REPO_ROOT): string | null {
   const p = `${root}/var/secrets/${agentId}.bot-token`;
   if (!existsSync(p)) return null;
   try {
@@ -73,14 +76,14 @@ function codexSecretToken(agentId: string): string | null {
 /** 이 팀원의 봇 토큰. 없으면 null. ★값은 반환만 하고 절대 로깅하지 않는다.★
  *  ★런타임별로 두는 자리가 다르다★ — claude 경로를 먼저 보고, codex 런타임일 때만 var/secrets 를 본다.
  *  hermes 계열을 여기 넣지 않는 이유는 파일 머리말 참고(지금 CLI 경로로 정상 동작 중이라 안 건드린다). */
-function botTokenFor(agent: BotTokenLookup): string | null {
+function botTokenFor(agent: BotTokenLookup, root: string = REPO_ROOT): string | null {
   return claudeChannelToken(agent.id)
-    ?? (agent.runtime === "codex" ? codexSecretToken(agent.id) : null);
+    ?? (agent.runtime === "codex" ? codexSecretToken(agent.id, root) : null);
 }
 
 /** 이 팀원이 자기 봇으로 보낼 수 있나 (토큰이 있나). */
-export function canSendAsBot(agent: BotTokenLookup): boolean {
-  return botTokenFor(agent) !== null;
+export function canSendAsBot(agent: BotTokenLookup, root: string = REPO_ROOT): boolean {
+  return botTokenFor(agent, root) !== null;
 }
 
 /**


### PR DESCRIPTION
## 증상 (Demis 품질스위트 S7, 2026-07-29)

`dex`(codex 런타임)에게 **`--direct-to-gd` 로 팀장께 직접 보고**하라고 시켰다.
dex 는 전부 제대로 했고, **실패를 숨기지 않고 보고**했다 — `posted:false, telegram_send_failed`.

**dex 가 아무리 좋은 결과를 내도 팀장 화면에는 안 떴다.**

## 원인

| | 경로 |
|---|---|
| `botTokenFor` 가 보는 곳 | `~/.claude/channels/telegram-<id>/.env` — **claude 규약만** |
| codex 가 실제로 두는 곳 | `<repo>/var/secrets/<id>.bot-token` (`launcher.ts:233`, 0600) |

→ `botTokenFor("dex")` = `null` → `canSendAsBot` false → **hermes CLI 폴백** → dex 는 hermes 가 아니라 실패.

**이 파일 머리말이 2026-07-14 에 이미 예고한 패턴이다**: *"'팀원이 직접 보낸다' 로 바꿨으면
모든 런타임이 실제로 보낼 수 있어야 한다"*. 그때는 claude 차례였고 **이번엔 codex 차례**다.

## 영향 범위 — **codex 단독** (파일 존재가 아니라 분기를 따라가서 확정)

`channels/telegram.ts` 분기를 끝까지 추적:
1. openclaw → 게이트웨이 (`codex`·`brief`·`devon` — `botTokenFor` 안 탐)
2. `canSendAsBot` → Bot API
3. 아니면 hermes CLI

`forin`·`ames` 는 `var/secrets` 에 토큰이 있어 **처음엔 나도 "3명 깨짐"으로 의심했다.**
그런데 ③으로 떨어져도 **그들은 실제 hermes 런타임이라 CLI 가 동작한다** = 안 깨졌다.
**파일 존재 표로는 틀린 답이 나오고, 호출 사슬을 따라가야 맞는 답이 나온다.**

## 수정 — 고장 안 난 것은 건드리지 않는다

runtime 으로 분기: claude 경로 우선, **codex 일 때만** `var/secrets` 폴백.
**hermes 계열은 일부러 뺐다** — `forin`·`ames` 는 지금 CLI 로 정상 동작 중이고,
전원에게 폴백을 열면 그 둘이 **조용히 Bot API 로 갈아탄다.** 열려면 별건으로 검증하고 연다.

## 경로는 쓰는 쪽과 같은 출처로 구한다

처음에 `process.env.B3OS_REPO_ROOT ?? process.cwd()` 로 썼다가 고쳤다 —
**`B3OS_REPO_ROOT` 는 이 저장소에 존재하지 않는 이름**이었고, `launcher` 는
`personaTemplates` 의 `REPO_ROOT` 로 그 파일을 **쓴다.** 읽는 쪽이 다른 출처를 쓰면
**서버가 다른 디렉토리에서 뜨는 순간 조용히 어긋난다.**

## 검증

- **검증 범위**: 신규 테스트 5건 · `bun test`(전체) · `tsc --noEmit` · 라이브 실측
- 테스트는 **실제 홈 디렉토리를 읽지 않는다**(격리 루트 주입 — 이 기계 상태를 안 탄다)
- **mutation 3종 전부 잡힘**: ①codex 폴백 제거 1 fail ②전원 폴백 2 fail ③빈파일 가드 제거 1 fail
- 전체 **1844 pass / 5 skip / 0 fail** (159파일)
- **라이브 실측(읽기 전용, 토큰 값 미출력)** — 기대와 정확히 일치:
  `dex` **true**(목적) · `forin`·`ames` false(CLI 유지) · `bill` true · `codex`(openclaw) false

## 미검증

- **실제로 dex 가 팀장님께 보내는 왕복** — 배포 후 Demis 가 S7 을 다시 돌리기로 했다
- 손상된 토큰으로 Bot API 가 어떻게 실패하는지(빈 파일은 가드로 막았다)

## 리뷰에서 봐줬으면 하는 곳

**hermes 를 뺀 판단**이 맞는지. `forin`·`ames` 의 `var/secrets` 토큰은 현재 **쓰이지 않는 죽은 자격증명**인데,
이걸 살리는 게 나은지 그대로 두는 게 나은지는 별건으로 봐야 한다고 판단했다.