### PR TITLE
feat(dashboard): CI 결과를 OS 탭에 표시 — 읽기만 하고, 모르는 것은 모른다고 말한다 (테스트지도 3단계)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,13 @@ TEAM_PUBLIC_BASE_URL=
 #   즉 이 설정은 "입구가 터널 하나뿐" 이라는 전제 위에서만 동작한다.
 # 미설정(기본)이면 아무것도 바뀌지 않는다 — 루프백 접속만 팀리드다.
 # TEAM_TRUSTED_DASHBOARD_HOSTS=
+# ─── 대시보드 OS 탭의 CI 결과 (선택) ───────────────
+# 대시보드가 GitHub Actions 실행 결과를 읽어서 보여준다. 읽기만 하고, 토큰을 쓰지 않는다(공개 API).
+# 어느 저장소를 볼지는 순서대로 정해진다:
+#   ① 이 값(TEAM_CI_REPO=owner/repo)  ② 이 설치본 자신의 git origin(github.com 일 때만)
+#   ③ 둘 다 없으면 ★기능이 꺼진다★ — 화면에 "GitHub CI 미설정" 이라고만 나오고 GitHub 을 호출하지 않는다.
+# GitHub 을 안 쓰거나 origin 이 GitHub 이 아니면 그냥 두면 된다. 오류가 아니다.
+# TEAM_CI_REPO=
 
 
 # 텔레그램 이미지/미디어 저장 위치. 미설정 시 <설치폴더>/../team-media (첫 이미지 수신 시 자동생성, 0700). GD 2026-07-02

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -49,6 +49,7 @@ import { createReportsApp } from "./routes/portal";
 import { createSettingsApp, PUBLIC_BUILD } from "./routes/settings";
 import { createAcceptanceRoutes } from "./routes/acceptance";
 import { createSchedulerRoutes } from "./routes/scheduler";
+import { createCiStatusRoutes } from "./routes/ciStatus";
 import { ensureDailyTaskReviewJobs, ensureWeeklySelfLearningJobs } from "./scheduler/core";
 import { renderAndRepoint } from "./lib/teamOsRender";
 import { installProgressHook } from "./runtimes/claude/launcher";
@@ -390,6 +391,10 @@ api.route("/", busApi);
 
 const monitoringApi = createMonitoringRoutes({ db });
 api.route("/", monitoringApi);
+
+// CI 결과는 ★읽기 전용★ — 여기서 테스트를 돌리지 않는다(routes/ciStatus.ts 주석 참고).
+const ciStatusApi = createCiStatusRoutes();
+api.route("/", ciStatusApi);
 
 const taskApi = createTaskRoutes({ db });
 api.route("/", taskApi);

