### PR TITLE
fix(bus): '응답하지 못했습니다' 가 재위임을 유도해 중복작업을 낼 뻔했다 (리사 신고)

### DIFF
--- a/docs/TEAM_COMMUNICATION.md
+++ b/docs/TEAM_COMMUNICATION.md
@@ -78,7 +78,7 @@ b3os에는 사람이 쓰는 채팅앱이 없다. AI 팀원들은 **팀버스(tea
    - `buildDispatchPlan`이 스킵 게이트들 통과: unknown→dead_letter, owner-set→completed, ack-only→completed, 핑퐁→blocked(§4), broadcast인데 `@all/@group` 마커 없음→inbox-only(안 깨움).
    - 런타임→어댑터: `claude_channel`→tmux 주입 / `openclaw`→게이트웨이 브리지 / `hermes`→one-shot 스폰 / `codex`·`b3os_native`→브리지.
    - `buildTeamContext`가 최근 대화 ≤6건을 붙임(§2-3).
-5. **결과 기록** — 성공→`wake_dispatched`, 미룸→`deferred`(backoff, 20회 초과→blocked), 예외→`failed`(재시도 backoff 1→2→4초, 3회 초과→dead_letter). openclaw/hermes는 ★expire-no-retry★(턴이 이미 발신했을 수 있어 재시도하면 중복). 실패 시 요청자에게 "[전달 실패]" 시스템 메시지 주입(영원히 안 기다리게).
+5. **결과 기록** — 성공→`wake_dispatched`, 미룸→`deferred`(backoff, 20회 초과→blocked), 예외→`failed`(재시도 backoff 1→2→4초, 3회 초과→dead_letter). openclaw/hermes는 ★expire-no-retry★(턴이 이미 발신했을 수 있어 재시도하면 중복). 응답이 시간 안에 안 오면 요청자에게 ★"[응답 대기]"★ 시스템 메시지 주입(영원히 안 기다리게). ★"실패" 가 아니라 "아직 안 왔다" 다★ — 상대가 작업 중일 수 있으므로 그 메시지는 ★재위임 전에 상대 작업물(브랜치·PR·카드)을 먼저 확인하라★ 고 안내한다 (2026-07-29 실사고: 옛 문구가 "응답하지 못했다" 라 요청자가 재위임했고 상대는 이미 끝내놓은 상태였다).
 
 ### 1-5. 실사례 A — "Bill이 Steve에게 질문"
 

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -599,7 +599,12 @@ function makeOpenclawAdapter(db: Database, agents: () => AgentRecord[]): WakeAda
             hopCount: row.hop_count,
             kind: oDirectedKind,
             });
-          return { ok, detail: "openclaw_directed_injected" };
+          // ★성공과 실패가 같은 코드를 쓰면 안 된다★ (리사 실측, 2026-07-29)
+          //   ok 가 false 여도 detail 이 "…injected" 라서 ★실패 통지에 성공 코드가 박혀 나갔다.★
+          //   받는 사람은 원인을 알 수 없고, 기록으로도 성공·실패를 못 가른다.
+          return ok
+            ? { ok, detail: "openclaw_directed_injected" }
+            : { ok, detail: "openclaw_directed_no_response_in_window" };
         } catch (e) {
           return { ok: false, detail: `openclaw_directed_error:${e instanceof Error ? e.message : String(e)}` };
         }
