### PR TITLE
fix(bus): '응답하지 못했습니다' 가 재위임을 유도해 중복작업을 낼 뻔했다 (리사 신고)

### DIFF
--- a/docs/TEAM_COMMUNICATION.md
+++ b/docs/TEAM_COMMUNICATION.md
@@ -78,7 +78,7 @@ b3os에는 사람이 쓰는 채팅앱이 없다. AI 팀원들은 **팀버스(tea
    - `buildDispatchPlan`이 스킵 게이트들 통과: unknown→dead_letter, owner-set→completed, ack-only→completed, 핑퐁→blocked(§4), broadcast인데 `@all/@group` 마커 없음→inbox-only(안 깨움).
    - 런타임→어댑터: `claude_channel`→tmux 주입 / `openclaw`→게이트웨이 브리지 / `hermes`→one-shot 스폰 / `codex`·`b3os_native`→브리지.
    - `buildTeamContext`가 최근 대화 ≤6건을 붙임(§2-3).
-5. **결과 기록** — 성공→`wake_dispatched`, 미룸→`deferred`(backoff, 20회 초과→blocked), 예외→`failed`(재시도 backoff 1→2→4초, 3회 초과→dead_letter). openclaw/hermes는 ★expire-no-retry★(턴이 이미 발신했을 수 있어 재시도하면 중복). 실패 시 요청자에게 "[전달 실패]" 시스템 메시지 주입(영원히 안 기다리게).
+5. **결과 기록** — 성공→`wake_dispatched`, 미룸→`deferred`(backoff, 20회 초과→blocked), 예외→`failed`(재시도 backoff 1→2→4초, 3회 초과→dead_letter). openclaw/hermes는 ★expire-no-retry★(턴이 이미 발신했을 수 있어 재시도하면 중복). 응답이 시간 안에 안 오면 요청자에게 ★"[응답 대기]"★ 시스템 메시지 주입(영원히 안 기다리게). ★"실패" 가 아니라 "아직 안 왔다" 다★ — 상대가 작업 중일 수 있으므로 그 메시지는 ★재위임 전에 상대 작업물(브랜치·PR·카드)을 먼저 확인하라★ 고 안내한다 (2026-07-29 실사고: 옛 문구가 "응답하지 못했다" 라 요청자가 재위임했고 상대는 이미 끝내놓은 상태였다).
 
 ### 1-5. 실사례 A — "Bill이 Steve에게 질문"
 

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -599,7 +599,12 @@ function makeOpenclawAdapter(db: Database, agents: () => AgentRecord[]): WakeAda
             hopCount: row.hop_count,
             kind: oDirectedKind,
             });
-          return { ok, detail: "openclaw_directed_injected" };
+          // ★성공과 실패가 같은 코드를 쓰면 안 된다★ (리사 실측, 2026-07-29)
+          //   ok 가 false 여도 detail 이 "…injected" 라서 ★실패 통지에 성공 코드가 박혀 나갔다.★
+          //   받는 사람은 원인을 알 수 없고, 기록으로도 성공·실패를 못 가른다.
+          return ok
+            ? { ok, detail: "openclaw_directed_injected" }
+            : { ok, detail: "openclaw_directed_no_response_in_window" };
         } catch (e) {
           return { ok: false, detail: `openclaw_directed_error:${e instanceof Error ? e.message : String(e)}` };
         }
