### PR TITLE
fix(scheduler): 실패한 반복 잡이 영구 정지하던 것 + 죽은 잡이 초록불로 보이던 것

### DIFF
--- a/src/server/lib/teamosProbe.test.ts
+++ b/src/server/lib/teamosProbe.test.ts
@@ -122,3 +122,52 @@ describe("teamOsSnapshot 이 문제를 화면 데이터에 실어 보낸다", ()
     expect(row?.detail).toContain("실패로 정지");
   });
 });
+
+// steve 리뷰의 블로커성 지적: A(실패 시 재예약)가 들어오면 ★방금 실패한 잡이 화면상 초록불★ 이 된다.
+//   연속 3회를 채워야 빨개지는데 일간 잡은 그게 3일이다. 이 화면이 고치려던 문제를 작게 다시 만드는 것.
+describe("judgeScheduledJob — 재시도 대기와 실행 중을 구분한다", () => {
+  const NOW = Date.parse("2026-07-30T01:00:00Z"); // 10:00 KST
+
+  test("★직전 시도가 실패했으면 초록불이 아니다★ — 재예약됐어도 amber", () => {
+    const v = judgeScheduledJob(
+      { enabled: 1, status: "pending", next_run_at: "2026-07-30 01:30:00", last_error: "exec_failed:..." },
+      NOW,
+    );
+    expect(v.running).toBe(false);
+    expect(v.problem).toBe("retrying");
+  });
+
+  test("성공해서 에러가 지워졌으면 초록불", () => {
+    const v = judgeScheduledJob(
+      { enabled: 1, status: "pending", next_run_at: "2026-07-30 01:30:00", last_error: null },
+      NOW,
+    );
+    expect(v.running).toBe(true);
+    expect(v.problem).toBeNull();
+  });
+
+  test("정지(failed)가 재시도보다 우선한다 — 더 나쁜 쪽을 보여준다", () => {
+    const v = judgeScheduledJob(
+      { enabled: 1, status: "failed", next_run_at: "2026-07-30 01:30:00", last_error: "boom" },
+      NOW,
+    );
+    expect(v.problem).toBe("failed");
+  });
+
+  test("★실행 중인 잡을 밀림으로 잡지 않는다★ — claim 은 next_run_at 을 안 옮긴다", () => {
+    // 긴 exec 가 도는 중: 예정 시각은 이미 지났지만 리스가 살아 있다.
+    const v = judgeScheduledJob(
+      { enabled: 1, status: "running", next_run_at: "2026-07-30 00:50:00", lock_until: "2026-07-30 01:05:00" },
+      NOW,
+    );
+    expect(v.problem).toBeNull();
+  });
+
+  test("리스가 만료된 채 running 이면 밀림이 맞다 — 죽은 워커가 물고 있는 것", () => {
+    const v = judgeScheduledJob(
+      { enabled: 1, status: "running", next_run_at: "2026-07-30 00:00:00", lock_until: "2026-07-30 00:10:00" },
+      NOW,
+    );
+    expect(v.problem).toBe("overdue");
+  });
+});

--- a/src/server/lib/teamosProbe.test.ts
+++ b/src/server/lib/teamosProbe.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
 import { migrate } from "../db/migrate";
 import { createCronJob } from "../scheduler/core";
