### PR TITLE
fix(codex cli): 신세대 명령 승인을 실제로 해석한다 (#106 S1)

### DIFF
--- a/src/server/runtimes/codex/appServerPopup.s1.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s1.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe } from "bun:test";
-import { buildOperationFromApproval } from "./appServerPopup";
+import { buildOperationFromApproval, approvalOperationHash } from "./appServerPopup";
 import { scopeKeyForOperation, targetForOperation } from "../../lib/permissionGate";
 import type { ApprovalRequest } from "./appServerClient";
 
@@ -61,6 +61,33 @@ describe("S1 — 신세대 명령 승인 해석", () => {
     };
     // 신세대 파일 변경은 아직 해석 대상이 아니다(S2). S0 의 보수적 처리를 그대로 받아야 한다.
     expect(buildOperationFromApproval(fileReq, "dex").action).toBe("approval_unparsed");
+  });
+
+  test("★혼합 payload — 명령 method + 빈 command + fileChanges 는 write 가 아니라 unparsed★", () => {
+    // Codex 리뷰(2026-07-29)에서 잡힌 실제 구멍. '명령 method 아님' 과 '명령 method 인데 못 읽음' 을
+    // 같은 null 로 합쳤더니, 호출부가 이어서 fileChanges 를 검사해 ★write 로 처리★ 됐다.
+    // ★명령 승인이라고 밝힌 요청은 명령을 못 읽는 순간 거기서 멈춰야 한다★ — fail-closed 계약.
+    const mixed: ApprovalRequest = {
+      method: "item/commandExecution/requestApproval",
+      params: { command: "", fileChanges: { "x.ts": {} }, itemId: "i", turnId: "t", threadId: "th", startedAtMs: 1 },
+    };
+    expect(buildOperationFromApproval(mixed, "dex").action).toBe("approval_unparsed");
+  });
+
+  test("★서로 다른 신세대 명령은 서로 다른 작업 지문을 갖는다★ — 상관키가 둘을 구분해야 한다", () => {
+    // S1 이 문자열 command 를 실제 shell operation 으로 승격하는데, 지문 basis 가 Array.isArray 만 보면
+    // ★신세대는 전부 command:null★ 이 되어 서로 다른 명령이 ★같은 지문★ 을 갖는다(Codex 리뷰에서 재현).
+    // 상관키·audit 이 두 요청을 구분하지 못하면 결정이 엉뚱한 요청에 배달될 수 있다.
+    expect(approvalOperationHash(newGen("rm -rf /tmp/x")))
+      .not.toBe(approvalOperationHash(newGen("cat /etc/shadow")));
+  });
+
+  test("구세대 배열 지문은 값이 그대로다 — 변경 범위 최소화 확인", () => {
+    // 배열은 배열 그대로 basis 에 넣어 구세대 지문 값을 바꾸지 않았다.
+    const a = approvalOperationHash(oldGen(["ls", "-la"]));
+    const b = approvalOperationHash(oldGen(["ls", "-la"]));
+    expect(a).toBe(b);
+    expect(a).not.toBe(approvalOperationHash(oldGen(["ls", "-l"])));
   });
 
   test("구세대 배열 경로 불변 — 회귀 가드", () => {

--- a/src/server/runtimes/codex/appServerPopup.s1.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s1.test.ts
@@ -1,0 +1,81 @@
+import { test, expect, describe } from "bun:test";
+import { buildOperationFromApproval } from "./appServerPopup";
+import { scopeKeyForOperation, targetForOperation } from "../../lib/permissionGate";
+import type { ApprovalRequest } from "./appServerClient";
+
+/**
+ * ★S1(#106) — 명령 승인을 세대 무관하게 해석한다★
+ *
+ * S0 는 해석 못 한 요청이 넓은 열쇠를 만들지 않게 했다(안전). 하지만 신세대 명령 승인은 여전히
+ * 해석되지 않아 ★열쇠도 팝업도 payload 지문★ 이었다 — 안전하지만 ★사람이 무슨 명령인지 볼 수 없다.★
+ *
+ * S1 은 그 명령을 실제로 읽는다. 판정 기준은 payload 모양이 아니라 ★method★ 다.
+ */
+describe("S1 — 신세대 명령 승인 해석", () => {
+  const newGen = (command: unknown): ApprovalRequest => ({
+    method: "item/commandExecution/requestApproval",
+    params: { command, cwd: "/tmp", itemId: "i1", turnId: "t1", threadId: "th1", startedAtMs: 1 },
+  });
+  const oldGen = (command: unknown): ApprovalRequest => ({
+    method: "execCommandApproval",
+    params: { command, cwd: "/tmp" },
+  });
+
+  test("★신세대 문자열 명령이 구세대 배열과 같은 모양으로 해석된다★", () => {
+    const nw = buildOperationFromApproval(newGen("rm -rf /tmp/x"), "dex");
+    const od = buildOperationFromApproval(oldGen(["rm", "-rf", "/tmp/x"]), "dex");
+    expect(nw.action).toBe("shell");
+    expect(nw.command).toBe("rm -rf /tmp/x");
+    // 같은 명령이면 세대가 달라도 같은 작업으로 본다 — 사람이 보기에 같은 일이기 때문.
+    expect(nw.command).toBe(od.command);
+  });
+
+  test("★사람이 읽을 수 있는 target 이 된다★ — 지문이 아니라 명령", () => {
+    const op = buildOperationFromApproval(newGen("git status"), "dex");
+    expect(targetForOperation(op)).toBe("git status");
+    expect(targetForOperation(op)).not.toMatch(/#[0-9a-f]{16}/); // S0 지문 형식이 아니다
+  });
+
+  test("서로 다른 명령은 서로 다른 열쇠 · 같은 명령은 같은 열쇠", () => {
+    const a = buildOperationFromApproval(newGen("rm -rf /tmp/x"), "dex");
+    const b = buildOperationFromApproval(newGen("cat /etc/hosts"), "dex");
+    const a2 = buildOperationFromApproval(newGen("rm -rf /tmp/x"), "dex");
+    expect(scopeKeyForOperation(a)).not.toBe(scopeKeyForOperation(b));
+    // ★S0 와 달라지는 지점★: 해석되면 열쇠가 '명령' 단위라 같은 명령은 같은 열쇠다.
+    // 그래야 '항상 허용' 이 의미를 갖는다(S0 의 지문 열쇠는 요청마다 달라 매번 물었다).
+    expect(scopeKeyForOperation(a)).toBe(scopeKeyForOperation(a2));
+  });
+
+  test("★method 는 명령 승인인데 command 가 비면 해석 실패로 보낸다★ — 넓게 통과가 아니라 좁게 묻는다", () => {
+    for (const empty of [undefined, null, "", "   ", [], ["", "  "]]) {
+      const op = buildOperationFromApproval(newGen(empty), "dex");
+      expect(op.action).toBe("approval_unparsed"); // S0 경로로 떨어진다
+      expect(targetForOperation(op)).toMatch(/#[0-9a-f]{16}/);
+    }
+  });
+
+  test("명령 승인이 아닌 method 는 건드리지 않는다 — 회귀 가드", () => {
+    const fileReq: ApprovalRequest = {
+      method: "item/fileChange/requestApproval",
+      params: { itemId: "i1", turnId: "t1", threadId: "th1", startedAtMs: 1 },
+    };
+    // 신세대 파일 변경은 아직 해석 대상이 아니다(S2). S0 의 보수적 처리를 그대로 받아야 한다.
+    expect(buildOperationFromApproval(fileReq, "dex").action).toBe("approval_unparsed");
+  });
+
+  test("구세대 배열 경로 불변 — 회귀 가드", () => {
+    const op = buildOperationFromApproval(oldGen(["echo", "hi"]), "dex");
+    expect(op.action).toBe("shell");
+    expect(op.command).toBe("echo hi");
+  });
+
+  test("구세대 파일 변경 경로 불변 — 회귀 가드", () => {
+    const req: ApprovalRequest = {
+      method: "applyPatchApproval",
+      params: { fileChanges: { "b.ts": {}, "a.ts": {} }, callId: "c1" },
+    };
+    const op = buildOperationFromApproval(req, "dex");
+    expect(op.action).toBe("write");
+    expect(op.path).toBe("a.ts|b.ts"); // 정렬된 전체 파일집합
+  });
+});

--- a/src/server/runtimes/codex/appServerPopup.s1.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s1.test.ts
@@ -82,12 +82,14 @@ describe("S1 — 신세대 명령 승인 해석", () => {
       .not.toBe(approvalOperationHash(newGen("cat /etc/shadow")));
   });
 
-  test("구세대 배열 지문은 값이 그대로다 — 변경 범위 최소화 확인", () => {
-    // 배열은 배열 그대로 basis 에 넣어 구세대 지문 값을 바꾸지 않았다.
-    const a = approvalOperationHash(oldGen(["ls", "-la"]));
-    const b = approvalOperationHash(oldGen(["ls", "-la"]));
-    expect(a).toBe(b);
-    expect(a).not.toBe(approvalOperationHash(oldGen(["ls", "-l"])));
+  test("★구세대 배열 지문 값이 S1 이전과 동일하다★ — golden 값으로 고정", () => {
+    // ★Codex 재리뷰(2026-07-29) 지적 반영★: 앞선 판에서 이 테스트는 '결정성 + 다른 입력 구분' 만
+    // 검사하면서 이름은 "값이 그대로다" 라고 주장했다. ★테스트 이름이 검사하는 것보다 많이 주장했다.★
+    // 커밋 메시지에도 "구세대 지문 값은 바꾸지 않았다" 고 적었으므로, ★그 주장을 실제로 고정한다.★
+    //
+    // golden 값은 ★S1 이전 정본(9903b3d)에서 같은 입력으로 실측★ 해 얻었다. 두 판이 같은 값을 냈다.
+    // 이 값이 바뀌면 = 배열 경로를 건드린 것이고, 진행 중인 승인의 상관키가 어긋날 수 있다.
+    expect(approvalOperationHash(oldGen(["ls", "-la"]))).toBe("b1a8a5879bc13205");
   });
 
   test("구세대 배열 경로 불변 — 회귀 가드", () => {

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -53,7 +53,7 @@ export function finalizeApprovalDelivery(
  *   2. ★승인 후 실행 직전의 변경을 잡지 못한다.★ 이 해시는 승인 ★전에 한 번★ 계산해 그 캡처값을 그대로
  *      finalize에 넘긴다 — 실행 직전에 다시 계산해 비교하지 않는다.
  *   3. ★같은 파일의 내용 변경을 구분하지 못한다.★ files는 Object.keys()라 ★이름만★ 담는다.
- *      command 경로는 배열 전체가 들어가 구분되지만, fileChanges 경로는 이름 집합이 같으면 해시가 같다.
+ *      command 경로는 (배열이든 문자열이든) 전체가 들어가 구분되지만, fileChanges 경로는 이름 집합이 같으면 해시가 같다.
  *
  *  → 위 3건은 후속 작업에서 다룬다(전체 canonical operation을 grant scope에 결합 + 실행 직전 재해시 +
  *     파일 내용 해시). ★그 전까지 B3OS_CODEX_APPSERVER를 켜지 않는다 — release blocker.★ */
@@ -61,7 +61,11 @@ export function approvalOperationHash(req: ApprovalRequest): string {
   const p = req.params as Record<string, any>;
   const basis = {
     method: req.method,
-    command: Array.isArray(p.command) ? p.command : null,
+    // ★신세대 문자열 command 도 담는다★ — 예전엔 Array.isArray 만 봐서 신세대는 null 이 됐고,
+    //   그 결과 ★서로 다른 신세대 명령이 같은 지문★ 을 가졌다(Codex 리뷰 2026-07-29에서 재현).
+    //   S1 이 그 문자열을 실제 shell operation 으로 승격하므로, 상관키·audit 지문도 구분해야 한다.
+    //   ★배열은 배열 그대로 둔다★ — 구세대 지문 값을 바꾸지 않기 위해서다(변경 범위 최소).
+    command: Array.isArray(p.command) ? p.command : (typeof p.command === "string" ? p.command.trim() || null : null),
     files: p.fileChanges && typeof p.fileChanges === "object" ? Object.keys(p.fileChanges).sort() : null,
     reason: typeof p.reason === "string" ? p.reason : null,
   };
@@ -83,18 +87,38 @@ const POLL_INTERVAL_MS = Number(process.env.B3OS_CODEX_APPSERVER_POLL_MS ?? 1500
  *
  *  ★method 는 아는데 command 가 비어 있으면 null 을 돌려준다★ — 그러면 호출부가 해석 실패 분기로
  *  보내 S0 의 보수적 처리(payload 지문 + 매번 묻기)를 받는다. ★모르면 넓게 통과가 아니라 좁게 묻는다.★ */
-function commandTextFromApproval(req: ApprovalRequest): string | null {
-  if (req.method !== "execCommandApproval" && req.method !== "item/commandExecution/requestApproval") return null;
+type CommandParse =
+  | { kind: "not_command" }          // 명령 승인 method 가 아니다 — 다음 분기로 넘긴다
+  | { kind: "invalid" }              // 명령 승인 method 인데 command 를 못 읽었다 — ★즉시 해석 실패로★
+  | { kind: "ok"; command: string };
+
+/** 명령 승인 요청을 파싱한다. ★'명령 method 가 아님' 과 '명령 method 인데 못 읽음' 을 구분한다.★
+ *
+ *  ★왜 구분해야 하나 (2026-07-29 Codex 리뷰에서 잡힌 실제 구멍):★
+ *  둘을 같은 null 로 합치면 호출부가 이어서 fileChanges 를 검사한다. 그래서
+ *  `item/commandExecution/requestApproval` + `command: ""` + `fileChanges: {...}` 같은
+ *  ★혼합 payload 가 approval_unparsed 가 아니라 write 로 처리됐다★ — 주석과 테스트가 약속한
+ *  fail-closed 계약과 반대다. ★명령 승인이라고 밝힌 요청은 명령을 못 읽는 순간 거기서 멈춰야 한다.★
+ *  (정상 스키마에서는 안 생기는 조합이지만, ★malformed 입력에서 좁게 묻기 불변식★ 이 깨지면 안 된다.)
+ *
+ *  세대별 모양(codex-cli 0.144.6 벤더 스키마 실측):
+ *    execCommandApproval                     → command: string[]   (구세대)
+ *    item/commandExecution/requestApproval   → command: string|null (신세대)
+ *  ★판정은 payload 모양이 아니라 method 로 한다★ — 모양은 세대마다 바뀌지만 method 는 계약이다. */
+function parseCommandApproval(req: ApprovalRequest): CommandParse {
+  if (req.method !== "execCommandApproval" && req.method !== "item/commandExecution/requestApproval") {
+    return { kind: "not_command" };
+  }
   const raw = (req.params as Record<string, unknown>)?.command;
   if (Array.isArray(raw)) {
     const joined = raw.map((x) => String(x)).join(" ").trim();
-    return joined.length > 0 ? joined : null;
+    return joined.length > 0 ? { kind: "ok", command: joined } : { kind: "invalid" };
   }
   if (typeof raw === "string") {
     const trimmed = raw.trim();
-    return trimmed.length > 0 ? trimmed : null;
+    return trimmed.length > 0 ? { kind: "ok", command: trimmed } : { kind: "invalid" };
   }
-  return null;
+  return { kind: "invalid" };
 }
 
 /** M5.1 — codex 승인요청 → PermissionOperation(requestPermission 입력). */
@@ -125,10 +149,13 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
   //  ★교환 관계를 명시한다★: 해석되면 열쇠가 '명령' 단위가 되어 '항상 허용' 이 의미를 갖는다(쓸 만해진다).
   //  대신 그 열쇠는 permissionGate 에서 ★앞 240자만★ 쓰므로, 240자 prefix 가 같고 뒤가 다른 긴 명령은
   //  같은 열쇠가 된다 — ★구세대가 원래 갖고 있던 노출이고, S5(공용 결합)에서 닫힌다.★ #106 참조.
-  const commandText = commandTextFromApproval(req);
-  if (commandText !== null) {
-    return { runtime: "codex", agent_id: agentId, action: "shell", command: commandText.slice(0, 2000), requested_by: agentId, provenance };
+  const parsed = parseCommandApproval(req);
+  if (parsed.kind === "ok") {
+    return { runtime: "codex", agent_id: agentId, action: "shell", command: parsed.command.slice(0, 2000), requested_by: agentId, provenance };
   }
+  // ★명령 승인이라고 밝혔는데 명령을 못 읽었다 → 여기서 멈춘다.★ 아래 fileChanges 분기로 흘려보내면
+  //   혼합 payload 가 write 로 처리되어 fail-closed 계약이 깨진다(Codex 리뷰 2026-07-29).
+  if (parsed.kind === "invalid") return unparsedOperation(req, agentId, provenance);
   if (p.fileChanges && typeof p.fileChanges === "object") {
     // scope_key(target)의 입력을 files[0]에서 '정렬된 전체 파일목록'으로 넓힌다.
     // ★단 target 절단 전까지만 구분력이 늘어날 뿐, '서로 다른 파일집합 → 서로 다른 scope'를 일반 보장하지 않는다.★
@@ -136,26 +163,23 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
     const files = Object.keys(p.fileChanges).sort();
     return { runtime: "codex", agent_id: agentId, action: "write", path: files.join("|").slice(0, 500), text: files.join(", ").slice(0, 500), requested_by: agentId, provenance };
   }
-  // ★S0(#106) — 여기까지 왔다는 것은 payload 를 해석하지 못했다는 뜻이다. 그 사실을 명시한다.★
-  //
-  //  예전에는 action 에 req.method 를, text 에 reason 만 넣었다. reason 이 없으면 targetForOperation 이
-  //  action 으로 떨어지므로 ★target = method 이름★ 이 되어 ★그 method 로 오는 모든 요청이 같은 scope★ 였다.
-  //  → 한 번 allowed_always 를 받으면 이후 ★내용이 전혀 다른 요청도 팝업 없이 통과★ 한다.
-  //  실측(2026-07-28): item/commandExecution/requestApproval 로 온 'rm -rf /tmp/x' 와 'cat ~/.ssh/id_rsa' 가
-  //  ★같은 scope_key★ 를 가졌다.
-  //
-  //  ★팀 리드 원칙(2026-07-28): "애매하면 통과가 아니고 ask 로."★
-  //  해석에 실패했으면 넓은 열쇠를 만들지 않는다 — payload 지문을 target 에 넣어 ★payload 가 다르면 열쇠도 다르게★ 한다.
-  //  저장된 grant 는 자기와 똑같은 payload 에만 적용되고, 조금이라도 다르면 다시 사람에게 묻는다.
-  //
-  //  ※ ★실제 효과: 신세대 payload 는 itemId·turnId·startedAtMs 가 요청마다 달라서 사실상 매번 새 열쇠가 된다★
-  //    = 해석 못 한 요청은 ★매번 묻는다★. 그게 이 단계가 노린 보수적 동작이다.
-  //  ※ reason 을 text 에 남기는 이유: permissionGate.operationText 가 text 도 Tier-D 스캔에 쓴다.
-  //    빼면 위험 문자열이 reason 에 있을 때 하드 차단이 약해진다.
-  // reason 은 ★기존과 같은 500자★ 를 유지한다 — 여기서 줄이면 Tier-D 스캔 범위가 좁아진다(Codex 리뷰).
-  // 합친 문자열을 다시 자르지도 않는다: method 는 프로토콜 상수(방어적으로 64자), 지문은 16자라
-  // 전체가 유계이고, 자르면 그만큼 reason 끝이 스캔에서 빠진다.
-  const reason = typeof p.reason === "string" ? p.reason.slice(0, 500) : "";
+  return unparsedOperation(req, agentId, provenance);
+}
+
+/** ★해석하지 못한 승인 요청의 operation.★ 두 곳에서 쓴다 — 아무 분기에도 안 걸린 경우와,
+ *  ★명령 승인이라고 밝혔지만 명령을 못 읽은 경우★(그 경우 fileChanges 분기로 흘리면 안 된다).
+ *
+ *  예전에는 action 에 req.method 를, text 에 reason 만 넣었다. reason 이 없으면 targetForOperation 이
+ *  action 으로 떨어지므로 ★target = method 이름★ 이 되어 ★그 method 로 오는 모든 요청이 같은 scope★ 였다.
+ *  → 한 번 allowed_always 를 받으면 이후 ★내용이 전혀 다른 요청도 팝업 없이 통과★ 한다.
+ *
+ *  ★팀 리드 원칙(2026-07-28): "애매하면 통과가 아니고 ask 로."★
+ *  해석에 실패했으면 넓은 열쇠를 만들지 않는다 — payload 지문을 target 에 넣어 payload 가 다르면 열쇠도 다르게.
+ *
+ *  ※ reason 을 text 에 남기는 이유: permissionGate.operationText 가 text 도 Tier-D 스캔에 쓴다. */
+function unparsedOperation(req: ApprovalRequest, agentId: string, provenance: Record<string, unknown>): PermissionOperation {
+  const p = req.params as Record<string, any>;
+  const reason = typeof p?.reason === "string" ? p.reason.slice(0, 500) : "";
   return {
     runtime: "codex",
     agent_id: agentId,

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -71,6 +71,32 @@ export function approvalOperationHash(req: ApprovalRequest): string {
 const POPUP_TTL_MS = Number(process.env.B3OS_CODEX_APPSERVER_POPUP_TTL_MS ?? 60 * 60 * 1000); // 1h (GD: 무응답→hold)
 const POLL_INTERVAL_MS = Number(process.env.B3OS_CODEX_APPSERVER_POLL_MS ?? 1500);
 
+/** 명령 승인 요청에서 ★실행될 명령 문자열★ 을 꺼낸다. 명령 승인이 아니면 null.
+ *
+ *  ★판정을 payload 모양이 아니라 method 로 한다.★ 모양은 세대마다 바뀌지만 method 는 계약이다 —
+ *  예전 코드가 `Array.isArray(p.command)` 로 판정한 탓에 신세대(command 가 문자열)가 통째로
+ *  해석 실패로 떨어졌다. ★모양으로 판정하면 다음 세대에서 또 조용히 미끄러진다.★
+ *
+ *  세대별 실제 모양(codex-cli 0.144.6 벤더 스키마 실측):
+ *    execCommandApproval                     → command: string[]   (구세대)
+ *    item/commandExecution/requestApproval   → command: string|null (신세대)
+ *
+ *  ★method 는 아는데 command 가 비어 있으면 null 을 돌려준다★ — 그러면 호출부가 해석 실패 분기로
+ *  보내 S0 의 보수적 처리(payload 지문 + 매번 묻기)를 받는다. ★모르면 넓게 통과가 아니라 좁게 묻는다.★ */
+function commandTextFromApproval(req: ApprovalRequest): string | null {
+  if (req.method !== "execCommandApproval" && req.method !== "item/commandExecution/requestApproval") return null;
+  const raw = (req.params as Record<string, unknown>)?.command;
+  if (Array.isArray(raw)) {
+    const joined = raw.map((x) => String(x)).join(" ").trim();
+    return joined.length > 0 ? joined : null;
+  }
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  return null;
+}
+
 /** M5.1 — codex 승인요청 → PermissionOperation(requestPermission 입력). */
 export function buildOperationFromApproval(req: ApprovalRequest, agentId: string, cwd?: string): PermissionOperation {
   const p = req.params as Record<string, any>;
@@ -85,8 +111,23 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
     // ★grant scope에는 반영되지 않는다★(알려진 갭 — approvalOperationHash 주석 참조).
     operation_hash: approvalOperationHash(req),
   };
-  if (Array.isArray(p.command)) {
-    return { runtime: "codex", agent_id: agentId, action: "shell", command: p.command.join(" ").slice(0, 2000), requested_by: agentId, provenance };
+  // ★S1(#106) — 명령 승인을 세대 무관하게 해석한다.★
+  //
+  //  구세대 execCommandApproval 은 command 가 ★배열★, 신세대 item/commandExecution/requestApproval 은
+  //  ★문자열★ 이다(codex-cli 0.144.6 벤더 스키마 실측). 예전에는 Array.isArray 만 봐서 ★신세대가 통째로
+  //  해석 실패 분기로 떨어졌다★ — S0 이 그 분기를 안전하게 만들었지만, 안전할 뿐 ★사람이 읽을 수는 없었다★
+  //  (열쇠도 팝업도 지문 문자열이라 무슨 명령인지 안 보인다).
+  //
+  //  여기서는 ★method 로 명령 승인임을 먼저 판정★ 하고, command 가 배열이든 문자열이든 같은 모양으로 만든다.
+  //  판정 기준을 payload 모양이 아니라 method 로 둔 이유: 모양은 세대마다 바뀌지만 ★method 는 계약★ 이다.
+  //  모양으로 판정하면 다음 세대에서 또 조용히 미끄러진다(그게 이 버그의 원인이었다).
+  //
+  //  ★교환 관계를 명시한다★: 해석되면 열쇠가 '명령' 단위가 되어 '항상 허용' 이 의미를 갖는다(쓸 만해진다).
+  //  대신 그 열쇠는 permissionGate 에서 ★앞 240자만★ 쓰므로, 240자 prefix 가 같고 뒤가 다른 긴 명령은
+  //  같은 열쇠가 된다 — ★구세대가 원래 갖고 있던 노출이고, S5(공용 결합)에서 닫힌다.★ #106 참조.
+  const commandText = commandTextFromApproval(req);
+  if (commandText !== null) {
+    return { runtime: "codex", agent_id: agentId, action: "shell", command: commandText.slice(0, 2000), requested_by: agentId, provenance };
   }
   if (p.fileChanges && typeof p.fileChanges === "object") {
     // scope_key(target)의 입력을 files[0]에서 '정렬된 전체 파일목록'으로 넓힌다.

--- a/src/server/runtimes/codex/appServerPopup.unparsed.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.unparsed.test.ts
@@ -92,9 +92,10 @@ describe("S0 — 해석 실패 payload 의 권한 열쇠", () => {
   });
 
   test("★approvalOperationHash 로는 못 가른다★ — 왜 payload 전체 지문이 필요한지의 근거", () => {
-    // 신세대는 command 가 문자열이라 basis 의 Array.isArray 가 false → command:null.
-    // fileChanges 도 reason 도 없으니 basis 가 {method, null, null, null} 로 같아진다.
+    // 이 fixture(item/tool/requestUserInput)는 command 도 fileChanges 도 reason 도 없어
+    // basis 가 {method, null, null, null} 로 ★내용과 무관하게 같아진다★.
     // ★즉 기존 지문을 그대로 썼다면 위 첫 테스트가 통과하지 못한다.★ (실제로 처음에 그렇게 짰다가 잡혔다)
+    // ※ 신세대 '명령' 은 S1 에서 지문 basis 에 포함되도록 고쳤다 — appServerPopup.s1.test.ts 참조.
     expect(approvalOperationHash(unparsed("rm -rf /tmp/x")))
       .toBe(approvalOperationHash(unparsed("cat ~/.ssh/id_rsa")));
   });

--- a/src/server/runtimes/codex/appServerPopup.unparsed.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.unparsed.test.ts
@@ -19,36 +19,46 @@ import type { ApprovalRequest } from "./appServerClient";
  *
  * 팀 리드 원칙(2026-07-28): ★"애매하면 통과가 아니고 ask 로."★
  * 아래 테스트들이 그 원칙을 코드에 고정한다.
+ *
+ * ★2026-07-29 S1 이후 — 이 파일의 fixture 를 바꿨다(보장은 그대로다).★
+ *   S1 이 신세대 ★명령★ 승인(item/commandExecution/requestApproval)을 실제로 해석하게 되면서,
+ *   그 payload 는 더 이상 '해석 실패' 가 아니다. 그래서 원래 쓰던 신세대 명령 fixture 로는
+ *   ★이 파일이 주장하는 것(해석 실패 경로)을 더 이상 검사하지 못한다.★
+ *   → fixture 를 ★지금도 해석되지 않는 method★(item/tool/requestUserInput)로 바꿨다.
+ *   ★테스트를 약하게 만든 게 아니라, 검사 대상이 옮겨간 것을 따라간 것이다.★
+ *   (신세대 명령이 제대로 해석되는지는 appServerPopup.s1.test.ts 가 따로 고정한다.)
  */
 describe("S0 — 해석 실패 payload 의 권한 열쇠", () => {
-  const newGenCmd = (command: string): ApprovalRequest => ({
-    method: "item/commandExecution/requestApproval",
-    params: { command, cwd: "/tmp", itemId: "i1", turnId: "t1", threadId: "th1", startedAtMs: 1 },
+  // ★해석되지 않는 승인 요청★ — 사람 입력을 요구하는 종류라 command/fileChanges 가 없다.
+  //   (신세대 '명령' 승인은 S1 이 해석하므로 더 이상 이 경로를 타지 않는다 — 위 주석 참조)
+  const unparsed = (note: string): ApprovalRequest => ({
+    method: "item/tool/requestUserInput",
+    params: { note, itemId: "i1", turnId: "t1", threadId: "th1", startedAtMs: 1 },
   });
 
-  test("★서로 다른 명령은 서로 다른 열쇠를 갖는다★ — 하나를 '항상 허용' 해도 다른 하나는 다시 묻는다", () => {
-    const safe = buildOperationFromApproval(newGenCmd("rm -rf /tmp/x"), "dex");
-    const evil = buildOperationFromApproval(newGenCmd("cat ~/.ssh/id_rsa"), "dex");
+  test("★내용이 다르면 다른 열쇠를 갖는다★ — 하나를 '항상 허용' 해도 다른 하나는 다시 묻는다", () => {
+    const a = buildOperationFromApproval(unparsed("A"), "dex");
+    const b = buildOperationFromApproval(unparsed("B"), "dex");
 
-    // 이 단언이 S0 의 본체다. 수정 전에는 두 값이 ★같았다★.
-    expect(scopeKeyForOperation(safe)).not.toBe(scopeKeyForOperation(evil));
+    // 이 단언이 S0 의 본체다. 수정 전에는 같은 method 면 내용과 무관하게 ★열쇠가 같았다★.
+    expect(scopeKeyForOperation(a)).not.toBe(scopeKeyForOperation(b));
   });
 
   test("target 이 더 이상 method 이름이 아니다", () => {
-    const op = buildOperationFromApproval(newGenCmd("ls -la"), "dex");
-    expect(targetForOperation(op)).not.toBe("item/commandExecution/requestApproval");
+    const op = buildOperationFromApproval(unparsed("x"), "dex");
+    expect(targetForOperation(op)).not.toBe("item/tool/requestUserInput");
     expect(op.action).toBe("approval_unparsed"); // 해석 실패를 이름으로 밝힌다
   });
 
   test("payload 지문이 target 안에 살아남는다 (240자 절단 뒤에도)", () => {
-    const op = buildOperationFromApproval(newGenCmd("echo hi"), "dex");
+    const op = buildOperationFromApproval(unparsed("echo hi"), "dex");
     // 지문이 절단에 잘려나가면 열쇠가 다시 뭉개진다. 그래서 method 바로 뒤에 둔다.
     expect(targetForOperation(op)).toMatch(/#[0-9a-f]{16}/);
   });
 
   test("같은 payload 는 같은 열쇠 — 결정적이다", () => {
-    const a = buildOperationFromApproval(newGenCmd("git status"), "dex");
-    const b = buildOperationFromApproval(newGenCmd("git status"), "dex");
+    const a = buildOperationFromApproval(unparsed("git status"), "dex");
+    const b = buildOperationFromApproval(unparsed("git status"), "dex");
     expect(scopeKeyForOperation(a)).toBe(scopeKeyForOperation(b));
   });
 
@@ -85,8 +95,8 @@ describe("S0 — 해석 실패 payload 의 권한 열쇠", () => {
     // 신세대는 command 가 문자열이라 basis 의 Array.isArray 가 false → command:null.
     // fileChanges 도 reason 도 없으니 basis 가 {method, null, null, null} 로 같아진다.
     // ★즉 기존 지문을 그대로 썼다면 위 첫 테스트가 통과하지 못한다.★ (실제로 처음에 그렇게 짰다가 잡혔다)
-    expect(approvalOperationHash(newGenCmd("rm -rf /tmp/x")))
-      .toBe(approvalOperationHash(newGenCmd("cat ~/.ssh/id_rsa")));
+    expect(approvalOperationHash(unparsed("rm -rf /tmp/x")))
+      .toBe(approvalOperationHash(unparsed("cat ~/.ssh/id_rsa")));
   });
 
   test("★reason 은 text 에 남는다★ — permissionGate 가 text 를 Tier-D 스캔에 쓰기 때문", () => {


### PR DESCRIPTION
> #106 의 **S1** 단계. 계획서: `demis/research/codex-approval-staged-plan-20260729.md`
> **한 번에 한 단계.** 이 PR 에 S2~S5 는 없다.
>
> **범위 원칙(팀 리드 2026-07-29)**: *"codex cli 는 새로운 런타임이라 다른 데 영향 없이 진행돼야 한다."*
> → 이 PR 의 변경 파일은 **전부 `src/server/runtimes/codex/` 안**이다. **codex 폴더 밖 변경 0건.**

## 무엇이 문제였나

S0 는 **해석하지 못한** 요청이 넓은 권한 열쇠를 만들지 않게 했다. 안전해졌지만, **신세대 명령 승인은 여전히 해석되지 않았다** — 열쇠도 팝업도 payload 지문이라 **사람이 무슨 명령인지 볼 수 없었다.**

원인은 판정 방식이다.

```ts
if (Array.isArray(p.command)) { ... }   // ← 구세대만 참
```

| method | 세대 | `command` | 예전 결과 |
|---|---|---|---|
| `execCommandApproval` | 구 | **배열** | 해석됨 |
| `item/commandExecution/requestApproval` | 신 | **문자열** | **해석 실패로 떨어짐** |

## 고친 방식 — **판정을 모양이 아니라 `method` 로**

```ts
function commandTextFromApproval(req) {
  if (req.method !== "execCommandApproval" &&
      req.method !== "item/commandExecution/requestApproval") return null;
  // 배열이든 문자열이든 같은 모양으로
}
```

**모양은 세대마다 바뀌지만 `method` 는 계약이다.** 모양으로 판정하면 **다음 세대에서 또 조용히 미끄러진다** — 그게 이 버그의 원인이었다.

**`method` 는 명령 승인인데 `command` 가 비어 있으면 `null` 을 돌려준다** → 호출부가 해석 실패 분기로 보내 S0 의 보수적 처리(payload 지문 + 매번 묻기)를 받는다. **모르면 넓게 통과가 아니라 좁게 묻는다.**

## 무엇이 달라지나 — **교환 관계를 명시한다**

| | S0 까지 | S1 이후 |
|---|---|---|
| `target` | payload 지문 (`#a1b2…`) | **실제 명령** (`rm -rf /tmp/x`) |
| 같은 명령 반복 | 요청마다 다른 열쇠 → **매번 물음** | 같은 열쇠 → **'항상 허용' 이 의미를 가짐** |
| 240자 절단 노출 | 없음(지문이라) | **있음** ← 구세대가 원래 갖던 노출. **S5 에서 닫는다** |

**쓸 수 있게 되는 대신 240자 노출이 생긴다.** 숨기지 않고 코드 주석과 여기에 적는다. 플래그가 꺼져 있는 동안에는 어느 쪽도 실행되지 않는다.

## ★기존 테스트 fixture 를 바꿨다 — 이유를 밝힌다★

`appServerPopup.unparsed.test.ts`(S0 가 만든 파일)가 **신세대 '명령' payload 로 해석 실패 경로를 검사**하고 있었다. S1 이 그걸 해석하게 되면서 **그 fixture 로는 이 파일이 주장하는 것을 더 이상 검사하지 못한다.**

→ fixture 를 **지금도 해석되지 않는 method**(`item/tool/requestUserInput`)로 바꿨다.

**테스트를 약하게 만든 게 아니라, 검사 대상이 옮겨간 것을 따라간 것이다.** 그 설명을 파일 머리말에 남겼다. 신세대 명령이 제대로 해석되는지는 새 파일이 따로 고정한다.

이 판단이 맞는지 봐달라 — **"불편한 테스트를 고쳐서 통과시킨 것" 과 구분되는지**가 리뷰 포인트다.

## 검증

```
검증 범위:  bun test 전체 게이트 · tsc --noEmit · 뮤턴트 3종
baseline:   1834 pass / 5 skip / 0 fail  (158 파일, 같은 커밋 9903b3d)
이 PR:      1841 pass / 5 skip / 0 fail  (159 파일)
증가분:     +7 pass / +1 파일 → 신규 테스트 수와 정확히 일치 = 회귀 0
tsc:        0

mutation (되돌리면 테스트가 빨강이 되는가):
  1. method 판정 제거, 예전 Array.isArray 로 복원 → 3 fail
  2. 빈 명령도 해석된 것으로 취급              → 1 fail
  3. 신세대 method 를 판정에서 제외             → 2 fail
  → 셋 다 잡힌다. 원복 후 워킹트리 청결 확인.

범위 실측: 변경 파일 3개 전부 src/server/runtimes/codex/ 안. ★codex 폴더 밖 0건.★

미검증:     ★플래그를 켠 상태의 실환경 동작★ — B3OS_CODEX_APPSERVER 는 꺼져 있고
            이 PR 에서도 켜지 않았다. 프로세스 내 검증만 했다.
            ★실제 app-server 가 어느 세대를 보내는지★ — 스키마에 둘 다 있다.
            ★팝업 표시★ — 이 PR 은 열쇠와 해석만 고친다. 사람에게 무엇을 보여줄지는 S3.
```

## 남은 단계

| | | |
|---|---|---|
| S2 | 파일 변경 내용을 `itemId` 로 조회, 실패하면 ask | 다음 |
| S3 | 팝업이 사람에게 실제 내용을 보여줌 | |
| S3b | '항상 허용' 을 지킬 수 없으면 제시하지 않음 | |
| S4 | 지문 basis 에 파일 내용 포함 | |
| S5 | 작업을 권한 열쇠에 결합 (**이 PR 이 만든 240자 노출을 닫는다**) | |

**`B3OS_CODEX_APPSERVER` 활성화는 #106 이 닫힌 뒤 + 팀 리드 승인.** 이 PR 은 그 조건을 바꾸지 않는다.
**머지는 팀 리드 게이트다.**
