### PR TITLE
feat(codex cli): 승인 팝업이 사람에게 읽히게 — 화면과 열쇠가 같은 줄이었다 (#106 S3)

### DIFF
--- a/src/server/runtimes/codex/appServerPopup.s1.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s1.test.ts
@@ -105,6 +105,7 @@ describe("S1 — 신세대 명령 승인 해석", () => {
     };
     const op = buildOperationFromApproval(req, "dex");
     expect(op.action).toBe("write");
-    expect(op.path).toBe("a.ts|b.ts"); // 정렬된 전체 파일집합
+    // ★S3 에서 표시 형식이 바뀌었다★ — 파일집합(정렬)은 그대로이고 사람이 읽을 말과 지문이 붙었다.
+    expect(op.path).toMatch(/^파일 2개 · change a\.ts, change b\.ts #[0-9a-f]{12}$/);
   });
 });

--- a/src/server/runtimes/codex/appServerPopup.s2.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s2.test.ts
@@ -36,8 +36,10 @@ describe("S2 — 신세대 파일변경 승인 해석", () => {
   test("★짝지어진 알림이 있으면 실제 파일을 쓰기 작업으로 해석한다★", () => {
     const op = buildOperationFromApproval(fileReq(observed([["src/a.ts", "update", 3]])), "dex");
     expect(op.action).toBe("write");
-    expect(op.path).toBe("src/a.ts");
-    expect(targetForOperation(op)).toBe("src/a.ts"); // 지문이 아니라 사람이 읽는 경로
+    // ★S3 — 이 한 줄이 화면이다.★ targetForOperation 이 text 가 아니라 path 를 쓰므로(우선순위
+    //   command > path > egress_url > text), path 자체가 사람이 읽을 말이어야 한다.
+    expect(op.path).toMatch(/^파일 1개 · update src\/a\.ts #[0-9a-f]{12}$/);
+    expect(targetForOperation(op)).toBe(op.path); // 화면에 그대로 나온다(240자 안)
   });
 
   test("사람이 규모를 볼 수 있다 — 종류·경로·줄수 요약", () => {
@@ -163,7 +165,7 @@ describe("S2 — 라이브 실측 재생", () => {
     expect(hit).not.toBeNull(); // ★여기가 깨지면 실물에서 전부 ask 로 떨어진다★
     const op = buildOperationFromApproval({ ...LIVE_APPROVAL, observedItem: hit! }, "dex");
     expect(op.action).toBe("write");
-    expect(op.path).toBe("/tmp/s2probe/target.txt");
+    expect(op.path).toMatch(/^파일 1개 · update \/tmp\/s2probe\/target\.txt #[0-9a-f]{12}$/);
     expect(op.text).toContain("update /tmp/s2probe/target.txt(+1/-2)");
     expect(op.provenance?.grant_root).toBeNull();
   });
@@ -209,9 +211,13 @@ describe("S2 — grantRoot 는 별개 승인이다", () => {
     const many = Array.from({ length: 40 }, (_, i) => [`src/very/long/path/file${i}.ts`, "update", 1] as [string, string, number]);
     const rooted = buildOperationFromApproval(fileReq(observed(many), { grantRoot: "/repo" }), "dex");
     const plain = buildOperationFromApproval(fileReq(observed(many)), "dex");
-    expect(targetForOperation(rooted).length).toBe(240); // 실제로 잘렸다
-    // 열쇠에는 ★전체 루트의 지문★ 이 맨 앞에 온다(P2 수정) — 원문만 앞에 두면 긴 루트끼리 충돌한다.
-    expect(targetForOperation(rooted)).toMatch(/^grant_root#[0-9a-f]{16}=\/repo/);
+    // ★파일 목록이 예산을 넘겼다★ — 예전엔 단어 중간에서 잘려 "몇 개를 못 보고 있는지" 가 사라졌다.
+    expect(targetForOperation(rooted)).toContain("…외");
+    expect(targetForOperation(rooted).length).toBeLessThanOrEqual(240);
+    // ★사람이 볼 경고가 맨 앞에 남는다★ — 이건 '파일 몇 개' 가 아니라 '폴더 전체' 요청이다.
+    expect(targetForOperation(rooted).startsWith("⚠")).toBe(true);
+    // ★열쇠 지문이 절단선 안에 살아남는다★ — 이게 P2 재발 방지의 조건이다(뒤에 두되 예산을 먼저 뗀다).
+    expect(targetForOperation(rooted)).toMatch(/#[0-9a-f]{12}$/);
     expect(scopeKeyForOperation(rooted)).not.toBe(scopeKeyForOperation(plain));
   });
 
@@ -219,7 +225,8 @@ describe("S2 — grantRoot 는 별개 승인이다", () => {
     const item = observed([["src/a.ts", "update", 1]]);
     for (const blank of ["", "   ", null, undefined, 123]) {
       const op = buildOperationFromApproval(fileReq(item, { grantRoot: blank }), "dex");
-      expect(op.path).toBe("src/a.ts");
+      expect(op.path).toMatch(/^파일 1개 · update src\/a\.ts #[0-9a-f]{12}$/);
+      expect(op.path.startsWith("⚠")).toBe(false); // 경고를 남발하지 않는다
       expect(op.provenance?.grant_root).toBeNull();
     }
   });
@@ -248,7 +255,7 @@ describe("S2 — 이동 목적지(P1)", () => {
     // 재현(수정 전): 팝업 문구는 달랐는데 scopeKey 가 완전히 같았다.
     expect(safe.text).not.toBe(evil.text);
     expect(scopeKeyForOperation(safe)).not.toBe(scopeKeyForOperation(evil));
-    expect(safe.path).toBe("a.ts>safe.ts");
+    expect(safe.path).toMatch(/^파일 1개 · update a\.ts→safe\.ts #[0-9a-f]{12}$/); // 목적지가 화면에 보인다
   });
 
   test("★구세대에도 같은 구멍이 있었다★ — UpdateFileChange.move_path", () => {
@@ -267,7 +274,8 @@ describe("S2 — 이동 목적지(P1)", () => {
       method: "applyPatchApproval",
       params: { fileChanges: { "b.ts": { type: "add", content: "x" }, "a.ts": {} }, callId: "c1" },
     }, "dex");
-    expect(op.path).toBe("a.ts|b.ts");
+    // ★S3 에서 표시 형식이 바뀌었다(의도)★ — 파일집합·정렬은 그대로, 사람이 읽을 종류·개수와 지문이 붙었다.
+    expect(op.path).toMatch(/^파일 2개 · change a\.ts, add b\.ts #[0-9a-f]{12}$/);
   });
 });
 
@@ -289,7 +297,8 @@ describe("S2 — 긴 grantRoot(P2)", () => {
     expect(scopeKeyForOperation(buildOperationFromApproval(one, "dex")))
       .not.toBe(scopeKeyForOperation(buildOperationFromApproval(two, "dex")));
     expect(approvalOperationHash(one)).not.toBe(approvalOperationHash(two));
-    expect(targetForOperation(buildOperationFromApproval(one, "dex"))).toMatch(/^grant_root#[0-9a-f]{16}=/);
+    // ★루트 원문은 표시용으로 줄어들지만(뒤 71자) 지문이 전체를 담아 열쇠를 가른다.★
+    expect(targetForOperation(buildOperationFromApproval(one, "dex"))).toMatch(/#[0-9a-f]{12}$/);
   });
 
   test("구세대도 같다", () => {
@@ -319,8 +328,10 @@ describe("S2 — 구세대 불변", () => {
     const apply: ApprovalRequest = { method: "applyPatchApproval", params: { fileChanges: { "b.ts": {}, "a.ts": {} }, callId: "c1" } };
     expect(approvalOperationHash(apply)).toBe("c7fa63459c642993");
     const op = buildOperationFromApproval(apply, "dex");
-    expect(op.path).toBe("a.ts|b.ts"); // 표시·열쇠 모두 그대로
-    expect(op.text).toBe("a.ts, b.ts");
+    // ★지문(approvalOperationHash) 은 그대로다★ — 진행 중 승인의 상관키가 어긋나지 않는다.
+    //   ★열쇠(scope) 는 S3 에서 의도적으로 바뀐다★ — 저장된 grant 는 0행이라 무효화될 것이 없다(실측 2026-07-30).
+    expect(op.path).toMatch(/^파일 2개 · change a\.ts, change b\.ts #[0-9a-f]{12}$/);
+    expect(op.text).toBe("파일 2개: change a.ts, change b.ts");
   });
 
   test("★구세대 명령 지문 값도 그대로다★ — S1 golden 재확인(basis 에 키를 무조건 추가하지 않았다)", () => {

--- a/src/server/runtimes/codex/appServerPopup.s2.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s2.test.ts
@@ -255,7 +255,7 @@ describe("S2 — 이동 목적지(P1)", () => {
     // 재현(수정 전): 팝업 문구는 달랐는데 scopeKey 가 완전히 같았다.
     expect(safe.text).not.toBe(evil.text);
     expect(scopeKeyForOperation(safe)).not.toBe(scopeKeyForOperation(evil));
-    expect(safe.path).toMatch(/^파일 1개 · update a\.ts→safe\.ts #[0-9a-f]{12}$/); // 목적지가 화면에 보인다
+    expect(safe.path).toMatch(/^파일 1개 · update a\.ts → safe\.ts #[0-9a-f]{12}$/); // 목적지가 화면에 보인다
   });
 
   test("★구세대에도 같은 구멍이 있었다★ — UpdateFileChange.move_path", () => {

--- a/src/server/runtimes/codex/appServerPopup.s2.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s2.test.ts
@@ -39,7 +39,7 @@ describe("S2 — 신세대 파일변경 승인 해석", () => {
     // ★S3 — 이 한 줄이 화면이다.★ targetForOperation 이 text 가 아니라 path 를 쓰므로(우선순위
     //   command > path > egress_url > text), path 자체가 사람이 읽을 말이어야 한다.
     expect(op.path).toMatch(/^파일 1개 · update src\/a\.ts #[0-9a-f]{12}$/);
-    expect(targetForOperation(op)).toBe(op.path); // 화면에 그대로 나온다(240자 안)
+    expect(targetForOperation(op)).toBe(op.path ?? ""); // 화면에 그대로 나온다(240자 안)
   });
 
   test("사람이 규모를 볼 수 있다 — 종류·경로·줄수 요약", () => {
@@ -226,7 +226,7 @@ describe("S2 — grantRoot 는 별개 승인이다", () => {
     for (const blank of ["", "   ", null, undefined, 123]) {
       const op = buildOperationFromApproval(fileReq(item, { grantRoot: blank }), "dex");
       expect(op.path).toMatch(/^파일 1개 · update src\/a\.ts #[0-9a-f]{12}$/);
-      expect(op.path.startsWith("⚠")).toBe(false); // 경고를 남발하지 않는다
+      expect(op.path?.startsWith("⚠")).toBe(false); // 경고를 남발하지 않는다
       expect(op.provenance?.grant_root).toBeNull();
     }
   });

--- a/src/server/runtimes/codex/appServerPopup.s3.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s3.test.ts
@@ -40,7 +40,7 @@ describe("S3 — 화면이 곧 열쇠라는 계약", () => {
   test("★화면에 나오는 줄은 text 가 아니라 path 다★ — 이 우선순위가 바뀌면 S3 전체 전제가 무너진다", () => {
     const op = buildOperationFromApproval(fileReq(observed([{ path: "src/a.ts", kind: "update" }])), "dex");
     expect(op.text).toContain("(+1/-1)");        // 규모는 text 에 있다
-    expect(screenLine(op)).toBe(op.path);        // ★그런데 화면은 path 다★
+    expect(screenLine(op)).toBe(op.path ?? "");  // ★그런데 화면은 path 다★
     expect(screenLine(op)).not.toContain("(+");  // → 규모는 화면에 안 나온다(렌더러 변경 대기)
   });
 
@@ -135,6 +135,21 @@ describe("S3 — 폴더 전체 요청은 경고가 먼저 보인다", () => {
     expect(screenLine(a)).toContain("alpha");   // 사람이 구별할 수 있다
     expect(screenLine(b)).toContain("bravo");
     expect(scopeKeyForOperation(a)).not.toBe(scopeKeyForOperation(b)); // 열쇠도 갈린다(P2)
+  });
+
+  test("★표시에 안 보이는 부분만 다른 두 루트도 열쇠가 갈린다★ — 지문이 루트 전문을 담는 이유", () => {
+    // ★이 시험은 뮤턴트가 살아남아서 추가했다(2026-07-30).★ 앞 시험은 두 루트의 ★뒤★ 가 달라서
+    //   표시 문자열만으로도 열쇠가 갈렸다 — 즉 지문을 지워도 초록이었다. ★기계가 아니라 입력이 문제였다.★
+    //   여기서는 ★뒤 71자가 완전히 같고 앞만 다른★ 두 루트를 쓴다. 표시로는 구별이 불가능하므로
+    //   지문이 grantRoot 전문을 담지 않으면 ★서로 다른 폴더 승인이 같은 열쇠★ 가 된다(P2 그 사고).
+    const tail = "/" + "x".repeat(300);
+    const a = root(`/alpha${tail}`);
+    const b = root(`/bravo${tail}`);
+    // ★사람이 읽는 부분(지문 앞까지)이 글자 하나까지 같다★ — 눈으로는 구별할 방법이 없다.
+    const readable = (s: string) => s.replace(/ #[0-9a-f]{12}$/, "");
+    expect(readable(screenLine(a))).toBe(readable(screenLine(b)));
+    // → 즉 ★이 두 요청을 가르는 것은 지문뿐이다★. 그래서 지문이 루트 전문을 담아야 한다.
+    expect(scopeKeyForOperation(a)).not.toBe(scopeKeyForOperation(b)); // ★그래도 열쇠는 갈려야 한다★
   });
 
   test("루트가 같으면 열쇠가 같다 — 세션 승인이 재사용된다", () => {

--- a/src/server/runtimes/codex/appServerPopup.s3.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s3.test.ts
@@ -152,6 +152,28 @@ describe("S3 — 폴더 전체 요청은 경고가 먼저 보인다", () => {
     expect(scopeKeyForOperation(a)).not.toBe(scopeKeyForOperation(b)); // ★그래도 열쇠는 갈려야 한다★
   });
 
+  test("★grantRoot 로 보이는 낯선 키가 있으면 해석 실패로 보낸다★ — 벤더 개명이 조용히 경고를 지우지 못하게", () => {
+    // ★빌 리뷰 후속(2026-07-30).★ 빌이 payload 를 `grant_root` 로 잘못 만들어 돌려보니
+    //   ★경고가 화면에서 사라지고 서로 다른 폴더 요청이 같은 열쇠★ 가 됐다. 0.144.6 에서는 도달 불가
+    //   (빌이 바이너리 문자열로 직접 확인: grantRoot 3건 / grant_root 0건). 그러나 ★벤더가 이름을
+    //   바꾸면 에러 없이★ 폴더 전체 권한이 평범한 파일 쓰기로 보인다 — 그래서 모르면 묻는다.
+    for (const key of ["grant_root", "GrantRoot", "grantroot", "grant-root"]) {
+      const op = buildOperationFromApproval(
+        fileReq(observed([{ path: "src/a.ts", kind: "update" }]), { [key]: "/some/root" }),
+        "dex",
+      );
+      expect(op.action).toBe("approval_unparsed");
+    }
+    // 우리가 읽는 이름은 정상 처리된다 — 가드가 정상 경로를 막지 않는다.
+    expect(root("/repo").action).toBe("write");
+    // 구세대도 같은 정책이다.
+    const old = buildOperationFromApproval(
+      { method: "applyPatchApproval", params: { fileChanges: { "a.ts": { type: "add", content: "x\n" } }, grant_root: "/r" } },
+      "dex",
+    );
+    expect(old.action).toBe("approval_unparsed");
+  });
+
   test("루트가 같으면 열쇠가 같다 — 세션 승인이 재사용된다", () => {
     expect(scopeKeyForOperation(root("/repo"))).toBe(scopeKeyForOperation(root("/repo")));
   });

--- a/src/server/runtimes/codex/appServerPopup.s3.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s3.test.ts
@@ -115,7 +115,7 @@ describe("S3 — 구세대도 같은 것을 보여준다", () => {
       oldGen({ "a.ts": { type: "update", unified_diff: "@@ -1 +1 @@\n-a\n+b\n", move_path: "b/c.ts" } }),
       "dex",
     );
-    expect(screenLine(op)).toContain("a.ts→b/c.ts");
+    expect(screenLine(op)).toContain("a.ts → b/c.ts");
   });
 });
 
@@ -154,6 +154,70 @@ describe("S3 — 폴더 전체 요청은 경고가 먼저 보인다", () => {
 
   test("루트가 같으면 열쇠가 같다 — 세션 승인이 재사용된다", () => {
     expect(scopeKeyForOperation(root("/repo"))).toBe(scopeKeyForOperation(root("/repo")));
+  });
+});
+
+/**
+ * ★코덱스 리뷰(2026-07-30)가 잡은 반례 — 전부 내가 직접 재현한 뒤 고쳤다.★
+ *
+ * 앞의 시험 39건은 전부 초록이었는데 아래 여섯 가지가 다 깨져 있었다. ★내 시험이 내가 주장한 것을
+ * 재고 있지 않았다★ — 오늘 M2 뮤턴트가 살아남은 것과 같은 형태다(입력이 메커니즘을 안 건드렸다).
+ * 그리고 두 번째 시험은 내가 코덱스에게 ★"열쇠는 지문이 갈라준다" 고 단언한 자리★ 다.
+ * 지문의 재료가 모호했으므로 그 단언이 틀렸다 — ★단언 전에 재료를 봐야 했다.★
+ */
+describe("S3 — 코덱스 리뷰 반례 (회귀 가드)", () => {
+  const one = (path: string, kind = "update", movePath: string | null = null, diff?: string) =>
+    buildOperationFromApproval(fileReq(observed([{ path, kind, movePath, diff }])), "dex");
+  const oldGen = (fileChanges: unknown): ApprovalRequest => ({
+    method: "applyPatchApproval",
+    params: { fileChanges, callId: "c1" },
+  });
+
+  test("★첫 항목이 예산을 넘어도 지문이 살아남는다★ — 안 그러면 긴 경로들이 한 열쇠로 합쳐진다", () => {
+    const a = one("src/" + "x".repeat(400) + ".ts");
+    const b = one("src/" + "x".repeat(400) + "-DIFFERENT.ts");
+    expect(targetForOperation(a).length).toBeLessThanOrEqual(240);
+    expect(targetForOperation(a)).toMatch(/#[0-9a-f]{12}$/);           // 지문 생존
+    expect(targetForOperation(a)).toContain("…");                      // 잘렸음을 말한다
+    expect(scopeKeyForOperation(a)).not.toBe(scopeKeyForOperation(b)); // ★앞 240자가 같아도 갈린다★
+  });
+
+  test("★이름에 '>' 가 든 파일과 '이동' 이 같은 열쇠가 되지 않는다★ — 지문 재료가 구조화 tuple 이라서", () => {
+    const plain = one("a>b.ts", "add", null, "X\n");
+    const move = one("a", "update", "b.ts");
+    expect(scopeKeyForOperation(plain)).not.toBe(scopeKeyForOperation(move));
+    // 표시도 원본 필드에서 조립한다 — 평범한 파일이 '옮긴다' 로 거짓 표시되지 않는다.
+    expect(screenLine(plain)).toContain("add a>b.ts");
+    expect(screenLine(plain)).not.toContain("→");
+  });
+
+  test("★'a>b'→'c' 와 'a'→'b>c' 는 서로 다른 쓰기다★ — 이어붙인 문자열로 해시하면 같은 열쇠였다", () => {
+    const x = one("a>b", "update", "c");
+    const y = one("a", "update", "b>c");
+    expect(scopeKeyForOperation(x)).not.toBe(scopeKeyForOperation(y));
+  });
+
+  test("★240 경계가 이모지를 반 토막 내지 않는다★ — 고아 서로게이트로 끝나면 안 된다", () => {
+    for (const pad of [220, 222, 224, 226]) {
+      const t = targetForOperation(one("a".repeat(pad) + "😀" + ".ts"));
+      const last = t.charCodeAt(t.length - 1);
+      expect(last >= 0xd800 && last <= 0xdbff).toBe(false);
+    }
+  });
+
+  test("★새 파일 내용에 '@@' 줄이 있어도 (+0/-0) 이 안 된다★ — 모양이 아니라 종류로 판정한다", () => {
+    expect(buildOperationFromApproval(oldGen({ "a.md": { type: "add", content: "@@ heading\nhello\n" } }), "dex").text)
+      .toContain("add a.md(+2/-0)");
+    expect(buildOperationFromApproval(oldGen({ "b.md": { type: "delete", content: "@@ x\ny\n" } }), "dex").text)
+      .toContain("delete b.md(+0/-2)");
+    expect(one("c.md", "add", null, "@@ heading\nhello\n").text).toContain("add c.md(+2/-0)"); // 신세대도
+  });
+
+  test("★빈 목록·배열은 '파일 0개 쓰기' 가 아니라 해석 실패다★ — 넓은 열쇠를 만들지 않는다", () => {
+    expect(buildOperationFromApproval(oldGen({}), "dex").action).toBe("approval_unparsed");
+    const arr = buildOperationFromApproval(oldGen(["src/z.ts"]), "dex");
+    expect(arr.action).toBe("approval_unparsed");
+    expect(screenLine(arr)).not.toContain("change 0"); // 인덱스를 경로로 표시하지 않는다
   });
 });
 

--- a/src/server/runtimes/codex/appServerPopup.s3.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s3.test.ts
@@ -197,11 +197,43 @@ describe("S3 — 코덱스 리뷰 반례 (회귀 가드)", () => {
     expect(scopeKeyForOperation(x)).not.toBe(scopeKeyForOperation(y));
   });
 
-  test("★240 경계가 이모지를 반 토막 내지 않는다★ — 고아 서로게이트로 끝나면 안 된다", () => {
-    for (const pad of [220, 222, 224, 226]) {
+  test("★같은 요청의 두 쓰기가 한 개로 합쳐지지 않는다★ — 합치면 하나가 화면에서 사라진다", () => {
+    // ★뮤턴트로 찾은 자리(2026-07-30).★ 지문·중복제거 재료가 이어붙인 문자열이면
+    //   `a>b` 새 파일과 `a`→`b` 이동이 ★같은 항목★ 이 되어 화면이 "파일 1개 · add a>b" 로 나온다 —
+    //   ★이동 쓰기가 통째로 안 보이는 채로 승인된다.★ 개수까지 거짓이 되므로 사람이 알아챌 수도 없다.
+    const op = buildOperationFromApproval(
+      fileReq({
+        itemId: "i1", turnId: "t1", threadId: "th1",
+        changes: [
+          { path: "a>b", kind: "add", movePath: null, diff: "X\n" },
+          { path: "a", kind: "update", movePath: "b", diff: "@@ -1 +1 @@\n-a\n+b\n" },
+        ],
+      }),
+      "dex",
+    );
+    expect(screenLine(op)).toContain("파일 2개");
+    expect(screenLine(op)).toContain("add a>b");
+    expect(screenLine(op)).toContain("update a → b");
+  });
+
+  test("★이모지가 반 토막 나지 않는다★ — 짝 없는 서로게이트가 문자열 어디에도 없다", () => {
+    // ★판정을 두 번 틀렸다(2026-07-30).★ 처음엔 ★끝 글자만★ 봤는데 잘린 조각은 ★중간★ 에 남는다.
+    //   다음엔 검사 함수가 ★정상 쌍에서 i 를 2 칸 건너뛰지 않아★ 뒷 짝을 고아로 오판했다.
+    //   ★재는 도구가 틀리면 초록도 빨강도 뜻이 없다.★ 고친 뒤 pad=208 에서 수정 전 코드가 깨지는 것을 확인했다.
+    const loneSurrogateAt = (s: string): number => {
+      for (let i = 0; i < s.length; i++) {
+        const c = s.charCodeAt(i);
+        if (c >= 0xd800 && c <= 0xdbff) {
+          const n = s.charCodeAt(i + 1);
+          if (!(n >= 0xdc00 && n <= 0xdfff)) return i;
+          i++; // 정상 쌍은 두 칸 건너뛴다
+        } else if (c >= 0xdc00 && c <= 0xdfff) return i;
+      }
+      return -1;
+    };
+    for (let pad = 180; pad <= 250; pad++) {
       const t = targetForOperation(one("a".repeat(pad) + "😀" + ".ts"));
-      const last = t.charCodeAt(t.length - 1);
-      expect(last >= 0xd800 && last <= 0xdbff).toBe(false);
+      expect({ pad, at: loneSurrogateAt(t) }).toEqual({ pad, at: -1 });
     }
   });
 

--- a/src/server/runtimes/codex/appServerPopup.s3.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s3.test.ts
@@ -1,0 +1,166 @@
+import { test, expect, describe } from "bun:test";
+import { buildOperationFromApproval } from "./appServerPopup";
+import { scopeKeyForOperation, targetForOperation } from "../../lib/permissionGate";
+import type { ApprovalRequest } from "./appServerClient";
+import type { ObservedItem } from "./appServerItemIndex";
+
+/**
+ * ★S3(#106) — 사람이 볼 수 있게.★
+ *
+ * ★이 단계가 왜 필요했는지 (실측으로 발견):★
+ * S2 는 `update a.ts(+1/-2)` 같은 사람용 요약을 `op.text` 에 잘 만들어 뒀다. 그런데
+ * ★팝업은 text 를 보여주지 않는다.★ telegramCapture 가 렌더하는 두 줄은
+ *   `${runtime}/${agent_id} · ${action}` / `${target}`
+ * 이고, `targetForOperation` 의 우선순위는 ★command > path > egress_url > text★ 다.
+ * → write 승인에서는 ★path 가 화면이고 text 는 아무도 못 본다.★
+ * 그래서 S2 의 완료 판정("파일명+규모가 포함된다")은 ★text 기준으로는 참, 화면 기준으로는 거짓★ 이었다.
+ *
+ * ★그래서 S3 의 대상은 path 다★ — 한 문자열이 ①열쇠 ②사람이 읽는 유일한 줄 두 일을 한다.
+ * 규모(+n/-n)는 ★열쇠에 넣을 수 없다★(내용이 바뀔 때마다 열쇠가 달라져 '항상 허용' 이 영원히 안 붙는다).
+ * 규모를 화면에 띄우려면 렌더러(codex 폴더 밖)를 고쳐야 한다 — ★팀 리드 판단 대기 항목.★
+ */
+
+const observed = (
+  changes: Array<{ path: string; kind: string; movePath?: string | null; diff?: string }>,
+): ObservedItem => ({
+  itemId: "i1",
+  turnId: "t1",
+  threadId: "th1",
+  changes: changes.map((c) => ({ path: c.path, kind: c.kind, movePath: c.movePath ?? null, diff: c.diff ?? "@@ -1 +1 @@\n-a\n+b\n" })),
+});
+const fileReq = (observedItem: ObservedItem, extra: Record<string, unknown> = {}): ApprovalRequest => ({
+  method: "item/fileChange/requestApproval",
+  params: { itemId: observedItem.itemId, turnId: "t1", threadId: "th1", ...extra },
+  observedItem,
+});
+/** 팝업이 실제로 보여주는 두 번째 줄(telegramCapture.ts) — 화면을 시험한다. */
+const screenLine = (op: ReturnType<typeof buildOperationFromApproval>) => targetForOperation(op);
+
+describe("S3 — 화면이 곧 열쇠라는 계약", () => {
+  test("★화면에 나오는 줄은 text 가 아니라 path 다★ — 이 우선순위가 바뀌면 S3 전체 전제가 무너진다", () => {
+    const op = buildOperationFromApproval(fileReq(observed([{ path: "src/a.ts", kind: "update" }])), "dex");
+    expect(op.text).toContain("(+1/-1)");        // 규모는 text 에 있다
+    expect(screenLine(op)).toBe(op.path);        // ★그런데 화면은 path 다★
+    expect(screenLine(op)).not.toContain("(+");  // → 규모는 화면에 안 나온다(렌더러 변경 대기)
+  });
+
+  test("사람이 읽는 순서로 시작한다 — 첫 글자가 지문이 아니다", () => {
+    const op = buildOperationFromApproval(fileReq(observed([{ path: "src/a.ts", kind: "update" }])), "dex");
+    expect(screenLine(op).startsWith("파일 ")).toBe(true);
+    expect(screenLine(op)).toMatch(/#[0-9a-f]{12}$/); // 지문은 맨 뒤
+  });
+});
+
+describe("S3 — 잘려도 열쇠가 갈린다 (지문을 뒤로 옮긴 근거)", () => {
+  const many = (tail: string) =>
+    observed(Array.from({ length: 20 }, (_, i) => ({ path: `src/very/long/directory/name/file${i}${i === 19 ? tail : ""}.ts`, kind: "update" })));
+
+  test("★앞부분이 같고 뒤만 다른 두 요청은 열쇠가 달라야 한다★ — 240자 절단이 합치지 못한다", () => {
+    const a = buildOperationFromApproval(fileReq(many("-alpha")), "dex");
+    const b = buildOperationFromApproval(fileReq(many("-bravo")), "dex");
+    // 화면에 보이는 부분은 같다 — 사람 눈으로는 구별이 안 된다.
+    expect(screenLine(a).slice(0, 100)).toBe(screenLine(b).slice(0, 100));
+    // ★그래도 열쇠는 갈린다★ — 파일집합 전체의 지문이 절단선 안에 남기 때문이다.
+    expect(scopeKeyForOperation(a)).not.toBe(scopeKeyForOperation(b));
+  });
+
+  test("몇 개가 안 보이는지 말한다 — 단어 중간에서 끊지 않는다", () => {
+    const op = buildOperationFromApproval(fileReq(many("")), "dex");
+    expect(screenLine(op)).toContain("…외 ");
+    expect(screenLine(op).length).toBeLessThanOrEqual(240);
+    expect(screenLine(op)).toMatch(/#[0-9a-f]{12}$/); // 잘림 뒤에도 지문 생존
+  });
+
+  test("같은 파일을 다시 고치면 열쇠가 같다 — '항상 허용' 이 계속 유효하다", () => {
+    const one = buildOperationFromApproval(fileReq(observed([{ path: "src/a.ts", kind: "update", diff: "@@ -1 +1 @@\n-a\n+b\n" }])), "dex");
+    const two = buildOperationFromApproval(fileReq(observed([{ path: "src/a.ts", kind: "update", diff: "@@ -1,9 +1,9 @@\n-x\n+y\n-z\n+w\n" }])), "dex");
+    expect(one.text).not.toBe(two.text);                          // 규모는 다르다
+    expect(scopeKeyForOperation(one)).toBe(scopeKeyForOperation(two)); // ★열쇠는 같다★
+  });
+});
+
+describe("S3 — 구세대도 같은 것을 보여준다", () => {
+  /** ★벤더 스키마 0.144.6 실측 모양★ — 짐작이 아니라 generate-json-schema 출력에서 읽었다.
+   *    add    `{ type:"add",    content }`      delete `{ type:"delete", content }`
+   *    update `{ type:"update", unified_diff, move_path? }` */
+  const oldGen = (fileChanges: Record<string, unknown>): ApprovalRequest => ({
+    method: "applyPatchApproval",
+    params: { fileChanges, callId: "c1" },
+  });
+
+  test("★구세대 payload 에도 내용이 있었다★ — 지금까지 이름만 보여준 것은 재료가 없어서가 아니었다", () => {
+    const op = buildOperationFromApproval(
+      oldGen({
+        "src/a.ts": { type: "update", unified_diff: "@@ -1,2 +1,3 @@\n a\n-b\n+B\n+C\n" },
+        "src/new.ts": { type: "add", content: "HELLO\nWORLD\n" },
+        "src/old.ts": { type: "delete", content: "X\n" },
+      }),
+      "dex",
+    );
+    expect(op.text).toContain("update src/a.ts(+2/-1)");
+    expect(op.text).toContain("add src/new.ts(+2/-0)");
+    expect(op.text).toContain("delete src/old.ts(+0/-1)");
+    expect(screenLine(op)).toContain("파일 3개");
+    expect(screenLine(op)).toContain("delete src/old.ts");
+  });
+
+  test("★내용을 모르면 규모를 지어내지 않는다★ — (+0/-0) 은 '아무것도 안 바뀐다' 는 거짓말이다", () => {
+    const op = buildOperationFromApproval(oldGen({ "src/a.ts": {} }), "dex");
+    expect(op.text).not.toContain("(+0/-0)");
+    expect(op.text).toContain("change src/a.ts");
+  });
+
+  test("구세대 이동도 목적지가 화면에 보인다", () => {
+    const op = buildOperationFromApproval(
+      oldGen({ "a.ts": { type: "update", unified_diff: "@@ -1 +1 @@\n-a\n+b\n", move_path: "b/c.ts" } }),
+      "dex",
+    );
+    expect(screenLine(op)).toContain("a.ts→b/c.ts");
+  });
+});
+
+describe("S3 — 폴더 전체 요청은 경고가 먼저 보인다", () => {
+  const root = (r: string) => buildOperationFromApproval(fileReq(observed([{ path: "src/a.ts", kind: "update" }]), { grantRoot: r }), "dex");
+
+  test("★화면 첫 글자가 경고다★ — 이건 파일 1개가 아니라 폴더 하위 전체 승인이다", () => {
+    const op = root("/Users/x/Development/proj");
+    expect(screenLine(op).startsWith("⚠")).toBe(true);
+    expect(screenLine(op)).toContain("/Users/x/Development/proj");
+  });
+
+  test("★긴 루트는 뒤를 남긴다★ — 뿌리는 앞이 아니라 뒤가 다르다", () => {
+    const base = "/Users/x/" + "deep/".repeat(30);
+    const a = root(`${base}alpha`);
+    const b = root(`${base}bravo`);
+    expect(screenLine(a)).toContain("alpha");   // 사람이 구별할 수 있다
+    expect(screenLine(b)).toContain("bravo");
+    expect(scopeKeyForOperation(a)).not.toBe(scopeKeyForOperation(b)); // 열쇠도 갈린다(P2)
+  });
+
+  test("루트가 같으면 열쇠가 같다 — 세션 승인이 재사용된다", () => {
+    expect(scopeKeyForOperation(root("/repo"))).toBe(scopeKeyForOperation(root("/repo")));
+  });
+});
+
+describe("S3 — 해석 실패 화면", () => {
+  test("★내부 용어만 두 줄 보여주지 않는다★ — 사람 말로 상황을 먼저 말한다", () => {
+    const op = buildOperationFromApproval(
+      { method: "item/fileChange/requestApproval", params: { itemId: "i9", turnId: "t9", reason: "패치를 적용해도 될까요" } },
+      "dex",
+    );
+    expect(op.action).toBe("approval_unparsed"); // 앞줄은 공용 코드가 만든다 — 여기서 못 바꾼다
+    expect(screenLine(op).startsWith("내용 해석 실패")).toBe(true); // ★뒷줄이 설명한다★
+    expect(screenLine(op)).toContain("패치를 적용해도 될까요");
+    expect(screenLine(op)).toMatch(/#[0-9a-f]{16}/); // payload 지문은 유지(요청마다 다른 열쇠)
+  });
+
+  test("사람 말 머리말이 열쇠 구분력을 줄이지 않는다 — 상수이므로", () => {
+    const mk = (reason: string): ApprovalRequest => ({
+      method: "item/fileChange/requestApproval",
+      params: { itemId: "i9", turnId: "t9", reason },
+    });
+    const a = buildOperationFromApproval(mk("하나"), "dex");
+    const b = buildOperationFromApproval(mk("둘"), "dex");
+    expect(scopeKeyForOperation(a)).not.toBe(scopeKeyForOperation(b));
+  });
+});

--- a/src/server/runtimes/codex/appServerPopup.s3.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.s3.test.ts
@@ -245,6 +245,19 @@ describe("S3 — 코덱스 리뷰 반례 (회귀 가드)", () => {
     expect(one("c.md", "add", null, "@@ heading\nhello\n").text).toContain("add c.md(+2/-0)"); // 신세대도
   });
 
+  test("★종류와 필드가 어긋난 payload 에서 규모를 지어내지 않는다★ — 재료를 종류에 맞춰 고른다", () => {
+    // ★코덱스 2회전 지적(2026-07-30).★ 앞선 판은 type 과 무관하게 unified_diff 를 먼저 집었고,
+    //   세는 쪽은 kind 로 판정하므로 ★짝이 어긋나면 규모를 지어냈다★ — 셋 다 실측 재현했다.
+    const t = (fileChanges: unknown) => buildOperationFromApproval(oldGen(fileChanges), "dex").text ?? "";
+    // update 인데 content 만 있다 → 예전엔 (+0/-0) = "아무것도 안 바뀐다" 는 거짓말
+    expect(t({ "x.txt": { type: "update", content: "hello\n" } })).toBe("파일 1개: update x.txt");
+    // add 인데 unified_diff 만 있다 → 예전엔 (+3/-0) = 없는 내용에서 규모를 만들었다
+    expect(t({ "x.txt": { type: "add", unified_diff: "@@ -1 +1 @@\n-a\n+b\n" } })).toBe("파일 1개: add x.txt");
+    // 둘 다 있으면 ★종류에 맞는 필드★ 를 쓴다 — content 1줄이 정답이고 예전엔 +3 이었다
+    expect(t({ "x.txt": { type: "add", content: "one\n", unified_diff: "@@ -1 +1 @@\n-a\n+b\n" } }))
+      .toBe("파일 1개: add x.txt(+1/-0)");
+  });
+
   test("★빈 목록·배열은 '파일 0개 쓰기' 가 아니라 해석 실패다★ — 넓은 열쇠를 만들지 않는다", () => {
     expect(buildOperationFromApproval(oldGen({}), "dex").action).toBe("approval_unparsed");
     const arr = buildOperationFromApproval(oldGen(["src/z.ts"]), "dex");

--- a/src/server/runtimes/codex/appServerPopup.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.test.ts
@@ -21,7 +21,8 @@ test("M5.1 buildOp — exec 명령 → action=shell + command", () => {
 test("M5.1 buildOp — patch → action=write + path(전체 파일집합, CRITICAL 1-B)", () => {
   const op = buildOperationFromApproval({ method: "applyPatchApproval", params: { fileChanges: { "/p/b.ts": {}, "/p/a.ts": {} } } }, "dex");
   expect(op.action).toBe("write");
-  expect(op.path).toBe("/p/a.ts|/p/b.ts"); // 정렬된 전체 파일집합(files[0]만 아님)
+  // ★S3: path 는 열쇠이면서 사람이 읽는 유일한 줄이다★ — 개수·종류·경로 + 뒤에 열쇠 지문.
+  expect(op.path).toMatch(/^파일 2개 · change \/p\/a\.ts, change \/p\/b\.ts #[0-9a-f]{12}$/);
   expect(op.text).toContain("b.ts");
 });
 

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -181,6 +181,9 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
   if (req.method === "item/fileChange/requestApproval") {
     const observed = req.observedItem;
     if (!observed || observed.changes.length === 0) return unparsedOperation(req, agentId, provenance);
+    // ★grantRoot 로 보이는 낯선 키가 있으면 여기서 멈춘다★ — 폴더 전체 요청이 평범한 파일 쓰기로
+    //   보이는 것보다 매번 묻는 게 낫다(벤더 개명 대비 · Bill 리뷰 후속).
+    if (hasUnreadGrantRootKey(p)) return unparsedOperation(req, agentId, provenance);
     return writeOperation(agentId, provenance, observed.changes, grantRootOf(p), observed.itemId);
   }
   // ★S3(#106) — 구세대도 신세대와 ★같은 것을 보여준다.★
@@ -196,6 +199,7 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
     // ★S2: grantRoot 는 구세대 applyPatchApproval 에도 있다★ — 지금까지 통째로 무시하고 있었다.
     //   있으면 '이 파일들' 이 아니라 ★'이 루트 하위 전부' 를 세션 동안 허용해 달라는 요청★ 이다.
     //   열쇠에 반영하지 않으면 파일 몇 개에 준 '항상 허용' 이 루트 전체 승인으로 재사용된다.
+    if (hasUnreadGrantRootKey(p)) return unparsedOperation(req, agentId, provenance); // 위와 같은 이유
     const oldChanges = oldGenChanges(p.fileChanges);
     // ★빈 목록은 '파일 0개 쓰기' 가 아니라 해석 실패다★ — 신세대(관측된 변경 0건)와 정책을 맞춘다.
     //   앞선 판은 `fileChanges: {}` 를 write 로 만들어 ★내용 없는 넓은 열쇠★ 를 하나 만들었다.
@@ -217,6 +221,22 @@ const UNPARSED_NOTICE = "내용 해석 실패 — 원문 확인 필요 · ";
  *  ★벤더 설명: "the agent is asking the user to allow writes under this root for the remainder of the
  *  session"★ — 즉 파일 단위 승인이 아니라 ★루트 단위 세션 승인★ 이다. UNSTABLE 표기지만 payload 에
  *  실려 오는 이상 ★우리 쪽 열쇠와 표시는 이걸 반영해야 한다.★ */
+/** ★grantRoot 로 보이는데 우리가 안 읽는 키가 있으면 해석 실패로 보낸다(Bill 리뷰 2026-07-30 후속).★
+ *
+ *  ★왜 필요한가 — 실패가 조용하기 때문이다.★ Bill 이 리뷰 중 payload 를 `grant_root` 로 잘못 만들어
+ *  돌려보니, ★"⚠ 세션 동안 폴더 하위 전체 쓰기 허용" 경고가 화면에서 사라지고★ 서로 다른 폴더 요청
+ *  두 건이 ★같은 열쇠★ 가 됐다. 0.144.6 에서는 도달 불가다(Bill 이 바이너리 문자열로 직접 확인:
+ *  `grantRoot` 3건 / `grant_root` 0건). 그러나 ★벤더가 다음 버전에서 이름을 바꾸면 에러 하나 없이★
+ *  폴더 전체 권한이 평범한 파일 쓰기로 보인다.
+ *
+ *  이 저장소에서 같은 형태로 두 번 데였다 — `patchUpdated` 를 짐작했고(안 오는 알림이었다),
+ *  `Array.isArray(command)` 로 세대를 판정했다(신세대가 통째로 미끄러졌다). ★모양이 바뀌면
+ *  조용히 미끄러지는 자리에는 가드를 둔다.★ 배열·빈 목록에 이미 같은 정책(모르면 ask)을 쓰고 있다. */
+function hasUnreadGrantRootKey(p: Record<string, any> | undefined): boolean {
+  if (!p || typeof p !== "object") return false;
+  return Object.keys(p).some((k) => k !== "grantRoot" && /grant.?root/i.test(k));
+}
+
 function grantRootOf(p: Record<string, any> | undefined): string | null {
   const raw = p?.grantRoot;
   if (typeof raw !== "string") return null;

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -11,7 +11,6 @@ import { createHash, randomUUID } from "node:crypto";
 import type { Database } from "bun:sqlite";
 import { requestPermission, getPermissionRequest, type PermissionOperation } from "../../lib/permissionGate";
 import type { ApprovalRequest, ReviewDecision } from "./appServerClient";
-import type { ObservedFileChange } from "./appServerItemIndex";
 import { CodexApprovalCorrelationStore } from "./state";
 
 /** ★Phase1 ③: 이 서버 프로세스 인스턴스 id — 재시작 감지용(옛 팝업을 새 프로세스가 새 turn에 재결합 금지).★ */
@@ -182,27 +181,20 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
   if (req.method === "item/fileChange/requestApproval") {
     const observed = req.observedItem;
     if (!observed || observed.changes.length === 0) return unparsedOperation(req, agentId, provenance);
-    return fileChangeOperation(agentId, provenance, observed.changes, grantRootOf(p), observed.itemId);
+    return writeOperation(agentId, provenance, observed.changes, grantRootOf(p), observed.itemId);
   }
+  // ★S3(#106) — 구세대도 신세대와 ★같은 것을 보여준다.★
+  //
+  //  지금까지 구세대 팝업은 ★파일 이름만★ 보여줬다("무엇이 어떻게 바뀌는지" 없이). 재료가 없어서가 아니었다 —
+  //  ★벤더 스키마(0.144.6)를 실제로 읽어보니 구세대 payload 에도 내용이 실려 있다:★
+  //    AddFileChange    { type: "add",    content }        DeleteFileChange { type: "delete", content }
+  //    UpdateFileChange { type: "update", unified_diff, move_path? }
+  //  ★모양을 짐작하지 않고 벤더 스키마에서 읽었다★ — 앞서 patchUpdated 를 짐작해 한 번 틀렸던 자리다.
   if (p.fileChanges && typeof p.fileChanges === "object") {
-    // scope_key(target)의 입력을 files[0]에서 '정렬된 전체 파일목록'으로 넓힌다.
-    // ★단 target 절단 전까지만 구분력이 늘어날 뿐, '서로 다른 파일집합 → 서로 다른 scope'를 일반 보장하지 않는다.★
-    // (여기서 500자, permissionGate.targetForOperation에서 240자로 잘린다.) 전체 결합은 미구현 — 이슈 #106.
-    // ★구세대에도 이동 목적지가 있다★ — UpdateFileChange.move_path. 신세대와 같은 구멍이었다(P1).
-    const files = fileChangeEntries(p.fileChanges);
     // ★S2: grantRoot 는 구세대 applyPatchApproval 에도 있다★ — 지금까지 통째로 무시하고 있었다.
     //   있으면 '이 파일들' 이 아니라 ★'이 루트 하위 전부' 를 세션 동안 허용해 달라는 요청★ 이다.
     //   열쇠에 반영하지 않으면 파일 몇 개에 준 '항상 허용' 이 루트 전체 승인으로 재사용된다.
-    const grantRoot = grantRootOf(p);
-    if (grantRoot) {
-      return {
-        runtime: "codex", agent_id: agentId, action: "write",
-        path: `${grantRootKey(grantRoot)} | ${files.join("|")}`.slice(0, 500),
-        text: `${GRANT_ROOT_WARNING}${grantRoot.slice(0, 200)} · 파일 ${files.length}개: ${files.join(", ")}`.slice(0, 500),
-        requested_by: agentId, provenance: { ...provenance, grant_root: grantRoot },
-      };
-    }
-    return { runtime: "codex", agent_id: agentId, action: "write", path: files.join("|").slice(0, 500), text: files.join(", ").slice(0, 500), requested_by: agentId, provenance };
+    return writeOperation(agentId, provenance, oldGenChanges(p.fileChanges), grantRootOf(p), null);
   }
   return unparsedOperation(req, agentId, provenance);
 }
@@ -210,6 +202,10 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
 /** ★팝업에서 '이건 파일 몇 개가 아니다' 를 사람이 놓치지 않게 하는 머리말.★ 문구가 두 곳에서 같아야
  *  하므로 상수로 둔다(구세대·신세대 경로 모두 같은 위험을 같은 말로 알린다). */
 const GRANT_ROOT_WARNING = "⚠ 세션 동안 아래 폴더 하위 전체에 쓰기 허용 요청 · ";
+
+/** ★해석 실패 팝업의 첫 말.★ 팝업 앞줄(`… · approval_unparsed`)은 공용 코드가 만들어 여기서 못 바꾼다 —
+ *  그래서 뒷줄이 사람에게 상황을 말한다. ★상수라서 열쇠 구분력에 영향이 없다.★ */
+const UNPARSED_NOTICE = "내용 해석 실패 — 원문 확인 필요 · ";
 
 /** grantRoot 를 꺼낸다. 빈 문자열·공백뿐이면 없는 것으로 본다.
  *  ★벤더 설명: "the agent is asking the user to allow writes under this root for the remainder of the
@@ -223,13 +219,6 @@ function grantRootOf(p: Record<string, any> | undefined): string | null {
   //   ★공통 prefix 가 긴 서로 다른 루트가 같은 값이 되어 열쇠·지문이 합쳐졌다★
   //   (310자 공통 + `/one` vs `/two` 로 재현 확인). 자르는 것은 ★표시할 때만★ 한다.
   return t.length > 0 ? t : null;
-}
-
-/** 열쇠에 넣을 grantRoot 표현. ★지문을 맨 앞에 둔다★ — permissionGate 가 target 을 앞 240자만 쓰므로,
- *  원문만 넣으면 ★잘려서 서로 다른 루트가 같은 열쇠★ 가 된다. 사람이 읽을 원문도 뒤에 조금 남긴다. */
-function grantRootKey(root: string): string {
-  const digest = createHash("sha256").update(root).digest("hex").slice(0, 16);
-  return `grant_root#${digest}=${root.slice(0, 120)}`;
 }
 
 /**
@@ -283,8 +272,60 @@ function changeStat(kind: string, diff: string): { added: number; removed: numbe
   return kind === "delete" ? { added: 0, removed: n } : { added: n, removed: 0 };
 }
 
+/** 쓰기 승인 한 건의 공통 내부 표현. 세대마다 payload 모양은 다르지만(신세대=알림 색인, 구세대=fileChanges)
+ *  ★사람이 봐야 하는 것은 같다★ — 무슨 파일을, 어떤 종류로, 얼마나 바꾸는가. 한 곳에서 만든다. */
+export interface WriteChange {
+  path: string;
+  kind: string;
+  movePath: string | null;
+  diff: string;
+}
+
+/** 구세대 `fileChanges`(경로 → FileChange) → WriteChange[].
+ *
+ *  ★벤더 스키마 0.144.6 실측(짐작 아님):★
+ *    AddFileChange    `{ type: "add",    content: string }`
+ *    DeleteFileChange `{ type: "delete", content: string }`
+ *    UpdateFileChange `{ type: "update", unified_diff: string, move_path?: string|null }`
+ *
+ *  ★내용이 없으면 규모를 지어내지 않는다★ — `diff: ""` 로 두면 표시에서 `(+n/-n)` 자체가 빠진다.
+ *  `(+0/-0)` 으로 채우면 사람에게 ★"아무것도 안 바뀐다"★ 로 읽힌다(S2 에서 새 파일 생성이 그렇게 보였던 것과 같은 거짓말). */
+function oldGenChanges(fileChanges: Record<string, unknown>): WriteChange[] {
+  return Object.entries(fileChanges).map(([path, raw]) => {
+    const ch = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+    const mv = typeof ch.move_path === "string" && ch.move_path.trim() ? ch.move_path : null;
+    const diff = typeof ch.unified_diff === "string" ? ch.unified_diff : typeof ch.content === "string" ? ch.content : "";
+    return { path, kind: typeof ch.type === "string" && ch.type ? ch.type : "change", movePath: mv, diff };
+  });
+}
+
+/** ★팝업에서 사람이 실제로 읽는 한 줄의 예산.★ permissionGate.targetForOperation 이 target 을
+ *  ★앞 240자만★ 쓰고, 텔레그램 팝업은 그 target 을 그대로 한 줄로 보여준다(telegramCapture 의
+ *  `${pr.runtime}/${pr.agent_id} · ${pr.action}\n${pr.target}`). ★즉 240자가 화면이다.★ */
+const VISIBLE_BUDGET = 240;
+
+/** 파일 목록을 예산 안에 담고, 넘치면 ★몇 개가 잘렸는지 말한다.★
+ *  예전에는 500자로 이어붙인 뒤 permissionGate 가 240자에서 ★단어 중간을 잘랐다★ —
+ *  화면에는 `…component/fil` 처럼 끝나고 ★"12개 중 5개만 보고 있다" 는 사실이 사라졌다.★ */
+function fitEntries(display: string[], budget: number): string {
+  const out: string[] = [];
+  let used = 0;
+  for (let i = 0; i < display.length; i++) {
+    const piece = display[i]!;
+    const cost = piece.length + (out.length ? 2 : 0);
+    const rest = display.length - i;
+    const tail = rest > 1 ? ` …외 ${rest}개`.length : 0;
+    if (used + cost + tail > budget && out.length > 0) {
+      return `${out.join(", ")} …외 ${rest}개`;
+    }
+    out.push(piece);
+    used += cost;
+  }
+  return out.join(", ");
+}
+
 /**
- * ★S2 — 관측된 파일변경으로 write operation 을 만든다.★
+ * ★S2 — 관측된 파일변경으로 write operation 을 만든다. S3 에서 ★그 한 줄이 읽히게★ 다시 짰다.★
  *
  * ■ 열쇠(scope)는 ★파일 경로 집합★ 이다 — 내용(diff)이 아니다.
  *   내용까지 열쇠에 넣으면 같은 파일을 두 번 고칠 때마다 다른 열쇠가 되어 ★'항상 허용' 이 영원히 안 붙는다★
@@ -296,40 +337,67 @@ function changeStat(kind: string, diff: string): { added: number; removed: numbe
  * ■ 내용(diff)은 ★사람이 보는 요약★ 과 ★audit 지문★ 에만 쓴다.
  *   diff 원문을 text 에 그대로 실으면 permissionGate.operationText 를 통해 ★파일 내용이 Tier-D 스캔에
  *   걸려★ 멀쩡한 코드가 차단될 수 있다. 그래서 ★경로·종류·줄수 요약만★ 싣는다.
+ *
+ * ■ ★S3 — path 는 열쇠이면서 ★동시에 사람이 읽는 유일한 한 줄★ 이다.★
+ *   targetForOperation 의 우선순위가 command > path > egress_url > text 이므로, write 승인에서는
+ *   ★path 가 target 이 되고 text 는 화면에 안 나온다★(실측 확인). 그래서 path 를 열쇠로만 짜면
+ *   사람은 `grant_root#…=/Users/… | a.ts|b.ts` 를 보게 된다 — ★열쇠를 사람에게 읽히는 셈★ 이다.
+ *   → 한 문자열이 두 일을 해야 하므로 순서를 이렇게 고정한다:
+ *     ①경고(사람) ②지문(열쇠 — 잘려도 구분됨) ③파일 개수·종류·경로(사람+열쇠)
+ *   ★규모(+n/-n)는 여기 못 넣는다★ — 내용이 바뀔 때마다 열쇠가 달라져 '항상 허용' 이 영원히 안 붙는다.
+ *   규모는 text 에 남고, 그것을 화면에 띄우려면 렌더러(codex 폴더 밖)를 고쳐야 한다 — ★팀 리드 판단 대기.★
  */
-function fileChangeOperation(
+function writeOperation(
   agentId: string,
   provenance: Record<string, unknown>,
-  changes: ObservedFileChange[],
+  changes: WriteChange[],
   grantRoot: string | null,
-  itemId: string,
+  itemId: string | null,
 ): PermissionOperation {
   // ★이동은 목적지까지가 쓰기 대상이다★ — 출발지만 넣으면 목적지가 달라도 같은 열쇠가 된다(P1).
   const entries = [...new Set(changes.map((c) => writeTargetEntry(c.path, c.movePath)))].sort();
-  const summary = changes
-    .slice()
-    .sort((a, b) => a.path.localeCompare(b.path))
+  const sorted = changes.slice().sort((a, b) => a.path.localeCompare(b.path));
+  // ★열쇠 지문 — 잘림이 서로 다른 요청을 합치지 못하게 한다.★ 예산 안에 못 들어간 파일이 있어도
+  //   집합이 다르면 지문이 다르다. 내용이 아니라 ★경로 집합 + grantRoot 전문★ 만 담으므로, 같은 파일을
+  //   다시 고칠 때는 같은 지문이다('항상 허용' 이 계속 유효). ★이 지문이 있어야 뒤쪽을 사람 말로 줄일 수 있다.★
+  //
+  //   ★grantRoot 를 반드시 지문에 넣는다(Codex 리뷰 P2 의 재발 방지).★ 표시용 grantRootDisplay 는
+  //   뒤 71자만 남기므로, 지문이 없으면 ★앞부분만 다른 두 루트가 같은 열쇠★ 가 된다 —
+  //   그게 P2 에서 실제로 재현했던 사고다(공통 prefix 가 긴 서로 다른 루트).
+  const setDigest = createHash("sha256")
+    .update(JSON.stringify({ grant_root: grantRoot, entries }))
+    .digest("hex")
+    .slice(0, 12);
+  const kindByEntry = new Map(sorted.map((c) => [writeTargetEntry(c.path, c.movePath), c.kind]));
+  const display = entries.map((e) => `${kindByEntry.get(e) ?? "change"} ${e.replace(">", "→")}`);
+  // ★사람이 읽는 순서로 놓는다 — 경고 → 개수 → 파일. 지문은 ★맨 뒤★ 다.★
+  //   지문을 앞에 두면 화면 첫 글자가 `#77b435181b45` 로 시작해 ★사람은 못 읽고 열쇠만 보인다.★
+  //   뒤로 보내도 안전한 이유: 아래에서 지문 길이만큼 예산을 ★먼저 떼어놓고★ 파일 목록을 채우므로
+  //   240자 절단선 안에 지문이 반드시 남는다(그게 P2 재발 방지의 조건이다).
+  const head = grantRoot ? `${GRANT_ROOT_WARNING}${grantRootDisplay(grantRoot)} · ` : "";
+  const prefix = `${head}파일 ${entries.length}개 · `;
+  const suffix = ` #${setDigest}`;
+  const scale = sorted
     .map((c) => {
-      const { added, removed } = changeStat(c.kind, c.diff);
+      const stat = c.diff ? changeStat(c.kind, c.diff) : null;
       const dest = c.movePath ? `→${c.movePath}` : "";
-      return `${c.kind} ${c.path}${dest}(+${added}/-${removed})`;
+      return `${c.kind} ${c.path}${dest}${stat ? `(+${stat.added}/-${stat.removed})` : ""}`;
     })
     .join(", ");
-  const head = grantRoot ? `${grantRootKey(grantRoot)} | ` : "";
-  const textHead = grantRoot ? `${GRANT_ROOT_WARNING}${grantRoot.slice(0, 200)} · ` : "";
   return {
     runtime: "codex",
     agent_id: agentId,
     action: "write",
-    path: `${head}${entries.join("|")}`.slice(0, 500),
-    text: `${textHead}파일 ${entries.length}개: ${summary}`.slice(0, 500),
+    // ★화면 = 앞 240자★ 이므로 예산을 그 기준으로 잡고, 열쇠용 전체는 500자까지 남긴다.
+    path: `${prefix}${fitEntries(display, Math.max(0, VISIBLE_BUDGET - prefix.length - suffix.length))}${suffix}`.slice(0, 500),
+    text: `${grantRoot ? `${GRANT_ROOT_WARNING}${grantRoot.slice(0, 200)} · ` : ""}파일 ${entries.length}개: ${scale}`.slice(0, 500),
     requested_by: agentId,
     provenance: {
       ...provenance,
       item_id: itemId,
       grant_root: grantRoot,
       // 관측 경로를 남긴다 — 나중에 "이 내용을 어디서 알았나" 를 답할 수 있어야 한다.
-      file_changes_source: "notification_index",
+      file_changes_source: itemId ? "notification_index" : "approval_payload",
       // ★audit 전용 내용 지문.★ 열쇠에는 안 들어간다(위 설명) — permissionGate 는 provenance 를 읽지 않는다.
       file_changes_digest: createHash("sha256")
         .update(JSON.stringify(changes.map((c) => [c.path, c.kind, c.movePath, c.diff]).sort()))
@@ -337,6 +405,14 @@ function fileChangeOperation(
         .slice(0, 16),
     },
   };
+}
+
+/** grantRoot 를 ★사람이 구별할 수 있게★ 줄인다. 열쇠 구분은 지문(setDigest)이 하므로
+ *  여기서는 읽히는 것만 신경 쓴다 — ★뿌리는 앞이 아니라 뒤가 다르다★
+ *  (`/Users/gdmini/Development/a` vs `…/b` 는 앞 60자가 똑같다). 그래서 길면 ★뒤를 남긴다.★ */
+function grantRootDisplay(root: string): string {
+  if (root.length <= 72) return root;
+  return `…${root.slice(-71)}`;
 }
 
 /** ★해석하지 못한 승인 요청의 operation.★ 두 곳에서 쓴다 — 아무 분기에도 안 걸린 경우와,
@@ -357,7 +433,12 @@ function unparsedOperation(req: ApprovalRequest, agentId: string, provenance: Re
     runtime: "codex",
     agent_id: agentId,
     action: "approval_unparsed",
-    text: `${req.method.slice(0, 64)} #${unparsedPayloadDigest(req)}${reason ? ` ${reason}` : ""}`,
+    // ★S3 — 화면 첫 글자를 사람 말로 시작한다.★ 팝업이 보여주는 두 줄은
+    //   `codex/dex · approval_unparsed` / `<target>` 인데, 앞줄의 action 은 codex 계층에서 바꿀 수 없다
+    //   (permissionGate 가 만든다 = 공용). ★그러면 최소한 뒷줄이 사람에게 상황을 말해야 한다.★
+    //   내부 식별자만 두 줄 연달아 보여주면 사람은 무엇을 승인/거절하는지 모른 채 버튼을 누른다.
+    //   지문은 그 뒤에 온다 — 앞머리는 ★모든 해석 실패에서 같은 상수★ 라 열쇠 구분력을 줄이지 않는다.
+    text: `${UNPARSED_NOTICE}${req.method.slice(0, 64)} #${unparsedPayloadDigest(req)}${reason ? ` ${reason}` : ""}`,
     requested_by: agentId,
     provenance,
   };

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -190,11 +190,17 @@ export function buildOperationFromApproval(req: ApprovalRequest, agentId: string
   //    AddFileChange    { type: "add",    content }        DeleteFileChange { type: "delete", content }
   //    UpdateFileChange { type: "update", unified_diff, move_path? }
   //  ★모양을 짐작하지 않고 벤더 스키마에서 읽었다★ — 앞서 patchUpdated 를 짐작해 한 번 틀렸던 자리다.
-  if (p.fileChanges && typeof p.fileChanges === "object") {
+  // ★배열은 파일 목록이 아니다(Codex 리뷰 2026-07-30).★ `typeof [] === "object"` 라 그냥 통과했고,
+  //   그 결과 ★인덱스 0 을 파일 경로로 표시★ 했다(실측: `change 0`). 모양이 아니면 해석 실패로 보낸다.
+  if (p.fileChanges && typeof p.fileChanges === "object" && !Array.isArray(p.fileChanges)) {
     // ★S2: grantRoot 는 구세대 applyPatchApproval 에도 있다★ — 지금까지 통째로 무시하고 있었다.
     //   있으면 '이 파일들' 이 아니라 ★'이 루트 하위 전부' 를 세션 동안 허용해 달라는 요청★ 이다.
     //   열쇠에 반영하지 않으면 파일 몇 개에 준 '항상 허용' 이 루트 전체 승인으로 재사용된다.
-    return writeOperation(agentId, provenance, oldGenChanges(p.fileChanges), grantRootOf(p), null);
+    const oldChanges = oldGenChanges(p.fileChanges);
+    // ★빈 목록은 '파일 0개 쓰기' 가 아니라 해석 실패다★ — 신세대(관측된 변경 0건)와 정책을 맞춘다.
+    //   앞선 판은 `fileChanges: {}` 를 write 로 만들어 ★내용 없는 넓은 열쇠★ 를 하나 만들었다.
+    if (oldChanges.length === 0) return unparsedOperation(req, agentId, provenance);
+    return writeOperation(agentId, provenance, oldChanges, grantRootOf(p), null);
   }
   return unparsedOperation(req, agentId, provenance);
 }
@@ -257,7 +263,12 @@ function fileChangeEntries(fileChanges: Record<string, unknown>): string[] {
  *  (delete 는 라이브로 못 봤다 — 통일diff 가 아니면 삭제 규모로 센다.) */
 function changeStat(kind: string, diff: string): { added: number; removed: number } {
   const lines = diff.split("\n");
-  const isUnified = lines.some((l) => l.startsWith("@@"));
+  // ★모양이 아니라 종류로 판정한다(Codex 리뷰 2026-07-30 P2).★ 앞선 판은 `@@` 로 시작하는 줄이
+  //   있으면 통일diff 로 봤는데, add/delete 의 `content` 는 ★파일 원문★ 이라 마크다운 제목 `@@ heading`
+  //   같은 줄이 들어오면 통일diff 로 오판해 ★(+0/-0)★ 을 만든다(실측 재현: add·delete·신세대 add 전부).
+  //   ★그게 이 함수가 애초에 막으려 했던 거짓말 그 자체다.★ 벤더 스키마상 통일diff 는 update 뿐이므로
+  //   update 면 diff 로 세고, add/delete 면 원문 줄수로 센다. ★모르는 종류만 모양으로 추정한다.★
+  const isUnified = kind === "update" ? true : kind === "add" || kind === "delete" ? false : lines.some((l) => l.startsWith("@@"));
   if (isUnified) {
     let added = 0, removed = 0;
     for (const line of lines) {
@@ -304,9 +315,27 @@ function oldGenChanges(fileChanges: Record<string, unknown>): WriteChange[] {
  *  `${pr.runtime}/${pr.agent_id} · ${pr.action}\n${pr.target}`). ★즉 240자가 화면이다.★ */
 const VISIBLE_BUDGET = 240;
 
+/** 코드포인트 경계에서 자른다. ★UTF-16 code unit 으로 자르면 이모지 한 자를 반 토막 낸다★ —
+ *  `a×224 + 😀` 경로에서 target 끝이 고아 서로게이트(U+D83D)로 끝나는 것을 재현했다(Codex 리뷰 2026-07-30).
+ *  화면에 깨진 글자가 뜨는 것 자체도 문제지만, ★"내가 지금 무엇을 승인하는가" 를 흐리는 것★ 이 더 나쁘다. */
+function cutCodePoints(s: string, max: number): string {
+  if (s.length <= max) return s;
+  let out = "";
+  for (const cp of s) {
+    if (out.length + cp.length > max) break;
+    out += cp;
+  }
+  return out;
+}
+
 /** 파일 목록을 예산 안에 담고, 넘치면 ★몇 개가 잘렸는지 말한다.★
  *  예전에는 500자로 이어붙인 뒤 permissionGate 가 240자에서 ★단어 중간을 잘랐다★ —
- *  화면에는 `…component/fil` 처럼 끝나고 ★"12개 중 5개만 보고 있다" 는 사실이 사라졌다.★ */
+ *  화면에는 `…component/fil` 처럼 끝나고 ★"12개 중 5개만 보고 있다" 는 사실이 사라졌다.★
+ *
+ *  ★첫 항목도 예산을 지킨다(Codex 리뷰 2026-07-30 P1).★ 앞선 판은 `out.length > 0` 일 때만 줄여서
+ *  ★첫 경로가 길면 통째로 밀어넣었다★ — 그러면 뒤에 붙는 지문이 permissionGate 의 240자 절단에서
+ *  ★사라지고, 앞 240자가 같은 서로 다른 긴 경로가 한 열쇠로 합쳐진다★(400자 단일 경로로 재현).
+ *  ★지문을 뒤에 두기로 한 결정이 성립하려면 "예산은 무조건 지킨다" 가 예외 없이 참이어야 한다.★ */
 function fitEntries(display: string[], budget: number): string {
   const out: string[] = [];
   let used = 0;
@@ -315,8 +344,12 @@ function fitEntries(display: string[], budget: number): string {
     const cost = piece.length + (out.length ? 2 : 0);
     const rest = display.length - i;
     const tail = rest > 1 ? ` …외 ${rest}개`.length : 0;
-    if (used + cost + tail > budget && out.length > 0) {
-      return `${out.join(", ")} …외 ${rest}개`;
+    if (used + cost + tail > budget) {
+      if (out.length > 0) return `${out.join(", ")} …외 ${rest}개`;
+      // ★첫 항목 하나도 안 들어간다 → 그 항목 자체를 예산에 맞춰 자르고 잘렸음을 표시한다.★
+      const room = Math.max(0, budget - (rest > 1 ? tail : 1));
+      const cut = `${cutCodePoints(piece, Math.max(0, room - 1))}…`;
+      return rest > 1 ? `${cut} …외 ${rest}개` : cut;
     }
     out.push(piece);
     used += cost;
@@ -355,7 +388,19 @@ function writeOperation(
   itemId: string | null,
 ): PermissionOperation {
   // ★이동은 목적지까지가 쓰기 대상이다★ — 출발지만 넣으면 목적지가 달라도 같은 열쇠가 된다(P1).
-  const entries = [...new Set(changes.map((c) => writeTargetEntry(c.path, c.movePath)))].sort();
+  //
+  // ★지문의 재료는 구조화 tuple 이다 — 이어붙인 문자열이 아니다(Codex 리뷰 2026-07-30 P1).★
+  //   앞선 판은 `path + ">" + movePath` 문자열 집합을 해시했다. 그래서
+  //     경로 이름이 그대로 `a>b` 인 파일  vs  `a` 를 `b` 로 옮기는 이동
+  //     `a>b` → `c`                      vs  `a` → `b>c`
+  //   가 ★완전히 같은 재료★ 가 됐다 — 뒤 쌍은 ★실제로 같은 열쇠★ 임을 재현했다.
+  //   ★"지문이 갈라준다" 는 지문의 재료가 모호하지 않을 때만 참이다.★ 내가 그 전제를 확인하지 않고
+  //   코덱스에게 단언했고, 그게 틀렸다. 이제 [path, movePath] 로 담아 구분이 구조에서 나온다.
+  const keyOf = (c: WriteChange) => JSON.stringify([c.path, c.movePath]);
+  const byKey = new Map<string, WriteChange>();
+  for (const c of changes) if (!byKey.has(keyOf(c))) byKey.set(keyOf(c), c);
+  const uniq = [...byKey.values()].sort((a, b) => keyOf(a).localeCompare(keyOf(b)));
+  const entries = uniq.map((c) => [c.path, c.movePath] as const);
   const sorted = changes.slice().sort((a, b) => a.path.localeCompare(b.path));
   // ★열쇠 지문 — 잘림이 서로 다른 요청을 합치지 못하게 한다.★ 예산 안에 못 들어간 파일이 있어도
   //   집합이 다르면 지문이 다르다. 내용이 아니라 ★경로 집합 + grantRoot 전문★ 만 담으므로, 같은 파일을
@@ -368,8 +413,9 @@ function writeOperation(
     .update(JSON.stringify({ grant_root: grantRoot, entries }))
     .digest("hex")
     .slice(0, 12);
-  const kindByEntry = new Map(sorted.map((c) => [writeTargetEntry(c.path, c.movePath), c.kind]));
-  const display = entries.map((e) => `${kindByEntry.get(e) ?? "change"} ${e.replace(">", "→")}`);
+  // ★표시도 원본 필드에서 조립한다★ — 이어붙인 문자열에서 `>` 를 `→` 로 바꾸면
+  //   이름에 `>` 가 든 평범한 파일이 ★"옮긴다" 로 거짓 표시된다★(실측: `a>b.ts` → `add a→b.ts`).
+  const display = uniq.map((c) => `${c.kind} ${c.path}${c.movePath ? ` → ${c.movePath}` : ""}`);
   // ★사람이 읽는 순서로 놓는다 — 경고 → 개수 → 파일. 지문은 ★맨 뒤★ 다.★
   //   지문을 앞에 두면 화면 첫 글자가 `#77b435181b45` 로 시작해 ★사람은 못 읽고 열쇠만 보인다.★
   //   뒤로 보내도 안전한 이유: 아래에서 지문 길이만큼 예산을 ★먼저 떼어놓고★ 파일 목록을 채우므로
@@ -380,7 +426,7 @@ function writeOperation(
   const scale = sorted
     .map((c) => {
       const stat = c.diff ? changeStat(c.kind, c.diff) : null;
-      const dest = c.movePath ? `→${c.movePath}` : "";
+      const dest = c.movePath ? ` → ${c.movePath}` : "";
       return `${c.kind} ${c.path}${dest}${stat ? `(+${stat.added}/-${stat.removed})` : ""}`;
     })
     .join(", ");

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -305,8 +305,21 @@ function oldGenChanges(fileChanges: Record<string, unknown>): WriteChange[] {
   return Object.entries(fileChanges).map(([path, raw]) => {
     const ch = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
     const mv = typeof ch.move_path === "string" && ch.move_path.trim() ? ch.move_path : null;
-    const diff = typeof ch.unified_diff === "string" ? ch.unified_diff : typeof ch.content === "string" ? ch.content : "";
-    return { path, kind: typeof ch.type === "string" && ch.type ? ch.type : "change", movePath: mv, diff };
+    const kind = typeof ch.type === "string" && ch.type ? ch.type : "change";
+    // ★필드를 종류에 맞춰 고른다(Codex 리뷰 2026-07-30, 2회전).★ 앞선 판은 type 과 무관하게
+    //   unified_diff 를 먼저 집었다. changeStat 은 kind 로 세는데 재료는 kind 를 안 보고 골랐으니
+    //   ★짝이 어긋난 payload 에서 규모를 지어냈다★ (전부 실측):
+    //     {type:"update", content:"hello\n"}            → update x(+0/-0)  ← "아무것도 안 바뀐다" 거짓말
+    //     {type:"add", unified_diff:"@@ …"}             → add x(+3/-0)     ← 없는 내용에서 규모를 만듦
+    //     {type:"add", content:"one\n", unified_diff:…} → add x(+3/-0)     ← 맞는 필드를 두고 틀린 걸 씀
+    //   ★모르면 비워 둔다★ — diff="" 면 표시에서 (+n/-n) 자체가 빠진다. 모르는 종류만 휴리스틱을 쓴다.
+    const diff =
+      kind === "update"
+        ? typeof ch.unified_diff === "string" ? ch.unified_diff : ""
+        : kind === "add" || kind === "delete"
+          ? typeof ch.content === "string" ? ch.content : ""
+          : typeof ch.unified_diff === "string" ? ch.unified_diff : typeof ch.content === "string" ? ch.content : "";
+    return { path, kind, movePath: mv, diff };
   });
 }
 


### PR DESCRIPTION
## 무엇을 발견했나 (이게 S3 의 실제 대상이다)

S2 는 `update a.ts(+1/-2)` 같은 사람용 요약을 `op.text` 에 잘 만들어 뒀습니다. **그런데 팝업은 `text` 를 보여주지 않습니다.**

`telegramCapture` 가 렌더하는 두 줄은 `${runtime}/${agent_id} · ${action}` / `${target}` 이고, `targetForOperation` 우선순위는 **command > path > egress_url > text** 입니다. → write 승인에서는 **`path` 가 화면이고 `text` 는 아무도 못 봅니다.**

즉 S2 의 완료 판정("파일명+규모가 포함된다")은 **text 기준으로는 참, 화면 기준으로는 거짓**이었습니다. 코드를 읽어서가 아니라 `buildOperationFromApproval` → `targetForOperation` 을 실제로 실행해 화면 문자열을 찍어보고 발견했습니다.

### 실측한 이전 화면 (팝업 둘째 줄)

| 경우 | 사람이 보던 것 | 문제 |
|---|---|---|
| grantRoot | `grant_root#bf42cf614766e323=/Users/gdmini/Development/demis \| src/a.ts` | **⚠ 경고가 안 보인다** — 폴더 전체 승인인지 알 방법이 화면에 없음 |
| 파일 12개 | `…/component/fil` | 단어 중간 절단. **12개 중 5개만 보고 있다는 사실이 사라짐** |
| 해석 실패 | 앞줄 `approval_unparsed` + 뒷줄 `item/fileChange/requestApproval #55de7ffe…` | **내부 용어만 두 줄** |

## 바꾼 것 (codex 계층만 · 공용 파일 0건)

- `path` 를 **①경고 ②개수·종류·경로 ③열쇠 지문** 순서로 짭니다 — 사람이 읽는 순서로 시작합니다.
- **지문을 맨 뒤로 옮기고 예산을 먼저 뗍니다** — 240자 안에 반드시 남으므로 P2(루트 합쳐짐) 재발이 없습니다. basis = `{grant_root 전문, 정렬된 파일집합}`. **내용은 안 담습니다** — 담으면 매 수정마다 열쇠가 달라져 '항상 허용' 이 영원히 안 붙습니다(S2 결정 유지).
- 잘릴 때 `…외 N개`.
- 긴 grantRoot 는 **뒤 71자**를 남깁니다 — 뿌리는 앞이 아니라 뒤가 다릅니다.
- **구세대도 규모를 보여줍니다.** 벤더 스키마 0.144.6 실측: `AddFileChange{content}` · `DeleteFileChange{content}` · `UpdateFileChange{unified_diff, move_path}`. **재료가 payload 에 있었습니다** — 이름만 보여준 건 재료가 없어서가 아니었습니다. 내용이 없으면 `(+0/-0)` 을 만들지 않습니다.
- 해석 실패 화면은 `내용 해석 실패 — 원문 확인 필요 · ` 로 시작합니다(상수라 열쇠 구분력 영향 0).

### 지금 화면

```
codex/dex · write
파일 2개 · update src/a.ts, add src/new.ts #77b435181b45

codex/dex · write
⚠ 세션 동안 아래 폴더 하위 전체에 쓰기 허용 요청 · /Users/gdmini/Development/demis · 파일 1개 · update src/a.ts #55193e87074b

codex/dex · write
파일 12개 · update src/…/file0.tsx, update src/…/file1.tsx, update src/…/file10.tsx …외 9개 #8bfcdc04bb11

codex/dex · approval_unparsed
내용 해석 실패 — 원문 확인 필요 · item/fileChange/requestApproval #55de7ffeefb5909e 패치를 적용해도 될까요
```

## 팀 리드 판단 대기 (이 PR 범위 밖)

**규모(+n/-n)는 열쇠에 넣을 수 없어 화면에 못 띄웁니다.** 띄우려면 렌더러(`telegramCapture` 또는 `permissionGate`)를 고쳐야 하고 **codex 폴더 밖**입니다. 팝업 앞줄의 `approval_unparsed` 도 같은 이유로 여기서 못 바꿉니다. 카드 stop_rule 대로 손대지 않고 올립니다.

## 영향 범위

- **열쇠(scope)가 바뀝니다.** 저장된 `permission_grant` = **0행**(실측 2026-07-30) → 무효화될 것이 없습니다.
- 지문(`approvalOperationHash`)은 **안 바뀝니다** — 진행 중 승인의 상관키가 어긋나지 않습니다(구세대 golden `c7fa63459c642993` 유지).
- 플래그 `B3OS_CODEX_APPSERVER` 는 **여전히 꺼져 있습니다.**

## 검증

- 신규 **14건**(`appServerPopup.s3.test.ts`) · codex 223 pass 0 fail
- 전체 **1917 pass** / 베이스라인(origin/main 동일 커밋 별도 워크트리) **1903 pass** → **델타 +14 = 신규분** = 회귀 0
- `tsc` 0
- **뮤턴트 9종 전부 사망.** 단 **M2(지문에서 grantRoot 제거)가 처음에 살아남았습니다** — 기계가 아니라 **제 시험 입력**이 문제였습니다(두 루트의 뒤가 달라 표시만으로 열쇠가 갈렸고 지문 역할을 안 쟀음). 뒤 71자가 같고 앞만 다른 루트로 바꿔 잡았습니다(커밋 6b5e220).
- **실패 1건은 `origin/main` 에 이미 있는 것**입니다 — `utcTimestamp.contract.test.ts` 가 `routes/scheduler.ts:120` 의 맨 `new Date(input.run_at)` 를 잡습니다. 제 변경과 무관하고 별도 보고했습니다.

작업은 격리 워크트리에서만 했고 라이브 트리는 무수정입니다.

cc @bill @codex — 리뷰 부탁드립니다. 각도가 겹치지 않게: **열쇠 안전성(지문·절단·grant 영향)** 과 **사람이 읽는 문구** 를 나눠 보시면 좋겠습니다.