-import { teamOsSnapshot, __resetTeamOsSnapshotCacheForTest } from "./teamosProbe";
+import { teamOsSnapshot, judgeScheduledJob, __resetTeamOsSnapshotCacheForTest } from "./teamosProbe";
 
 describe("teamOsSnapshot scheduled_job rows", () => {
   test("labels DB scheduled jobs separately and renders next/last in KST", () => {
@@ -41,5 +41,84 @@ describe("teamOsSnapshot scheduled_job rows", () => {
     __resetTeamOsSnapshotCacheForTest();
 
     expect(teamOsSnapshot(db).scheduled.some((job) => job.label === "retired-job")).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 죽은 잡을 초록불로 보여주던 판정 (2026-07-30 사고)
+//   실패로 정지한 잡이 "next=9시간 전" 이라고 적힌 채 running=true 로 떴다. 화면이 고장을 정상이라 말했다.
+//   ★시각을 인자로 받아 고정한다★ — "지금"에 의존하면 이 판정을 검증할 수 없다.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("judgeScheduledJob — 초록불을 줄지 판정", () => {
+  const NOW = Date.parse("2026-07-30T01:00:00Z"); // 10:00 KST
+  const at = (iso: string) => ({ enabled: 1, status: "pending" as string | null, next_run_at: iso });
+
+  test("정상: 다음 실행이 미래 → 초록불", () => {
+    const v = judgeScheduledJob(at("2026-07-30 01:30:00"), NOW);
+    expect(v.running).toBe(true);
+    expect(v.problem).toBeNull();
+  });
+
+  test("★실패로 정지한 잡은 초록불이 아니다★ (사고 회귀)", () => {
+    // 사고 그대로의 행: 실패 상태인데 next_run_at 은 9시간 전에 멈춰 있다.
+    const v = judgeScheduledJob({ enabled: 1, status: "failed", next_run_at: "2026-07-29 15:30:00" }, NOW);
+    expect(v.running).toBe(false);
+    expect(v.problem).toBe("failed");
+  });
+
+  test("★status 가 pending 이어도 시각이 한참 지났으면 밀림★ — 값이 있다는 것만으로 통과시키지 않는다", () => {
+    const v = judgeScheduledJob(at("2026-07-29 15:30:00"), NOW);
+    expect(v.running).toBe(false);
+    expect(v.problem).toBe("overdue");
+    expect(v.overdueMin).toBe(570); // 9시간 30분
+  });
+
+  test("유예(5분) 안쪽으로 지난 건 밀림이 아니다 — tick 간격의 정상적인 찰나까지 잡으면 거짓 경보", () => {
+    const v = judgeScheduledJob(at("2026-07-30 00:58:00"), NOW); // 2분 지남
+    expect(v.running).toBe(true);
+    expect(v.problem).toBeNull();
+  });
+
+  test("유예를 넘긴 순간부터 밀림", () => {
+    expect(judgeScheduledJob(at("2026-07-30 00:54:00"), NOW).problem).toBe("overdue"); // 6분
+  });
+
+  test("다음 시각이 없으면 초록불도 아니고 밀림도 아니다 — 모르는 것은 모른다고 둔다", () => {
+    const v = judgeScheduledJob({ enabled: 1, status: "pending", next_run_at: null }, NOW);
+    expect(v.running).toBe(false);
+    expect(v.problem).toBeNull();
+  });
+
+  test("시각 문자열이 깨졌으면 밀림으로 단정하지 않는다", () => {
+    const v = judgeScheduledJob(at("not-a-date"), NOW);
+    expect(v.problem).toBeNull();
+  });
+
+  test("꺼둔 잡은 고장이 아니다 — disabled 와 죽음을 구분한다", () => {
+    const v = judgeScheduledJob({ enabled: 0, status: "pending", next_run_at: "2026-07-30 01:30:00" }, NOW);
+    expect(v.running).toBe(false);
+    expect(v.problem).toBeNull();
+  });
+});
+
+describe("teamOsSnapshot 이 문제를 화면 데이터에 실어 보낸다", () => {
+  test("★실패한 잡은 detail 에 이유가 찍히고 running=false★", () => {
+    const db = new Database(":memory:");
+    migrate(db);
+    createCronJob(db, {
+      id: "guard-job",
+      title: "진행 지속 가드",
+      cron: "*/30 * * * *",
+      timezone: "Asia/Seoul",
+      createdBy: "test",
+      payload: { type: "exec", execKey: "task-continuation-guard" },
+    });
+    db.prepare("UPDATE scheduled_job SET status='failed', next_run_at='2026-07-29 15:30:00' WHERE id='guard-job'").run();
+    __resetTeamOsSnapshotCacheForTest();
+
+    const row = teamOsSnapshot(db).scheduled.find((j) => j.label === "guard-job");
+    expect(row?.running).toBe(false);
+    expect(row?.problem).toBe("failed");
+    expect(row?.detail).toContain("실패로 정지");
   });
 });

--- a/src/server/lib/teamosProbe.ts
+++ b/src/server/lib/teamosProbe.ts
@@ -42,10 +42,11 @@ export interface TeamOsScheduled {
   /**
    * 초록불이 아닌 ★이유★. null/undefined 면 문제 없음.
    * running 이 boolean 하나뿐이라 "꺼둔 것"과 "죽은 것"이 화면에서 같게 보였다.
-   *  - "failed"  : 실행하다 실패해 정지된 상태
-   *  - "overdue" : 다음 실행 시각이 이미 지났는데 안 돌고 있다(밀림)
+   *  - "failed"   : 실행하다 실패해 정지된 상태
+   *  - "overdue"  : 다음 실행 시각이 이미 지났는데 안 돌고 있다(밀림)
+   *  - "retrying" : 직전 시도가 실패했고 다음 차례에 다시 해본다(죽지는 않았지만 정상도 아니다)
    */
-  problem?: "failed" | "overdue" | null;
+  problem?: "failed" | "overdue" | "retrying" | null;
 }
 
 /**
@@ -259,22 +260,47 @@ function listLaunchd(running: Map<string, boolean>): TeamOsScheduled[] {
  *   실제로 08:00 에 정지한 잡이 "next=00:30" 이라고 적힌 채 running=true 로 9시간을 버텼다.
  *   ★사람이 화면을 보고도 못 본다. 화면이 잘못된 판단에 동의해준다.★
  *
+ * ★'retrying' 이 왜 필요한가★ (steve 리뷰의 블로커성 지적)
+ *   같은 PR 의 A(실패 시 재예약)가 들어오면 실패한 잡이 곧바로 status='pending' + 미래 시각이 된다.
+ *   그러면 이 판정은 problem=null → ★초록불★ 이다. 즉 ★방금 실패한 잡이 화면상 정상★ 이고,
+ *   연속 3회를 채워야 빨개진다. 30분 잡은 90분, ★일간 잡은 3일★ 이 걸린다.
+ *   그건 이 함수가 고치려는 명제("화면이 고장을 정상이라 말했다")를 작은 판으로 다시 만드는 것이다.
+ *   → 직전 시도가 실패했다는 신호(last_error)를 받아 amber 로 표시한다. 죽은 건 아니지만 정상도 아니다.
+ *
+ * ★'running' 상태를 밀림에서 빼는 이유★
+ *   claim 은 status='running' 으로 바꾸면서 next_run_at 을 ★안 옮긴다★. 그래서 실행 중인 잡은
+ *   next_run_at 이 과거인 채로 있다. 유예가 최대 실행시간보다 짧으면 ★정상 실행 중인 잡이 밀림으로 뜬다.★
+ *   지금 수치로는 245s < 300s 라 아슬아슬하게 안전한데, timeout 이 긴 exec 키가 하나 추가되면 깨진다.
+ *   유예 값을 키우는 대신 ★"지금 돌고 있다"는 사실 자체★ 로 거른다(리스가 살아 있는 동안만).
+ *
  * now 를 인자로 받는 이유: 시각 판정은 테스트에서 시각을 고정할 수 있어야 검증이 된다.
  */
 export function judgeScheduledJob(
-  row: { enabled: number; status: string | null; next_run_at: string | null },
+  row: {
+    enabled: number;
+    status: string | null;
+    next_run_at: string | null;
+    last_error?: string | null;
+    lock_until?: string | null;
+  },
   nowMs: number,
-): { running: boolean; problem: "failed" | "overdue" | null; overdueMin: number } {
+): { running: boolean; problem: "failed" | "overdue" | "retrying" | null; overdueMin: number } {
   // ★새 시각 파서를 만들지 않는다★ — 스케줄러가 자기 컬럼을 읽는 방식(fromSqliteDate)을 그대로 쓴다.
   //   판정과 저장이 다른 규칙을 쓰면 KST 서버에서 정확히 9시간 어긋난다(utcTimestamp.contract.test 의 교훈).
   const overdueMs = row.next_run_at ? nowMs - fromSqliteDate(row.next_run_at).getTime() : Number.NaN;
   const isFailed = row.status === "failed";
+  // 리스가 아직 살아 있는 실행 중 = 늦은 게 아니라 ★지금 하는 중★ 이다.
+  const leaseMs = row.lock_until ? fromSqliteDate(row.lock_until).getTime() : Number.NaN;
+  const isRunningNow = row.status === "running" && Number.isFinite(leaseMs) && leaseMs > nowMs;
   // 시각이 없거나 파싱 불가면 ★밀림으로 단정하지 않는다★ — 모르는 것은 모른다고 둔다(거짓 경보 금지).
-  const isOverdue = Number.isFinite(overdueMs) && overdueMs > OVERDUE_GRACE_SEC * 1000;
+  const isOverdue = !isRunningNow && Number.isFinite(overdueMs) && overdueMs > OVERDUE_GRACE_SEC * 1000;
+  // 재시도 대기: 다음 차례는 잡혀 있는데 ★직전 시도가 실패했다.★
+  //   last_error 는 성공 시 NULL 로 지워지고 실패 시 채워지므로 "직전 시도 결과" 신호가 된다.
+  const isRetrying = !isFailed && !isOverdue && row.status === "pending" && !!row.last_error;
   return {
-    // "예정대로 살아있나" = 켜져 있고 · 다음 실행이 잡혀 있고 · 실패로 정지하지 않았고 · 밀리지 않았나.
-    running: row.enabled === 1 && !!row.next_run_at && !isFailed && !isOverdue,
-    problem: isFailed ? "failed" : isOverdue ? "overdue" : null,
+    // "예정대로 살아있나" = 켜져 있고 · 다음 실행이 잡혀 있고 · 정지/밀림/재시도 중이 아니다.
+    running: row.enabled === 1 && !!row.next_run_at && !isFailed && !isOverdue && !isRetrying,
+    problem: isFailed ? "failed" : isOverdue ? "overdue" : isRetrying ? "retrying" : null,
     overdueMin: Number.isFinite(overdueMs) ? Math.floor(overdueMs / 60000) : 0,
   };
 }
@@ -282,7 +308,9 @@ export function judgeScheduledJob(
 function listScheduledJobs(db: Database): TeamOsScheduled[] {
   try {
     const rows = db.prepare(
-      `SELECT id, title, schedule_expr, enabled, status, next_run_at, last_run_at
+      // ★판정에 쓸 값은 전부 가져온다★ — 이 SELECT 에 last_error 가 없어서 화면은 "직전 시도가 실패했다"를
+      //   ★알 방법 자체가 없었다.★ 신호가 판정부에 도달하지 않는 것은 status 를 안 쓰던 것과 같은 결함이다.
+      `SELECT id, title, schedule_expr, enabled, status, next_run_at, last_run_at, last_error, lock_until
          FROM scheduled_job
         WHERE kind='recurring'
           AND NOT (enabled=0 AND status='cancelled')
@@ -290,6 +318,7 @@ function listScheduledJobs(db: Database): TeamOsScheduled[] {
     ).all() as Array<{
       id: string; title: string | null; schedule_expr: string | null;
       enabled: number; status: string | null; next_run_at: string | null; last_run_at: string | null;
+      last_error: string | null; lock_until: string | null;
     }>;
     const nowMs = Date.now();
     return rows.map((r) => {
@@ -307,6 +336,7 @@ function listScheduledJobs(db: Database): TeamOsScheduled[] {
           `last=${last ?? "-"}`,
           v.problem === "failed" && "★실패로 정지★",
           v.problem === "overdue" && `★${v.overdueMin}분 밀림★`,
+          v.problem === "retrying" && "★직전 시도 실패 — 다음 차례에 재시도★",
         ].filter(Boolean).join(" · "),
         description: r.title ?? "",
         source: "scheduled_job" as const,

--- a/src/server/lib/teamosProbe.ts
+++ b/src/server/lib/teamosProbe.ts
@@ -16,6 +16,7 @@ import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import { teamosLaunchdPrefix } from "./agentControl";
 import { captureConfigStatus } from "./captureConfig";
+import { fromSqliteDate } from "../scheduler/core";
 
 // teamosProbe.ts lives in src/server/lib → three levels up is the repo root.
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../..");
@@ -38,7 +39,20 @@ export interface TeamOsScheduled {
   source: "launchd" | "openclaw_cron" | "scheduled_job";
   running: boolean | null;
   enabled: boolean;
+  /**
+   * 초록불이 아닌 ★이유★. null/undefined 면 문제 없음.
+   * running 이 boolean 하나뿐이라 "꺼둔 것"과 "죽은 것"이 화면에서 같게 보였다.
+   *  - "failed"  : 실행하다 실패해 정지된 상태
+   *  - "overdue" : 다음 실행 시각이 이미 지났는데 안 돌고 있다(밀림)
+   */
+  problem?: "failed" | "overdue" | null;
 }
+
+/**
+ * 다음 실행 시각이 이 초 이상 지났을 때만 "밀림"으로 본다.
+ * 0 이면 스케줄러 tick 간격(기본 60s) 안의 정상적인 찰나까지 밀림으로 잡아 매 화면마다 거짓 경보가 난다.
+ */
+export const OVERDUE_GRACE_SEC = 300;
 
 // What each launchd job does, in human terms (labels are cryptic).
 function launchdDesc(): Record<string, string> {
@@ -236,6 +250,35 @@ function listLaunchd(running: Map<string, boolean>): TeamOsScheduled[] {
  *
  * launchd 와 달리 next_run_at/last_run_at 이 DB 에 있으므로 "언제 돌았나" 까지 같이 보여준다.
  */
+/**
+ * ★죽은 잡을 초록불로 보여주던 판정을 여기로 모았다★ (2026-07-30 사고).
+ *
+ * 고치기 전: `running = enabled === 1 && !!next_run_at`.
+ *   - `status` 를 SELECT 해놓고 ★판정에 쓰지 않았다★ → 실패로 정지한 잡도 초록불
+ *   - `next_run_at` 은 "값이 있나" 만 봤다 → ★9시간 전 시각★ 이 적혀 있어도 "다음 실행 잡힘" 으로 통과
+ *   실제로 08:00 에 정지한 잡이 "next=00:30" 이라고 적힌 채 running=true 로 9시간을 버텼다.
+ *   ★사람이 화면을 보고도 못 본다. 화면이 잘못된 판단에 동의해준다.★
+ *
+ * now 를 인자로 받는 이유: 시각 판정은 테스트에서 시각을 고정할 수 있어야 검증이 된다.
+ */
+export function judgeScheduledJob(
+  row: { enabled: number; status: string | null; next_run_at: string | null },
+  nowMs: number,
+): { running: boolean; problem: "failed" | "overdue" | null; overdueMin: number } {
+  // ★새 시각 파서를 만들지 않는다★ — 스케줄러가 자기 컬럼을 읽는 방식(fromSqliteDate)을 그대로 쓴다.
+  //   판정과 저장이 다른 규칙을 쓰면 KST 서버에서 정확히 9시간 어긋난다(utcTimestamp.contract.test 의 교훈).
+  const overdueMs = row.next_run_at ? nowMs - fromSqliteDate(row.next_run_at).getTime() : Number.NaN;
+  const isFailed = row.status === "failed";
+  // 시각이 없거나 파싱 불가면 ★밀림으로 단정하지 않는다★ — 모르는 것은 모른다고 둔다(거짓 경보 금지).
+  const isOverdue = Number.isFinite(overdueMs) && overdueMs > OVERDUE_GRACE_SEC * 1000;
+  return {
+    // "예정대로 살아있나" = 켜져 있고 · 다음 실행이 잡혀 있고 · 실패로 정지하지 않았고 · 밀리지 않았나.
+    running: row.enabled === 1 && !!row.next_run_at && !isFailed && !isOverdue,
+    problem: isFailed ? "failed" : isOverdue ? "overdue" : null,
+    overdueMin: Number.isFinite(overdueMs) ? Math.floor(overdueMs / 60000) : 0,
+  };
+}
+
 function listScheduledJobs(db: Database): TeamOsScheduled[] {
   try {
     const rows = db.prepare(
@@ -248,21 +291,28 @@ function listScheduledJobs(db: Database): TeamOsScheduled[] {
       id: string; title: string | null; schedule_expr: string | null;
       enabled: number; status: string | null; next_run_at: string | null; last_run_at: string | null;
     }>;
+    const nowMs = Date.now();
     return rows.map((r) => {
       let cron = "";
       try { cron = String((JSON.parse(r.schedule_expr ?? "{}") as { cron?: string }).cron ?? ""); } catch { /* 표시용이라 실패해도 넘어간다 */ }
       const next = r.next_run_at ? formatKst(r.next_run_at) : null;
       const last = r.last_run_at ? formatKst(r.last_run_at) : null;
+      const v = judgeScheduledJob(r, nowMs);
       return {
         label: r.id,
         kind: "scheduled" as const,
-        detail: [cron && `cron=${cron}`, `next=${next ?? "-"}`, `last=${last ?? "-"}`].filter(Boolean).join(" · "),
+        detail: [
+          cron && `cron=${cron}`,
+          `next=${next ?? "-"}`,
+          `last=${last ?? "-"}`,
+          v.problem === "failed" && "★실패로 정지★",
+          v.problem === "overdue" && `★${v.overdueMin}분 밀림★`,
+        ].filter(Boolean).join(" · "),
         description: r.title ?? "",
         source: "scheduled_job" as const,
-        // ★running 은 launchd 처럼 프로세스 상주 여부가 아니다★ — 잡은 평소엔 안 떠 있는 게 정상이다.
-        //   여기선 "예정대로 살아있나" = enabled && 다음 실행이 잡혀 있나 로 본다.
-        running: r.enabled === 1 && !!r.next_run_at,
+        running: v.running,
         enabled: r.enabled === 1,
+        problem: v.problem,
       };
     });
   } catch {

--- a/src/server/scheduler/core.test.ts
+++ b/src/server/scheduler/core.test.ts
@@ -20,6 +20,8 @@ import {
   scheduleReminder,
   failScheduledJob,
   completeScheduledJob,
+  skipScheduledJob,
+  consecutiveFailures,
 } from "./core";
 import { nextCronRun } from "./cron";
 
@@ -832,5 +834,54 @@ describe("실패한 반복 잡은 다음 슬롯으로 되살아난다", () => {
     expect(row.status).toBe("failed");
     const audit = d.prepare(`SELECT detail_json FROM audit_event WHERE action='scheduler_job_parked'`).get() as { detail_json: string };
     expect(JSON.parse(audit.detail_json)).toMatchObject({ reason: "max_runs_reached" });
+  });
+});
+
+// steve 리뷰에서 나온 실질 위험: skip 이 연속 카운트를 리셋해 ★진짜 고장이 영원히 park 되지 않는다.★
+// 오늘은 잠복(미스파이어 유예 기본 꺼짐)이지만 그 env 를 켜면 살아난다.
+describe("연속 실패 카운트는 성공에서만 끊긴다", () => {
+  const T0 = new Date(Date.UTC(2026, 6, 30, 0, 0, 0));
+  function guard(d: ReturnType<typeof db>) {
+    const j = createCronJob(d, {
+      id: "skipmix", title: "30분 가드", cron: "*/30 * * * *", timezone: "Asia/Seoul",
+      createdBy: "system", payload: { type: "exec", execKey: "task-review-ping" }, from: T0,
+    });
+    return getScheduledJob(d, j.id)!;
+  }
+
+  test("★skip 이 섞여도 연속 카운트가 리셋되지 않는다★ — 실패·skip·실패·skip·실패 = park", () => {
+    const d = db();
+    let job = guard(d);
+    for (let i = 0; i < 3; i++) {
+      job = getScheduledJob(d, job.id)!;
+      failScheduledJob(d, job, `깨짐 ${i + 1}`, { now: new Date(T0.getTime() + i * 2 * 60_000) });
+      if (i < 2) {
+        job = getScheduledJob(d, job.id)!;
+        skipScheduledJob(d, job, "misfire", { now: new Date(T0.getTime() + (i * 2 + 1) * 60_000) });
+      }
+    }
+    // skip 이 리셋했다면 연속은 1 이라 계속 살아 있다 = 영원히 park 안 됨.
+    expect(getScheduledJob(d, job.id)!.status).toBe("failed");
+  });
+
+  test("skip 자체는 실패로 세지 않는다 — '돌려보지도 않았다' 는 고장의 증거가 아니다", () => {
+    const d = db();
+    let job = guard(d);
+    for (let i = 0; i < 3; i++) {
+      job = getScheduledJob(d, job.id)!;
+      skipScheduledJob(d, job, "misfire", { now: new Date(T0.getTime() + i * 60_000) });
+    }
+    expect(consecutiveFailures(d, job.id, 5)).toBe(0);
+  });
+
+  test("성공은 연속을 끊는다", () => {
+    const d = db();
+    let job = guard(d);
+    failScheduledJob(d, job, "1", { now: T0 });
+    job = getScheduledJob(d, job.id)!;
+    completeScheduledJob(d, job, { now: new Date(T0.getTime() + 60_000) });
+    job = getScheduledJob(d, job.id)!;
+    failScheduledJob(d, job, "2", { now: new Date(T0.getTime() + 120_000) });
+    expect(consecutiveFailures(d, job.id, 5)).toBe(1);
   });
 });

--- a/src/server/scheduler/core.test.ts
+++ b/src/server/scheduler/core.test.ts
@@ -18,6 +18,8 @@ import {
   pickCapabilityWorkloopTarget,
   runDueSchedulerJobsOnce,
   scheduleReminder,
+  failScheduledJob,
+  completeScheduledJob,
 } from "./core";
 import { nextCronRun } from "./cron";
 
@@ -725,5 +727,110 @@ describe("b3os scheduler misfire grace", () => {
     expect(results).toHaveLength(5);
     expect(results.every((r) => r.status === "skipped")).toBe(true);
     expect(d.prepare(`SELECT count(*) AS n FROM message`).get()).toEqual({ n: 0 });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 실패한 반복 잡의 재예약 (2026-07-30 사고)
+//   사고: 부팅 경합으로 한 번 실패한 30분 주기 잡이 ★9시간 정지★. 원인은 일시적인데 결과가 영구적.
+//   근본: failScheduledJob 이 next_run_at 을 안 옮기는데 dueScheduledJobs 는 status='pending' 만 고른다.
+//   ★검증은 "행 값이 바뀌었나" 가 아니라 "스케줄러가 다시 뽑나" 로 한다★ — 값만 보면 선정 쿼리와
+//   어긋나도 통과한다(그게 원래 사고의 모양이었다: 값은 멀쩡해 보이는데 아무도 안 뽑았다).
+// ─────────────────────────────────────────────────────────────────────────────
+describe("실패한 반복 잡은 다음 슬롯으로 되살아난다", () => {
+  const T0 = new Date(Date.UTC(2026, 6, 30, 0, 0, 0)); // 2026-07-30 09:00 KST
+  function every30(d: ReturnType<typeof db>, id = "guard") {
+    const job = createCronJob(d, {
+      id,
+      title: "30분 가드",
+      cron: "*/30 * * * *",
+      timezone: "Asia/Seoul",
+      createdBy: "system",
+      payload: { type: "exec", execKey: "task-review-ping" },
+      from: T0,
+    });
+    return getScheduledJob(d, job.id)!;
+  }
+  const due = (d: ReturnType<typeof db>, at: Date) => dueScheduledJobs(d, at).map((j) => j.id);
+
+  test("★한 번 실패해도 스케줄러가 다시 뽑는다★ (사고 회귀)", () => {
+    const d = db();
+    const job = every30(d);
+    failScheduledJob(d, job, "boot race: Unable to connect", { now: T0 });
+
+    const after = getScheduledJob(d, job.id)!;
+    expect(after.status).toBe("pending");
+    // 다음 시각이 ★앞으로★ 갔는지 — 실패 시각보다 미래여야 한다.
+    expect(fromSqliteDate(after.next_run_at!).getTime()).toBeGreaterThan(T0.getTime());
+    // ★공개 경로 검증★: 그 시각이 되면 선정 쿼리가 실제로 이 잡을 집는다.
+    expect(due(d, fromSqliteDate(after.next_run_at!))).toContain(job.id);
+    // 실패 기록 자체는 남는다(원인 추적용).
+    expect(after.last_error).toContain("Unable to connect");
+  });
+
+  test("고치기 전 동작(영구 정지)이 되살아나면 실패한다 — 한도 전에는 park 하지 않는다", () => {
+    const d = db();
+    const job = every30(d);
+    failScheduledJob(d, job, "일시적", { now: T0 });
+    expect(getScheduledJob(d, job.id)!.status).not.toBe("failed");
+  });
+
+  test("★연속 3회 실패하면 park★ — 진짜 고장이 30분마다 영원히 헛돌지 않게", () => {
+    const d = db();
+    let job = every30(d);
+    for (let i = 0; i < 3; i++) {
+      job = getScheduledJob(d, job.id)!;
+      failScheduledJob(d, job, `계속 깨짐 #${i + 1}`, { now: new Date(T0.getTime() + i * 60_000) });
+    }
+    const parked = getScheduledJob(d, job.id)!;
+    expect(parked.status).toBe("failed");
+    // park 된 뒤에는 시각이 지나도 아무도 안 뽑는다 = 헛돌지 않는다.
+    expect(due(d, new Date(T0.getTime() + 24 * 3600_000))).not.toContain(job.id);
+    // park 은 흔적을 남긴다(조용히 죽지 않는다).
+    const audit = d
+      .prepare(`SELECT detail_json FROM audit_event WHERE action = 'scheduler_job_parked'`)
+      .all() as Array<{ detail_json: string }>;
+    expect(audit).toHaveLength(1);
+    expect(JSON.parse(audit[0]!.detail_json)).toMatchObject({ job_id: job.id, reason: "retry_limit", limit: 3 });
+  });
+
+  test("중간에 성공하면 연속 카운트가 리셋된다 — 가끔 실패하는 잡이 park 되지 않게", () => {
+    const d = db();
+    let job = every30(d);
+    failScheduledJob(d, job, "1", { now: T0 });
+    job = getScheduledJob(d, job.id)!;
+    failScheduledJob(d, job, "2", { now: new Date(T0.getTime() + 60_000) });
+    job = getScheduledJob(d, job.id)!;
+    completeScheduledJob(d, job, { now: new Date(T0.getTime() + 120_000) });   // ← 한 번 성공
+    job = getScheduledJob(d, job.id)!;
+    failScheduledJob(d, job, "3", { now: new Date(T0.getTime() + 180_000) });
+    // 누적 3회지만 연속은 1회 → 아직 살아 있어야 한다.
+    expect(getScheduledJob(d, job.id)!.status).toBe("pending");
+  });
+
+  test("oneshot 은 재예약하지 않는다 — 다음 차례라는 게 없다", () => {
+    const d = db();
+    const job = execJob(d, "echo-ok");
+    failScheduledJob(d, job, "한 번짜리", { now: T0 });
+    expect(getScheduledJob(d, job.id)!.status).toBe("failed");
+  });
+
+  test("cron 표현식이 깨졌으면 park 한다 — 되살려봐야 매번 같은 자리에서 죽는다", () => {
+    const d = db();
+    const job = every30(d, "broken");
+    d.prepare(`UPDATE scheduled_job SET schedule_expr = '{"cron":""}' WHERE id = ?`).run(job.id);
+    failScheduledJob(d, getScheduledJob(d, job.id)!, "표현식 깨짐", { now: T0 });
+    expect(getScheduledJob(d, job.id)!.status).toBe("failed");
+  });
+
+  test("max_runs 를 다 쓴 잡은 재예약하지 않는다", () => {
+    const d = db();
+    const job = every30(d, "capped");
+    d.prepare(`UPDATE scheduled_job SET max_runs = 2, run_count = 2 WHERE id = ?`).run(job.id);
+    failScheduledJob(d, getScheduledJob(d, job.id)!, "상한 소진", { now: T0 });
+    const row = getScheduledJob(d, job.id)!;
+    expect(row.status).toBe("failed");
+    const audit = d.prepare(`SELECT detail_json FROM audit_event WHERE action='scheduler_job_parked'`).get() as { detail_json: string };
+    expect(JSON.parse(audit.detail_json)).toMatchObject({ reason: "max_runs_reached" });
   });
 });

--- a/src/server/scheduler/core.ts
+++ b/src/server/scheduler/core.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { nanoid } from "nanoid";
 import type { EnvelopeInbound } from "../../shared/envelopeSchema";
 import { acceptInbound } from "../db/inbox/acceptInbound";
+import { appendAudit } from "../db/queries";
 import { ambientAgents } from "../lib/registry";
 import { hasCapability } from "../lib/capabilities";
 import { isTeamOfficialMember } from "../lib/agentMembership";
@@ -643,6 +644,47 @@ export function completeScheduledJob(
   ).run(nowSql, nowSql, job.id);
 }
 
+/**
+ * 연속 실패를 몇 번까지 봐주고 재예약할지. 이 횟수에 도달하면 park(=status 'failed' 로 정지)한다.
+ * 0·음수·NaN 은 1 로 올린다 — 0 을 허용하면 "실패 즉시 영구 정지"(고치기 전 동작)로 조용히 되돌아간다.
+ */
+export const DEFAULT_FAILURE_RETRY_LIMIT = 3;
+export function failureRetryLimit(): number {
+  const raw = Number(process.env.SCHEDULER_FAILURE_RETRY_LIMIT ?? DEFAULT_FAILURE_RETRY_LIMIT);
+  return Number.isFinite(raw) && raw >= 1 ? Math.floor(raw) : DEFAULT_FAILURE_RETRY_LIMIT;
+}
+
+/** 이 잡의 가장 최근 실행부터 거슬러 올라가며 연속 'failed' 개수를 센다(이번 실패 포함). */
+export function consecutiveFailures(db: Database, jobId: string, limit: number): number {
+  const rows = db
+    .prepare(
+      // rowid = 삽입 순서. started_at 은 같은 초에 여러 건이 들어갈 수 있어 정렬 기준으로 불안정하다.
+      `SELECT outcome FROM scheduled_job_run WHERE job_id = ? ORDER BY rowid DESC LIMIT ?`,
+    )
+    .all(jobId, limit) as Array<{ outcome: string }>;
+  let n = 0;
+  for (const r of rows) {
+    if (r.outcome !== "failed") break;
+    n += 1;
+  }
+  return n;
+}
+
+/**
+ * ★실패해도 다음 시각은 잡아준다★ (2026-07-30 사고 수정)
+ *
+ * 고치기 전: status='failed' 로 두고 next_run_at 을 ★안 옮겼다★. 그런데 `dueScheduledJobs` 는
+ * status='pending' 만 고른다 → ★반복 잡이 한 번 실패하면 영구 정지★ 했다. 재시도도 재스케줄도 없고
+ * 복구 API 도 없어서(취소만 있다) 사람이 DB 를 직접 고쳐야 살아났다.
+ * 실제 사고: 부팅 직후 서버가 아직 안 떠서 실패한 `sched_task_continuation_guard`(30분 주기) 가 9시간 정지.
+ * ★원인은 일시적이었는데 결과가 영구적이었다.★
+ *
+ * 고친 뒤: 성공 경로(completeScheduledJob)와 같은 계산으로 다음 슬롯을 잡고 'pending' 으로 되돌린다.
+ * 단 ★무한 재시도는 안 된다★ — 진짜 고장(스크립트 깨짐 등)이면 30분마다 영원히 실패만 반복하고
+ * 아무도 모른다. 그래서 연속 실패가 한도에 닿으면 park 하고, park 사실을 audit 으로 남긴다.
+ * (park 를 사람에게 ★알리는★ 경로는 여기서 새로 만들지 않는다 — 알림 경로는 opNotice 쪽 작업과
+ *  겹치므로 그 위에 얹는 게 맞다. 지금은 대시보드 표시 + acceptance-check 가 잡는다.)
+ */
 export function failScheduledJob(
   db: Database,
   job: ScheduledJobRow,
@@ -652,11 +694,42 @@ export function failScheduledJob(
   const now = opts.now ?? new Date();
   const nowSql = toSqliteDate(now);
   const runId = `sjr_${nanoid(10)}`;
+  const err = error.slice(0, 500);
   db.prepare(
     `INSERT INTO scheduled_job_run
        (id, job_id, scheduled_for, started_at, finished_at, outcome, error, detail_json)
      VALUES (?, ?, ?, ?, ?, 'failed', ?, ?)`,
-  ).run(runId, job.id, job.next_run_at, nowSql, nowSql, error.slice(0, 500), opts.detail ? JSON.stringify(opts.detail) : null);
+  ).run(runId, job.id, job.next_run_at, nowSql, nowSql, err, opts.detail ? JSON.stringify(opts.detail) : null);
+
+  const limit = failureRetryLimit();
+  const failures = consecutiveFailures(db, job.id, limit);
+  // 재예약 자격: 반복 잡이고 · 아직 한도 전이고 · 실행 횟수 상한이 남아 있고 · 다음 시각이 계산되어야 한다.
+  // run_count 는 성공/skip 만 올린다(실패는 소비로 치지 않는다). 그래서 상한 판정은 run_count 그대로 본다.
+  const capLeft = job.max_runs == null || job.run_count < job.max_runs;
+  let nextRun: string | null = null;
+  if (job.kind === "recurring" && failures < limit && capLeft) {
+    // cron 표현식이 깨져 있으면 computeNextRun 이 throw 한다 → 재예약 대상이 아니다(park).
+    try {
+      nextRun = computeNextRun(db, job, now);
+    } catch {
+      nextRun = null;
+    }
+  }
+
+  if (nextRun) {
+    db.prepare(
+      `UPDATE scheduled_job
+       SET status = 'pending',
+           next_run_at = ?,
+           lock_until = NULL,
+           lock_owner = NULL,
+           updated_at = ?,
+           last_error = ?
+       WHERE id = ? AND (lock_owner = ? OR ? IS NULL)`,
+    ).run(nextRun, nowSql, err, job.id, job.lock_owner, job.lock_owner);
+    return;
+  }
+
   db.prepare(
     `UPDATE scheduled_job
      SET status = 'failed',
@@ -665,7 +738,15 @@ export function failScheduledJob(
          updated_at = ?,
          last_error = ?
      WHERE id = ? AND (lock_owner = ? OR ? IS NULL)`,
-  ).run(nowSql, error.slice(0, 500), job.id, job.lock_owner, job.lock_owner);
+  ).run(nowSql, err, job.id, job.lock_owner, job.lock_owner);
+  // park 은 "이제 아무도 안 돌린다" 는 뜻이라 흔적을 남긴다. 재시도로 넘어간 실패는 남기지 않는다(소음).
+  appendAudit(db, "scheduler", "scheduler_job_parked", null, {
+    job_id: job.id,
+    consecutive_failures: failures,
+    limit,
+    reason: job.kind !== "recurring" ? "not_recurring" : !capLeft ? "max_runs_reached" : failures >= limit ? "retry_limit" : "no_next_run",
+    error: err,
+  });
 }
 
 export function skipScheduledJob(

--- a/src/server/scheduler/core.ts
+++ b/src/server/scheduler/core.ts
@@ -645,8 +645,12 @@ export function completeScheduledJob(
 }
 
 /**
- * 연속 실패를 몇 번까지 봐주고 재예약할지. 이 횟수에 도달하면 park(=status 'failed' 로 정지)한다.
- * 0·음수·NaN 은 1 로 올린다 — 0 을 허용하면 "실패 즉시 영구 정지"(고치기 전 동작)로 조용히 되돌아간다.
+ * 연속 실패를 몇 번까지 봐주고 재예약할지. 이 횟수에 ★도달하면★ park(=status 'failed' 로 정지)한다.
+ *
+ * 하한은 1 이다. ★1 은 "첫 실패에 바로 park" = 고치기 전 동작을 의도적으로 되사는 값★ 이므로
+ * 막지 않는다(그렇게 쓰고 싶은 운영자가 있을 수 있다). 다만 ★기본값이 아니라 명시적으로 골라야★ 한다.
+ * 막는 것은 0·음수·NaN 뿐 — 그건 설정 실수이지 선택이 아니고, 그대로 두면 루프가 아예 안 돈다.
+ * (처음 주석은 "1 로 올린다 = 옛 동작 방지" 라고 적었는데 ★1 이 바로 그 옛 동작★ 이라 앞뒤가 안 맞았다. steve 지적.)
  */
 export const DEFAULT_FAILURE_RETRY_LIMIT = 3;
 export function failureRetryLimit(): number {
@@ -654,17 +658,30 @@ export function failureRetryLimit(): number {
   return Number.isFinite(raw) && raw >= 1 ? Math.floor(raw) : DEFAULT_FAILURE_RETRY_LIMIT;
 }
 
-/** 이 잡의 가장 최근 실행부터 거슬러 올라가며 연속 'failed' 개수를 센다(이번 실패 포함). */
+/**
+ * 이 잡의 가장 최근 실행부터 거슬러 올라가며 연속 'failed' 개수를 센다(이번 실패 포함).
+ *
+ * ★'failed 가 아니면 멈춘다' 가 아니라 'succeeded 에서만 리셋한다'★ (steve 리뷰).
+ * 처음엔 outcome 이 failed 가 아니면 즉시 break 했는데, 그러면 ★skip 이 카운트를 리셋한다.★
+ * `skipScheduledJob` 은 outcome='skipped' 행을 넣으므로 fail·skip·fail·skip 이 섞이면
+ * 연속 카운트가 매번 1 로 돌아가 ★진짜 고장이 영원히 park 되지 않는다.★
+ * 오늘은 잠복이다(미스파이어 유예가 기본 꺼짐이라 skip 행이 안 생긴다) — 그 env 를 켜는 순간 살아난다.
+ * 같은 구멍이 하나 더 있다: 스키마 CHECK 가 outcome 에 'started' 를 이미 허용한다(지금 writer 는 없다).
+ * → 조회를 'succeeded'·'failed' 로 좁히면 두 구멍이 같이 닫힌다.
+ *   skip 은 "돌려보지도 않았다" 라서 ★잡이 나아졌다는 증거가 아니다★ — 세지도 리셋하지도 않는 중립이 맞다.
+ */
 export function consecutiveFailures(db: Database, jobId: string, limit: number): number {
   const rows = db
     .prepare(
       // rowid = 삽입 순서. started_at 은 같은 초에 여러 건이 들어갈 수 있어 정렬 기준으로 불안정하다.
-      `SELECT outcome FROM scheduled_job_run WHERE job_id = ? ORDER BY rowid DESC LIMIT ?`,
+      `SELECT outcome FROM scheduled_job_run
+        WHERE job_id = ? AND outcome IN ('succeeded','failed')
+        ORDER BY rowid DESC LIMIT ?`,
     )
     .all(jobId, limit) as Array<{ outcome: string }>;
   let n = 0;
   for (const r of rows) {
-    if (r.outcome !== "failed") break;
+    if (r.outcome === "succeeded") break; // 성공에서만 연속이 끊긴다
     n += 1;
   }
   return n;

--- a/src/web/components/JobsView.ts
+++ b/src/web/components/JobsView.ts
@@ -14,6 +14,8 @@ interface ReadOnlyJob {
   source: JobSource;
   running: boolean | null;
   enabled: boolean;
+  // 초록불이 아닌 이유. 서버가 안 보내는 구버전이면 undefined — 그땐 예전처럼 running 만 본다.
+  problem?: "failed" | "overdue" | null;
 }
 
 interface JobGroup {
@@ -92,6 +94,14 @@ function jobBadge(kind: JobKind): string {
 function jobState(j: ReadOnlyJob): string {
   if (!j.enabled) {
     return `<span class="inline-flex items-center gap-1 text-xs text-status-blocked"><span class="w-2 h-2 rounded-full bg-status-blocked"></span>disabled</span>`;
+  }
+  // ★"꺼둔 것"과 "죽은 것"을 구분한다★ — 이 갈래가 없어서 실패로 정지한 잡이 초록불로 떴다(2026-07-30).
+  //   disabled 를 먼저 보는 이유: 사람이 의도적으로 끈 것은 고장이 아니다.
+  if (j.problem === "failed") {
+    return `<span class="inline-flex items-center gap-1 text-xs text-status-blocked"><span class="w-2 h-2 rounded-full bg-status-blocked"></span>${pick("실패", "failed")}</span>`;
+  }
+  if (j.problem === "overdue") {
+    return `<span class="inline-flex items-center gap-1 text-xs text-txt-amber"><span class="w-2 h-2 rounded-full bg-amber-500"></span>${pick("밀림", "overdue")}</span>`;
   }
   if (j.running === true) {
     return `<span class="inline-flex items-center gap-1 text-xs text-slate-300"><span class="w-2 h-2 rounded-full bg-accent-green"></span>running</span>`;

--- a/src/web/components/JobsView.ts
+++ b/src/web/components/JobsView.ts
@@ -15,7 +15,7 @@ interface ReadOnlyJob {
   running: boolean | null;
   enabled: boolean;
   // 초록불이 아닌 이유. 서버가 안 보내는 구버전이면 undefined — 그땐 예전처럼 running 만 본다.
-  problem?: "failed" | "overdue" | null;
+  problem?: "failed" | "overdue" | "retrying" | null;
 }
 
 interface JobGroup {
@@ -99,6 +99,11 @@ function jobState(j: ReadOnlyJob): string {
   //   disabled 를 먼저 보는 이유: 사람이 의도적으로 끈 것은 고장이 아니다.
   if (j.problem === "failed") {
     return `<span class="inline-flex items-center gap-1 text-xs text-status-blocked"><span class="w-2 h-2 rounded-full bg-status-blocked"></span>${pick("실패", "failed")}</span>`;
+  }
+  // 재시도 대기 = 죽지는 않았지만 초록불도 아니다. 이게 없으면 A(실패 시 재예약)가
+  //   "방금 실패한 잡을 화면상 정상" 으로 만들어, 이 화면이 고치려던 문제를 작게 다시 만든다.
+  if (j.problem === "retrying") {
+    return `<span class="inline-flex items-center gap-1 text-xs text-txt-amber"><span class="w-2 h-2 rounded-full bg-amber-400"></span>${pick("재시도 대기", "retrying")}</span>`;
   }
   if (j.problem === "overdue") {
     return `<span class="inline-flex items-center gap-1 text-xs text-txt-amber"><span class="w-2 h-2 rounded-full bg-amber-500"></span>${pick("밀림", "overdue")}</span>`;


### PR DESCRIPTION
fix(scheduler): 실패한 반복 잡이 영구 정지하던 것 + 죽은 잡이 초록불로 보이던 것

2026-07-30 실사고. 부팅 직후 서버가 아직 안 떠서 실패한 30분 주기 잡이
9시간 동안 멈춰 있었는데, 대시보드는 그 잡을 초록불 running 으로 보여줬다.

A) 실패해도 다음 시각을 잡아준다 (scheduler/core.ts)
   failScheduledJob 이 status='failed' 로 두고 next_run_at 을 안 옮겼는데
   dueScheduledJobs 는 status='pending' 만 고른다 → 한 번 실패 = 영구 정지.
   재시도도 재스케줄도 복구 API 도 없어(취소만 있다) 사람이 DB 를 직접 고쳐야 했다.
   → 성공 경로와 같은 계산으로 다음 슬롯을 잡고 pending 으로 되돌린다.
   무한 재시도 방지: 연속 실패가 한도(기본 3, SCHEDULER_FAILURE_RETRY_LIMIT)에 닿으면
   park + audit(scheduler_job_parked). 연속 카운트는 실행 이력에서 세므로 스키마 변경 없음.
   park 을 사람에게 '알리는' 경로는 만들지 않았다 — opNotice 작업과 겹쳐서 그 위에 얹는 게 맞다.

B) 죽은 잡을 죽었다고 보여준다 (lib/teamosProbe.ts, web/JobsView.ts)
   running = enabled && !!next_run_at 이었다. status 를 SELECT 해놓고 판정에 안 썼고,
   next_run_at 은 '값이 있나'만 봤다 → 9시간 전 시각이 적힌 채로 초록불.
   → judgeScheduledJob 으로 판정을 모으고 problem('failed'|'overdue')을 화면까지 전달.
   밀림 유예 5분(tick 간격 안의 찰나를 거짓 경보로 잡지 않게).
   화면에도 failed/overdue 상태를 추가했다 — 기존엔 disabled/running/stopped/idle 뿐이라
   '꺼둔 것'과 '죽은 것'이 같게 보였다.

둘은 짝이다: A 만 있으면 진짜 고장이 여전히 안 보이고, B 만 있으면 매번 손으로 살려야 한다.

검증
 · tsc 0
 · 신규 15건(스케줄러 7 · 판정 8), 전체 1919 pass / 1 fail
 · 잔여 1건은 origin/main 에서도 실패한다(utcTimestamp.contract → routes/scheduler.ts:120,
   내가 안 건드린 파일. 데미스가 독립적으로 같은 것을 잡았다). 내 회귀 아님
 · 뮤턴트 3종 전부 사망: 재예약 끄기(4건 실패) · 한도 없애기(park 시험 1건 실패)
   · 판정을 옛 방식으로 되돌리기(3건 실패)
 · 시각 파서를 새로 만들었다가 기존 fromSqliteDate 로 교체 — 계약 시험이 '새 헬퍼를 만들지 마라'

라이브 트리 무수정(worktree 격리). GD 승인 2026-07-30.