@@ -1362,9 +1367,16 @@ function notifyRequesterOfExpiry(
     if (!requester || requester === row.agent_id) return;
     if (!agents.some((a) => a.id === requester)) return;
 
+    // ★문구가 사실과 달라서 실제 중복작업을 낼 뻔했다★ (리사 실측, 2026-07-29)
+    //   리사가 clo 에게 위임 → clo 는 ★받아서 작업 중★ → 이 통지가 "응답하지 못했습니다" 를 보냄
+    //   → 리사가 미착수로 판단해 herm 에게 ★재위임★ → 그 사이 clo 가 ★정상 완료(PR 생성)★
+    //   → herm 이 중복 작업 직전, 리사가 저장소를 직접 확인해서 막았다.
+    //   ★실제 뜻은 "정해진 대기 시간 안에 응답이 안 왔다" 이지 "못 했다" 가 아니다.★
+    //   그리고 이 문구가 ★"없이 마감해도 된다" 고 권했다★ — 리사는 그 말대로 한 것이다.
     const body =
-      `[전달 실패] ${row.agent_id} 가 응답하지 못했습니다 (${reason}). ` +
-      `이 요청은 재시도되지 않습니다 — ${row.agent_id} 없이 마감하셔도 됩니다. ` +
+      `[응답 대기] ${row.agent_id} 에게서 아직 응답이 없습니다 — 대기 시간 초과 (${reason}). ` +
+      `${row.agent_id} 가 작업 중일 수 있습니다: ★다시 시키기 전에 그쪽 작업물(브랜치·PR·카드)을 먼저 확인하세요.★ ` +
+      `이 요청은 자동 재시도되지 않습니다 — 확인 후 ${row.agent_id} 없이 마감하셔도 됩니다. ` +
       `(수집이면 ${row.agent_id} 를 '미응답' 으로 명시하고 나머지로 종합하세요)`;
 
     const msg = insertMessage(db, {


### PR DESCRIPTION
★#126 을 팀 계정으로 다시 연 것입니다★ — 내용 동일, 커밋 동일(3c1a650).

**왜 다시 여나**: 제가 #126 을 ★승인 계정(gd452)으로 열었습니다.★ 규칙은 ★작성=gdb3rys · 승인=gd452★ 인데 반대로 했습니다. 승인자 게이트가 그걸 잡았습니다. **게이트가 제 실수를 잡은 것이라 우회하지 않고 다시 엽니다.**

## 실제로 일어난 일 — 리사, 오늘

1. 리사가 **clo 에게 위임** → clo 가 **받아서 작업 시작**
2. 시스템: **"전달 실패 — clo 가 응답하지 못했습니다"**
3. 리사: 미착수구나 → **herm 에게 재위임**
4. 그 사이 **clo 가 정상 완료**(PR 생성)
5. **herm 이 중복 작업 직전**, 리사가 저장소를 직접 확인해서 막음

**추정이 아니라 실제 사고입니다.**

## 고친 것

| | 전 | 후 |
|---|---|---|
| 실패 코드 | 성공과 동일 | 별도 코드로 분리 |
| 문구 | `[전달 실패] X 가 응답하지 못했습니다` | `[응답 대기] X 에게서 아직 응답이 없습니다 — 대기 시간 초과` |
| 안내 | "없이 마감하셔도 됩니다" | **"다시 시키기 전에 그쪽 작업물을 먼저 확인하세요"** |
| 문서 | 옛 문구를 안내 | 새 문구 + **실사고 경위** (demis 권고) |

**문서를 같이 고친 이유**: 이 사고 자체가 **그 안내를 따라서** 생겼습니다. 코드만 고치면 다음 사람이 같은 판단을 합니다.

## 리뷰 (#126 에서 완료 — ★각도를 나눠서★)

- **demis — 코드 소비처**: 깨지는 곳 **0건**. 위험 가설(라우팅이 접두어를 보나?)을 먼저 쳐서 제외
- **codex — 실제 버스 동작**: 격리 사본에서 전 경로 실행, **실제 본문까지 관측** (38 pass)
- **steve — 읽는 사람**: 반대 오해 낮음(본문이 '닫아도 된다' 를 세 번 말함). **3c1a650 재승인 완료**

## 안 넣은 것 (기록)

- steve 제안 `[응답 대기 — 확인 필요]` — **본인이 '다음에' 라고 함**
- codex 메모: 실패 원인이 둘인데 새 이름도 완전 분류는 아님. **기존보다 낫고 사용자 문구는 단정하지 않아** 이번엔 그대로
- `wakeDispatcher.ts:408·425` 주석이 아직 옛 이름으로 설명 (steve) — 후속

## 검증

`tsc --noEmit` 0건 · **bus 시험 299건 통과** · 옛 문구 기대 시험 **0건**(steve·demis 독립 확인)

Reviewed-by: bill