@@ -1362,9 +1367,16 @@ function notifyRequesterOfExpiry(
     if (!requester || requester === row.agent_id) return;
     if (!agents.some((a) => a.id === requester)) return;
 
+    // ★문구가 사실과 달라서 실제 중복작업을 낼 뻔했다★ (리사 실측, 2026-07-29)
+    //   리사가 clo 에게 위임 → clo 는 ★받아서 작업 중★ → 이 통지가 "응답하지 못했습니다" 를 보냄
+    //   → 리사가 미착수로 판단해 herm 에게 ★재위임★ → 그 사이 clo 가 ★정상 완료(PR 생성)★
+    //   → herm 이 중복 작업 직전, 리사가 저장소를 직접 확인해서 막았다.
+    //   ★실제 뜻은 "정해진 대기 시간 안에 응답이 안 왔다" 이지 "못 했다" 가 아니다.★
+    //   그리고 이 문구가 ★"없이 마감해도 된다" 고 권했다★ — 리사는 그 말대로 한 것이다.
     const body =
-      `[전달 실패] ${row.agent_id} 가 응답하지 못했습니다 (${reason}). ` +
-      `이 요청은 재시도되지 않습니다 — ${row.agent_id} 없이 마감하셔도 됩니다. ` +
+      `[응답 대기] ${row.agent_id} 에게서 아직 응답이 없습니다 — 대기 시간 초과 (${reason}). ` +
+      `${row.agent_id} 가 작업 중일 수 있습니다: ★다시 시키기 전에 그쪽 작업물(브랜치·PR·카드)을 먼저 확인하세요.★ ` +
+      `이 요청은 자동 재시도되지 않습니다 — 확인 후 ${row.agent_id} 없이 마감하셔도 됩니다. ` +
       `(수집이면 ${row.agent_id} 를 '미응답' 으로 명시하고 나머지로 종합하세요)`;
 
     const msg = insertMessage(db, {


### PR DESCRIPTION
## 실제로 일어난 일 — 리사(b3rys-translate 대표), 오늘

1. 리사가 **clo 에게 위임** → clo 가 **받아서 작업 시작**
2. 시스템: **"전달 실패 — clo 가 응답하지 못했습니다"**
3. 리사: 미착수구나 → **herm 에게 재위임**
4. 그 사이 **clo 가 정상 완료**(PR 생성)
5. **herm 이 중복 작업 직전**, 리사가 저장소를 직접 확인해서 막음

**추정이 아니라 실제 사고입니다.** 리사가 근거(파일:줄)까지 짚어 넘겼고, 제가 코드로 확인했습니다.

## 원인 두 가지

**① 성공과 실패가 같은 코드를 썼다** — `wakeDispatcher.ts:602`
`ok` 가 true 든 false 든 detail 이 `openclaw_directed_injected` 였습니다.
→ **실패 통지에 성공 코드가 박혀 나가고**, 기록으로도 성공·실패를 못 가릅니다.

**② 문구가 사실과 달랐다** — `wakeDispatcher.ts:1366`
실제 뜻은 **"정해진 대기 시간 안에 응답이 안 왔다"** 인데 **"응답하지 못했습니다"** 로 읽힙니다.
게다가 그 문구가 **"없이 마감하셔도 됩니다" 라고 권했습니다** — 리사는 그 말대로 한 것입니다.

## 고친 것

| | 전 | 후 |
|---|---|---|
| 실패 코드 | `openclaw_directed_injected` (성공과 동일) | `openclaw_directed_no_response_in_window` |
| 문구 | `[전달 실패] X 가 응답하지 못했습니다` | `[응답 대기] X 에게서 아직 응답이 없습니다 — 대기 시간 초과` |
| 안내 | "없이 마감하셔도 됩니다" | **"다시 시키기 전에 그쪽 작업물(브랜치·PR·카드)을 먼저 확인하세요"** + 확인 후 마감 가능 |

## 안 건드린 것

`syncPolicy.ts:88` 도 "전달 실패" 를 쓰지만 **dead_letter(진짜 배달 불가) 경로**라 문구가 맞습니다. **다른 조건입니다.**

## 검증

- `tsc --noEmit` 오류 0건
- **bus 시험 299건 통과**
- **이 문구를 기대하는 시험이 있는지 전수 확인** — 없음

## 봐줬으면 하는 것

- 새 문구가 **반대 방향으로 오해를 만들지 않나** ("기다리면 오나 보다" 하고 무한정 기다리게)
- 실패 코드를 나눈 것이 **다른 소비처를 깨지 않나** (`openclaw_directed_injected` 를 문자열로 보는 곳)

Reviewed-by: bill