### PR TITLE
fix(release-ops): 승인 게이트 구멍 8종 — 화면과 원문이 갈리는 자리를 막는다

### DIFF
--- a/skills/b3os-release-ops/SKILL.md
+++ b/skills/b3os-release-ops/SKILL.md
@@ -109,9 +109,15 @@ skills/b3os-release-ops/scripts/release-preflight.sh --mode deploy --live-dir /p
 
 옵션:
 
-- `--mode merge|deploy|hotfix|force-push|post-merge`
+- `--mode merge|deploy|force-push|post-merge`
+  - ★`hotfix` 는 없앴다★ (2026-07-29): 받아주기만 하고 ★승인 확인부에는 없어서 조용히 건너뛰고 "passed" 를 찍었다.★
+    ★핫픽스도 `--mode merge` 를 쓴다★ — 급해도 승인은 받는다.
+- `--pr <n>` (생략하면 현재 브랜치의 PR 을 찾는다. ★주면 그 PR 이 이 브랜치·이 커밋의 것인지 대조한다★)
 - `--base origin/main`
 - `--live-dir <path>`
+- `--settings-url <url>` (기본값이 아니면 마지막 요약 줄에 크게 찍힌다)
+- `--skip-approver-check "<이유>"` — ★이유가 필수다★. 진짜 비상(설정 서버 다운 + 핫픽스)에만.
+  ★크게 찍히고 요약 줄에도 남는다★ — 통과와 우회가 출력에서 구분돼야 하기 때문이다.
 - `--skip-branch-protection` (GitHub API를 쓸 수 없는 로컬 dry-run 때만)
 - `--allow-main` (deploy 모드처럼 main worktree 검사가 필요한 때만)
 

--- a/skills/b3os-release-ops/scripts/approver-check.mutants.sh
+++ b/skills/b3os-release-ops/scripts/approver-check.mutants.sh
@@ -57,16 +57,16 @@ mutate "③ 명부 대조 제거" \
   '        if False:'
 
 mutate "④ ★작성자 계정 검사 제거 (#119 증상)★" \
-  '    if author != team:' \
+  '    if author.lower() != team.lower():' \
   '    if False:'
 
 mutate "④b ★작성자 조회 실패를 통과시킴 (ames BLOCKER)★" \
   '    if not author:' \
   '    if False:'
 
-mutate "⑤ 승인 계정 검사 제거" \
-  '        if acct != appr:' \
-  '        if False:'
+mutate "⑤ ★승인 자격 제거 (아무 계정의 승인이나 인정)★" \
+  '    mine = [(a, r) for a, r in approvals if a.lower() == appr.lower()]' \
+  '    mine = list(approvals)'
 
 mutate "⑥ ★설정 누락 검사 제거 (기본값으로 때움)★" \
   '    if missing:' \
@@ -76,13 +76,44 @@ mutate "⑦ ★배열 아닌 응답을 '승인 없음' 으로 삼킴★" \
   '    if not isinstance(reviews, list):' \
   '    if False:'
 
-mutate "⑧ ★본문 전체의 중복 서명 검사 제거★" \
-  '        if len(all_hits) > 1:' \
+mutate "⑧ ★중복 서명 검사 제거★" \
+  '        if len(attempts) > 1:' \
   '        if False:'
 
 mutate "⑨ ★마지막 줄 제한을 버리고 아무 줄이나 허용★ (예시가 서명이 됨)" \
   '    for line in reversed(body.replace("\r\n", "\n").split("\n")):' \
   '    for line in body.replace("\r\n", "\n").split("\n"):'
+
+# ══ 2026-07-29 하네스 실측으로 넣은 가드들 — ★이것도 되돌려서 빨개지는지 본다★ ══
+mutate "⑩ ★안 닫힌 코드펜스 검사 제거★ (화면엔 예시, 원문엔 서명)" \
+  '    if len(re.findall(r"^[ \t]*(?:```|~~~)", body, re.M)) % 2:' \
+  '    if False:'
+
+mutate "⑪ ★안 닫힌 HTML 주석 검사 제거★ (화면에서 사라지는 서명)" \
+  '    if body.count("<!--") != body.count("-->"):' \
+  '    if False:'
+
+mutate "⑫ ★모호한 마크업이어도 그냥 진행★ (가드 호출 자체를 무력화)" \
+  '        if bad:
+            return False, why' \
+  '        if False:
+            return False, why'
+
+mutate "⑬ ★중복 세기를 다시 엄격 정규식으로★ (백슬래시 우회 부활)" \
+  '        attempts = LOOSE_TRAILER.findall(candidate)' \
+  '        attempts = TRAILER.findall(candidate)'
+
+mutate "⑭ ★예시 제거를 안 함★ (규약 문서 인용이 다시 막힘)" \
+  '        candidate = strip_examples(body)' \
+  '        candidate = body'
+
+mutate "⑮ ★계정 대조를 다시 대소문자 구분으로★" \
+  '    mine = [(a, r) for a, r in approvals if a.lower() == appr.lower()]' \
+  '    mine = [(a, r) for a, r in approvals if a == appr]'
+
+mutate "⑯ ★'승인 없음' 원인 구분 제거★ (셋이 같은 말)" \
+  '    if any(s == "DISMISSED" for s in final_states):' \
+  '    if False:'
 
 echo
 if [ "$bad" = "0" ]; then

--- a/skills/b3os-release-ops/scripts/approver-check.mutants.sh
+++ b/skills/b3os-release-ops/scripts/approver-check.mutants.sh
@@ -85,16 +85,20 @@ mutate "⑨ ★마지막 줄 제한을 버리고 아무 줄이나 허용★ (예
   '    for line in body.replace("\r\n", "\n").split("\n"):'
 
 # ══ 2026-07-29 하네스 실측으로 넣은 가드들 — ★이것도 되돌려서 빨개지는지 본다★ ══