--- a/src/server/routes/ciStatus.test.ts
+++ b/src/server/routes/ciStatus.test.ts
@@ -185,11 +185,28 @@ describe("저장소 해석 — 우리 저장소를 박아두지 않는다", () =
       ["https://github.com/acme/widgets", "acme/widgets"],
       ["ssh://git@github.com/acme/widgets.git", "acme/widgets"],
       ["https://github.com/acme/widgets/", "acme/widgets"],
+      ["ssh://git@github.com/acme/widgets", "acme/widgets"],
+      ["git@GitHub.com:acme/widgets.git", "acme/widgets"],   // 호스트는 대소문자 무관
+      ["https://github.com./acme/widgets", "acme/widgets"],  // 트레일링 점은 같은 호스트
+      ["https://github.com/acme/my.repo-1.git", "acme/my.repo-1"],
       // ★GitHub 이 아니면 null★ — 추측하지 않는다
       ["git@gitlab.com:acme/widgets.git", null],
       ["https://bitbucket.org/acme/widgets.git", null],
       ["/some/local/path", null],
       ["", null],
+      // ★부분일치로 뚫리던 것들(hermes 교차검증 2026-07-30 · 전부 통과했었다)★
+      //   호스트를 문자열 안에서 "찾으면" 접두·접미·경로가 다 뚫린다.
+      ["git@notgithub.com:acme/widgets.git", null],
+      ["https://notgithub.com/acme/widgets.git", null],
+      ["https://xgithub.com/acme/widgets.git", null],
+      ["https://github.com.attacker.net/acme/widgets", null],
+      ["https://evil.com/github.com/acme/widgets", null],    // 경로 안에 있어도 잡혔었다
+      // 조각 개수가 안 맞으면 GitHub 원격이 아니다
+      ["https://github.com/acme", null],
+      ["https://github.com/acme/widgets/extra", null],
+      // 이름 규칙 밖
+      ["https://github.com/-bad/widgets", null],
+      ["https://github.com/acme/..", null],
     ];
     for (const [url, want] of cases) {
       expect([url, parseRepoFromRemote(url)]).toEqual([url, want]);
@@ -205,10 +222,25 @@ describe("저장소 해석 — 우리 저장소를 박아두지 않는다", () =
     try {
       process.env.TEAM_CI_REPO = "acme/widgets";
       expect(resolveCiRepo("/nonexistent")).toBe("acme/widgets");
-      process.env.TEAM_CI_REPO = "이건-owner/repo-모양이-아니다/셋";
-      expect(resolveCiRepo("/nonexistent")).toBe(null);
-      process.env.TEAM_CI_REPO = "";
-      expect(resolveCiRepo("/nonexistent")).toBe(null);
+      process.env.TEAM_CI_REPO = "acme/my.repo-1";
+      expect(resolveCiRepo("/nonexistent")).toBe("acme/my.repo-1");
+      // ★이 값은 그대로 요청 URL 의 path 가 된다★ — 넓히면 의도와 다른 요청이 나간다.
+      //   아래는 전부 통과했었다(hermes 교차검증 2026-07-30):
+      //     https://api.github.com/repos/★owner/repo?x=1★/actions/runs?per_page=10
+      for (const bad of [
+        "이건-owner/repo-모양이-아니다/셋",
+        "owner/repo?x=1",
+        "owner/repo#frag",
+        "owner/repo%2f..",
+        ".git/config",
+        "owner/",
+        "/repo",
+        "owner repo/x",
+        "",
+      ]) {
+        process.env.TEAM_CI_REPO = bad;
+        expect([bad, resolveCiRepo("/nonexistent")]).toEqual([bad, null]);
+      }
     } finally {
       if (prev === undefined) delete process.env.TEAM_CI_REPO;
       else process.env.TEAM_CI_REPO = prev;

--- a/src/server/routes/ciStatus.test.ts
+++ b/src/server/routes/ciStatus.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { createCiStatusRoutes, normalizeRuns } from "./ciStatus";
+import { createCiStatusRoutes, normalizeRuns, parseRateLimit, RateLimitedError } from "./ciStatus";
 
 const sample = {
   workflow_runs: [
@@ -60,11 +60,86 @@ describe("CI 결과 표시 — ★모르는 것을 정상으로 보여주지 않
     expect(j.cached).toBe(true);
   });
 
-  test("응답이 이상해도 터지지 않고 빈 목록 — ★추측하지 않는다★", () => {
-    expect(normalizeRuns(null)).toEqual([]);
-    expect(normalizeRuns({})).toEqual([]);
-    expect(normalizeRuns({ workflow_runs: "nope" })).toEqual([]);
+  // ★이 테스트는 뒤집혔다 (Codex 반려, 2026-07-29)★
+  //   예전엔 "이상한 응답 → 빈 목록" 을 옳다고 봤다. ★틀렸다.★
+  //   빈 목록은 화면에 ★"실행 0건 = 정상"★ 으로 보이고, ★진짜 0건과 구분이 안 된다.★
+  //   상류가 깨진 것은 ★모르는 상태★ 지 정상이 아니다 — 이 파일의 존재 이유가 그것이다.
+  test("★상류 응답이 우리가 아는 모양이 아니면 '확인 불가' 다 — 빈 목록으로 삼키지 않는다★", () => {
+    expect(() => normalizeRuns(null)).toThrow();
+    expect(() => normalizeRuns({})).toThrow();
+    expect(() => normalizeRuns({ workflow_runs: "nope" })).toThrow();
+    // 배열이면 항목이 비어 있어도 정상 — ★진짜 0건은 0건이다★
+    expect(normalizeRuns({ workflow_runs: [] })).toEqual([]);
     expect(normalizeRuns({ workflow_runs: [{}] })[0]?.name).toBe("");
+  });
+
+  test("★깨진 응답은 ok:false 로 나간다 — 초록 0건이 아니다★", async () => {
+    const app = createCiStatusRoutes({ fetchRuns: async () => ({ oops: 1 }), now: () => 1000 });
+    const j = await (await app.request("/ci-status")).json() as any;
+    expect(j.ok).toBe(false);
+    expect(j.reason).toContain("workflow_runs");
+  });
+});
+
+// ★한도(rate limit) 를 지키는가 — 토큰 없는 GitHub API 는 IP 당 60 req/hr★
+// 캐시만으로는 못 막는 두 구멍을 고정한다(Codex 반려, 2026-07-29).
+describe("한도 보호 — ★캐시가 못 막는 두 경로★", () => {
+  test("★동시 요청 10개 → 실제 호출 1회★ (캐시는 '응답 후' 라 동시엔 무력하다)", async () => {
+    let calls = 0;
+    let release: (v: unknown) => void = () => {};
+    const gate = new Promise((r) => { release = r; });
+    const app = createCiStatusRoutes({
+      fetchRuns: async () => { calls++; await gate; return sample; },
+      now: () => 1000,
+    });
+    // 캐시가 빈 상태에서 한꺼번에 들어온다 — 아무도 아직 응답을 못 받았다.
+    const all = Promise.all(Array.from({ length: 10 }, () => app.request("/ci-status")));
+    await Promise.resolve();
+    release(null);
+    const res = await all;
+    expect(calls).toBe(1);                       // ★10 이 아니라 1★
+    for (const r of res) expect(((await r.json()) as any).ok).toBe(true);
+  });
+
+  test("★한도에 걸리면 리셋까지 한 번도 안 부른다★ — 계속 두드리면 차단이 늘어난다", async () => {
+    let calls = 0;
+    let t = 1_000_000;
+    const resetMs = t + 10 * 60_000;
+    const app = createCiStatusRoutes({
+      fetchRuns: async () => {
+        calls++;
+        throw new RateLimitedError(resetMs, "github 403 rate limited");
+      },
+      now: () => t,
+    });
+    const first = await (await app.request("/ci-status")).json() as any;
+    expect(first.ok).toBe(false);
+    expect(first.retry_after).toBe(new Date(resetMs).toISOString());  // ★언제 풀리는지 밝힌다★
+    expect(calls).toBe(1);
+
+    // 리셋 전 — 캐시가 만료돼도(6분 뒤) ★추가 호출 0★
+    t += 6 * 60_000;
+    for (let i = 0; i < 5; i++) await app.request("/ci-status");
+    expect(calls).toBe(1);                       // ★여전히 1★
+
+    // 리셋 후 — 다시 한 번만 시도한다
+    t = resetMs + 1;
+    await app.request("/ci-status");
+    expect(calls).toBe(2);
+  });
+
+  test("★403 을 전부 한도로 보지 않는다★ — 권한 오류도 403 이다", () => {
+    const h = (m: Record<string, string>) => ({ get: (k: string) => m[k.toLowerCase()] ?? null });
+    // remaining 이 0 이 아니면 한도가 아니다 → null
+    expect(parseRateLimit(403, h({ "x-ratelimit-remaining": "42" }), 0)).toBeNull();
+    expect(parseRateLimit(404, h({}), 0)).toBeNull();
+    // 한도 맞음 — retry-after 우선
+    expect(parseRateLimit(403, h({ "x-ratelimit-remaining": "0", "retry-after": "60" }), 1000))
+      .toBe(1000 + 60_000);
+    // retry-after 없으면 x-ratelimit-reset(초 단위 epoch)
+    expect(parseRateLimit(429, h({ "x-ratelimit-reset": "500" }), 1000)).toBe(500_000);
+    // 리셋이 과거면 신뢰하지 않고 기본 백오프로 — ★즉시 재시도로 떨어지지 않는다★
+    expect(parseRateLimit(429, h({ "x-ratelimit-reset": "1" }), 10_000_000)).toBeGreaterThan(10_000_000);
   });
 });
 

--- a/src/server/routes/ciStatus.test.ts
+++ b/src/server/routes/ciStatus.test.ts
@@ -207,6 +207,15 @@ describe("저장소 해석 — 우리 저장소를 박아두지 않는다", () =
       // 이름 규칙 밖
       ["https://github.com/-bad/widgets", null],
       ["https://github.com/acme/..", null],
+      // ★query·fragment 는 버리지 않고 거절한다★ (hermes 3회전) — 버리면 없던 주소를 지어내는 것이고,
+      //   scp 형식(git@github.com:acme/widgets?x=1 → null)과 규칙이 갈렸다.
+      ["https://github.com/acme/widgets.git?x=1", null],
+      ["https://github.com/acme/widgets#frag", null],
+      ["git@github.com:acme/widgets?x=1", null],
+      // ★빈 조각도 실패★ — filter 로 지우면 acme//widgets 가 정상 주소가 된다
+      ["https://github.com/acme//widgets", null],
+      ["https://github.com/acme/widgets//", null],
+      ["https://github.com//widgets", null],
     ];
     for (const [url, want] of cases) {
       expect([url, parseRepoFromRemote(url)]).toEqual([url, want]);

--- a/src/server/routes/ciStatus.test.ts
+++ b/src/server/routes/ciStatus.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { createCiStatusRoutes, normalizeRuns, parseRateLimit, RateLimitedError } from "./ciStatus";
+import { createCiStatusRoutes, normalizeRuns, parseRateLimit, RateLimitedError, parseRepoFromRemote, repoFromGitConfig, resolveCiRepo } from "./ciStatus";
 
 const sample = {
   workflow_runs: [
@@ -173,5 +173,99 @@ describe("ciBlockHtml — 실패가 초록으로 보이지 않는다", () => {
       { name: "CI", event: "push", status: "in_progress", conclusion: null,
         branch: "main", created_at: "2026-07-29T00:00:00Z", url: "https://x" }]});
     expect(h).toContain("text-txt-amber");
+  });
+});
+
+// ─── 어느 저장소의 CI 인가 (2026-07-30, hermes 교차검증에서 출발) ────────────────
+describe("저장소 해석 — 우리 저장소를 박아두지 않는다", () => {
+  test("★git origin 에서 owner/repo 를 읽는다★ — 형태가 여러 가지다", () => {
+    const cases: Array<[string, string | null]> = [
+      ["git@github.com:acme/widgets.git", "acme/widgets"],
+      ["https://github.com/acme/widgets.git", "acme/widgets"],
+      ["https://github.com/acme/widgets", "acme/widgets"],
+      ["ssh://git@github.com/acme/widgets.git", "acme/widgets"],
+      ["https://github.com/acme/widgets/", "acme/widgets"],
+      // ★GitHub 이 아니면 null★ — 추측하지 않는다
+      ["git@gitlab.com:acme/widgets.git", null],
+      ["https://bitbucket.org/acme/widgets.git", null],
+      ["/some/local/path", null],
+      ["", null],
+    ];
+    for (const [url, want] of cases) {
+      expect([url, parseRepoFromRemote(url)]).toEqual([url, want]);
+    }
+  });
+
+  test("★.git/config 이 없으면 null★ — 던지지 않는다(설치본이 tarball 일 수 있다)", () => {
+    expect(repoFromGitConfig("/nonexistent/path/that/does/not/exist")).toBe(null);
+  });
+
+  test("★TEAM_CI_REPO 가 설정을 이긴다★ · 모양이 틀리면 켜지지 않는다", () => {
+    const prev = process.env.TEAM_CI_REPO;
+    try {
+      process.env.TEAM_CI_REPO = "acme/widgets";
+      expect(resolveCiRepo("/nonexistent")).toBe("acme/widgets");
+      process.env.TEAM_CI_REPO = "이건-owner/repo-모양이-아니다/셋";
+      expect(resolveCiRepo("/nonexistent")).toBe(null);
+      process.env.TEAM_CI_REPO = "";
+      expect(resolveCiRepo("/nonexistent")).toBe(null);
+    } finally {
+      if (prev === undefined) delete process.env.TEAM_CI_REPO;
+      else process.env.TEAM_CI_REPO = prev;
+    }
+  });
+
+  test("★미설정이면 GitHub 을 한 번도 안 친다★ — 화면에는 이유가 나간다", async () => {
+    const prev = process.env.TEAM_CI_REPO;
+    let calls = 0;
+    try {
+      process.env.TEAM_CI_REPO = "";
+      // fetchRuns 는 주입하지 않는다(실제 경로). ciRepo 만 "못 찾음" 으로 고정한다 —
+      // ★주변 git 설정에 테스트 결과가 달라지면 안 된다★(워크트리·클론에서 다르게 나왔다).
+      const origFetch = globalThis.fetch;
+      globalThis.fetch = (async () => { calls += 1; throw new Error("★불렀다★"); }) as unknown as typeof fetch;
+      try {
+        const app = createCiStatusRoutes({ ciRepo: () => null });
+        const res = await app.request("/ci-status");
+        const body = await res.json() as { ok: boolean; reason?: string; runs: unknown[] };
+        expect(body.ok).toBe(false);
+        expect(body.runs).toEqual([]);
+        expect(body.reason).toContain("TEAM_CI_REPO");
+        expect(calls).toBe(0); // ★네트워크 0회★
+      } finally {
+        globalThis.fetch = origFetch;
+      }
+    } finally {
+      if (prev === undefined) delete process.env.TEAM_CI_REPO;
+      else process.env.TEAM_CI_REPO = prev;
+    }
+  });
+});
+
+// ★2층 방어를 둘 다 검증한다.★ 관문(핸들러)만 지우면 defaultFetch 안의 재확인이 잡아내서
+//   결과가 같다 — 즉 관문 하나만 지우는 뮤턴트는 ★살아남는다(2026-07-30 실측).★
+//   그건 방어가 겹쳐 있다는 뜻이고 나쁘지 않다. 다만 "관문이 검증됐다" 고 말할 수는 없으므로,
+//   ★둘 다 지웠을 때 실제로 GitHub 을 치는지★ 를 여기서 못 박는다.
+describe("미설정 방어는 2층이다", () => {
+  test("★어느 층이든 남아 있으면 네트워크가 안 나간다★ — 같은 응답, 호출 0회", async () => {
+    const prev = process.env.TEAM_CI_REPO;
+    let calls = 0;
+    const origFetch = globalThis.fetch;
+    try {
+      process.env.TEAM_CI_REPO = "";
+      globalThis.fetch = (async () => { calls += 1; throw new Error("★불렀다★"); }) as unknown as typeof fetch;
+      const app = createCiStatusRoutes({ ciRepo: () => null });
+      // 두 번 불러도(캐시 없음) 호출은 0 이어야 한다
+      for (let i = 0; i < 2; i++) {
+        const body = await (await app.request("/ci-status")).json() as { ok: boolean; reason?: string };
+        expect(body.ok).toBe(false);
+        expect(body.reason).toContain("TEAM_CI_REPO");
+      }
+      expect(calls).toBe(0);
+    } finally {
+      globalThis.fetch = origFetch;
+      if (prev === undefined) delete process.env.TEAM_CI_REPO;
+      else process.env.TEAM_CI_REPO = prev;
+    }
   });
 });

--- a/src/server/routes/ciStatus.test.ts
+++ b/src/server/routes/ciStatus.test.ts
@@ -1,0 +1,102 @@
+import { describe, test, expect } from "bun:test";
+import { createCiStatusRoutes, normalizeRuns } from "./ciStatus";
+
+const sample = {
+  workflow_runs: [
+    { name: "CI", event: "pull_request", status: "completed", conclusion: "success",
+      head_branch: "docs/test-map", created_at: "2026-07-28T15:15:00Z", html_url: "https://x/1" },
+    { name: "CI", event: "push", status: "in_progress", conclusion: null,
+      head_branch: "main", created_at: "2026-07-29T00:00:00Z", html_url: "https://x/2" },
+  ],
+};
+
+describe("CI 결과 표시 — ★모르는 것을 정상으로 보여주지 않는다★", () => {
+  test("정상: 결과를 그대로 내려준다", async () => {
+    const app = createCiStatusRoutes({ fetchRuns: async () => sample, now: () => 1000 });
+    const j = await (await app.request("/ci-status")).json() as any;
+    expect(j.ok).toBe(true);
+    expect(j.runs.length).toBe(2);
+    expect(j.runs[0].conclusion).toBe("success");
+    expect(j.fetched_at).not.toBeNull();
+  });
+
+  test("★실패하면 ok:false 와 이유를 준다 — 빈 초록이 아니다★", async () => {
+    const app = createCiStatusRoutes({ fetchRuns: async () => { throw new Error("github 403"); }, now: () => 1000 });
+    const j = await (await app.request("/ci-status")).json() as any;
+    expect(j.ok).toBe(false);
+    expect(j.reason).toContain("403");
+    expect(j.fetched_at).toBeNull();
+  });
+
+  test("★실패를 캐시하지 않는다★ — 일시적 오류가 5분간 굳으면 안 된다", async () => {
+    let fail = true;
+    const app = createCiStatusRoutes({ fetchRuns: async () => { if (fail) throw new Error("boom"); return sample; }, now: () => 1000 });
+    expect(((await (await app.request("/ci-status")).json()) as any).ok).toBe(false);
+    fail = false;
+    // 같은 시각인데도 다시 시도해야 한다(실패는 캐시 안 됨)
+    expect(((await (await app.request("/ci-status")).json()) as any).ok).toBe(true);
+  });
+
+  test("★실패했을 때 직전 성공값을 대신 보여주지 않는다★ — 낡은 초록이 현재처럼 보인다", async () => {
+    let mode: "ok" | "err" = "ok";
+    let t = 1000;
+    const app = createCiStatusRoutes({
+      fetchRuns: async () => { if (mode === "err") throw new Error("down"); return sample; },
+      now: () => t,
+    });
+    expect(((await (await app.request("/ci-status")).json()) as any).runs.length).toBe(2);
+    mode = "err"; t += 6 * 60_000;             // 캐시 만료 후 실패
+    const j = await (await app.request("/ci-status")).json() as any;
+    expect(j.ok).toBe(false);
+    expect(j.runs.length).toBe(0);             // ★직전 성공 결과를 재사용하지 않는다★
+  });
+
+  test("성공은 캐시한다 — 한도 60/시간이라 매번 부르면 안 된다", async () => {
+    let calls = 0;
+    const app = createCiStatusRoutes({ fetchRuns: async () => { calls++; return sample; }, now: () => 1000 });
+    await app.request("/ci-status");
+    const j = await (await app.request("/ci-status")).json() as any;
+    expect(calls).toBe(1);
+    expect(j.cached).toBe(true);
+  });
+
+  test("응답이 이상해도 터지지 않고 빈 목록 — ★추측하지 않는다★", () => {
+    expect(normalizeRuns(null)).toEqual([]);
+    expect(normalizeRuns({})).toEqual([]);
+    expect(normalizeRuns({ workflow_runs: "nope" })).toEqual([]);
+    expect(normalizeRuns({ workflow_runs: [{}] })[0]?.name).toBe("");
+  });
+});
+
+// ★화면이 '모르는 것' 을 '정상' 으로 그리지 않는지 — 렌더 함수 자체를 검증한다★
+// 서버가 ok:false 를 줘도 화면이 조용히 비어 보이면 사용자는 "문제 없구나" 로 읽는다.
+// 이 PR 의 목적이 정확히 그 착각을 없애는 것이라 렌더까지 테스트로 고정한다.
+import { ciBlockHtml } from "../../web/components/TeamOS";
+
+describe("ciBlockHtml — 실패가 초록으로 보이지 않는다", () => {
+  test("★실패하면 '확인 불가' 와 이유가 화면에 뜬다★", () => {
+    const h = ciBlockHtml({ ok: false, reason: "github 403", runs: [], fetched_at: null });
+    expect(h).toContain("확인 불가");
+    expect(h).toContain("github 403");
+    expect(h).toContain("정상' 이 아닙니다");   // ★모르는 것 ≠ 정상★ 을 문장으로 말한다
+  });
+
+  test("아직 안 불러왔으면 '불러오는 중' — 빈 화면이 아니다", () => {
+    expect(ciBlockHtml(null)).toContain("불러오는 중");
+  });
+
+  test("성공하면 기준 시각을 밝힌다 — 언제 것인지 모르는 초록은 위험하다", () => {
+    const h = ciBlockHtml({ ok: true, fetched_at: "2026-07-29T00:00:00Z", runs: [
+      { name: "CI", event: "push", status: "completed", conclusion: "success",
+        branch: "main", created_at: "2026-07-29T00:00:00Z", url: "https://x" }]});
+    expect(h).toContain("기준 시각");
+    expect(h).toContain("main");
+  });
+
+  test("실행 중(completed 아님)은 초록도 빨강도 아닌 표시", () => {
+    const h = ciBlockHtml({ ok: true, fetched_at: "2026-07-29T00:00:00Z", runs: [
+      { name: "CI", event: "push", status: "in_progress", conclusion: null,
+        branch: "main", created_at: "2026-07-29T00:00:00Z", url: "https://x" }]});
+    expect(h).toContain("text-txt-amber");
+  });
+});

--- a/src/server/routes/ciStatus.ts
+++ b/src/server/routes/ciStatus.ts
@@ -40,14 +40,52 @@ const FETCH_TIMEOUT_MS = 6_000;
  *  → 순서: ①`TEAM_CI_REPO`(owner/repo) ②설치본 자신의 git origin ③★못 찾으면 기능을 끈다.★
  *    ③에서 추측하지 않는다 — 모르면 "미설정" 이라고 말하고 ★네트워크를 아예 안 탄다.★
  */
+/** GitHub 이 실제로 허용하는 모양만 받는다. 여기서 넓히면 그대로 요청 URL 이 된다. */
+const OWNER_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/;
+const REPO_RE = /^[A-Za-z0-9._-]+$/;
+
+/** `owner/repo` 두 조각이 GitHub 이름 규칙에 맞나. 아니면 null(추측하지 않는다). */
+export function normalizeRepoSlug(owner: string, repo: string): string | null {
+  const r = repo.replace(/\.git$/i, "");
+  if (!OWNER_RE.test(owner) || !REPO_RE.test(r)) return null;
+  if (r === "." || r === "..") return null;
+  return `${owner}/${r}`;
+}
+
 export function parseRepoFromRemote(url: string): string | null {
   const t = url.trim();
-  // git@github.com:owner/repo.git · https://github.com/owner/repo(.git) · ssh://git@github.com/owner/repo
-  const m = t.match(/github\.com[:/]+([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i);
-  if (!m) return null;
-  const [, owner, repo] = m;
-  if (!owner || !repo || owner === "." || repo === ".") return null;
-  return `${owner}/${repo}`;
+  if (!t) return null;
+
+  // ★호스트를 문자열 안에서 "찾지" 않는다 — 파싱해서 정확히 일치시킨다.★
+  //   앞선 판은 /github\.com[:/]+…/ 로 ★어디에 있든★ 잡았다. 그래서 전부 통과했다(전부 실측):
+  //     git@★not★github.com:acme/widgets.git · https://★x★github.com/acme/widgets
+  //     https://evil.com/★github.com★/acme/widgets   ← 경로 안에 있어도 잡혔다
+  //   GitHub 이 아닌 origin 인데 기능이 켜지고 GitHub API 를 친다.
+  //   ★부분일치는 호스트 판정이 될 수 없다★ — 경계를 안 고정하면 접두·접미·경로가 다 뚫린다.
+  const host = (h: string): boolean => h.toLowerCase().replace(/\.$/, "") === "github.com";
+
+  // ① scp 형식: [user@]host:owner/repo(.git)   ★스킴이 없을 때만★ (ssh:// 는 ②가 본다)
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(t)) {
+    const m = t.match(/^(?:[^@\s/]+@)?([^:/\s]+):([^/\s]+)\/([^/\s]+?)\/?$/);
+    if (m) {
+      const [, h, owner, repo] = m;
+      return h && host(h) && owner && repo ? normalizeRepoSlug(owner, repo) : null;
+    }
+    return null;
+  }
+
+  // ② 스킴이 있는 형식: https:// · ssh:// · git://
+  let u: URL;
+  try {
+    u = new URL(t);
+  } catch {
+    return null;
+  }
+  if (!host(u.hostname)) return null;
+  // ★path 만 본다★ — query·fragment 는 버린다(원격 주소에 있을 이유가 없다)
+  const seg = u.pathname.split("/").filter(Boolean);
+  if (seg.length !== 2) return null; // owner/repo 정확히 둘. 더 깊으면 GitHub 원격이 아니다
+  return normalizeRepoSlug(seg[0]!, seg[1]!);
 }
 
 /** 설치본의 origin 을 `.git/config` 에서 읽는다. ★git 을 실행하지 않는다★(요청마다 프로세스를 띄우지 않으려고).
@@ -90,7 +128,15 @@ export function repoFromGitConfig(root: string): string | null {
 /** 설정 → git origin → null. null 이면 기능이 꺼진다. */
 export function resolveCiRepo(root = REPO_ROOT): string | null {
   const env = (process.env.TEAM_CI_REPO ?? "").trim();
-  if (env) return /^[^/\s]+\/[^/\s]+$/.test(env) ? env : null;
+  if (env) {
+    // ★설정값도 같은 규칙으로 좁힌다.★ 앞선 판은 `[^/\s]+/[^/\s]+` 라서
+    //   `owner/repo?x=1` · `owner/repo#frag` · `.git/config` 이 통과했고(실측),
+    //   그대로 요청 URL 의 path·query 가 됐다:
+    //     https://api.github.com/repos/★owner/repo?x=1★/actions/runs?per_page=10
+    //   호스트를 벗어나진 않지만 ★의도와 다른 요청★ 이다. 이름 규칙으로 막는다.
+    const parts = env.split("/");
+    return parts.length === 2 ? normalizeRepoSlug(parts[0]!, parts[1]!) : null;
+  }
   return repoFromGitConfig(root);
 }
 

--- a/src/server/routes/ciStatus.ts
+++ b/src/server/routes/ciStatus.ts
@@ -12,12 +12,24 @@
 // ★실패를 초록으로 만들지 않는다★: 못 가져왔으면 `ok:false` 와 이유를 그대로 내려보낸다.
 //   화면은 그걸 "확인 불가" 로 보여준다. ★모르는 것을 정상으로 표시하는 게 제일 위험하다★
 //   — 이 대시보드가 고치려는 문제가 정확히 그것이다.
+//
+// ★★한도(rate limit) 를 지키는 것이 이 파일의 두 번째 책임이다 (Codex 반려, 2026-07-29)★★
+//   토큰 없는 GitHub API 는 ★IP 당 60 req/hr★ 이다. 캐시만으로는 부족했다:
+//     ① ★동시 요청★ — 캐시가 빈 순간 10명이 열면 ★10번 나간다.★ 캐시는 '응답 후' 에 채워지므로
+//        아직 안 끝난 요청은 아무도 막지 못한다. → ★single-flight★ 로 진행중 요청을 공유한다.
+//     ② ★한도 소진 후★ — 실패를 캐시하지 않는 정책(위) 때문에 ★막힌 뒤에도 계속 두드린다.★
+//        GitHub 는 이걸 남용으로 보고 차단을 늘릴 수 있다. → ★리셋 시각까지는 아예 안 나간다.★
+//   ★이 둘은 "실패를 초록으로 만들지 않는다" 와 충돌하지 않는다★ — 여전히 ok:false 를 내려보내고,
+//   다만 ★이유에 '언제 다시 시도하는지' 를 같이 적는다.★
 import { Hono } from "hono";
 
 const CACHE_MS = 5 * 60_000;
 const FETCH_TIMEOUT_MS = 6_000;
 const RUNS_URL =
   "https://api.github.com/repos/b3rys/b3rys-team-os/actions/runs?per_page=10";
+
+/** 리셋 시각을 못 읽었을 때 쓰는 보수적 기본 대기. 한도 창이 1시간이라 그 절반. */
+const DEFAULT_BACKOFF_MS = 30 * 60_000;
 
 export interface CiRun {
   name: string;
@@ -37,12 +49,68 @@ export interface CiStatusBody {
   /** 이 데이터를 실제로 가져온 시각(UTC ISO). 화면이 "언제 기준" 인지 밝히는 데 쓴다. */
   fetched_at: string | null;
   cached: boolean;
+  /** 한도에 걸려 쉬는 중이면 다시 시도할 시각(UTC ISO). 평소에는 없다. */
+  retry_after?: string;
 }
 
-/** GitHub 응답 → 화면이 쓰는 최소 형태. 필드가 없으면 빈 문자열로 두고 ★추측하지 않는다.★ */
+/** 한도 초과를 ★다른 실패와 구분★ 하기 위한 전용 오류.
+ *  ★resetMs 는 epoch 밀리초(숫자)다★ — 이 저장소에서 `...At`/`..._at` 는 ★DB 시각 문자열★ 을 뜻하므로
+ *  그 이름을 쓰면 안 된다(utcTimestamp.contract 가 잡는다). 이름에 단위를 박아 오독을 막는다. */
+export class RateLimitedError extends Error {
+  constructor(public resetMs: number, message: string) {
+    super(message);
+    this.name = "RateLimitedError";
+  }
+}
+
+/** 상류 응답이 우리가 아는 모양이 아닐 때. ★빈 배열로 삼키지 않기 위해★ 오류로 올린다. */
+export class MalformedUpstreamError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MalformedUpstreamError";
+  }
+}
+
+/**
+ * 429·403 응답에서 ★언제 풀리는지★ 를 뽑는다.
+ *
+ * ★403 을 전부 한도로 보면 안 된다★ — 권한 오류도 403 이다.
+ * GitHub 은 한도 소진 시 `x-ratelimit-remaining: 0` 을 같이 준다. 그 조합일 때만 한도로 본다.
+ * 우선순위: `retry-after`(초) → `x-ratelimit-reset`(epoch 초) → 기본 백오프.
+ */
+export function parseRateLimit(
+  status: number,
+  headers: { get(name: string): string | null },
+  nowMs: number,
+): number | null {
+  const remaining = headers.get("x-ratelimit-remaining");
+  const isLimited = status === 429 || (status === 403 && remaining === "0");
+  if (!isLimited) return null;
+
+  const retryAfter = Number(headers.get("retry-after"));
+  if (Number.isFinite(retryAfter) && retryAfter > 0) {
+    return nowMs + retryAfter * 1000;
+  }
+  const reset = Number(headers.get("x-ratelimit-reset"));
+  // 초 단위 epoch. 과거 값이면 신뢰하지 않고 기본 백오프로 떨어진다.
+  if (Number.isFinite(reset) && reset * 1000 > nowMs) {
+    return reset * 1000;
+  }
+  return nowMs + DEFAULT_BACKOFF_MS;
+}
+
+/**
+ * GitHub 응답 → 화면이 쓰는 최소 형태. 필드가 없으면 빈 문자열로 두고 ★추측하지 않는다.★
+ *
+ * ★`workflow_runs` 가 배열이 아니면 던진다★ (Codex 반려, 2026-07-29):
+ *   예전엔 `[]` 를 돌려줬는데, 그러면 상류가 깨졌을 때 화면이 ★"실행 0건" = 정상★ 으로 보인다.
+ *   ★진짜 0건과 구분이 안 된다.★ 모르는 것은 모른다고 해야 한다 — 이 파일의 존재 이유다.
+ */
 export function normalizeRuns(raw: unknown): CiRun[] {
   const runs = (raw as { workflow_runs?: unknown[] } | null)?.workflow_runs;
-  if (!Array.isArray(runs)) return [];
+  if (!Array.isArray(runs)) {
+    throw new MalformedUpstreamError("upstream: workflow_runs 가 배열이 아님");
+  }
   return runs.slice(0, 10).map((r) => {
     const o = (r ?? {}) as Record<string, unknown>;
     return {
@@ -65,13 +133,28 @@ export function createCiStatusRoutes(deps?: {
   const app = new Hono();
   const now = deps?.now ?? (() => Date.now());
   let cache: { at: number; body: CiStatusBody } | null = null;
+  /** ★single-flight★ — 진행중인 요청. 동시 요청은 이걸 함께 기다린다(추가 호출 0). */
+  let inFlight: Promise<CiRun[]> | null = null;
+  /** 한도에 걸린 동안은 이 시각까지 ★아예 안 나간다.★ */
+  let blockedUntil = 0;
 
   const defaultFetch = async (): Promise<unknown> => {
     const res = await fetch(RUNS_URL, {
-      headers: { accept: "application/vnd.github+json", "user-agent": "b3os-dashboard" },
+      headers: {
+        accept: "application/vnd.github+json",
+        // ★버전을 고정한다★ — 안 보내면 GitHub 이 기본값을 바꿀 때 응답 모양이 조용히 달라진다.
+        "x-github-api-version": "2022-11-28",
+        "user-agent": "b3os-dashboard",
+      },
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
-    if (!res.ok) throw new Error(`github ${res.status}`);
+    if (!res.ok) {
+      const resetMs = parseRateLimit(res.status, res.headers, now());
+      if (resetMs !== null) {
+        throw new RateLimitedError(resetMs, `github ${res.status} rate limited`);
+      }
+      throw new Error(`github ${res.status}`);
+    }
     return await res.json();
   };
   const fetchRuns = deps?.fetchRuns ?? defaultFetch;
@@ -81,11 +164,30 @@ export function createCiStatusRoutes(deps?: {
     if (cache && t - cache.at < CACHE_MS) {
       return c.json({ ...cache.body, cached: true });
     }
+    // ★한도로 쉬는 중 — 호출하지 않고 즉시 답한다.★ (초록으로 위장하지는 않는다)
+    if (t < blockedUntil) {
+      const body: CiStatusBody = {
+        ok: false,
+        reason: "GitHub API 한도 초과 — 리셋까지 요청하지 않습니다",
+        runs: [],
+        fetched_at: null,
+        cached: false,
+        retry_after: new Date(blockedUntil).toISOString(),
+      };
+      return c.json(body);
+    }
+
     try {
-      const raw = await fetchRuns();
+      // 진행중인 요청이 있으면 ★새로 부르지 않고 그것을 기다린다.★
+      if (!inFlight) {
+        inFlight = (async () => normalizeRuns(await fetchRuns()))().finally(() => {
+          inFlight = null;
+        });
+      }
+      const runs = await inFlight;
       const body: CiStatusBody = {
         ok: true,
-        runs: normalizeRuns(raw),
+        runs,
         fetched_at: new Date(t).toISOString(),
         cached: false,
       };
@@ -94,6 +196,8 @@ export function createCiStatusRoutes(deps?: {
     } catch (e) {
       // ★실패를 캐시하지 않는다★ — 캐시하면 일시적 오류가 5분간 굳는다.
       //   그리고 ★직전 성공값을 대신 보여주지도 않는다★: 그러면 낡은 초록이 현재처럼 보인다.
+      //   ★단 하나의 예외가 한도 초과다★ — 그건 '쉬는 시각' 을 기억한다. 계속 두드리면
+      //   GitHub 이 차단을 늘리기 때문이고, 이건 결과를 숨기는 게 아니라 ★요청을 줄이는 것★ 이다.
       const body: CiStatusBody = {
         ok: false,
         reason: e instanceof Error ? e.message : String(e),
@@ -101,6 +205,10 @@ export function createCiStatusRoutes(deps?: {
         fetched_at: null,
         cached: false,
       };
+      if (e instanceof RateLimitedError) {
+        blockedUntil = e.resetMs;
+        body.retry_after = new Date(e.resetMs).toISOString();
+      }
       return c.json(body);
     }
   });

--- a/src/server/routes/ciStatus.ts
+++ b/src/server/routes/ciStatus.ts
@@ -22,11 +22,85 @@
 //   ★이 둘은 "실패를 초록으로 만들지 않는다" 와 충돌하지 않는다★ — 여전히 ok:false 를 내려보내고,
 //   다만 ★이유에 '언제 다시 시도하는지' 를 같이 적는다.★
 import { Hono } from "hono";
+import { readFileSync } from "node:fs";
+import { REPO_ROOT } from "../lib/paths";
 
 const CACHE_MS = 5 * 60_000;
 const FETCH_TIMEOUT_MS = 6_000;
-const RUNS_URL =
-  "https://api.github.com/repos/b3rys/b3rys-team-os/actions/runs?per_page=10";
+
+/**
+ * ★어느 저장소의 CI 인가 — 설치본마다 다르다.★ (hermes 교차검증 2026-07-30 에서 출발, 빌 실측)
+ *
+ *  앞선 판은 `https://api.github.com/repos/★b3rys/b3rys-team-os★/actions/runs` 로 ★박아놨다.★
+ *  그러면 공개 설치본에서 이런 일이 난다:
+ *    · 자기 CI 가 아니라 ★우리 CI 가 자기 대시보드에 뜬다★ — 화면에 거짓을 표시하는 것이다
+ *    · GitHub 를 안 쓰는 설치본도 ★5분마다 GitHub API 를 친다★(미인증 한도는 IP 공유)
+ *  "우리 맥 사정을 저장소 기본값으로 박는" 형태이고, 이 저장소에서 이미 겪은 종류다.
+ *
+ *  → 순서: ①`TEAM_CI_REPO`(owner/repo) ②설치본 자신의 git origin ③★못 찾으면 기능을 끈다.★
+ *    ③에서 추측하지 않는다 — 모르면 "미설정" 이라고 말하고 ★네트워크를 아예 안 탄다.★
+ */
+export function parseRepoFromRemote(url: string): string | null {
+  const t = url.trim();
+  // git@github.com:owner/repo.git · https://github.com/owner/repo(.git) · ssh://git@github.com/owner/repo
+  const m = t.match(/github\.com[:/]+([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i);
+  if (!m) return null;
+  const [, owner, repo] = m;
+  if (!owner || !repo || owner === "." || repo === ".") return null;
+  return `${owner}/${repo}`;
+}
+
+/** 설치본의 origin 을 `.git/config` 에서 읽는다. ★git 을 실행하지 않는다★(요청마다 프로세스를 띄우지 않으려고).
+ *
+ *  ★워크트리에서는 `.git` 이 디렉토리가 아니라 파일이다★ (2026-07-30 실측) — 안에 `gitdir: <경로>` 한 줄이 있고
+ *  진짜 config 는 그 경로의 `commondir` 쪽에 있다. 정상 클론만 상정하면 ★팀원이 워크트리에서 볼 때
+ *  "미설정" 으로 보인다★ — 기능이 멀쩡한데 고장난 것처럼 읽힌다. 그래서 파일 형태도 따라간다. */
+export function repoFromGitConfig(root: string): string | null {
+  try {
+    let gitDir = `${root}/.git`;
+    // `.git` 이 파일이면 `gitdir: …` 포인터다 → 그 안의 commondir 를 따라 진짜 저장소로 간다
+    let head: string;
+    try {
+      head = readFileSync(gitDir, "utf8");
+    } catch {
+      head = "";
+    }
+    const ptr = head.match(/^gitdir:\s*(.+)$/m)?.[1]?.trim();
+    if (ptr) {
+      const abs = ptr.startsWith("/") ? ptr : `${root}/${ptr}`;
+      // 워크트리 gitdir 안의 commondir 가 공용 저장소를 가리킨다(대개 `../..`)
+      let common = "";
+      try {
+        common = readFileSync(`${abs}/commondir`, "utf8").trim();
+      } catch {
+        common = "";
+      }
+      gitDir = common ? (common.startsWith("/") ? common : `${abs}/${common}`) : abs;
+    }
+    const cfg = readFileSync(`${gitDir}/config`, "utf8");
+    // [remote "origin"] 블록의 url 한 줄만 본다
+    const block = cfg.split(/^\[/m).find((b) => /^remote\s+"origin"\]/.test(b));
+    const url = block?.match(/^\s*url\s*=\s*(.+)$/m)?.[1];
+    return url ? parseRepoFromRemote(url) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** 설정 → git origin → null. null 이면 기능이 꺼진다. */
+export function resolveCiRepo(root = REPO_ROOT): string | null {
+  const env = (process.env.TEAM_CI_REPO ?? "").trim();
+  if (env) return /^[^/\s]+\/[^/\s]+$/.test(env) ? env : null;
+  return repoFromGitConfig(root);
+}
+
+export const CI_UNCONFIGURED_REASON =
+  "GitHub CI 미설정 — 이 설치본의 git origin 이 GitHub 이 아니거나 확인되지 않습니다. " +
+  "표시하려면 .env 에 TEAM_CI_REPO=owner/repo 를 적어 주세요.";
+
+function runsUrl(repo: string): string {
+  return `https://api.github.com/repos/${repo}/actions/runs?per_page=10`;
+}
 
 /** 리셋 시각을 못 읽었을 때 쓰는 보수적 기본 대기. 한도 창이 1시간이라 그 절반. */
 const DEFAULT_BACKOFF_MS = 30 * 60_000;
@@ -51,6 +125,9 @@ export interface CiStatusBody {
   cached: boolean;
   /** 한도에 걸려 쉬는 중이면 다시 시도할 시각(UTC ISO). 평소에는 없다. */
   retry_after?: string;
+  /** ★설정 자체가 안 된 상태★ — 실패가 아니다. GitHub 을 안 쓰는 설치본의 정상 상태이므로
+   *  화면이 ★빨간 오류★ 가 아니라 중립으로 그려야 한다(false 일 때만 실린다). */
+  configured?: boolean;
 }
 
 /** 한도 초과를 ★다른 실패와 구분★ 하기 위한 전용 오류.
@@ -129,9 +206,12 @@ export function createCiStatusRoutes(deps?: {
   /** 테스트 주입용 — 실제 네트워크를 타지 않게 한다(테스트가 환경을 타면 안 된다). */
   fetchRuns?: () => Promise<unknown>;
   now?: () => number;
+  /** 테스트 주입용 — ★주변 git 설정에 결과가 달라지면 안 된다.★ 기본은 실제 해석기. */
+  ciRepo?: () => string | null;
 }): Hono {
   const app = new Hono();
   const now = deps?.now ?? (() => Date.now());
+  const ciRepo = deps?.ciRepo ?? (() => resolveCiRepo());
   let cache: { at: number; body: CiStatusBody } | null = null;
   /** ★single-flight★ — 진행중인 요청. 동시 요청은 이걸 함께 기다린다(추가 호출 0). */
   let inFlight: Promise<CiRun[]> | null = null;
@@ -139,7 +219,10 @@ export function createCiStatusRoutes(deps?: {
   let blockedUntil = 0;
 
   const defaultFetch = async (): Promise<unknown> => {
-    const res = await fetch(RUNS_URL, {
+    const repo = ciRepo();
+    // ★여기 오면 안 된다★ — 핸들러가 미설정을 먼저 걸러낸다. 방어적으로 한 번 더 막는다.
+    if (!repo) throw new Error(CI_UNCONFIGURED_REASON);
+    const res = await fetch(runsUrl(repo), {
       headers: {
         accept: "application/vnd.github+json",
         // ★버전을 고정한다★ — 안 보내면 GitHub 이 기본값을 바꿀 때 응답 모양이 조용히 달라진다.
@@ -161,6 +244,18 @@ export function createCiStatusRoutes(deps?: {
 
   app.get("/ci-status", async (c) => {
     const t = now();
+    // ★미설정이면 네트워크를 아예 안 탄다.★ 캐시보다도 앞이다 — 켜지지도 않은 기능이
+    //   한 번이라도 GitHub 을 치면 안 된다. deps.fetchRuns 를 주입한 테스트는 이 관문을 지난다.
+    if (!deps?.fetchRuns && !ciRepo()) {
+      return c.json({
+        ok: false,
+        reason: CI_UNCONFIGURED_REASON,
+        runs: [],
+        fetched_at: null,
+        cached: false,
+        configured: false,
+      } satisfies CiStatusBody);
+    }
     if (cache && t - cache.at < CACHE_MS) {
       return c.json({ ...cache.body, cached: true });
     }

--- a/src/server/routes/ciStatus.ts
+++ b/src/server/routes/ciStatus.ts
@@ -82,10 +82,18 @@ export function parseRepoFromRemote(url: string): string | null {
     return null;
   }
   if (!host(u.hostname)) return null;
-  // ★path 만 본다★ — query·fragment 는 버린다(원격 주소에 있을 이유가 없다)
-  const seg = u.pathname.split("/").filter(Boolean);
-  if (seg.length !== 2) return null; // owner/repo 정확히 둘. 더 깊으면 GitHub 원격이 아니다
-  return normalizeRepoSlug(seg[0]!, seg[1]!);
+  // ★query·fragment 가 있으면 거절한다 — 버리지 않는다.★ (hermes 교차검증 3회전, 2026-07-30)
+  //   앞선 판은 pathname 만 보고 나머지를 조용히 버려서 `…/widgets.git?x=1` 이 정상 원격으로 통과했다.
+  //   scp 형식에서는 같은 입력이 null 이라 ★두 형식의 규칙이 서로 달랐다.★
+  //   원격 주소에 query·fragment 가 있을 이유가 없으므로 ★모르는 입력으로 보고 거절한다★
+  //   (버리면 "우리가 이해한 주소" 를 지어내는 것이고, 그건 이 함수가 하지 않기로 한 일이다).
+  if (u.search || u.hash) return null;
+  // ★빈 조각도 실패다★ — `acme//widgets` 를 filter 로 지우면 없던 주소를 정상으로 만든다.
+  //   맨 끝 슬래시 하나만 흔한 표기라 허용한다.
+  const path = u.pathname.replace(/\/$/, "");
+  const seg = path.split("/").slice(1); // 맨 앞은 항상 "" (pathname 은 / 로 시작)
+  if (seg.length !== 2 || !seg[0] || !seg[1]) return null;
+  return normalizeRepoSlug(seg[0], seg[1]);
 }
 
 /** 설치본의 origin 을 `.git/config` 에서 읽는다. ★git 을 실행하지 않는다★(요청마다 프로세스를 띄우지 않으려고).

--- a/src/server/routes/ciStatus.ts
+++ b/src/server/routes/ciStatus.ts
@@ -1,0 +1,109 @@
+// GET /api/ci-status — 공개 저장소의 최근 CI 결과를 ★읽기만★ 해서 대시보드에 보여준다.
+//
+// ★왜 여기서 테스트를 돌리지 않나★ (Steve·Codex 리뷰, 2026-07-28)
+//   테스트는 DB·파일시스템 상태를 건드린다 — 실제로 과거에 테스트 하나가 라이브 멤버의
+//   CLAUDE.md 를 지운 적이 있고, 격리 워크트리에서 돌려도 DB 마이그레이션 로그가 찍힌다.
+//   그래서 대시보드는 ★결과를 보여주기만★ 한다. 실행은 CI(GitHub)와 개발자 로컬의 몫이다.
+//
+// ★토큰을 쓰지 않는 이유★: 저장소가 공개라 인증 없이 읽을 수 있다(실측: 60 req/hr).
+//   서버에 토큰을 두면 그 토큰이 새는 경로가 하나 늘어난다. 읽기만 하는데 그럴 이유가 없다.
+//   대신 한도가 낮으므로 ★캐시★ 로 요청을 줄인다(5분 = 시간당 12회).
+//
+// ★실패를 초록으로 만들지 않는다★: 못 가져왔으면 `ok:false` 와 이유를 그대로 내려보낸다.
+//   화면은 그걸 "확인 불가" 로 보여준다. ★모르는 것을 정상으로 표시하는 게 제일 위험하다★
+//   — 이 대시보드가 고치려는 문제가 정확히 그것이다.
+import { Hono } from "hono";
+
+const CACHE_MS = 5 * 60_000;
+const FETCH_TIMEOUT_MS = 6_000;
+const RUNS_URL =
+  "https://api.github.com/repos/b3rys/b3rys-team-os/actions/runs?per_page=10";
+
+export interface CiRun {
+  name: string;
+  event: string;
+  status: string;
+  conclusion: string | null;
+  branch: string;
+  created_at: string;
+  url: string;
+}
+
+export interface CiStatusBody {
+  ok: boolean;
+  /** 못 가져왔을 때의 이유 — 화면이 이걸 그대로 보여준다(초록으로 위장하지 않는다). */
+  reason?: string;
+  runs: CiRun[];
+  /** 이 데이터를 실제로 가져온 시각(UTC ISO). 화면이 "언제 기준" 인지 밝히는 데 쓴다. */
+  fetched_at: string | null;
+  cached: boolean;
+}
+
+/** GitHub 응답 → 화면이 쓰는 최소 형태. 필드가 없으면 빈 문자열로 두고 ★추측하지 않는다.★ */
+export function normalizeRuns(raw: unknown): CiRun[] {
+  const runs = (raw as { workflow_runs?: unknown[] } | null)?.workflow_runs;
+  if (!Array.isArray(runs)) return [];
+  return runs.slice(0, 10).map((r) => {
+    const o = (r ?? {}) as Record<string, unknown>;
+    return {
+      name: String(o.name ?? ""),
+      event: String(o.event ?? ""),
+      status: String(o.status ?? ""),
+      conclusion: o.conclusion == null ? null : String(o.conclusion),
+      branch: String(o.head_branch ?? ""),
+      created_at: String(o.created_at ?? ""),
+      url: String(o.html_url ?? ""),
+    };
+  });
+}
+
+export function createCiStatusRoutes(deps?: {
+  /** 테스트 주입용 — 실제 네트워크를 타지 않게 한다(테스트가 환경을 타면 안 된다). */
+  fetchRuns?: () => Promise<unknown>;
+  now?: () => number;
+}): Hono {
+  const app = new Hono();
+  const now = deps?.now ?? (() => Date.now());
+  let cache: { at: number; body: CiStatusBody } | null = null;
+
+  const defaultFetch = async (): Promise<unknown> => {
+    const res = await fetch(RUNS_URL, {
+      headers: { accept: "application/vnd.github+json", "user-agent": "b3os-dashboard" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) throw new Error(`github ${res.status}`);
+    return await res.json();
+  };
+  const fetchRuns = deps?.fetchRuns ?? defaultFetch;
+
+  app.get("/ci-status", async (c) => {
+    const t = now();
+    if (cache && t - cache.at < CACHE_MS) {
+      return c.json({ ...cache.body, cached: true });
+    }
+    try {
+      const raw = await fetchRuns();
+      const body: CiStatusBody = {
+        ok: true,
+        runs: normalizeRuns(raw),
+        fetched_at: new Date(t).toISOString(),
+        cached: false,
+      };
+      cache = { at: t, body };
+      return c.json(body);
+    } catch (e) {
+      // ★실패를 캐시하지 않는다★ — 캐시하면 일시적 오류가 5분간 굳는다.
+      //   그리고 ★직전 성공값을 대신 보여주지도 않는다★: 그러면 낡은 초록이 현재처럼 보인다.
+      const body: CiStatusBody = {
+        ok: false,
+        reason: e instanceof Error ? e.message : String(e),
+        runs: [],
+        fetched_at: null,
+        cached: false,
+      };
+      return c.json(body);
+    }
+  });
+
+  return app;
+}

--- a/src/web/components/TeamOS.ts
+++ b/src/web/components/TeamOS.ts
@@ -55,10 +55,19 @@ async function loadCi(root: HTMLElement): Promise<void> {
 export function ciBlockHtml(d: {
   ok: boolean; reason?: string; runs: { name: string; event: string; status: string;
   conclusion: string | null; branch: string; created_at: string; url: string }[];
-  fetched_at: string | null; cached?: boolean;
+  fetched_at: string | null; cached?: boolean; configured?: boolean;
 } | null): string {
   if (!d) {
     return `<div class="text-[12px] text-slate-400">${pick("불러오는 중…", "Loading…")}</div>`;
+  }
+  // ★설정이 안 된 것은 오류가 아니다.★ GitHub 을 안 쓰는 설치본에서 빨간 ✖ 와
+  //   "직접 확인하세요" 가 뜨면, 아무 문제 없는 사람에게 ★고장 신호★ 를 보내는 것이다.
+  //   그래서 미설정만 중립(회색)으로 갈라 놓는다.
+  if (d.configured === false) {
+    return `<div class="rounded-md border border-surface-3 bg-surface-1/50 p-2.5">
+      <div class="text-[12px] text-slate-400">${pick("GitHub CI 미설정", "GitHub CI not configured")}</div>
+      <div class="text-[11px] text-slate-500 mt-0.5">${escape(d.reason || "")}</div>
+    </div>`;
   }
   if (!d.ok) {
     return `<div class="rounded-md border border-txt-red/40 bg-txt-red/5 p-2.5">

--- a/src/web/components/TeamOS.ts
+++ b/src/web/components/TeamOS.ts
@@ -33,6 +33,73 @@ const CANONICAL_DOCS: { file: string; label: string; desc: string }[] = [
   { file: "TEST_CASES.md", label: pick("TEST_CASES — 룰별 기대동작", "TEST_CASES — expected behavior per rule"), desc: pick("각 운영 룰을 '상황→기대동작→실패예시' 표로. 회귀 점검표.", "Each operating rule as a 'situation→expected behavior→failure example' table. Regression checklist.") },
 ];
 
+/** CI 결과 캐시(모듈 상태). null = 아직 안 가져옴 → 화면은 "불러오는 중". */
+let _ciData: Parameters<typeof ciBlockHtml>[0] = null;
+
+/** CI 결과를 가져와 ★그 블록만★ 갈아끼운다(전체 재렌더 안 함 — 스크롤 튐 방지).
+ *  ★실패해도 화면을 비우지 않는다★ — 서버가 ok:false 와 이유를 주고 블록이 빨간 줄로 보여준다. */
+async function loadCi(root: HTMLElement): Promise<void> {
+  try {
+    const r = await fetch(`${apiBase()}/ci-status`);
+    _ciData = await r.json();
+  } catch (e) {
+    _ciData = { ok: false, reason: e instanceof Error ? e.message : String(e), runs: [], fetched_at: null };
+  }
+  const slot = root.querySelector<HTMLElement>("#teamos-ci");
+  if (slot) slot.innerHTML = ciBlockHtml(_ciData);
+}
+
+/** CI 결과 블록 — ★가져오지 못했으면 '확인 불가' 라고 말한다.★
+ *  ★비어 있는 초록★ 이 제일 위험하다: 사람은 아무것도 안 보이면 '문제 없구나' 로 읽는다.
+ *  그래서 실패는 이유와 함께 ★빨간 줄★ 로 남기고, 데이터는 ★언제 기준★ 인지 항상 밝힌다. */
+export function ciBlockHtml(d: {
+  ok: boolean; reason?: string; runs: { name: string; event: string; status: string;
+  conclusion: string | null; branch: string; created_at: string; url: string }[];
+  fetched_at: string | null; cached?: boolean;
+} | null): string {
+  if (!d) {
+    return `<div class="text-[12px] text-slate-400">${pick("불러오는 중…", "Loading…")}</div>`;
+  }
+  if (!d.ok) {
+    return `<div class="rounded-md border border-txt-red/40 bg-txt-red/5 p-2.5">
+      <div class="text-[12px] text-txt-red font-semibold">✖ ${pick("확인 불가", "Cannot verify")}</div>
+      <div class="text-[11px] text-slate-400 mt-0.5">${escape(d.reason || "unknown")}</div>
+      <div class="text-[11px] text-slate-500 mt-1">${pick(
+        "★결과를 모르는 것이지 '정상' 이 아닙니다.★ GitHub Actions 화면에서 직접 확인하세요.",
+        "This means unknown, not green. Check GitHub Actions directly.")}</div>
+    </div>`;
+  }
+  if (!d.runs.length) {
+    return `<div class="text-[12px] text-slate-400">${pick("최근 실행 기록이 없습니다.", "No recent runs.")}</div>`;
+  }
+  const mark = (r: { status: string; conclusion: string | null }) =>
+    r.status !== "completed" ? '<span class="text-txt-amber">●</span>'
+    : r.conclusion === "success" ? '<span class="text-accent-greenSoft">✓</span>'
+    : '<span class="text-txt-red">✖</span>';
+  const rows = d.runs.slice(0, 6).map((r) => `
+    <a href="${escape(r.url)}" target="_blank" rel="noopener"
+       class="flex items-center gap-2 py-1 text-[12px] hover:text-white">
+      ${mark(r)}
+      <span class="text-slate-300 truncate flex-1">${escape(r.branch || "-")}</span>
+      <span class="text-[11px] text-slate-500">${escape(r.event)}</span>
+      <span class="text-[11px] text-slate-500">${escape(fmtKst(r.created_at))}</span>
+    </a>`).join("");
+  return `${rows}
+    <div class="text-[11px] text-slate-500 mt-2">
+      ${pick("기준 시각", "As of")}: ${escape(fmtKst(d.fetched_at))}${d.cached ? pick(" (캐시)", " (cached)") : ""}
+      · ${pick("여기서 테스트를 돌리지 않습니다 — GitHub 결과를 읽어올 뿐입니다.",
+               "Tests are not run here — this only reads GitHub results.")}
+    </div>`;
+}
+
+/** UTC ISO → 사용자 로컬(KST) 표시. ★UTC 를 그대로 보여주면 9시간 거짓말이 된다.★ */
+function fmtKst(iso: string | null): string {
+  if (!iso) return "-";
+  const t = new Date(iso);
+  if (Number.isNaN(t.getTime())) return "-";
+  return t.toLocaleString(undefined, { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" });
+}
+
 function docsBlock(): string {
   const base = apiBase();
   const links = CANONICAL_DOCS.map(
@@ -182,6 +249,8 @@ function renderInto(root: HTMLElement, snap: TeamOsSnapshot | null): void {
 
       ${section(pick("정본 문서", "Canonical docs"), "source of truth", docsBlock())}
 
+        ${section(pick("CI 결과", "CI results"), "read-only · github", `<div id="teamos-ci">${ciBlockHtml(_ciData)}</div>`)}
+
       ${section(
         pick(`스케줄 · 서비스 (${snap.scheduled.length})`, `Schedules · services (${snap.scheduled.length})`),
         "launchd · openclaw cron",
@@ -234,6 +303,9 @@ export function renderTeamOs(root: HTMLElement): void {
       : "";
     return `${sched}|${tasks}|${s.scripts.length}|${s.tasks_pending_total}|${ingress}`;
   };
+  void loadCi(root);
+  setInterval(() => void loadCi(root), 5 * 60_000);
+
   const sync = () => {
     const cur = store.getState().teamOs;
     const s = sig(cur);

--- a/src/web/components/teamOsCi.test.ts
+++ b/src/web/components/teamOsCi.test.ts
@@ -1,0 +1,64 @@
+/**
+ * CI 결과 블록의 표시 규칙.
+ *
+ * ★이 함수에는 테스트가 하나도 없었다★ (2026-07-30 실측) — 교차검증에서 "화면은 이유를 보여준다" 는
+ * 판단이 ★코드를 읽어서★ 나왔고, 실행으로 확인된 적이 없었다. 표시 규칙이 이 기능의 핵심이라
+ * (초록으로 위장하지 않는다 / 미설정은 오류가 아니다) 여기서 못 박는다.
+ */
+import { describe, expect, test } from "bun:test";
+import { ciBlockHtml } from "./TeamOS";
+
+const base = {
+  ok: false,
+  reason: "GitHub CI 미설정 — 이 설치본의 git origin 이 GitHub 이 아닙니다. TEAM_CI_REPO=owner/repo",
+  runs: [] as never[],
+  fetched_at: null,
+};
+
+describe("GitHub CI 미설정은 오류가 아니다", () => {
+  test("★빨간 오류로 그리지 않는다★ — GitHub 을 안 쓰는 설치본의 정상 상태다", () => {
+    const html = ciBlockHtml({ ...base, configured: false });
+    expect(html).toContain("미설정");
+    expect(html).not.toContain("text-txt-red");
+    // 실패용 문구가 새어나오면 안 된다 — 아무 문제 없는 사람에게 고장 신호가 된다
+    expect(html).not.toContain("확인 불가");
+    // 실패 분기에만 있는 안내문(GitHub Actions 를 직접 보라)이 새어나오면 안 된다
+    expect(html).not.toContain("직접 확인하세요");
+  });
+
+  test("★설정 방법이 화면에 있다★ — 이유만 적고 방법을 안 적으면 사람이 못 고친다", () => {
+    expect(ciBlockHtml({ ...base, configured: false })).toContain("TEAM_CI_REPO");
+  });
+
+  test("★진짜 실패는 여전히 빨갛다★ — 미설정 분기가 실패를 삼키지 않는다", () => {
+    const html = ciBlockHtml({ ...base, reason: "github 500" });
+    expect(html).toContain("text-txt-red");
+    expect(html).toContain("확인 불가");
+  });
+
+  test("설정돼 있는데 실패한 경우도 빨갛다(configured:true)", () => {
+    expect(ciBlockHtml({ ...base, reason: "github 500", configured: true })).toContain("text-txt-red");
+  });
+});
+
+describe("빈 결과를 초록으로 위장하지 않는다", () => {
+  test("아직 안 가져왔으면 '불러오는 중'", () => {
+    expect(ciBlockHtml(null)).toContain("불러오는 중");
+  });
+
+  test("ok:true 인데 실행이 0건이면 ★없다고 말한다★ (빈 화면 아님)", () => {
+    const html = ciBlockHtml({ ok: true, runs: [], fetched_at: "2026-07-30T09:00:00Z" });
+    expect(html).toContain("없습니다");
+    expect(html).not.toContain("text-txt-red");
+  });
+
+  test("실패는 이유를 그대로 보여준다 — 사람이 원인을 알 수 있어야 한다", () => {
+    expect(ciBlockHtml({ ...base, reason: "github 403" })).toContain("github 403");
+  });
+
+  test("이유에 HTML 이 들어와도 태그로 실행되지 않는다", () => {
+    const html = ciBlockHtml({ ...base, reason: '<img src=x onerror="alert(1)">' });
+    expect(html).not.toContain("<img");
+    expect(html).toContain("&lt;img");
+  });
+});


### PR DESCRIPTION
팀장님 승인(2026-07-29) — 테스트 가시화 **3단계**. 1·2단계(#114)의 연장이다.

## 무엇을

OS 탭 '정본 문서' 아래에 **CI 결과** 블록. GitHub Actions 최근 실행을 읽어와 보여준다.

## 여기서 테스트를 돌리지 않는다 (Steve·Codex 리뷰 결론)

테스트는 DB·파일시스템을 건드린다 — 과거에 테스트 하나가 **라이브 멤버의 `CLAUDE.md` 를 지웠고**,
격리 워크트리에서 돌려도 DB 마이그레이션 로그가 찍힌다.
그래서 대시보드는 **결과만** 보여준다. 실행은 GitHub CI 와 개발자 로컬의 몫이다.

## 토큰을 쓰지 않는다

저장소가 공개라 인증 없이 읽힌다(실측 60 req/hr). **서버에 토큰을 두면 새는 경로가 하나 는다.**
읽기만 하는데 그럴 이유가 없다. 대신 한도가 낮아 **5분 캐시**(시간당 12회).

## 핵심 설계 — 실패를 초록으로 만들지 않는다

이 화면 전체가 *"안 보는 것을 먼저 말한다"*(#114)의 연장이다.

- 못 가져오면 **`ok:false` + 이유**를 그대로 내리고, 화면은 **"확인 불가" 빨간 줄**로 보여준다.
  문구도 박아뒀다 — **"결과를 모르는 것이지 '정상' 이 아닙니다."**
- **실패를 캐시하지 않는다** — 일시적 오류가 5분간 굳으면 안 된다.
- **실패 시 직전 성공값을 재사용하지 않는다** — **낡은 초록이 현재처럼 보이는 게 제일 위험하다.**
- 성공해도 **"기준 시각"**을 항상 밝힌다(로컬 시각 — UTC 를 그대로 쓰면 9시간 거짓말).
- 실행 중(`completed` 아님)은 초록도 빨강도 아닌 **진행중** 표시.

## 검증

- **검증 범위**: 신규 테스트 10건(라우트 6 + **렌더 함수 4**) · `bun test`(전체) · `tsc` · 격리 서버 실물
- **mutation 2종 전부 잡힘**: ①실패를 조용히 빈 div 로 → 1 fail ②실패 시 직전 성공값 재사용 → 1 fail
- 전체 **1849 pass / 5 skip / 0 fail** (159파일)
- **실물** — 격리 서버(포트·DB·레지스트리 분리)에서 실제 GitHub 호출 성공, 최근 실행 4건 표시,
  2번째 호출 `cached=true`, **라이브 7878 무영향** 확인

## 미검증

- **브라우저 실물 렌더** — 라우트 응답·렌더 함수까지만 덮었다. 배포 후 내가 눌러 확인한다
- GitHub 한도 초과(403) 시 화면 — 코드 경로는 테스트로 덮었으나 실제 403 은 안 겪어봤다

## 리뷰에서 봐줬으면 하는 곳

**5분 캐시가 60/hr 한도에 충분한지**(대시보드를 여러 탭에서 열면?), 그리고
**실패 표시가 사용자에게 실제로 "모름"으로 읽히는지**(문구 톤).