-mutate "⑩ ★안 닫힌 코드펜스 검사 제거★ (화면엔 예시, 원문엔 서명)" \
-  '    if unclosed:' \
-  '    if False:'
+mutate "⑩ ★안 닫힌 펜스를 통과시킴★ (화면엔 예시, 원문엔 서명)" \
+  '    if fence is not None:
+        return "", ("the approval body opens a code fence' \
+  '    if False:
+        return "", ("the approval body opens a code fence'
 
-mutate "⑪ ★안 닫힌 HTML 주석 검사 제거★ (화면에서 사라지는 서명)" \
-  '    if visible.count("<!--") > visible.count("-->"):' \
-  '    if False:'
+mutate "⑪ ★안 닫힌 주석을 통과시킴★ (화면에서 사라지는 서명)" \
+  '    if in_comment:
+        return "", ("the approval body opens an HTML comment' \
+  '    if False:
+        return "", ("the approval body opens an HTML comment'
 
-mutate "⑫ ★모호한 마크업이어도 그냥 진행★ (가드 호출 자체를 무력화)" \
-  '        if bad:
+mutate "⑫ ★차단 사유를 무시하고 진행★ (가드 호출 자체를 무력화)" \
+  '        if why:
             return False, why' \
   '        if False:
             return False, why'
@@ -103,44 +107,72 @@ mutate "⑬ ★중복 세기를 다시 엄격 정규식으로★ (백슬래시 �
   '        attempts = LOOSE_TRAILER.findall(candidate)' \
   '        attempts = TRAILER.findall(candidate)'
 
-mutate "⑭ ★예시 제거를 안 함★ (규약 문서 인용이 다시 막힘)" \
-  '        candidate = strip_examples(body)' \
-  '        candidate = body'
+mutate "⑭ ★화면 기준 대신 원문을 그대로 씀★ (예시가 다시 서명이 된다)" \
+  '        candidate, why = visible_text(body)' \
+  '        candidate, why = body, ""'
 
 mutate "⑮ ★계정 대조를 다시 대소문자 구분으로★" \
   '    mine = [(a, r) for a, r in approvals if a.lower() == appr.lower()]' \
   '    mine = [(a, r) for a, r in approvals if a == appr]'
 
 mutate "⑯ ★'승인 없음' 원인 구분 제거★ (셋이 같은 말)" \
-  '    if any(s == "DISMISSED" for s in final_states):' \
+  '    if last == "DISMISSED":' \
   '    if False:'
 
-# ══ PR#125 리뷰 반영분 — ★네 명이 같은 곳을 짚은 자리★ (codex·steve·hermes·demis) ══
+# ══ 2차 리뷰 반영분 — ★통합 스캐너의 각 판단★ ══
 # ★주의: 설명·문자열에 백틱을 쓰지 마라.★ 큰따옴표 안의 백틱은 셸이 ★명령으로 실행★ 해서
 #   이 스크립트가 문법 오류로 죽는다(여기서 실제로 한 번 죽였다). 펜스는 '펜스' 라고 쓴다.
 mutate "⑰ ★펜스 문자 구분 제거★ (백틱 펜스를 물결 펜스로 닫히게 — codex BLOCKER)" \
-  '        closer = re.compile(r"^ {0,3}" + re.escape(char) + "{" + str(width) + r",}[ \t]*$")' \
-  '        closer = re.compile(r"^ {0,3}(?:" + chr(96) + "{3,}|~{3,})[ \t]*$")'
+  '            if re.match(r"^ {0,3}" + re.escape(fence[0]) + "{" + str(fence[1]) + r",}[ \t]*$", line):' \
+  '            if re.match(r"^ {0,3}(?:" + chr(96) + "{3,}|~{3,})[ \t]*$", line):'
 
 mutate "⑱ ★펜스 길이 조건 제거★ (긴 펜스를 짧은 펜스로 닫히게 — codex BLOCKER)" \
-  '"{" + str(width) + r",}[ \t]*$")' \
-  '"{3,}[ \t]*$")'
+  '+ "{" + str(fence[1]) + r",}[ \t]*$"' \
+  '+ "{3,}[ \t]*$"'
 
 mutate "⑲ ★들여쓰기 3칸 제한을 풀기★ (들여쓴 코드블록을 펜스로 오인)" \
   'r"^(?P<indent> {0,3})(?P<fence>' \
   'r"^(?P<indent>[ \t]*)(?P<fence>'
 
-mutate "⑳ ★주석 균형을 다시 양방향(!=)으로★ (화살표 하나로 정당 승인 차단 — steve·demis)" \
-  '    if visible.count("<!--") > visible.count("-->"):' \
-  '    if visible.count("<!--") != visible.count("-->"):'
+mutate "⑳ ★주석을 왼쪽부터 훑지 않고 개수로 판정★ (고아 닫는 토큰이 상쇄 — codex·hermes BLOCKER)" \
+  '            line = line[:a]                           # 여기서부터 안 보인다
+            in_comment = True' \
+  '            line = line[:a]                           # 여기서부터 안 보인다
+            in_comment = body.count("<!--") > body.count("-->")'
 
-mutate "㉑ ★주석 검사를 원문에 하기★ (펜스 안 예시가 다시 막음 — hermes)" \
-  '    visible = strip_examples(body)' \
-  '    visible = body'
+mutate "㉑ ★펜스와 주석을 한 번에 훑지 않음★ (펜스 안 토큰이 주석을 연다 — hermes·steve)" \
+  '            continue                                  # 펜스 안은 통째로 예시다' \
+  '            pass'
 
 mutate "㉒ ★인라인 코드를 안 걷어냄★ (코드 안 토큰 언급이 막힘 — steve)" \
-  '    text = INLINE_CODE.sub("", text)' \
-  '    text = text'
+  '        line = INLINE_CODE.sub("", line)' \
+  '        line = line'
+
+# ㉓ ★'인라인 코드가 줄을 넘는다' 는 이제 뮤턴트로 못 잰다 — 그래서 안 넣는다.★
+#   예전엔 정규식 플래그(re.S)가 막았지만, 지금은 ★스캐너가 한 줄씩 처리하는 구조★ 가 막는다.
+#   즉 플래그를 되돌려도 sub() 에 들어가는 문자열이 한 줄이라 ★결과가 안 바뀐다.★
+#   ★변이가 결과를 못 바꾸는 자리에 뮤턴트를 두면 '가드에 시험이 없다' 와 구분이 안 된다.★
+#   (그 경로 자체는 ㉒ 가 덮는다 — 인라인 코드 제거를 통째로 지우면 빨개진다)
+
+mutate "㉔ ★인용줄을 중복으로 셈★ (남의 서명을 인용하면 막힘 — 내 하네스)" \
+  '        if re.match(r"^ {0,3}>", line):               # ★인용줄★ — 남의 서명을 인용한 것이다
+            continue' \
+  '        if False:
+            continue'
+
+mutate "㉕ ★들여쓴 코드블록을 중복으로 셈★ (엄격·느슨 판정이 어긋남 — 내 하네스)" \
+  '        if re.match(r"^ {4,}\S", line):               # ★4칸 이상 들여쓴 줄 = 들여쓴 코드블록★
+            continue' \
+  '        if False:
+            continue'
+
+mutate "㉖ ★목록 표시가 붙은 서명을 중복으로 안 셈★ (두 이름이 통과 — 내 하네스)" \
+  'LOOSE_TRAILER = re.compile(r"^[ \t*_`#+\-　]*(?:\d+[.)][ \t]*)?approved-by[ \t]*:", re.I | re.M)' \
+  'LOOSE_TRAILER = re.compile(r"^[ \t*_`#\-]*approved-by[ \t]*:", re.I | re.M)'
+
+mutate "㉗ ★원인 판정에 남의 계정 상태를 섞음★ (틀린 원인을 단언 — 내 하네스)" \
+  '                       if ((r.get("user") or {}).get("login") or "").lower() == appr.lower()' \
+  '                       if True'
 
 echo
 if [ "$bad" = "0" ]; then

--- a/skills/b3os-release-ops/scripts/approver-check.mutants.sh
+++ b/skills/b3os-release-ops/scripts/approver-check.mutants.sh
@@ -86,11 +86,11 @@ mutate "⑨ ★마지막 줄 제한을 버리고 아무 줄이나 허용★ (예
 
 # ══ 2026-07-29 하네스 실측으로 넣은 가드들 — ★이것도 되돌려서 빨개지는지 본다★ ══
 mutate "⑩ ★안 닫힌 코드펜스 검사 제거★ (화면엔 예시, 원문엔 서명)" \
-  '    if len(re.findall(r"^[ \t]*(?:```|~~~)", body, re.M)) % 2:' \
+  '    if unclosed:' \
   '    if False:'
 
 mutate "⑪ ★안 닫힌 HTML 주석 검사 제거★ (화면에서 사라지는 서명)" \
-  '    if body.count("<!--") != body.count("-->"):' \
+  '    if visible.count("<!--") > visible.count("-->"):' \
   '    if False:'
 
 mutate "⑫ ★모호한 마크업이어도 그냥 진행★ (가드 호출 자체를 무력화)" \
@@ -114,6 +114,33 @@ mutate "⑮ ★계정 대조를 다시 대소문자 구분으로★" \
 mutate "⑯ ★'승인 없음' 원인 구분 제거★ (셋이 같은 말)" \
   '    if any(s == "DISMISSED" for s in final_states):' \
   '    if False:'
+
+# ══ PR#125 리뷰 반영분 — ★네 명이 같은 곳을 짚은 자리★ (codex·steve·hermes·demis) ══
+# ★주의: 설명·문자열에 백틱을 쓰지 마라.★ 큰따옴표 안의 백틱은 셸이 ★명령으로 실행★ 해서
+#   이 스크립트가 문법 오류로 죽는다(여기서 실제로 한 번 죽였다). 펜스는 '펜스' 라고 쓴다.
+mutate "⑰ ★펜스 문자 구분 제거★ (백틱 펜스를 물결 펜스로 닫히게 — codex BLOCKER)" \
+  '        closer = re.compile(r"^ {0,3}" + re.escape(char) + "{" + str(width) + r",}[ \t]*$")' \
+  '        closer = re.compile(r"^ {0,3}(?:" + chr(96) + "{3,}|~{3,})[ \t]*$")'
+
+mutate "⑱ ★펜스 길이 조건 제거★ (긴 펜스를 짧은 펜스로 닫히게 — codex BLOCKER)" \
+  '"{" + str(width) + r",}[ \t]*$")' \
+  '"{3,}[ \t]*$")'
+
+mutate "⑲ ★들여쓰기 3칸 제한을 풀기★ (들여쓴 코드블록을 펜스로 오인)" \
+  'r"^(?P<indent> {0,3})(?P<fence>' \
+  'r"^(?P<indent>[ \t]*)(?P<fence>'
+
+mutate "⑳ ★주석 균형을 다시 양방향(!=)으로★ (화살표 하나로 정당 승인 차단 — steve·demis)" \
+  '    if visible.count("<!--") > visible.count("-->"):' \
+  '    if visible.count("<!--") != visible.count("-->"):'
+
+mutate "㉑ ★주석 검사를 원문에 하기★ (펜스 안 예시가 다시 막음 — hermes)" \
+  '    visible = strip_examples(body)' \
+  '    visible = body'
+
+mutate "㉒ ★인라인 코드를 안 걷어냄★ (코드 안 토큰 언급이 막힘 — steve)" \
+  '    text = INLINE_CODE.sub("", text)' \
+  '    text = text'
 
 echo
 if [ "$bad" = "0" ]; then

--- a/skills/b3os-release-ops/scripts/approver-check.mutants.sh
+++ b/skills/b3os-release-ops/scripts/approver-check.mutants.sh
@@ -130,9 +130,11 @@ mutate "⑱ ★펜스 길이 조건 제거★ (긴 펜스를 짧은 펜스로 �
   '+ "{" + str(fence[1]) + r",}[ \t]*$"' \
   '+ "{3,}[ \t]*$"'
 
-mutate "⑲ ★들여쓰기 3칸 제한을 풀기★ (들여쓴 코드블록을 펜스로 오인)" \
-  'r"^(?P<indent> {0,3})(?P<fence>' \
-  'r"^(?P<indent>[ \t]*)(?P<fence>'
+# ⑲ ★펜스 정규식의 '들여쓰기 3칸 제한' 은 이제 뮤턴트로 못 잰다 — 그래서 안 넣는다.★
+#   ★들여쓴 코드블록을 먼저 걷어내는 가드(㉘)가 그 줄을 이미 건너뛴다.★ 제한을 풀어도
+#   그 줄이 펜스 판정에 도달하지 못해 ★결과가 안 바뀐다.★
+#   ★가드 둘이 같은 것을 덮으면 변이가 결과를 못 바꾸고, 그건 '시험이 없다' 와 구분이 안 된다.★
+#   (동작 자체는 ㉘ 이 덮는다 — 앞선 건너뛰기를 지우면 빨개진다)
 
 mutate "⑳ ★주석을 왼쪽부터 훑지 않고 개수로 판정★ (고아 닫는 토큰이 상쇄 — codex·hermes BLOCKER)" \
   '            line = line[:a]                           # 여기서부터 안 보인다
@@ -144,9 +146,19 @@ mutate "㉑ ★펜스와 주석을 한 번에 훑지 않음★ (펜스 안 토�
   '            continue                                  # 펜스 안은 통째로 예시다' \
   '            pass'
 
-mutate "㉒ ★인라인 코드를 안 걷어냄★ (코드 안 토큰 언급이 막힘 — steve)" \
-  '        line = INLINE_CODE.sub("", line)' \
-  '        line = line'
+mutate "㉒ ★코드 스팬 가림막을 안 씀★ (코드 안 토큰 언급이 막힘 — steve)" \
+  '        probe, span = blank_code_spans(line, span)' \
+  '        probe, span = line, span'
+
+mutate "㉓ ★가림막이 아니라 본문을 지움★ (화면에 없는 서명을 만들어냄 — demis 3차)" \
+  '                line = line[:a] + line[b + 3:]        # 한 줄 안에서 닫혔다
+                probe = probe[:a] + probe[b + 3:]' \
+  '                line = probe[:a] + probe[b + 3:]
+                probe = probe[:a] + probe[b + 3:]'
+
+mutate "㉘ ★들여쓴 코드블록을 주석보다 늦게 걷어냄★ (코드 안 토큰이 주석을 염 — codex 3차)" \
+  '        elif span == 0 and re.match(r"^ {4,}' \
+  '        elif False and re.match(r"^ {4,}'
 
 # ㉓ ★'인라인 코드가 줄을 넘는다' 는 이제 뮤턴트로 못 잰다 — 그래서 안 넣는다.★
 #   예전엔 정규식 플래그(re.S)가 막았지만, 지금은 ★스캐너가 한 줄씩 처리하는 구조★ 가 막는다.
@@ -160,11 +172,7 @@ mutate "㉔ ★인용줄을 중복으로 셈★ (남의 서명을 인용하면 �
   '        if False:
             continue'
 
-mutate "㉕ ★들여쓴 코드블록을 중복으로 셈★ (엄격·느슨 판정이 어긋남 — 내 하네스)" \
-  '        if re.match(r"^ {4,}\S", line):               # ★4칸 이상 들여쓴 줄 = 들여쓴 코드블록★
-            continue' \
-  '        if False:
-            continue'
+# ㉕ 는 ㉘ 로 대체됐다 — 들여쓴 코드블록 처리가 주석보다 앞으로 옮겨가 대상 줄이 사라졌다.
 
 mutate "㉖ ★목록 표시가 붙은 서명을 중복으로 안 셈★ (두 이름이 통과 — 내 하네스)" \
   'LOOSE_TRAILER = re.compile(r"^[ \t*_`#+\-　]*(?:\d+[.)][ \t]*)?approved-by[ \t]*:", re.I | re.M)' \

--- a/skills/b3os-release-ops/scripts/approver-check.py
+++ b/skills/b3os-release-ops/scripts/approver-check.py
@@ -34,6 +34,50 @@ import sys
 #  그 사람의 승인으로 기록된다. (그리고 이 기능을 설명하는 SKILL.md 자체가 그 예시를 담고 있다)
 TRAILER = re.compile(r"^approved-by[ \t]*:[ \t]*([A-Za-z0-9._-]+)[ \t]*$", re.I | re.M)
 
+#: ★서명을 '시도한' 줄★ — 엄격 형식에 안 맞아도 잡는다. ★중복 검사는 이걸로 센다.★
+#  이유(하네스 실측 2026-07-29): 엄격 정규식은 줄 끝이 `[ \t]*$` 라
+#  ★`Approved-by: dex\` 처럼 백슬래시로 끝나면 매칭이 안 돼 '중복' 으로 세어지지 않았다.★
+#  그래서 서명 두 줄을 넣고도 통과했다 — ★가드가 막으려던 "누가 승인했는지 갈리는" 상태 그대로.★
+#  ★잡는 그물(중복)은 넓게, 인정하는 형식(서명)은 좁게.★
+LOOSE_TRAILER = re.compile(r"^[ \t>*_`#\-]*approved-by[ \t]*:", re.I | re.M)
+
+
+def strip_examples(body: str) -> str:
+    """★닫힌 코드펜스·닫힌 HTML 주석 안은 '예시' 다★ — 서명 후보에서 뺀다.
+
+    ★왜 필요한가★ (하네스 실측 2026-07-29): 중복 검사가 본문 전체를 세다 보니
+    ★규약을 알려주는 SKILL.md 의 형식 예시를 인용하면 '서명이 두 줄' 로 막혔다.★
+    ★규칙을 지키려고 문서를 인용한 사람이 막히는 형태다.★
+    """
+    body = re.sub(r"<!--.*?-->", "", body, flags=re.S)
+    out, in_fence = [], False
+    for line in body.split("\n"):
+        if re.match(r"^[ \t]*(?:```|~~~)", line):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            out.append(line)
+    return "\n".join(out)
+
+
+def ambiguous_markup(body: str):
+    """★사람이 보는 화면과 이 도구가 읽는 원문이 갈릴 수 있으면 (True, 이유).★
+
+    ★이 게이트의 결함은 전부 이 한 가지 부류였다★ (하네스 실측 2026-07-29):
+      · 안 닫힌 코드펜스 → 화면엔 예시로 보이는데 원문에선 ★마지막 줄★ 이라 서명이 된다
+      · 안 닫힌 `<!--`   → ★화면에서는 통째로 사라지는데★ 원문에는 남아 서명이 된다
+    변종마다 막지 않고 ★'갈릴 수 있는 상태' 자체를 거부한다★ — 이 파일의 계약이 '모르면 막는다' 다.
+    """
+    if len(re.findall(r"^[ \t]*(?:```|~~~)", body, re.M)) % 2:
+        return True, ("the approval body has an UNCLOSED code fence (``` or ~~~) — "
+                      "what a reader sees and what this tool reads can differ, so the signature is not trusted; "
+                      "close the fence and re-approve")
+    if body.count("<!--") != body.count("-->"):
+        return True, ("the approval body has an UNBALANCED HTML comment (<!-- without -->) — "
+                      "a signature can be hidden from the rendered view; "
+                      "close the comment and re-approve")
+    return False, ""
+
 
 def last_line(body: str) -> str:
     """★본문의 마지막 비어있지 않은 줄★ 만 서명 후보다.
@@ -80,6 +124,24 @@ def standing_approvals(reviews):
     return [(a, r) for a, r in final.items() if (r.get("state") or "") == "APPROVED"]
 
 
+def why_no_approval(reviews, final_states) -> str:
+    """★'승인 없음' 의 원인을 갈라서 말한다.★
+
+    ★왜★ (하네스 실측 2026-07-29): 서로 다른 세 원인이 ★완전히 같은 문장★ 을 내고 있었고,
+    그 문장은 ★"나중 CHANGES_REQUESTED 가 앞선 승인을 덮었다"★ 라고 ★원인을 단언★ 했다.
+    라이브 브랜치 보호가 `dismiss_stale_reviews: true` 라 ★push 할 때마다 승인이 폐기된다★ —
+    ★가장 흔한 실패에 대해 게이트가 틀린 원인을 말하고 있었다.★
+    """
+    if not reviews:
+        return "no review on this PR at all — request a review and get an approval first"
+    if any(s == "DISMISSED" for s in final_states):
+        return ("the approval was DISMISSED — a push after the approval dismisses it "
+                "(branch protection: dismiss_stale_reviews). Ask for a re-approval on the current commits")
+    if any(s == "CHANGES_REQUESTED" for s in final_states):
+        return "the approval was withdrawn — a later CHANGES_REQUESTED supersedes the earlier approval"
+    return "no standing approval on this PR (reviews exist, but none of them is a current APPROVED)"
+
+
 def check(settings, reviews, pr_author):
     """(ok: bool, message: str). ★모르면 ok=False.★"""
     if not isinstance(reviews, list):
@@ -100,34 +162,68 @@ def check(settings, reviews, pr_author):
                        "-d '{\"github_team_account\":\"...\",\"github_approver_account\":\"...\",\"merge_approvers_normal\":\"bill,codex,steve\"}' "
                        "http://127.0.0.1:7878/team/api/settings   (do not hardcode)")
 
-    if team == appr:
+    # ★계정 비교는 대소문자를 가리지 않는다★ (하네스 실측 2026-07-29): GitHub 로그인은 대소문자 무관인데
+    #   설정에 `GD452` 로 저장하면(PUT 검증이 대문자를 허용한다) ★그 순간부터 머지가 영구 차단★ 됐다.
+    #   ★이름(Approved-by)만 소문자로 접고 계정은 안 접은 비일관★ 이 원인이었다.
+    if team.lower() == appr.lower():
         return False, f"author account and approver account are the same ({team}) — the review requirement cannot hold"
     if not author:
         # ★조회 실패·빈값을 통과시키지 않는다★ (ames BLOCKER) — 이 도구의 계약은 '모르면 막는다' 다.
         return False, "PR author unknown (lookup failed or empty) — cannot verify the author account"
-    if author != team:
+    if author.lower() != team.lower():
         return False, (f"PR author is {author}, expected the team account {team} — "
                        f"recreate the PR with the team account (a PR authored by the approver account cannot be approved)")
 
     approvals = standing_approvals(reviews)
-    if not approvals:
-        return False, "no standing approval (a later CHANGES_REQUESTED supersedes an earlier approval)"
+    # ★승인 계정의 승인 하나를 찾는다★ — 남의 승인은 세지 않되 ★조용히 버리지도 않는다.★
+    #   ★왜 바꿨나★ (하네스 실측 2026-07-29): 예전엔 '모든 승인이 승인 계정이어야' 통과였다.
+    #   ★이 저장소는 public 이라 아무나 APPROVED 를 남길 수 있고★, 그러면 gd452 가 규격대로 서명해도
+    #   ★하드 실패★ 했다. 게다가 메시지가 "승인 계정에서 승인이 안 왔다" 로 읽혀 ★원인을 정반대로 지목★ 했다.
+    #   자격은 여전히 승인 계정에만 있다 — 남의 승인은 ★통과의 근거가 되지 못한다.★
+    mine = [(a, r) for a, r in approvals if a.lower() == appr.lower()]
+    others = sorted({a for a, _ in approvals if a.lower() != appr.lower()})
+    if not mine:
+        if others:
+            return False, (f"no approval from the approver account {appr} — "
+                           f"these accounts approved but do not count: {', '.join(others)}")
+        states = [(r.get("state") or "") for r in
+                  {((rr.get("user") or {}).get("login")) or "?": rr
+                   for rr in sorted([x for x in reviews if isinstance(x, dict)],
+                                    key=lambda x: x.get("submitted_at") or "")}.values()]
+        return False, why_no_approval(reviews, states)
 
     signed = []
-    for acct, r in approvals:
-        if acct != appr:
-            return False, f"approval came from account {acct}, expected the approver account {appr}"
+    for acct, r in mine:
         # ★set 이 아니라 줄 수를 센다★ (ames): 같은 이름이 두 줄이어도 set 은 1개로 접혀
         #   ★'서명이 여럿' 검사를 조용히 통과했다.★
         body = (r.get("body") or "").replace("\\r\\n", "\n").replace("\\n", "\n").replace("\r\n", "\n")
-        # ★본문 어디든 서명 모양이 둘 이상이면 모호하다★ (ames): 마지막 줄만 보면
-        #   앞의 것이 조용히 무시돼 ★누가 승인했는지가 갈린다.★ set 으로 접으면
-        #   같은 이름 두 줄이 1개로 세어져 이 검사를 통과했다 — ★줄 수를 센다.★
-        all_hits = TRAILER.findall(body)
-        if len(all_hits) > 1:
-            return False, "approval has more than one Approved-by line: " + ", ".join(sorted({h.lower() for h in all_hits}))
-        names = [h.lower() for h in TRAILER.findall(last_line(body))]
+
+        # ★화면과 원문이 갈릴 수 있으면 여기서 멈춘다★ — 서명을 읽기 전에 본다.
+        bad, why = ambiguous_markup(body)
+        if bad:
+            return False, why
+
+        # ★예시(닫힌 펜스·닫힌 주석)를 뺀 뒤에 센다★ — 규약 문서를 인용해도 막히지 않게.
+        candidate = strip_examples(body)
+
+        # ★서명 모양이 둘 이상이면 모호하다★ (ames): 마지막 줄만 보면 앞의 것이 조용히 무시돼
+        #   ★누가 승인했는지가 갈린다.★ ★엄격 형식이 아니라 '시도한 줄' 을 센다★ — 엄격 정규식으로 세면
+        #   백슬래시로 끝나는 줄이 안 세어져 ★두 줄을 넣고도 통과★ 했다(하네스 실측).
+        attempts = LOOSE_TRAILER.findall(candidate)
+        if len(attempts) > 1:
+            shown = ", ".join(sorted({h.strip().lower() for h in TRAILER.findall(candidate)})) or "(unparsable)"
+            return False, (f"the approval has more than one Approved-by line ({len(attempts)}): {shown} — "
+                           "leave exactly one, on the final line")
+
+        tail = last_line(candidate)
+        names = [h.lower() for h in TRAILER.findall(tail)]
         if not names:
+            if LOOSE_TRAILER.match(tail):
+                # ★'모양은 맞는데 안 맞다' 를 구분해 말한다★ — 사용자 눈에는 정확히 그 줄이다.
+                #   실측으로 확인된 것: @멘션 · ✦ 같은 기호 · NBSP · 전각공백 · **볼드** · 리스트 하이픈
+                return False, (f"the last line looks like a signature but does not match exactly: {tail!r} — "
+                               "it must be exactly 'Approved-by: <name>' with no @, bold, list marker, "
+                               "trailing punctuation, emoji, or non-breaking/full-width space")
             return False, ("the LAST line of the approval is not 'Approved-by: <name>' — "
                            "put it on the final line (a signature elsewhere in the body is not read; "
                            "the account is shared, so the account alone does not say who reviewed)")
@@ -137,7 +233,9 @@ def check(settings, reviews, pr_author):
             return False, f"Approved-by: {names[0]} is not in merge_approvers_normal ({', '.join(pool)})"
         signed.append(names[0])
 
-    return True, f"approved by {', '.join(signed)} (account {appr}, author {author or '?'})"
+    # ★남의 승인이 있었으면 통과할 때도 말한다★ — 조용히 버리면 '없었던 것' 이 된다.
+    extra = f" [ignored approvals from: {', '.join(others)}]" if others else ""
+    return True, f"approved by {', '.join(signed)} (account {appr}, author {author}){extra}"
 
 
 def main() -> int:
@@ -147,9 +245,12 @@ def main() -> int:
         ok, msg = check(payload.get("settings") or {}, payload.get("reviews"), payload.get("pr_author"))
     except Exception as e:  # 판정 자체가 실패한 것 — 통과가 아니다
         print(f"FAIL\tapprover check could not run: {e}")
-        return 0
+        return 1
     print(("OK\t" if ok else "FAIL\t") + msg)
-    return 0
+    # ★FAIL 이면 종료코드도 실패다★ (하네스 실측 2026-07-29): 예전엔 FAIL 도 0 이라
+    #   ★`if approver-check.py; then merge; fi` 로 쓰면 조용히 통과★ 했다.
+    #   지금 호출부(release-preflight.sh)는 stdout 접두사를 보므로 이 변경에 영향받지 않는다.
+    return 0 if ok else 1
 
 
 if __name__ == "__main__":

--- a/skills/b3os-release-ops/scripts/approver-check.py
+++ b/skills/b3os-release-ops/scripts/approver-check.py
@@ -39,7 +39,9 @@ TRAILER = re.compile(r"^approved-by[ \t]*:[ \t]*([A-Za-z0-9._-]+)[ \t]*$", re.I 
 #  ★`Approved-by: dex\` 처럼 백슬래시로 끝나면 매칭이 안 돼 '중복' 으로 세어지지 않았다.★
 #  그래서 서명 두 줄을 넣고도 통과했다 — ★가드가 막으려던 "누가 승인했는지 갈리는" 상태 그대로.★
 #  ★잡는 그물(중복)은 넓게, 인정하는 형식(서명)은 좁게.★
-LOOSE_TRAILER = re.compile(r"^[ \t>*_`#\-]*approved-by[ \t]*:", re.I | re.M)
+#  ★목록 표시(+ · 1.)와 전각공백도 넣는다★ — 안 넣었더니 `+ Approved-by: steve` 가
+#  중복으로 안 세어져 ★두 이름이 든 본문이 통과했다★ (내 적대 하네스 실측).
+LOOSE_TRAILER = re.compile(r"^[ \t*_`#+\-　]*(?:\d+[.)][ \t]*)?approved-by[ \t]*:", re.I | re.M)
 
 
 #: 펜스 여는 줄. ★들여쓰기 3칸까지만 펜스다★ — 4칸부터는 마크다운에서 '들여쓴 코드블록' 이라
@@ -47,86 +49,77 @@ LOOSE_TRAILER = re.compile(r"^[ \t>*_`#\-]*approved-by[ \t]*:", re.I | re.M)
 FENCE_OPEN = re.compile(r"^(?P<indent> {0,3})(?P<fence>`{3,}|~{3,})(?P<info>[^\n]*)$")
 
 #: 인라인 코드(`...`). ★코드 안의 토큰은 렌더링에서 주석을 열지 않는다★ (steve).
-INLINE_CODE = re.compile(r"(?P<t>`+)(?:(?!(?P=t)).)*(?P=t)", re.S)
+#  ★줄을 넘지 않는다★ — re.S 를 붙였더니 ★원문에 없던 서명 줄을 만들어냈다★ (내 적대 하네스 실측):
+#    "Approved-by: `" + 개행 + "검토 안 했습니다" + 개행 + "`bill"  → 이어붙어 서명이 됐다.
+#    화면에는 "Approved-by: 검토 안 했습니다bill" 로 보이는데 도구는 bill 이 승인했다고 기록했다.
+INLINE_CODE = re.compile(r"(?P<t>`+)(?:(?!(?P=t))[^\n])*(?P=t)")
 
 
-def fence_spans(body: str):
-    """(닫힌 펜스 구간 [(시작줄, 끝줄)], 안 닫힌 펜스가 있나)
 
-    ★마크다운 규칙대로 센다★ (codex BLOCKER, 2026-07-29):
-      · ★여는 문자를 유지한다★ — ``` 은 ~~~ 로 닫히지 않는다
-      · ★닫는 펜스는 여는 것 이상으로 길어야 한다★ — ```` 는 ``` 로 닫히지 않는다
-      · ★닫는 줄에는 그 문자 말고 아무것도 없어야 한다★
-    ★전에는 셋 다 무시하고 '펜스처럼 생긴 줄' 을 켜고 끄기만 했다★ — 그래서
-    ```` ```(열고) → ~~~ → 서명 ````  이 통과했다(실측). 화면에서는 전부 코드 안인데.
+def visible_text(body: str):
+    """(사람이 화면에서 읽는 것에 가까운 텍스트, 차단사유 or "")
+
+    ★이 게이트의 결함은 전부 한 부류였다★ — ★화면과 원문이 갈리는 것.★
+    그래서 변종마다 막지 않고 ★'화면에서 사라지는 상태' 를 거부하고, 나머지는 화면 기준으로 본다.★
+
+    ★펜스와 주석을 따로 훑으면 반드시 어느 한쪽이 틀린다★ (2026-07-29, 두 번 겪었다):
+      · 펜스를 먼저 걷으면 ★펜스 안의 여는 토큰이 펜스 밖 닫는 토큰과 짝지어 본문을 지운다★ (hermes)
+      · 주석을 먼저 걷으면 ★인라인 코드·펜스 안의 토큰이 주석을 여는 것으로 잡혀 정당한 승인이 막힌다★ (steve)
+    ★둘은 서로를 가리므로 한 번에 훑어야 한다.★ 아래는 위에서 아래로 한 번 지나가며
+    ★그 자리에서 무엇이 먼저 열렸는지★ 를 따라간다 — 마크다운 파서가 하는 일과 같은 순서다.
+
+    걷어내는 것: 펜스 블록 · 안 닫힌 주석 뒤 전부 · 닫힌 주석 안 · 인라인 코드 ·
+                 들여쓴 코드블록(4칸+) · 인용줄(>)  — ★전부 '예시' 이거나 '안 보이는 것' 이다.★
     """
     lines = body.split("\n")
-    spans, i, unclosed = [], 0, False
+    out, i = [], 0
+    fence = None            # (문자, 길이) — 열려 있는 펜스
+    in_comment = False      # 여는 주석 안 (닫는 토큰을 기다리는 중)
     while i < len(lines):
-        m = FENCE_OPEN.match(lines[i])
-        if not m:
-            i += 1
+        line = lines[i]
+        i += 1
+        if fence is not None:
+            if re.match(r"^ {0,3}" + re.escape(fence[0]) + "{" + str(fence[1]) + r",}[ \t]*$", line):
+                fence = None
+            continue                                  # 펜스 안은 통째로 예시다
+        if in_comment:
+            j = line.find("-->")
+            if j < 0:
+                continue                              # 아직 주석 안 — 화면에 없다
+            in_comment = False
+            line = line[j + 3:]                       # 닫힌 뒤부터는 다시 본문이다
+        m = FENCE_OPEN.match(line)
+        if m and not (m.group("fence")[0] == "`" and "`" in m.group("info")):
+            fence = (m.group("fence")[0], len(m.group("fence")))
             continue
-        fence = m.group("fence")
-        char, width = fence[0], len(fence)
-        # 백틱 펜스의 info 문자열에 백틱이 있으면 펜스가 아니다(마크다운 규칙)
-        if char == "`" and "`" in m.group("info"):
-            i += 1
-            continue
-        closer = re.compile(r"^ {0,3}" + re.escape(char) + "{" + str(width) + r",}[ \t]*$")
-        j = i + 1
-        while j < len(lines) and not closer.match(lines[j]):
-            j += 1
-        if j < len(lines):
-            spans.append((i, j))
-            i = j + 1
-        else:
-            unclosed = True
+        # ★인라인 코드를 먼저 지운다★ — 코드 안의 토큰은 주석을 열지 않는다
+        line = INLINE_CODE.sub("", line)
+        while True:
+            a = line.find("<!--")
+            if a < 0:
+                break
+            b = line.find("-->", a + 4)
+            if b >= 0:
+                line = line[:a] + line[b + 3:]        # 한 줄 안에서 닫혔다
+                continue
+            line = line[:a]                           # 여기서부터 안 보인다
+            in_comment = True
             break
-    return spans, unclosed
+        if re.match(r"^ {4,}\S", line):               # ★4칸 이상 들여쓴 줄 = 들여쓴 코드블록★
+            continue
+        if re.match(r"^ {0,3}>", line):               # ★인용줄★ — 남의 서명을 인용한 것이다
+            continue
+        out.append(line)
 
-
-def strip_examples(body: str) -> str:
-    """★예시로 보이는 것을 서명 후보에서 뺀다★ — 닫힌 펜스 · 인라인 코드 · 닫힌 HTML 주석.
-
-    ★순서가 중요하다★ (steve·hermes): 펜스를 먼저 걷어내야
-    ★펜스 안의 `<!--` 예시가 펜스 밖 `-->` 와 짝지어 본문을 지우는 일★ 이 안 생긴다.
-    """
-    lines = body.split("\n")
-    spans, _ = fence_spans(body)
-    drop = set()
-    for a, b in spans:
-        drop.update(range(a, b + 1))
-    text = "\n".join(l for k, l in enumerate(lines) if k not in drop)
-    text = INLINE_CODE.sub("", text)
-    return re.sub(r"<!--.*?-->", "", text, flags=re.S)
-
-
-def ambiguous_markup(body: str):
-    """★사람이 보는 화면과 이 도구가 읽는 원문이 갈릴 수 있으면 (True, 이유).★
-
-    ★이 게이트의 결함은 전부 이 한 가지 부류였다★ (하네스 실측 2026-07-29):
-      · 안 닫힌 코드펜스 → 화면엔 예시로 보이는데 원문에선 ★마지막 줄★ 이라 서명이 된다
-      · 안 닫힌 `<!--`   → ★화면에서는 통째로 사라지는데★ 원문에는 남아 서명이 된다
-    변종마다 막지 않고 ★'갈릴 수 있는 상태' 자체를 거부한다★ — 이 파일의 계약이 '모르면 막는다' 다.
-
-    ★단, 넓게 막으면 규칙을 지키려는 사람이 막힌다★ (steve 실측):
-      · 안 닫힌 펜스는 ★원문에서★ 본다 — 안 닫혔으면 스트립 결과 자체를 믿을 수 없다
-      · 주석은 ★펜스·인라인 코드를 걷어낸 뒤★ 보고, ★여는 게 닫는 것보다 많을 때만★ 막는다.
-        `!=` 로 보면 ★표에 쓰는 화살표(닫는 토큰 모양)만 있어도 막혔다★ — 여는 토큰이 하나도 없는데.
-        ★가리는 것은 여는 토큰뿐이다.★ 닫는 토큰만 떠 있으면 아무것도 안 가려진다.
-    """
-    _, unclosed = fence_spans(body)
-    if unclosed:
-        return True, ("the approval body has an UNCLOSED code fence (``` or ~~~) — "
-                      "what a reader sees and what this tool reads can differ, so the signature is not trusted; "
-                      "close the fence and re-approve")
-    visible = strip_examples(body)
-    if visible.count("<!--") > visible.count("-->"):
-        return True, ("the approval body has an UNCLOSED HTML comment (<!-- without -->) outside code — "
-                      "everything after it disappears from the rendered view while this tool still reads it; "
-                      "close the comment and re-approve")
-    return False, ""
+    if fence is not None:
+        return "", ("the approval body opens a code fence (``` or ~~~) that is never closed — "
+                    "everything after it renders as code, so what a reader sees is not a signature. "
+                    "Close the fence and re-approve")
+    if in_comment:
+        return "", ("the approval body opens an HTML comment (<!--) that is never closed — "
+                    "everything after it disappears from the rendered view while this tool still reads it. "
+                    "If you meant to mention the token, wrap it in `backticks`; otherwise close the comment")
+    return "\n".join(out), ""
 
 
 def last_line(body: str) -> str:
@@ -184,12 +177,16 @@ def why_no_approval(reviews, final_states) -> str:
     """
     if not reviews:
         return "no review on this PR at all — request a review and get an approval first"
-    if any(s == "DISMISSED" for s in final_states):
+    if not final_states:
+        return "no review from the approver account on this PR — request a review and get an approval first"
+    # ★마지막 상태가 원인이다★ — any() 로 보면 앞선 상태가 나중 상태를 이겨 ★틀린 원인을 단언한다.★
+    last = final_states[-1]
+    if last == "DISMISSED":
         return ("the approval was DISMISSED — a push after the approval dismisses it "
                 "(branch protection: dismiss_stale_reviews). Ask for a re-approval on the current commits")
-    if any(s == "CHANGES_REQUESTED" for s in final_states):
+    if last == "CHANGES_REQUESTED":
         return "the approval was withdrawn — a later CHANGES_REQUESTED supersedes the earlier approval"
-    return "no standing approval on this PR (reviews exist, but none of them is a current APPROVED)"
+    return f"no standing approval from the approver account (its latest review state is {last or 'unknown'})"
 
 
 def check(settings, reviews, pr_author):
@@ -236,11 +233,15 @@ def check(settings, reviews, pr_author):
         if others:
             return False, (f"no approval from the approver account {appr} — "
                            f"these accounts approved but do not count: {', '.join(others)}")
-        states = [(r.get("state") or "") for r in
-                  {((rr.get("user") or {}).get("login")) or "?": rr
-                   for rr in sorted([x for x in reviews if isinstance(x, dict)],
-                                    key=lambda x: x.get("submitted_at") or "")}.values()]
-        return False, why_no_approval(reviews, states)
+        # ★원인은 '승인 계정이 무엇을 했나' 로 판단한다★ — 아무 계정의 상태나 섞으면
+        #   ★남이 DISMISS 된 것을 보고 "당신 승인이 폐기됐다" 고 단언한다★ (내 적대 하네스 실측).
+        #   COMMENTED 를 빼는 것도 standing_approvals 와 맞춘다 — 안 맞추면 원인 구분이 어긋난다.
+        mine_states = [(r.get("state") or "")
+                       for r in sorted([x for x in reviews if isinstance(x, dict)],
+                                       key=lambda x: x.get("submitted_at") or "")
+                       if ((r.get("user") or {}).get("login") or "").lower() == appr.lower()
+                       and (r.get("state") or "") != "COMMENTED"]
+        return False, why_no_approval(reviews, mine_states)
 
     signed = []
     for acct, r in mine:
@@ -248,13 +249,10 @@ def check(settings, reviews, pr_author):
         #   ★'서명이 여럿' 검사를 조용히 통과했다.★
         body = (r.get("body") or "").replace("\\r\\n", "\n").replace("\\n", "\n").replace("\r\n", "\n")
 
-        # ★화면과 원문이 갈릴 수 있으면 여기서 멈춘다★ — 서명을 읽기 전에 본다.
-        bad, why = ambiguous_markup(body)
-        if bad:
+        # ★화면과 원문이 갈릴 수 있으면 여기서 멈추고, 아니면 화면 기준으로 본다.★
+        candidate, why = visible_text(body)
+        if why:
             return False, why
-
-        # ★예시(닫힌 펜스·닫힌 주석)를 뺀 뒤에 센다★ — 규약 문서를 인용해도 막히지 않게.
-        candidate = strip_examples(body)
 
         # ★서명 모양이 둘 이상이면 모호하다★ (ames): 마지막 줄만 보면 앞의 것이 조용히 무시돼
         #   ★누가 승인했는지가 갈린다.★ ★엄격 형식이 아니라 '시도한 줄' 을 센다★ — 엄격 정규식으로 세면

--- a/skills/b3os-release-ops/scripts/approver-check.py
+++ b/skills/b3os-release-ops/scripts/approver-check.py
@@ -56,7 +56,33 @@ INLINE_CODE = re.compile(r"(?P<t>`+)(?:(?!(?P=t))[^\n])*(?P=t)")
 
 
 
-def visible_text(body: str):
+def blank_code_spans(line: str, span: int):
+    """(코드 스팬 내용을 공백으로 바꾼 줄, 줄 끝에 아직 열려 있는 백틱 개수)
+
+    ★지우지 않고 공백으로 바꾼다★ (codex 3차): 양끝을 이어붙이면
+    ★원문에 없던 서명 줄★ 이 생긴다 — 내가 앞 라운드에서 실제로 그렇게 만들었다.
+    ★닫는 백틱 런은 여는 것과 개수가 같아야 한다★ (CommonMark).
+    """
+    out, i, n = [], 0, len(line)
+    while i < n:
+        if line[i] != "`":
+            out.append(" " if span else line[i])
+            i += 1
+            continue
+        m = i
+        while m < n and line[m] == "`":
+            m += 1
+        run = m - i
+        out.append(" " * run)
+        if span == 0:
+            span = run
+        elif run == span:
+            span = 0                     # 같은 개수로 닫혔다
+        i = m
+    return "".join(out), span
+
+
+def visible_text(body: str, use_code_spans: bool = True):
     """(사람이 화면에서 읽는 것에 가까운 텍스트, 차단사유 or "")
 
     ★이 게이트의 결함은 전부 한 부류였다★ — ★화면과 원문이 갈리는 것.★
@@ -75,6 +101,7 @@ def visible_text(body: str):
     out, i = [], 0
     fence = None            # (문자, 길이) — 열려 있는 펜스
     in_comment = False      # 여는 주석 안 (닫는 토큰을 기다리는 중)
+    span = 0                # 열려 있는 인라인 코드의 백틱 개수 (0 = 없음)
     while i < len(lines):
         line = lines[i]
         i += 1
@@ -88,25 +115,40 @@ def visible_text(body: str):
                 continue                              # 아직 주석 안 — 화면에 없다
             in_comment = False
             line = line[j + 3:]                       # 닫힌 뒤부터는 다시 본문이다
-        m = FENCE_OPEN.match(line)
-        if m and not (m.group("fence")[0] == "`" and "`" in m.group("info")):
-            fence = (m.group("fence")[0], len(m.group("fence")))
+        elif span == 0 and re.match(r"^ {4,}\S", line):
+            # ★들여쓴 코드블록은 주석 토큰보다 먼저 걷어낸다★ (codex 3차 BLOCKER):
+            #   나중에 걷으면 ★코드 안의 여는 토큰이 먼저 주석을 열어★ 뒤의 정당한 서명이 막혔다.
+            #   ★이미 주석 안이면 주석 상태가 이긴다★ — 주석 안에서는 코드블록이 안 열린다.
             continue
-        # ★인라인 코드를 먼저 지운다★ — 코드 안의 토큰은 주석을 열지 않는다
-        line = INLINE_CODE.sub("", line)
+        if span == 0:
+            m = FENCE_OPEN.match(line)
+            if m and not (m.group("fence")[0] == "`" and "`" in m.group("info")):
+                fence = (m.group("fence")[0], len(m.group("fence")))
+                continue
+        # ★코드 스팬은 '가림막' 으로만 쓰고 본문은 그대로 둔다★ (demis 3차 BLOCKER)
+        #   ★렌더링에서 코드 스팬은 사라지지 않는다.★ 지우거나 공백으로 바꾸면 ★양옆이 붙어
+        #   화면에 없는 서명이 만들어진다★ — demis 실측:
+        #     화면 "Approved-by: (백틱)x(백틱)bill"  → 도구가 "Approved-by: bill" 로 읽고 통과
+        #     화면 "Approved(백틱)z(백틱)-by: bill"  → ★화면엔 서명 형식으로 보이지도 않는데★ 통과
+        #   → ★주석 토큰을 찾을 때만 같은 길이로 가리고, 서명 판정은 원문으로 한다.★
+        #     길이를 보존하므로 probe 에서 찾은 위치를 line 에 그대로 쓸 수 있다.
+        #   코드 스팬은 ★줄을 넘을 수 있다★ (codex 3차: CommonMark 가 인정한다).
+        probe, span = blank_code_spans(line, span)
+        if span > 0:
+            out.append(line)                          # 아직 코드 스팬 안 — 주석 토큰은 안 센다
+            continue
         while True:
-            a = line.find("<!--")
+            a = probe.find("<!--")
             if a < 0:
                 break
-            b = line.find("-->", a + 4)
+            b = probe.find("-->", a + 4)
             if b >= 0:
                 line = line[:a] + line[b + 3:]        # 한 줄 안에서 닫혔다
+                probe = probe[:a] + probe[b + 3:]
                 continue
             line = line[:a]                           # 여기서부터 안 보인다
             in_comment = True
             break
-        if re.match(r"^ {4,}\S", line):               # ★4칸 이상 들여쓴 줄 = 들여쓴 코드블록★
-            continue
         if re.match(r"^ {0,3}>", line):               # ★인용줄★ — 남의 서명을 인용한 것이다
             continue
         out.append(line)

--- a/skills/b3os-release-ops/scripts/approver-check.py
+++ b/skills/b3os-release-ops/scripts/approver-check.py
@@ -42,22 +42,64 @@ TRAILER = re.compile(r"^approved-by[ \t]*:[ \t]*([A-Za-z0-9._-]+)[ \t]*$", re.I 
 LOOSE_TRAILER = re.compile(r"^[ \t>*_`#\-]*approved-by[ \t]*:", re.I | re.M)
 
 
-def strip_examples(body: str) -> str:
-    """★닫힌 코드펜스·닫힌 HTML 주석 안은 '예시' 다★ — 서명 후보에서 뺀다.
+#: 펜스 여는 줄. ★들여쓰기 3칸까지만 펜스다★ — 4칸부터는 마크다운에서 '들여쓴 코드블록' 이라
+#  펜스가 아니다. 이걸 `[ \t]*` 로 느슨하게 잡았더니 ★들여쓴 코드 안의 진짜 서명을 지웠다.★
+FENCE_OPEN = re.compile(r"^(?P<indent> {0,3})(?P<fence>`{3,}|~{3,})(?P<info>[^\n]*)$")
 
-    ★왜 필요한가★ (하네스 실측 2026-07-29): 중복 검사가 본문 전체를 세다 보니
-    ★규약을 알려주는 SKILL.md 의 형식 예시를 인용하면 '서명이 두 줄' 로 막혔다.★
-    ★규칙을 지키려고 문서를 인용한 사람이 막히는 형태다.★
+#: 인라인 코드(`...`). ★코드 안의 토큰은 렌더링에서 주석을 열지 않는다★ (steve).
+INLINE_CODE = re.compile(r"(?P<t>`+)(?:(?!(?P=t)).)*(?P=t)", re.S)
+
+
+def fence_spans(body: str):
+    """(닫힌 펜스 구간 [(시작줄, 끝줄)], 안 닫힌 펜스가 있나)
+
+    ★마크다운 규칙대로 센다★ (codex BLOCKER, 2026-07-29):
+      · ★여는 문자를 유지한다★ — ``` 은 ~~~ 로 닫히지 않는다
+      · ★닫는 펜스는 여는 것 이상으로 길어야 한다★ — ```` 는 ``` 로 닫히지 않는다
+      · ★닫는 줄에는 그 문자 말고 아무것도 없어야 한다★
+    ★전에는 셋 다 무시하고 '펜스처럼 생긴 줄' 을 켜고 끄기만 했다★ — 그래서
+    ```` ```(열고) → ~~~ → 서명 ````  이 통과했다(실측). 화면에서는 전부 코드 안인데.
     """
-    body = re.sub(r"<!--.*?-->", "", body, flags=re.S)
-    out, in_fence = [], False
-    for line in body.split("\n"):
-        if re.match(r"^[ \t]*(?:```|~~~)", line):
-            in_fence = not in_fence
+    lines = body.split("\n")
+    spans, i, unclosed = [], 0, False
+    while i < len(lines):
+        m = FENCE_OPEN.match(lines[i])
+        if not m:
+            i += 1
             continue
-        if not in_fence:
-            out.append(line)
-    return "\n".join(out)
+        fence = m.group("fence")
+        char, width = fence[0], len(fence)
+        # 백틱 펜스의 info 문자열에 백틱이 있으면 펜스가 아니다(마크다운 규칙)
+        if char == "`" and "`" in m.group("info"):
+            i += 1
+            continue
+        closer = re.compile(r"^ {0,3}" + re.escape(char) + "{" + str(width) + r",}[ \t]*$")
+        j = i + 1
+        while j < len(lines) and not closer.match(lines[j]):
+            j += 1
+        if j < len(lines):
+            spans.append((i, j))
+            i = j + 1
+        else:
+            unclosed = True
+            break
+    return spans, unclosed
+
+
+def strip_examples(body: str) -> str:
+    """★예시로 보이는 것을 서명 후보에서 뺀다★ — 닫힌 펜스 · 인라인 코드 · 닫힌 HTML 주석.
+
+    ★순서가 중요하다★ (steve·hermes): 펜스를 먼저 걷어내야
+    ★펜스 안의 `<!--` 예시가 펜스 밖 `-->` 와 짝지어 본문을 지우는 일★ 이 안 생긴다.
+    """
+    lines = body.split("\n")
+    spans, _ = fence_spans(body)
+    drop = set()
+    for a, b in spans:
+        drop.update(range(a, b + 1))
+    text = "\n".join(l for k, l in enumerate(lines) if k not in drop)
+    text = INLINE_CODE.sub("", text)
+    return re.sub(r"<!--.*?-->", "", text, flags=re.S)
 
 
 def ambiguous_markup(body: str):
@@ -67,14 +109,22 @@ def ambiguous_markup(body: str):
       · 안 닫힌 코드펜스 → 화면엔 예시로 보이는데 원문에선 ★마지막 줄★ 이라 서명이 된다
       · 안 닫힌 `<!--`   → ★화면에서는 통째로 사라지는데★ 원문에는 남아 서명이 된다
     변종마다 막지 않고 ★'갈릴 수 있는 상태' 자체를 거부한다★ — 이 파일의 계약이 '모르면 막는다' 다.
+
+    ★단, 넓게 막으면 규칙을 지키려는 사람이 막힌다★ (steve 실측):
+      · 안 닫힌 펜스는 ★원문에서★ 본다 — 안 닫혔으면 스트립 결과 자체를 믿을 수 없다
+      · 주석은 ★펜스·인라인 코드를 걷어낸 뒤★ 보고, ★여는 게 닫는 것보다 많을 때만★ 막는다.
+        `!=` 로 보면 ★표에 쓰는 화살표(닫는 토큰 모양)만 있어도 막혔다★ — 여는 토큰이 하나도 없는데.
+        ★가리는 것은 여는 토큰뿐이다.★ 닫는 토큰만 떠 있으면 아무것도 안 가려진다.
     """
-    if len(re.findall(r"^[ \t]*(?:```|~~~)", body, re.M)) % 2:
+    _, unclosed = fence_spans(body)
+    if unclosed:
         return True, ("the approval body has an UNCLOSED code fence (``` or ~~~) — "
                       "what a reader sees and what this tool reads can differ, so the signature is not trusted; "
                       "close the fence and re-approve")
-    if body.count("<!--") != body.count("-->"):
-        return True, ("the approval body has an UNBALANCED HTML comment (<!-- without -->) — "
-                      "a signature can be hidden from the rendered view; "
+    visible = strip_examples(body)
+    if visible.count("<!--") > visible.count("-->"):
+        return True, ("the approval body has an UNCLOSED HTML comment (<!-- without -->) outside code — "
+                      "everything after it disappears from the rendered view while this tool still reads it; "
                       "close the comment and re-approve")
     return False, ""
 

--- a/skills/b3os-release-ops/scripts/approver-check.test.py
+++ b/skills/b3os-release-ops/scripts/approver-check.test.py
@@ -72,19 +72,19 @@ for key in ("github_team_account", "github_approver_account", "merge_approvers_n
          expect_msg="settings missing")
 
 # ── 승인 상태 ────────────────────────────────────────────────────────────────
-case("승인 0건", False, SETTINGS, [], expect_msg="no standing approval")
+case("승인 0건", False, SETTINGS, [], expect_msg="no review on this PR at all")
 case("반려만 있음", False, SETTINGS, [review("Approved-by: bill", state="CHANGES_REQUESTED")])
 case("★승인 뒤 철회 — 나중 것이 이긴다★", False, SETTINGS,
      [review("Approved-by: bill", at="2026-07-01T00:00:00Z"),
       review("되돌립니다", state="CHANGES_REQUESTED", at="2026-07-05T00:00:00Z")],
-     expect_msg="no standing approval")
+     expect_msg="withdrawn")
 # ★위 케이스만으로는 '시간순 정렬' 을 안 재고 있었다★ (뮤턴트로 발견):
 #   시험 데이터가 이미 시간순이라 정렬을 지워도 결과가 같았다.
 #   ★정렬이 실제로 일하는 곳은 API 가 순서를 뒤섞어 줄 때★ 다 — GitHub 은 순서를 보장하지 않는다.
 case("★순서가 뒤섞여 와도 나중 철회가 이긴다★", False, SETTINGS,
      [review("되돌립니다", state="CHANGES_REQUESTED", at="2026-07-05T00:00:00Z"),
       review("Approved-by: bill", at="2026-07-01T00:00:00Z")],   # ← 승인이 배열 뒤에 있지만 ★더 이르다★
-     expect_msg="no standing approval")
+     expect_msg="withdrawn")
 case("★철회 뒤 재승인 — 이번엔 통과★", True, SETTINGS,
      [review("되돌립니다", state="CHANGES_REQUESTED", at="2026-07-01T00:00:00Z"),
       review("Approved-by: bill", at="2026-07-05T00:00:00Z")])
@@ -109,6 +109,48 @@ case("★마지막 줄이 아니면 서명이 아니다★", False, SETTINGS,
 # ★ames BLOCKER — 작성자 조회 실패를 통과시키지 않는다★
 case("★작성자 조회 실패(빈값) → 막는다★", False, SETTINGS,
      [review("Approved-by: bill")], author="", expect_msg="author unknown")
+
+# ══ 하네스 실측 2026-07-29 — ★화면과 원문이 갈리는 자리★ ═══════════════════════
+# ★이 넷은 전부 같은 부류다★: 사람이 보는 렌더 결과와 이 도구가 읽는 원문이 다르다.
+#   그래서 변종마다 막지 않고 ★'갈릴 수 있는 상태' 자체를 거부★ 하게 바꿨다.
+case("★안 닫힌 코드펜스 뒤 서명 → 막는다★ (열려 있으면 화면엔 예시로 보인다)", False, SETTINGS,
+     [review("질문: 형식이 이거 맞나요?\n\n```\nApproved-by: steve\n")], expect_msg="UNCLOSED code fence")
+case("★안 닫힌 HTML 주석 뒤 서명 → 막는다★ (화면에서는 통째로 사라진다)", False, SETTINGS,
+     [review("리뷰 안 했습니다.\n<!-- 메모\nApproved-by: bill")], expect_msg="UNBALANCED HTML comment")
+case("★닫힌 주석은 정상 통과★ (막는 건 '안 닫힌 것' 이지 주석 자체가 아니다)", True, SETTINGS,
+     [review("<!-- 메모 -->\n확인했습니다.\n\nApproved-by: bill")])
+case("★줄 끝 백슬래시로 중복서명 가드를 우회하지 못한다★", False, SETTINGS,
+     [review("Approved-by: dex\\\nApproved-by: bill")], expect_msg="more than one")
+
+# ★규약을 알려주는 문서를 인용해도 막히지 않는다★ — 규칙을 지키려는 사람이 막히던 자리
+case("★SKILL.md 형식 예시(닫힌 펜스)를 인용하고 진짜 서명 → 통과★", True, SETTINGS,
+     [review("형식이 이건가요?\n\n```\nApproved-by: bill\n```\n\n확인했습니다.\n\nApproved-by: codex")])
+
+# ★남의 승인이 있어도 내 승인을 막지 않는다★ — public repo 라 아무나 APPROVED 를 남길 수 있다
+case("★제3자 APPROVED 가 있어도 승인계정 서명이 있으면 통과★", True, SETTINGS,
+     [review("looks fine", acct="randomdev", at="2026-07-01T00:00:00Z"),
+      review("Approved-by: bill", at="2026-07-02T00:00:00Z")], expect_msg="ignored approvals from")
+case("★제3자 승인만 있으면 통과 못 한다★ (자격은 승인계정에만 있다)", False, SETTINGS,
+     [review("looks fine", acct="randomdev")], expect_msg="do not count")
+
+# ★계정 대소문자★ — GitHub 로그인은 대소문자 무관인데 설정 표기가 갈리면 영구 차단됐다
+case("★승인계정 표기가 대문자여도 통과★", True, SETTINGS, [review("Approved-by: bill", acct="GD452")])
+case("★작성자 표기가 대문자여도 통과★", True, SETTINGS, [review("Approved-by: bill")], author="GDB3rys")
+
+# ★'승인 없음' 의 원인을 갈라 말한다★ — 셋이 같은 문장을 내면서 원인을 단언했다
+case("원인구분: 리뷰가 아예 없음", False, SETTINGS, [], expect_msg="no review on this PR at all")
+case("원인구분: ★push 로 폐기됨(dismiss_stale_reviews)★", False, SETTINGS,
+     [review("Approved-by: bill", state="DISMISSED")], expect_msg="DISMISSED")
+case("원인구분: 실제 철회", False, SETTINGS,
+     [review("Approved-by: bill", at="2026-07-01T00:00:00Z"),
+      review("되돌립니다", state="CHANGES_REQUESTED", at="2026-07-05T00:00:00Z")], expect_msg="withdrawn")
+
+# ★'모양은 맞는데 안 맞다' 를 구분해 말한다★ — 사용자 눈에는 정확히 그 줄이라 원인을 못 찾았다
+for _tag, _body in [("@멘션", "Approved-by: @bill"), ("기호", "Approved-by: bill ✦"),
+                    ("NBSP", "Approved-by: bill\xa0"), ("볼드", "**Approved-by: bill**"),
+                    ("리스트", "- Approved-by: bill")]:
+    case(f"★{_tag} → 막되 이유를 말한다★", False, SETTINGS, [review(_body)],
+         expect_msg="looks like a signature but does not match exactly")
 
 
 def main():

--- a/skills/b3os-release-ops/scripts/approver-check.test.py
+++ b/skills/b3os-release-ops/scripts/approver-check.test.py
@@ -230,6 +230,22 @@ case("★남의 리뷰가 나중에 DISMISSED 여도 내 반려를 반려라고 
       review("검토중", acct="randomdev", state="DISMISSED", at="2026-07-03T00:00:00Z")],
      expect_msg="withdrawn")
 
+# ══ 3차 리뷰 — ★코드 스팬은 '가림막' 이지 '지우는 것' 이 아니다★ (codex·demis) ══
+# ★렌더링에서 코드 스팬은 사라지지 않는다.★ 지우면 양옆이 붙어 ★화면에 없는 서명★ 이 생긴다.
+case("★들여쓴 코드블록 안의 여는 토큰은 주석을 열지 않는다★ (codex)", True, SETTINGS,
+     [review("예시:\n\n    " + _OPEN + "\n\n확인했습니다.\nApproved-by: bill")])
+case("★여러 줄 코드 스팬 안의 여는 토큰도 주석을 열지 않는다★ (codex)", True, SETTINGS,
+     [review("예시: " + _B + _OPEN + "\n여전히 코드" + _B + "\n\nApproved-by: bill")])
+# ★아래 둘은 화면에 백틱이 그대로 보인다★ — 사람은 서명으로 안 읽는데 도구만 서명으로 읽으면 안 된다
+case("★서명 안에 코드 스팬이 있으면 막는다★ (지우면 통과했다 — demis)", False, SETTINGS,
+     [review("Approved-by: " + _B + "x" + _B + "bill")])
+case("★서명 형식이 코드로 쪼개져 있으면 막는다★ (화면엔 서명으로 보이지도 않는다 — demis)", False, SETTINGS,
+     [review("Approved" + _B + "z" + _B + "-by: bill")])
+# ★주석을 잘라낼 때도 가림막이 아니라 원문을 남겨야 한다★ — 가림막을 본문에 쓰면
+#   코드 스팬이 공백이 되어 ★화면에 없는 서명★ 이 만들어진다(같은 결함의 다른 경로).
+case("★주석이 같은 줄에서 닫혀도 서명은 원문으로 판정한다★", False, SETTINGS,
+     [review("Approved-by: " + _B + "x" + _B + "bill " + _OPEN + " 메모 " + _CLOSE)])
+
 # ★'모양은 맞는데 안 맞다' 를 구분해 말한다★ — 사용자 눈에는 정확히 그 줄이라 원인을 못 찾았다
 for _tag, _body in [("@멘션", "Approved-by: @bill"), ("기호", "Approved-by: bill ✦"),
                     ("NBSP", "Approved-by: bill\xa0"), ("볼드", "**Approved-by: bill**"),

--- a/skills/b3os-release-ops/scripts/approver-check.test.py
+++ b/skills/b3os-release-ops/scripts/approver-check.test.py
@@ -116,7 +116,7 @@ case("★작성자 조회 실패(빈값) → 막는다★", False, SETTINGS,
 case("★안 닫힌 코드펜스 뒤 서명 → 막는다★ (열려 있으면 화면엔 예시로 보인다)", False, SETTINGS,
      [review("질문: 형식이 이거 맞나요?\n\n```\nApproved-by: steve\n")], expect_msg="UNCLOSED code fence")
 case("★안 닫힌 HTML 주석 뒤 서명 → 막는다★ (화면에서는 통째로 사라진다)", False, SETTINGS,
-     [review("리뷰 안 했습니다.\n<!-- 메모\nApproved-by: bill")], expect_msg="UNBALANCED HTML comment")
+     [review("리뷰 안 했습니다.\n<!-- 메모\nApproved-by: bill")], expect_msg="UNCLOSED HTML comment")
 case("★닫힌 주석은 정상 통과★ (막는 건 '안 닫힌 것' 이지 주석 자체가 아니다)", True, SETTINGS,
      [review("<!-- 메모 -->\n확인했습니다.\n\nApproved-by: bill")])
 case("★줄 끝 백슬래시로 중복서명 가드를 우회하지 못한다★", False, SETTINGS,
@@ -144,6 +144,42 @@ case("원인구분: ★push 로 폐기됨(dismiss_stale_reviews)★", False, SET
 case("원인구분: 실제 철회", False, SETTINGS,
      [review("Approved-by: bill", at="2026-07-01T00:00:00Z"),
       review("되돌립니다", state="CHANGES_REQUESTED", at="2026-07-05T00:00:00Z")], expect_msg="withdrawn")
+
+# ══ PR#125 리뷰 — ★네 명이 같은 곳을 짚었다★ (codex·steve·hermes·demis, 2026-07-29) ══
+# ★내가 이 PR 에서 고친 결함을 이 PR 이 새로 만들었다.★ 그래서 여기 전부 시험으로 박는다.
+_B = "`"
+_OPEN, _CLOSE = "<!" + "--", "--" + ">"
+
+# ── 펜스를 ★마크다운 규칙대로★ 세지 않아 뚫렸던 것 (codex BLOCKER, 내가 실측 재현) ──
+#   전에는 ```/~~~ 를 같은 토글로 보고 길이를 안 봐서 ★아래 둘이 통과했다.★
+case("★``` 열고 ~~~ 로 '닫고' 서명 → 막는다★ (여는 문자를 유지해야 한다)", False, SETTINGS,
+     [review(_B * 3 + "\n~~~\nApproved-by: bill")], expect_msg="UNCLOSED code fence")
+case("★```` 열고 ``` 로 '닫고' 서명 → 막는다★ (닫는 펜스가 더 짧으면 안 닫힌다)", False, SETTINGS,
+     [review(_B * 4 + "\n" + _B * 3 + "\nApproved-by: bill")], expect_msg="UNCLOSED code fence")
+# ★4백틱으로 3백틱 예시를 감싸는 건 마크다운에서 펜스를 인용하는 정석이다★ (demis)
+case("★4백틱으로 3백틱 예시를 감싸고 진짜 서명 → 통과★", True, SETTINGS,
+     [review(_B * 4 + "\n예시:\n" + _B * 3 + "\nApproved-by: <이름>\n" + _B * 3 + "\n" + _B * 4 +
+             "\n\nApproved-by: bill")])
+# ★들여쓰기 4칸부터는 펜스가 아니라 '들여쓴 코드블록' 이다★ (마크다운 규칙 · codex·demis)
+#   느슨하게 잡으면 이게 ★안 닫힌 펜스★ 로 보여서 ★뒤의 진짜 서명이 통째로 막힌다.★
+#   ★이 시험이 없으면 들여쓰기 제한을 지워도 아무도 모른다★ (뮤턴트가 잡아줬다).
+case("★4칸 들여쓴 줄은 펜스가 아니다 → 뒤의 서명이 살아있다★", True, SETTINGS,
+     [review("    " + _B * 3 + "\n\nApproved-by: bill")])
+
+# ── ★닫는 토큰만 있으면 아무것도 안 가려진다★ (steve·demis) ──
+#   전에는 `!=` 라 ★표에 흔히 쓰는 화살표 하나로 정당한 승인이 통째로 막혔다★ —
+#   게다가 메시지는 있지도 않은 여는 토큰을 찾으라고 했다(원인을 정반대로 지목).
+case("★산문 속 화살표 하나로 막히지 않는다★", True, SETTINGS,
+     [review("A " + _CLOSE + " B 로 바뀝니다\n\nApproved-by: bill")])
+case("★화살표 여러 개여도 통과★", True, SETTINGS,
+     [review("a " + _CLOSE + " b\nc " + _CLOSE + " d\n\nApproved-by: bill")])
+case("★인라인 코드로 여는 토큰을 언급해도 통과★ (코드 안은 주석을 열지 않는다)", True, SETTINGS,
+     [review("`" + _OPEN + "` 는 주석 시작입니다\n\nApproved-by: bill")])
+case("★닫힌 펜스 안에 주석 예시를 넣어도 통과★ (hermes)", True, SETTINGS,
+     [review(_B * 3 + "\n" + _OPEN + " 숨김 예시\n" + _B * 3 + "\n\nApproved-by: bill")])
+# ★진짜 공격은 그대로 막혀야 한다★ — 위 완화가 방어를 깎지 않았는지 같이 잰다
+case("★여는 토큰이 실제로 남으면 막는다★ (완화가 방어를 깎지 않았다)", False, SETTINGS,
+     [review("리뷰 안 했습니다.\n" + _OPEN + " 메모\nApproved-by: bill")], expect_msg="UNCLOSED HTML comment")
 
 # ★'모양은 맞는데 안 맞다' 를 구분해 말한다★ — 사용자 눈에는 정확히 그 줄이라 원인을 못 찾았다
 for _tag, _body in [("@멘션", "Approved-by: @bill"), ("기호", "Approved-by: bill ✦"),

--- a/skills/b3os-release-ops/scripts/approver-check.test.py
+++ b/skills/b3os-release-ops/scripts/approver-check.test.py
@@ -114,11 +114,16 @@ case("★작성자 조회 실패(빈값) → 막는다★", False, SETTINGS,
 # ★이 넷은 전부 같은 부류다★: 사람이 보는 렌더 결과와 이 도구가 읽는 원문이 다르다.
 #   그래서 변종마다 막지 않고 ★'갈릴 수 있는 상태' 자체를 거부★ 하게 바꿨다.
 case("★안 닫힌 코드펜스 뒤 서명 → 막는다★ (열려 있으면 화면엔 예시로 보인다)", False, SETTINGS,
-     [review("질문: 형식이 이거 맞나요?\n\n```\nApproved-by: steve\n")], expect_msg="UNCLOSED code fence")
+     [review("질문: 형식이 이거 맞나요?\n\n```\nApproved-by: steve\n")], expect_msg="never closed")
 case("★안 닫힌 HTML 주석 뒤 서명 → 막는다★ (화면에서는 통째로 사라진다)", False, SETTINGS,
-     [review("리뷰 안 했습니다.\n<!-- 메모\nApproved-by: bill")], expect_msg="UNCLOSED HTML comment")
+     [review("리뷰 안 했습니다.\n<!-- 메모\nApproved-by: bill")], expect_msg="never closed")
 case("★닫힌 주석은 정상 통과★ (막는 건 '안 닫힌 것' 이지 주석 자체가 아니다)", True, SETTINGS,
      [review("<!-- 메모 -->\n확인했습니다.\n\nApproved-by: bill")])
+# ★위 케이스는 '주석을 걷어낸다' 를 안 재고 있었다★ (내 회귀 하네스가 잡았다):
+#   주석 안에 서명이 없어서 ★걷어내든 말든 결과가 같았다.★ 가드를 지워도 초록이었다.
+#   ★주석 안에 서명을 넣어야 그 가드가 일하는 자리가 된다.★
+case("★닫힌 주석 안의 서명은 세지 않는다★ (주석 제거 가드가 실제로 일하는 자리)", True, SETTINGS,
+     [review("형식 예시입니다:\n<!--\nApproved-by: dex\n-->\n\n확인했습니다.\n\nApproved-by: bill")])
 case("★줄 끝 백슬래시로 중복서명 가드를 우회하지 못한다★", False, SETTINGS,
      [review("Approved-by: dex\\\nApproved-by: bill")], expect_msg="more than one")
 
@@ -139,8 +144,11 @@ case("★작성자 표기가 대문자여도 통과★", True, SETTINGS, [review
 
 # ★'승인 없음' 의 원인을 갈라 말한다★ — 셋이 같은 문장을 내면서 원인을 단언했다
 case("원인구분: 리뷰가 아예 없음", False, SETTINGS, [], expect_msg="no review on this PR at all")
+# ★이 시험은 'DISMISSED' 만 봐서 가드를 안 재고 있었다★ (뮤턴트가 잡았다):
+#   구분을 지워도 폴백 문장에 그 단어가 들어 있어 ★지우든 말든 초록★ 이었다.
+#   ★그 원인일 때만 나오는 안내 문구★ 로 재야 그 갈래가 살아있는지 알 수 있다.
 case("원인구분: ★push 로 폐기됨(dismiss_stale_reviews)★", False, SETTINGS,
-     [review("Approved-by: bill", state="DISMISSED")], expect_msg="DISMISSED")
+     [review("Approved-by: bill", state="DISMISSED")], expect_msg="dismiss_stale_reviews")
 case("원인구분: 실제 철회", False, SETTINGS,
      [review("Approved-by: bill", at="2026-07-01T00:00:00Z"),
       review("되돌립니다", state="CHANGES_REQUESTED", at="2026-07-05T00:00:00Z")], expect_msg="withdrawn")
@@ -153,9 +161,9 @@ _OPEN, _CLOSE = "<!" + "--", "--" + ">"
 # ── 펜스를 ★마크다운 규칙대로★ 세지 않아 뚫렸던 것 (codex BLOCKER, 내가 실측 재현) ──
 #   전에는 ```/~~~ 를 같은 토글로 보고 길이를 안 봐서 ★아래 둘이 통과했다.★
 case("★``` 열고 ~~~ 로 '닫고' 서명 → 막는다★ (여는 문자를 유지해야 한다)", False, SETTINGS,
-     [review(_B * 3 + "\n~~~\nApproved-by: bill")], expect_msg="UNCLOSED code fence")
+     [review(_B * 3 + "\n~~~\nApproved-by: bill")], expect_msg="never closed")
 case("★```` 열고 ``` 로 '닫고' 서명 → 막는다★ (닫는 펜스가 더 짧으면 안 닫힌다)", False, SETTINGS,
-     [review(_B * 4 + "\n" + _B * 3 + "\nApproved-by: bill")], expect_msg="UNCLOSED code fence")
+     [review(_B * 4 + "\n" + _B * 3 + "\nApproved-by: bill")], expect_msg="never closed")
 # ★4백틱으로 3백틱 예시를 감싸는 건 마크다운에서 펜스를 인용하는 정석이다★ (demis)
 case("★4백틱으로 3백틱 예시를 감싸고 진짜 서명 → 통과★", True, SETTINGS,
      [review(_B * 4 + "\n예시:\n" + _B * 3 + "\nApproved-by: <이름>\n" + _B * 3 + "\n" + _B * 4 +
@@ -179,7 +187,48 @@ case("★닫힌 펜스 안에 주석 예시를 넣어도 통과★ (hermes)", Tr
      [review(_B * 3 + "\n" + _OPEN + " 숨김 예시\n" + _B * 3 + "\n\nApproved-by: bill")])
 # ★진짜 공격은 그대로 막혀야 한다★ — 위 완화가 방어를 깎지 않았는지 같이 잰다
 case("★여는 토큰이 실제로 남으면 막는다★ (완화가 방어를 깎지 않았다)", False, SETTINGS,
-     [review("리뷰 안 했습니다.\n" + _OPEN + " 메모\nApproved-by: bill")], expect_msg="UNCLOSED HTML comment")
+     [review("리뷰 안 했습니다.\n" + _OPEN + " 메모\nApproved-by: bill")], expect_msg="never closed")
+
+# ══ 2차 리뷰 — ★개수를 세면 순서를 못 본다★ (codex·hermes BLOCKER) ═══════════════
+# ★고아 닫는 토큰이 뒤에 오는 여는 토큰을 개수상 상쇄했다.★ 렌더링은 앞의 닫는 토큰을
+#   뒤의 여는 토큰에 쓸 수 없는데, 개수 비교는 균형으로 봤다 → ★서명이 화면에서 사라지는데 통과★.
+case("★닫는 토큰이 먼저 나온 뒤 여는 토큰이 열리면 막는다★ (개수는 균형)", False, SETTINGS,
+     [review("표: A " + _CLOSE + " B\n" + _OPEN + " 숨김 시작\nApproved-by: bill")],
+     expect_msg="never closed")
+case("★고아 닫는 토큰만 있으면 통과★ (완화가 살아있는지 같이 잰다)", True, SETTINGS,
+     [review("표: A " + _CLOSE + " B\n\nApproved-by: bill")])
+
+# ── ★내 적대 하네스가 찾은 것 — 내가 이 PR 로 새로 만든 구멍·오차단★ ──
+# ①인라인 코드 제거가 ★줄을 넘어 원문에 없던 서명을 만들어냈다★
+case("★인라인 코드가 줄을 넘어 서명을 만들어내지 않는다★", False, SETTINGS,
+     [review("Approved-by: `\n검토 안 했습니다\n`bill")])
+# ②목록 표시가 붙은 서명이 ★중복으로 안 세어져 두 이름이 통과했다★
+for _mark in ("+ ", "1. ", "　"):
+    case(f"★목록·전각 표시 {_mark.strip() or '전각공백'} 가 붙어도 중복으로 센다★", False, SETTINGS,
+         [review(_mark + "Approved-by: steve\n\nApproved-by: bill")], expect_msg="more than one")
+# ③남의 서명을 ★인용★ 하면 중복으로 세어져 막혔다 — 인용은 내 서명이 아니다
+case("★남의 서명을 인용해도 막히지 않는다★", True, SETTINGS,
+     [review("> Approved-by: steve 라고 하셨는데 그 줄 확인했습니다.\n\nApproved-by: bill")])
+# ④들여쓴 예시를 중복으로 셌다 — TRAILER 는 예시로 보는데 LOOSE 는 안 그래서 ★자기모순★ 이었다
+case("★들여쓴 예시는 중복으로 세지 않는다★ (엄격·느슨 판정이 어긋나면 안 된다)", True, SETTINGS,
+     [review("예시:\n\n    Approved-by: steve\n\nApproved-by: bill")])
+# ★위 둘은 그 가드를 안 재고 있었다★ (뮤턴트가 잡았다): 인용줄·들여쓴 줄은 어차피
+#   느슨 정규식에도 안 걸려서 ★건너뛰기를 지워도 결과가 같았다.★
+#   ★그 건너뛰기가 실제로 일하는 자리는 '서명 뒤에 그런 줄이 올 때'★ 다 — 마지막 줄이 바뀐다.
+case("★서명 뒤의 인용줄은 마지막 줄로 안 친다★ (건너뛰기가 실제로 일하는 자리)", True, SETTINGS,
+     [review("확인했습니다.\n\nApproved-by: bill\n\n> 참고: 위 줄이 서명입니다")])
+case("★서명 뒤의 들여쓴 코드는 마지막 줄로 안 친다★", True, SETTINGS,
+     [review("확인했습니다.\n\nApproved-by: bill\n\n    참고용 코드 조각")])
+# ⑤화면에 없는 주석 안의 펜스 때문에 ★정상 승인이 '펜스를 닫아라' 로 막혔다★ (따를 수 없는 지시)
+case("★주석 안의 펜스는 세지 않는다★ (화면에 없는 것으로 막지 않는다)", True, SETTINGS,
+     [review(_OPEN + "\n" + _B * 3 + "\n" + _CLOSE + "\nApproved-by: bill")])
+# ⑥원인 단언 — ★남이 DISMISS 된 걸 보고 "당신 승인이 폐기됐다" 고 말했다★
+# ★남의 리뷰가 '나중' 이어야 이 가드를 잰다★ (뮤턴트가 잡았다): 남의 것이 앞서면
+#   섞든 안 섞든 마지막이 내 것이라 ★결과가 같아 가드를 안 재고 있었다.★
+case("★남의 리뷰가 나중에 DISMISSED 여도 내 반려를 반려라고 말한다★", False, SETTINGS,
+     [review("고쳐주세요", state="CHANGES_REQUESTED", at="2026-07-02T00:00:00Z"),
+      review("검토중", acct="randomdev", state="DISMISSED", at="2026-07-03T00:00:00Z")],
+     expect_msg="withdrawn")
 
 # ★'모양은 맞는데 안 맞다' 를 구분해 말한다★ — 사용자 눈에는 정확히 그 줄이라 원인을 못 찾았다
 for _tag, _body in [("@멘션", "Approved-by: @bill"), ("기호", "Approved-by: bill ✦"),

--- a/skills/b3os-release-ops/scripts/release-preflight.args.test.sh
+++ b/skills/b3os-release-ops/scripts/release-preflight.args.test.sh
@@ -47,12 +47,23 @@ run --mode bogus
   ok "$RC" 1 "④ 모르는 모드는 거부"
   ok "$(has 'invalid --mode')" yes "④ 이유를 말한다"
 
+# ★hotfix 는 '모르는 모드' 로 뭉뚱그리지 않는다★ (하네스 실측 2026-07-29)
+#   이 모드는 ★받아주는 목록에는 있는데 승인 확인부에는 없어서★ 조용히 건너뛰고 "passed" 를 찍었다.
+#   지우기만 하면 쓰던 사람이 ★"오타인가?" 하고 헤맨다★ — ★무엇으로 바꿔야 하는지까지 말한다.★
+run --mode hotfix
+  ok "$RC" 1 "★④b --mode hotfix 는 거부한다★ (조용한 스킵 경로였다)"
+  ok "$(has 'was removed')" yes "★④b 지웠다고 말한다★"
+  ok "$(has 'Use --mode merge')" yes "★④b 무엇을 쓰라고 알려준다★ (안 알려주면 못 따른다)"
+  ok "$(has 'invalid --mode')" no "④b '모르는 모드' 로 뭉뚱그리지 않는다"
+
 run --nosuchflag
   ok "$RC" 1 "⑤ 모르는 인자는 거부 — 조용히 무시하지 않는다"
 
 run --help
   ok "$RC" 0 "⑥ --help 는 정상 종료"
   ok "$(has 'skip-approver-check')" yes "★⑦ usage 가 이유 필수를 알려준다★ (steve: 안 알려주면 못 따른다)"
+  ok "$(has 'hotfix was REMOVED')" yes "★⑧ usage 가 hotfix 제거를 알려준다★"
+  ok "$(has "must be this branch's own PR")" yes "★⑨ usage 가 --pr 대조를 알려준다★"
 
 echo "  통과 $pass · 실패 $fail"
 [ "$fail" = "0" ]

--- a/skills/b3os-release-ops/scripts/release-preflight.sh
+++ b/skills/b3os-release-ops/scripts/release-preflight.sh
@@ -14,12 +14,15 @@ SETTINGS_URL="${B3OS_SETTINGS_URL:-http://127.0.0.1:7878/team/api/settings}"
 
 usage() {
   cat <<'USAGE'
-Usage: release-preflight.sh [--mode merge|deploy|hotfix|force-push|post-merge] [--base origin/main] [--live-dir PATH]
+Usage: release-preflight.sh [--mode merge|deploy|force-push|post-merge] [--base origin/main] [--live-dir PATH]
        [--pr N] [--settings-url URL] [--skip-approver-check REASON] [--skip-branch-protection] [--allow-main]
+
+  NOTE: --mode hotfix was REMOVED (it skipped the approver check silently). A hotfix uses --mode merge.
+  NOTE: --pr N must be this branch's own PR — it is checked. Omit --pr to derive it from the branch.
 
 Checks:
   - clean git worktree
-  - non-main branch for merge/hotfix unless --allow-main
+  - non-main branch for merge unless --allow-main
   - commits in BASE..HEAD use GitHub noreply author and committer email
   - post-merge origin/main tip uses GitHub noreply author and committer email
   - force-push annotated tags use GitHub noreply tagger email
@@ -79,7 +82,12 @@ is_noreply_email() {
 }
 
 case "$MODE" in
-  merge|deploy|hotfix|force-push|post-merge) ;;
+  merge|deploy|force-push|post-merge) ;;
+  # ★hotfix 를 없앴다★ (하네스 실측 2026-07-29): 받아주는 목록에는 있는데 ★승인 확인부에는 없어서★
+  #   `--mode hotfix` 를 쓰면 ★승인 확인을 조용히 건너뛰고 "passed" 를 찍었다.★ 경고 한 줄도 없었다.
+  #   ★문서 어디에도 이 모드를 쓰라는 절차가 없었다★ — 급할 때도 merge 를 쓰라고 적혀 있다.
+  #   ★안 쓰이는데 받아주기만 하는 이름은 지운다★ (이름만 보고 집기 딱 좋은 자리였다).
+  hotfix) fail "--mode hotfix was removed: it skipped the approver check silently. Use --mode merge (a hotfix still needs an approval); for a real emergency use --mode merge --skip-approver-check \"why\" — that path is loud and recorded" ;;
   *) fail "invalid --mode: $MODE" ;;
 esac
 
@@ -201,16 +209,41 @@ if [ "$MODE" = "merge" ] && [ "$CHECK_APPROVER" -eq 0 ]; then
 fi
 if [ "$MODE" = "merge" ] && [ "$CHECK_APPROVER" -eq 1 ]; then
   command -v gh >/dev/null 2>&1 || fail "gh CLI missing; needed to read PR reviews"
+  PR_WAS_EXPLICIT=1
   if [ -z "$PR_NUMBER" ]; then
+    PR_WAS_EXPLICIT=0
     PR_NUMBER="$(gh pr view --json number --jq .number 2>/dev/null || true)"
   fi
   [ -n "$PR_NUMBER" ] || fail "PR number unknown; pass --pr <n> (or run on a branch with an open PR)"
+
+  # ★승인을 지금 머지하려는 것에 묶는다★ (하네스 실측 2026-07-29)
+  #   예전엔 `--pr N` 을 주면 ★그 PR 이 이 브랜치의 것인지 한 번도 묻지 않았다.★
+  #   → ★예전에 승인받은 아무 PR 번호★ 하나면 ★리뷰 안 받은 브랜치가 통과★ 했다.
+  #   번호를 안 주면 현재 브랜치에서 유도하므로 원래 묶여 있다 — ★손으로 주는 순간 끊겼다.★
+  #   ★그래서 손으로 준 경우에만 대조한다★ (유도한 경우는 이미 같은 것이다).
+  if [ "$PR_WAS_EXPLICIT" -eq 1 ]; then
+    PR_HEAD_REF="$(gh pr view "$PR_NUMBER" --json headRefName --jq .headRefName 2>/dev/null || true)"
+    PR_HEAD_SHA="$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid 2>/dev/null || true)"
+    [ -n "$PR_HEAD_REF" ] || fail "could not read PR #$PR_NUMBER head branch — cannot tie the approval to what is being merged"
+    if [ "$PR_HEAD_REF" != "$BRANCH" ]; then
+      fail "PR #$PR_NUMBER is for branch '$PR_HEAD_REF' but you are on '$BRANCH' — an approval on a different PR does not approve this branch (drop --pr to use this branch's own PR)"
+    fi
+    if [ -n "$PR_HEAD_SHA" ] && [ "$PR_HEAD_SHA" != "$(git rev-parse HEAD)" ]; then
+      fail "PR #$PR_NUMBER head is $(printf '%.7s' "$PR_HEAD_SHA") but local HEAD is $(git rev-parse --short HEAD) — push first so the approval refers to these commits"
+    fi
+    ok "PR #$PR_NUMBER matches this branch ($BRANCH)"
+  fi
 
   SETTINGS_JSON="$(curl -fsS "$SETTINGS_URL" 2>/dev/null || true)"
   # ★설정을 못 읽으면 통과시키지 않는다★ — '확인 불가' 는 '통과' 가 아니다.
   [ -n "$SETTINGS_JSON" ] || fail "settings unreadable at $SETTINGS_URL — cannot verify approver (this is 'unknown', not 'ok')"
 
-  REVIEWS_JSON="$(gh api "repos/$(repo_slug)/pulls/$PR_NUMBER/reviews" --paginate 2>/dev/null || true)"
+  # ★--slurp 를 붙인다★ (하네스 실측 2026-07-29): `--paginate` 는 ★페이지마다 별개 JSON★ 을 이어 붙인다
+  #   (gh 자체 도움말: "Each page is a separate JSON array or object. Pass --slurp to wrap all pages").
+  #   그래서 ★리뷰가 30건 넘는 PR★ 에서 json 파싱이 깨지고 "could not run" 으로 막혔다 —
+  #   ★가장 리뷰가 많은(=가장 중요한) PR 에서 원인불명으로 막히고 --skip 으로 몰린다.★
+  #   --slurp 는 [[page1],[page2]] 로 감싸므로 아래 인코딩 단계에서 평탄화한다.
+  REVIEWS_JSON="$(gh api "repos/$(repo_slug)/pulls/$PR_NUMBER/reviews" --paginate --slurp 2>/dev/null || true)"
   [ -n "$REVIEWS_JSON" ] || fail "could not read reviews for PR #$PR_NUMBER — cannot verify approver"
 
   PR_AUTHOR="$(gh pr view "$PR_NUMBER" --json author --jq .author.login 2>/dev/null || true)"
@@ -220,8 +253,13 @@ if [ "$MODE" = "merge" ] && [ "$CHECK_APPROVER" -eq 1 ]; then
   #   ★stdin 으로 넘긴다★ — argv 면 리뷰가 많은 PR 에서 Argument list too long 이 난다.
   APPROVER_REPORT="$(printf '%s' "$(SETTINGS_JSON="$SETTINGS_JSON" REVIEWS_JSON="$REVIEWS_JSON" PR_AUTHOR="$PR_AUTHOR" "${B3OS_PYTHON:-python3}" -c '
 import json, os, sys
+# ★--slurp 는 페이지를 [[...],[...]] 로 감싼다★ — 한 겹 벗겨서 리뷰 목록으로 만든다.
+#   ★리스트가 아닌 응답은 손대지 않고 그대로 넘긴다★ — 판정기가 "모르면 막는다" 로 처리해야 한다.
+reviews = json.loads(os.environ["REVIEWS_JSON"] or "[]")
+if isinstance(reviews, list) and reviews and all(isinstance(p, list) for p in reviews):
+    reviews = [r for page in reviews for r in page]
 json.dump({"settings": json.loads(os.environ["SETTINGS_JSON"]),
-           "reviews": json.loads(os.environ["REVIEWS_JSON"] or "[]"),
+           "reviews": reviews,
            "pr_author": os.environ.get("PR_AUTHOR", "")}, sys.stdout)
 ' 2>/dev/null)" | "${B3OS_PYTHON:-python3}" "$(dirname "$0")/approver-check.py" 2>/dev/null || true)"
   # ★판정이 안 일어났으면 통과가 아니다★ — 파이썬이 없거나 죽으면 빈 문자열이 온다.
@@ -258,4 +296,14 @@ if [ "$MODE" = "force-push" ]; then
   warn "force-push/history rewrite still requires GD approval, backup, secret scan, 2-person or harness review, and rollback commands"
 fi
 
-ok "release preflight passed"
+# ★마지막 줄에 '무엇을 어떤 범위로 봤나' 를 같이 찍는다★ (하네스 실측 2026-07-29)
+#   예전엔 "release preflight passed" 한 줄이라 ★--base 로 범위를 좁혔는지 보고만 봐서는 알 수 없었다★
+#   (--base HEAD~1 이면 그 앞 커밋의 실메일 유출이 감사에서 통째로 빠지는데 출력은 똑같았다).
+#   ★우회 사실도 stdout 에 남긴다★ — 예전엔 stderr 에만 있어서
+#   ★stdout 만 캡처하거나 종료코드만 보는 호출자에겐 우회가 안 보였다.★
+SUMMARY="release preflight passed (mode=$MODE"
+[ "$MODE" = "deploy" ] || [ "$MODE" = "post-merge" ] || SUMMARY="$SUMMARY, base=$BASE"
+[ -n "${SKIPPED_NOTE:-}" ] && SUMMARY="$SUMMARY, ★APPROVER CHECK SKIPPED: $SKIP_REASON★"
+[ "$SETTINGS_URL" = "http://127.0.0.1:7878/team/api/settings" ] || SUMMARY="$SUMMARY, ★non-default settings source: $SETTINGS_URL★"
+[ -z "${B3OS_PYTHON:-}" ] || SUMMARY="$SUMMARY, ★non-default python: $B3OS_PYTHON★"
+ok "$SUMMARY)"

--- a/skills/b3os-release-ops/scripts/release-preflight.sh
+++ b/skills/b3os-release-ops/scripts/release-preflight.sh
@@ -221,18 +221,22 @@ if [ "$MODE" = "merge" ] && [ "$CHECK_APPROVER" -eq 1 ]; then
   #   → ★예전에 승인받은 아무 PR 번호★ 하나면 ★리뷰 안 받은 브랜치가 통과★ 했다.
   #   번호를 안 주면 현재 브랜치에서 유도하므로 원래 묶여 있다 — ★손으로 주는 순간 끊겼다.★
   #   ★그래서 손으로 준 경우에만 대조한다★ (유도한 경우는 이미 같은 것이다).
+  PR_HEAD_REF="$(gh pr view "$PR_NUMBER" --json headRefName --jq .headRefName 2>/dev/null || true)"
+  PR_HEAD_SHA="$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid 2>/dev/null || true)"
+  # 브랜치 대조는 ★손으로 준 경우에만★ 의미가 있다(유도한 경우는 이미 이 브랜치의 PR 이다).
   if [ "$PR_WAS_EXPLICIT" -eq 1 ]; then
-    PR_HEAD_REF="$(gh pr view "$PR_NUMBER" --json headRefName --jq .headRefName 2>/dev/null || true)"
-    PR_HEAD_SHA="$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid 2>/dev/null || true)"
     [ -n "$PR_HEAD_REF" ] || fail "could not read PR #$PR_NUMBER head branch — cannot tie the approval to what is being merged"
     if [ "$PR_HEAD_REF" != "$BRANCH" ]; then
       fail "PR #$PR_NUMBER is for branch '$PR_HEAD_REF' but you are on '$BRANCH' — an approval on a different PR does not approve this branch (drop --pr to use this branch's own PR)"
     fi
-    if [ -n "$PR_HEAD_SHA" ] && [ "$PR_HEAD_SHA" != "$(git rev-parse HEAD)" ]; then
-      fail "PR #$PR_NUMBER head is $(printf '%.7s' "$PR_HEAD_SHA") but local HEAD is $(git rev-parse --short HEAD) — push first so the approval refers to these commits"
-    fi
-    ok "PR #$PR_NUMBER matches this branch ($BRANCH)"
   fi
+  # ★커밋 대조는 어느 쪽이든 한다★ (codex): 번호를 유도했더라도 ★로컬에 안 올린 커밋★ 이 있으면
+  #   승인은 ★올라간 커밋★ 에 대한 것이고 머지되는 건 다른 것이 된다. 유도했다고 묶인 게 아니다.
+  [ -n "$PR_HEAD_SHA" ] || fail "could not read PR #$PR_NUMBER head commit — cannot tie the approval to these commits"
+  if [ "$PR_HEAD_SHA" != "$(git rev-parse HEAD)" ]; then
+    fail "PR #$PR_NUMBER head is $(printf '%.7s' "$PR_HEAD_SHA") but local HEAD is $(git rev-parse --short HEAD) — push first so the approval refers to the commits being merged"
+  fi
+  ok "PR #$PR_NUMBER is this branch ($BRANCH) at $(git rev-parse --short HEAD)"
 
   SETTINGS_JSON="$(curl -fsS "$SETTINGS_URL" 2>/dev/null || true)"
   # ★설정을 못 읽으면 통과시키지 않는다★ — '확인 불가' 는 '통과' 가 아니다.

--- a/skills/b3os-release-ops/scripts/release-preflight.sh
+++ b/skills/b3os-release-ops/scripts/release-preflight.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# b3os release preflight — merge/deploy/hotfix/force-push gate checks.
+# b3os release preflight — merge/deploy/force-push/post-merge gate checks.
 set -euo pipefail
 
 MODE="merge"
@@ -117,14 +117,14 @@ ok "worktree clean"
 
 BRANCH="$(git branch --show-current)"
 if [ "$ALLOW_MAIN" -ne 1 ] && [ "$MODE" != "deploy" ] && [ "$MODE" != "post-merge" ]; then
-  [ "$BRANCH" != "main" ] || fail "do not merge/hotfix directly from main"
+  [ "$BRANCH" != "main" ] || fail "do not merge directly from main"
 fi
 ok "branch check: ${BRANCH:-detached}"
 
 git fetch origin main -q || fail "git fetch origin main failed"
 git rev-parse --verify "$BASE" >/dev/null 2>&1 || fail "base not found: $BASE"
 
-if [ "$MODE" = "merge" ] || [ "$MODE" = "hotfix" ] || [ "$MODE" = "force-push" ]; then
+if [ "$MODE" = "merge" ] || [ "$MODE" = "force-push" ]; then
   AHEAD_COUNT="$(git rev-list --count "$BASE"..HEAD)"
   if [ "$MODE" != "force-push" ]; then
     [ "$AHEAD_COUNT" -gt 0 ] || fail "no commits ahead of $BASE"
@@ -307,7 +307,7 @@ fi
 #   ★stdout 만 캡처하거나 종료코드만 보는 호출자에겐 우회가 안 보였다.★
 SUMMARY="release preflight passed (mode=$MODE"
 [ "$MODE" = "deploy" ] || [ "$MODE" = "post-merge" ] || SUMMARY="$SUMMARY, base=$BASE"
-[ -n "${SKIPPED_NOTE:-}" ] && SUMMARY="$SUMMARY, ★APPROVER CHECK SKIPPED: $SKIP_REASON★"
-[ "$SETTINGS_URL" = "http://127.0.0.1:7878/team/api/settings" ] || SUMMARY="$SUMMARY, ★non-default settings source: $SETTINGS_URL★"
-[ -z "${B3OS_PYTHON:-}" ] || SUMMARY="$SUMMARY, ★non-default python: $B3OS_PYTHON★"
+[ -n "${SKIPPED_NOTE:-}" ] && SUMMARY="$SUMMARY, ★APPROVER CHECK SKIPPED: ${SKIP_REASON}★"
+[ "$SETTINGS_URL" = "http://127.0.0.1:7878/team/api/settings" ] || SUMMARY="$SUMMARY, ★non-default settings source: ${SETTINGS_URL}★"
+[ -z "${B3OS_PYTHON:-}" ] || SUMMARY="$SUMMARY, ★non-default python: ${B3OS_PYTHON}★"
 ok "$SUMMARY)"


### PR DESCRIPTION
하네스 실측(소넷·오퍼스 각 3개, 대상 3파일)에서 나온 것 중 **코드로 고칠 수 있는 8건**.
전부 재현 입력이 시험으로 들어가 있고, 되돌리면 빨개지는지(뮤턴트)까지 확인했다.

## 근본은 하나였다 — ★사람이 보는 화면과 이 도구가 읽는 원문이 갈린다★

부정 통과 4건 중 3건이 같은 부류였다. 그래서 **변종마다 막지 않고 '갈릴 수 있는 상태' 자체를 거부**한다.
(이 파일의 계약이 원래 "모르면 막는다" 다 — 그 계약을 이 자리에도 적용했다.)

| 입력 | 화면에 보이는 것 | 이 도구가 읽던 것 |
|---|---|---|
| 안 닫힌 ``` 뒤 서명 | 코드 예시 | **마지막 줄 = 서명** |
| 안 닫힌 `<!--` 뒤 서명 | **아무것도 안 보임** | **마지막 줄 = 서명** |
| 줄 끝 `\` + 서명 두 줄 | 서명 두 줄 | **한 줄** (중복 검사가 못 셈) |

## 고친 것

### 부정 통과 — 승인 없이 통과하던 경로
- **안 닫힌 코드펜스 / 안 닫힌 HTML 주석** → 서명을 읽기 전에 거부
- **줄 끝 백슬래시로 중복 서명 가드 우회** → **잡는 그물(중복)은 넓게, 인정하는 형식(서명)은 좁게**로 분리.
  엄격 정규식은 줄 끝이 `[ \t]*$` 라 `\` 로 끝나는 줄을 못 세었다
- **`--mode hotfix`** → 삭제. 받아주는 목록에는 있는데 **승인 확인부에는 없어서** 조용히 건너뛰고 `passed` 를 찍었다.
  문서 어디에도 이 모드를 쓰라는 절차가 없다(급할 때도 `merge` 를 쓰라고 적혀 있다).
  **지우기만 하면 쓰던 사람이 "오타인가?" 하고 헤매므로 무엇으로 바꿔야 하는지까지 말한다**
- **`--pr N` 이 브랜치와 무관** → 손으로 준 경우 **PR 의 head 브랜치·SHA 를 현재 것과 대조**.
  번호를 안 주면 브랜치에서 유도하므로 원래 묶여 있었다 — **손으로 주는 순간 끊겼다**

### 오차단 — 정당한 승인이 막히던 경로
- **제3자 APPROVED 하나가 하드 실패** → 이 저장소는 public 이라 아무나 남길 수 있다.
  자격은 승인 계정에만 두되 **남의 승인은 무시하고, 무시했다는 사실은 통과할 때도 찍는다**(조용히 버리지 않는다).
  기존 메시지는 *"승인 계정에서 승인이 안 왔다"* 로 읽혀 **원인을 정반대로 지목**했다
- **규약을 알려주는 SKILL.md 의 예시를 인용하면 "중복 서명" 으로 막힘** → 닫힌 펜스·주석 안은 예시로 보고 세지 않는다.
  **규칙을 지키려고 문서를 인용한 사람이 막히던 자리다**
- **계정 비교만 대소문자를 구분** → 이름은 접고 계정은 안 접는 비일관이었다.
  설정에 `GD452` 로 저장되면(PUT 검증이 대문자를 허용한다) 그 순간부터 머지가 영구 차단된다
- **리뷰 30건 초과 PR 이 영구 실패** → `gh api --paginate` 는 **페이지마다 별개 JSON** 이다
  (gh 자체 도움말: *"Each page is a separate JSON array or object. Pass `--slurp`…"*).
  **가장 리뷰가 많은(=가장 중요한) PR 에서 원인불명으로 막히고 `--skip` 으로 몰린다**

### 보이게 하기
- **'승인 없음' 세 원인이 같은 문장** 이었고, 그 문장이 *"나중 CHANGES_REQUESTED 가 덮었다"* 로 **원인을 단언**했다.
  라이브가 `dismiss_stale_reviews: true` 라 **push 할 때마다 폐기 경로를 타는데**, 가장 흔한 실패에 틀린 원인을 말하고 있었다
- **모양은 맞는데 안 맞는 서명**(`@멘션`·기호·NBSP·전각공백·`**볼드**`·리스트 하이픈) → 무엇이 문제인지 말한다.
  전부 같은 메시지였고 그 메시지는 *"마지막 줄이 `Approved-by: <name>` 이 아니다"* 인데 **사용자 눈에는 정확히 그 줄이다**
- **FAIL 인데 종료코드 0** → 1. 현 호출부는 stdout 접두사를 보므로 영향 없다
- **마지막 줄에 `mode`·`base`·우회·비기본 설정 출처를 찍는다** — 우회 기록이 **stderr 에만** 있어
  stdout 만 캡처하거나 종료코드만 보는 호출자에겐 **우회가 안 보였다**

## 검증

| 무엇 | 결과 |
|---|---|
| 판정기 시험 | **48건 통과** (신규 15건) |
| 뮤턴트 | **17종 전부 잡힘** — 신규 가드 7개 포함 |
| 인자 시험 | **18건 통과** (신규 6건) |
| bash 3.2 구문 | 통과 (macOS 기본 셸) |
| `--slurp` 평탄화 | 4가지 입력 모양 확인 (페이지 나뉨·단일 배열·빈 것·에러 객체) |
| **실제 PR 로 종단 확인** | PR #124 의 진짜 승인 → `OK approved by bill`, 종료코드 0 |
| **새 가드 종단 확인** | 다른 브랜치의 `--pr 124` → 거부, 종료코드 1 / `--mode hotfix` → 거부, 종료코드 1 |

## ★고치지 않은 것 — 알면서 남긴다★

**산문 속 리터럴 `\n` 이 가짜 마지막 줄을 만드는 경로는 못 막았다.**
`"형식은 이렇게 씁니다: 확인함.\nApproved-by: steve"` 가 서명으로 읽힌다.

**왜 안 고쳤나**: 이 정규화는 [PR#103 실측] 때문에 **필요해서 되돌린 것**이다
(그 PR 승인 본문은 진짜 개행 0개·리터럴 11개였다 — 우리 팀 도구 중 그렇게 쓰는 게 있다).
그리고 **정상 형태와 공격 형태가 문자열상 구분되지 않는다** — 둘 다 `…\nApproved-by: <이름>` 이다.
억지로 막으면 그 클라이언트로는 서명 자체가 불가능해진다.

**반쪽인 걸 아는 것과 반쪽이라고 적어두는 것은 다르다**(steve) — 그래서 여기 적는다.
이 게이트의 목적은 **기록이지 작정한 사람을 막는 것이 아니다**(GD 결정)는 전제에서, 이건 사고 위험이고 우선순위가 낮다.

## 이 PR 로 안 고치는 것 (별건)

- **이 맥에 승인 확인이 없는 옛 사본 20벌** — 코드로 못 고친다(옛 사본에는 그 코드가 없다). GD 판단 대기
- **`B3OS_SETTINGS_URL`·`B3OS_PYTHON` 으로 판정 기준·판정기 자체를 바꿀 수 있음** — 신뢰 경계 문제.
  이번엔 **비기본값이면 마지막 줄에 크게 찍는 것**까지만 했다
- **승인 리뷰의 `commit_id` 미검사** — 현재는 `dismiss_stale_reviews: true` 가 GitHub 쪽에서 막고 있다(플랫폼 의존)
- **`src/server/lib/approvals.ts` 쪽 8건** — 다른 subsystem 이고 그중 3건은 지금 라이브에서 성립한다. 따로 올린다

Reviewed-by: bill
