### PR TITLE
fix(claude start): 같은 초에 뜬 봇 두 개가 공유 플러그인 캐시 링크를 다퉈 한쪽이 28분 죽어 있었다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,11 @@ archiving/
 #   없는 상태로 PR 이 올라갔다(로직을 되돌려도 실패 0건). 조용한 누락이라 status 출력을
 #   보고도 못 본다. 개별 등록은 같은 사고를 다음 사람에게 넘기는 것이라 패턴으로 연다.
 !/scripts/*.test.ts
+# 셸 인수테스트도 같은 이유로 ★클래스로★ 연다(`*.test.sh`). 위 .test.ts 주석의 사고가 셸에서도
+#   그대로 난다 — 2026-07-30 stagger fix 때 실측: scripts/test-*.sh 로 짰더니 /scripts/* 에 걸려
+#   git status 에 아예 안 나타났고, 그대로 커밋하면 "소스만 있고 지키는 테스트는 없는" PR 이 된다.
+#   ※ 기존 GD 머신 전용 ops 테스트는 `test-*.sh` 라 이 패턴에 걸리지 않는다(공개 노출 없음).
+!/scripts/*.test.sh
 /docs/*
 !/docs/AUTO_HEAL_CORE.md
 !/docs/SLACK_SETUP.md

--- a/scripts/claude-start-stagger.test.sh
+++ b/scripts/claude-start-stagger.test.sh
@@ -129,6 +129,12 @@ for _f in outA outB; do
     || pass "$_f 상한 초과 없음"
 done
 
+# F1 회귀 가드: release 에 pid 일치 확인을 넣었으니 ★정상 경로에서는 여전히 해제돼야★ 한다.
+#   여기서 락이 남으면 다음 부팅의 모든 멤버가 상한까지 헛기다린다 — 고치려던 것보다 나쁘다.
+[[ ! -d "$TMPROOT/spawn.lock" ]] \
+  && pass "정상 종료 후 락 해제됨 (F1 이 정상 release 를 막지 않는다)" \
+  || fail "락이 남았다 — 다음 기동이 상한까지 헛기다린다"
+
 for n in "$A" "$B"; do tmux kill-session -t "claude-$n" 2>/dev/null || true; done
 
 echo "── T2: CLAUDE_START_NO_STAGGER=1 탈출구 ──"

--- a/scripts/claude-start-stagger.test.sh
+++ b/scripts/claude-start-stagger.test.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# start-telegram-channel.sh 의 spawn stagger(공유 플러그인 캐시 binlink 경합 가드) 인수테스트.
+#
+# 무엇을 막는 테스트인가 (2026-07-30 실측 사고):
+#   jane·lisa launchd 잡이 RunAtLoad 로 같은 초에 떠서 두 세션의 claude 가 공유 플러그인 캐시에
+#   `bun run` 을 동시에 걸었다 → `error: Failed to link which: EEXIST` → `MCP error -32000:
+#   Connection closed`(144ms) → bot.pid 미생성 → 리사가 28분간 텔레그램을 못 받았다.
+#   처방은 "머신 단위 mutex 로 스폰만 직렬화" 이고, 이 테스트가 그 직렬화를 실제로 검증한다.
+#
+# FS 격리(b3os-infra-safety ④): HOME 을 mktemp 로 갈아 실제 ~/.claude 를 건드리지 않는다.
+#   claude 바이너리는 stub(실제 CC 안 뜬다). tmux 는 실물을 쓰되 세션 이름에 PID 를 붙여 격리하고
+#   종료 시 반드시 kill 한다.
+#
+# 실행: scripts/test-claude-start-stagger.sh   (0=통과, 1=실패)
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/src/server/runtimes/claude/start-telegram-channel.sh"
+[[ -x "$SCRIPT" ]] || { echo "FAIL: 대상 스크립트 없음/실행권한 없음: $SCRIPT"; exit 1; }
+
+FAILED=0
+pass() { echo "  ✓ $1"; }
+fail() { echo "  ✗ $1"; FAILED=1; }
+
+TMPROOT="$(mktemp -d)"
+SUFFIX="$$"
+A="stagtesta$SUFFIX"
+B="stagtestb$SUFFIX"
+
+cleanup() {
+  for n in "$A" "$B"; do tmux kill-session -t "claude-$n" 2>/dev/null || true; done
+  rm -rf "$TMPROOT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ─── stub claude: 지연 후 bot.pid 를 쓰고(=MCP poller 안착 신호) 살아있는다 ──────
+#   ★타임스탬프는 STATE_DIR 안에 남긴다★ — 이미 떠 있는 tmux 서버에 new-session 을 걸면 새 세션은
+#   ★클라이언트가 아니라 서버★의 환경을 물려받으므로, 테스트가 export 한 변수는 스텁에 안 보인다.
+#   INNER_CMD 에 명시적으로 실리는 TELEGRAM_STATE_DIR 만이 확실한 전달 경로다(실측 함정).
+mkdir -p "$TMPROOT/bin"
+cat > "$TMPROOT/bin/claude" <<'STUB'
+#!/usr/bin/env bash
+sd="${TELEGRAM_STATE_DIR:?}"
+mkdir -p "$sd"
+date +%s > "$sd/start.stamp"
+sleep "${STUB_LINK_DELAY:-3}"      # 공유 캐시 링크에 걸리는 시간을 모사
+echo $$ > "$sd/bot.pid"
+date +%s > "$sd/pid.stamp"
+sleep 300                           # 세션 유지
+STUB
+chmod +x "$TMPROOT/bin/claude"
+
+run_start() { # <botname> [VAR=val ...]  — env 로 넘긴다(prefix 할당은 "$@" 뒤에선 명령어로 해석됨)
+  local name="$1"; shift
+  env HOME="$TMPROOT/home" \
+      PATH="$TMPROOT/bin:$PATH" \
+      WORKDIR="$TMPROOT/work" \
+      CLAUDE_START_STAGGER_LOCK="$TMPROOT/spawn.lock" \
+      "$@" \
+      "$SCRIPT" "$name" 2>&1
+}
+
+stamp() { cat "$TMPROOT/home/.claude/channels/telegram-$1/$2.stamp" 2>/dev/null || echo ""; }
+
+prep_home() {
+  mkdir -p "$TMPROOT/home/.claude/channels/telegram-$A" \
+           "$TMPROOT/home/.claude/channels/telegram-$B" \
+           "$TMPROOT/work"
+  # 토큰은 형식만 있는 더미 — 네트워크로 나가지 않는다(stub claude 는 텔레그램에 접속하지 않음).
+  for n in "$A" "$B"; do
+    printf 'TELEGRAM_BOT_TOKEN=000000:TEST_DUMMY_NOT_A_REAL_TOKEN\n' \
+      > "$TMPROOT/home/.claude/channels/telegram-$n/.env"
+    chmod 600 "$TMPROOT/home/.claude/channels/telegram-$n/.env"
+  done
+}
+
+echo "── T1: 동시 기동이 직렬화되는가 (경합 재발 방지 본체) ──"
+prep_home
+
+run_start "$A" >"$TMPROOT/outA" 2>&1 &
+pidA=$!
+run_start "$B" >"$TMPROOT/outB" 2>&1 &
+pidB=$!
+wait $pidA; rcA=$?
+wait $pidB; rcB=$?
+
+[[ $rcA -eq 0 && $rcB -eq 0 ]] && pass "두 기동 모두 exit 0 (rcA=$rcA rcB=$rcB)" \
+                               || fail "기동 실패 (rcA=$rcA rcB=$rcB)"
+
+# 두 멤버 모두 bot.pid 가 생겼는가 = 아무도 링크 경합에 탈락하지 않았다
+for n in "$A" "$B"; do
+  if [[ -s "$TMPROOT/home/.claude/channels/telegram-$n/bot.pid" ]]; then
+    pass "$n bot.pid 생성됨"
+  else
+    fail "$n bot.pid 없음 (경합 탈락 = 사고 재현)"
+  fi
+done
+
+# 핵심 단정: 나중에 뜬 쪽의 start 가 먼저 뜬 쪽의 pid(링크 완료) 이후여야 한다.
+#   = 두번째 claude 는 캐시 링크가 끝난 뒤에 떴다 → 링크할 게 없어 EEXIST 경합이 불가능하다.
+sA="$(stamp "$A" start)"; pA="$(stamp "$A" pid)"
+sB="$(stamp "$B" start)"; pB="$(stamp "$B" pid)"
+if [[ -n "$sA" && -n "$pA" && -n "$sB" && -n "$pB" ]]; then
+  first_pid_t=$(( pA < pB ? pA : pB ))
+  last_start_t=$(( sA > sB ? sA : sB ))
+  if (( last_start_t >= first_pid_t )); then
+    pass "직렬화 확인 — 늦은 start($last_start_t) ≥ 이른 bot.pid($first_pid_t)"
+  else
+    fail "직렬화 실패 — 두번째 세션이 첫 세션 링크 완료 전에 떴다 (start=$last_start_t < pid=$first_pid_t)"
+  fi
+else
+  fail "stamp 부족 — A(start=$sA pid=$pA) B(start=$sB pid=$pB)"
+fi
+
+grep -q "Stagger     : 락 확보" "$TMPROOT/outA" "$TMPROOT/outB" \
+  && pass "락 확보 로그 노출" || fail "락 확보 로그 없음"
+
+for n in "$A" "$B"; do tmux kill-session -t "claude-$n" 2>/dev/null || true; done
+
+echo "── T2: CLAUDE_START_NO_STAGGER=1 탈출구 ──"
+rm -rf "$TMPROOT/home" "$TMPROOT/spawn.lock"; prep_home
+
+out="$(run_start "$A" CLAUDE_START_NO_STAGGER=1)"
+if grep -q "Stagger     : OFF" <<<"$out"; then
+  pass "OFF 경로 동작 (락 미사용)"
+else
+  fail "OFF 경로 미동작"; sed 's/^/    /' <<<"$out" | head -20
+fi
+[[ ! -d "$TMPROOT/spawn.lock" ]] && pass "OFF 시 락 디렉토리 미생성" || fail "OFF 인데 락이 생겼다"
+tmux kill-session -t "claude-$A" 2>/dev/null || true
+
+echo "── T3: 죽은 소유자의 stale 락을 회수하는가 (부팅 중 크래시 복구) ──"
+rm -rf "$TMPROOT/home" "$TMPROOT/spawn.lock"; prep_home
+
+# 절대 존재하지 않는 pid 로 락을 선점 → 스크립트가 회수해야 한다.
+mkdir -p "$TMPROOT/spawn.lock"
+echo "999999" > "$TMPROOT/spawn.lock/pid"
+out="$(run_start "$A")"
+if grep -q "stale 락 회수" <<<"$out"; then
+  pass "stale 락 회수됨"
+else
+  fail "stale 락을 회수하지 못했다 (부팅 실패 후 영구 블록 위험)"; sed 's/^/    /' <<<"$out" | head -20
+fi
+[[ -s "$TMPROOT/home/.claude/channels/telegram-$A/bot.pid" ]] \
+  && pass "회수 후 정상 기동" || fail "회수 후에도 기동 실패"
+tmux kill-session -t "claude-$A" 2>/dev/null || true
+
+echo
+if [[ $FAILED -eq 0 ]]; then echo "ALL PASS — start-telegram-channel stagger"; else echo "FAILED — start-telegram-channel stagger"; fi
+exit $FAILED

--- a/scripts/claude-start-stagger.test.sh
+++ b/scripts/claude-start-stagger.test.sh
@@ -11,7 +11,7 @@
 #   claude 바이너리는 stub(실제 CC 안 뜬다). tmux 는 실물을 쓰되 세션 이름에 PID 를 붙여 격리하고
 #   종료 시 반드시 kill 한다.
 #
-# 실행: scripts/test-claude-start-stagger.sh   (0=통과, 1=실패)
+# 실행: scripts/claude-start-stagger.test.sh   (0=통과, 1=실패)
 set -uo pipefail
 
 SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/src/server/runtimes/claude/start-telegram-channel.sh"
@@ -111,8 +111,23 @@ else
   fail "stamp 부족 — A(start=$sA pid=$pA) B(start=$sB pid=$pB)"
 fi
 
-grep -q "Stagger     : 락 확보" "$TMPROOT/outA" "$TMPROOT/outB" \
-  && pass "락 확보 로그 노출" || fail "락 확보 로그 없음"
+# ★파일별로 각각 단정한다★ — `grep -q pat fileA fileB` 는 ★한 파일만 맞아도 exit 0★ 이다.
+#   두 파일을 한 번에 주면 두번째 세션이 락 획보에 실패해 ⚠ 경로로 빠져도 통과한다.
+#   직렬화의 핵심 증거인데 절반만 보게 되므로, 반드시 각각 본다. (리사 리뷰 R2, 2026-07-30)
+for _f in outA outB; do
+  if grep -q "Stagger     : 락 확보" "$TMPROOT/$_f"; then
+    pass "$_f 락 확보 로그 노출"
+  else
+    fail "$_f 락 확보 실패 — ⚠ 경로로 빠졌다(직렬화 안 됨)"
+    grep -E "Stagger" "$TMPROOT/$_f" | sed 's/^/    /'
+  fi
+done
+# 어느 세션도 '경합 위험을 안고 진행' 으로 빠지지 않았어야 한다.
+for _f in outA outB; do
+  grep -q "경합 위험을 안고 계속 진행" "$TMPROOT/$_f" \
+    && fail "$_f 가 락 대기 상한을 초과했다(경합 안고 진행)" \
+    || pass "$_f 상한 초과 없음"
+done
 
 for n in "$A" "$B"; do tmux kill-session -t "claude-$n" 2>/dev/null || true; done
 
@@ -142,6 +157,26 @@ else
 fi
 [[ -s "$TMPROOT/home/.claude/channels/telegram-$A/bot.pid" ]] \
   && pass "회수 후 정상 기동" || fail "회수 후에도 기동 실패"
+tmux kill-session -t "claude-$A" 2>/dev/null || true
+
+echo "── T4: ★살아있는 소유자의 락은 절대 회수하지 않는다★ (상호배제 붕괴 방지) ──"
+# R1(TOCTOU) 이 지키는 불변식. 살아있는 pid 가 적힌 락을 선점해두고, 회수하지 않고 상한까지
+# 기다렸다 ⚠ 경로로 빠지는지 본다. 여기서 회수해버리면 두 세션이 동시에 락을 쥔다.
+rm -rf "$TMPROOT/home" "$TMPROOT/spawn.lock"; prep_home
+sleep 120 & LIVE_PID=$!
+disown "$LIVE_PID" 2>/dev/null || true   # kill 시 'Terminated' job 알림이 출력에 섞이지 않게
+mkdir -p "$TMPROOT/spawn.lock"; echo "$LIVE_PID" > "$TMPROOT/spawn.lock/pid"
+out="$(run_start "$A" CLAUDE_START_STAGGER_ACQUIRE=8 CLAUDE_START_STAGGER_STALE_CONFIRM=2)"
+if grep -q "stale 락 회수" <<<"$out"; then
+  fail "★살아있는 소유자의 락을 회수했다★ — 상호배제가 깨진다"
+else
+  pass "살아있는 락 회수 안 함"
+fi
+grep -q "경합 위험을 안고 계속 진행" <<<"$out" \
+  && pass "상한까지 기다린 뒤 경고 경로 (기동은 막지 않음)" \
+  || fail "예상한 상한 초과 경로가 아니다"
+[[ -d "$TMPROOT/spawn.lock" ]] && pass "선점 락이 그대로 남아있다" || fail "선점 락이 사라졌다"
+kill "$LIVE_PID" 2>/dev/null || true
 tmux kill-session -t "claude-$A" 2>/dev/null || true
 
 echo

--- a/src/server/runtimes/claude/start-telegram-channel.sh
+++ b/src/server/runtimes/claude/start-telegram-channel.sh
@@ -293,8 +293,19 @@ fi
 #   → 두 번째 멤버의 claude 는 캐시 링크가 끝난 뒤에 뜨므로 링크할 게 없다(경합 소멸).
 # flock(1) 은 macOS 기본 미포함 → mkdir 원자성으로 구현. 락 획득 실패는 ★기동을 막지 않는다★(경고 후 진행).
 STAGGER_LOCK="${CLAUDE_START_STAGGER_LOCK:-$HOME/.claude/channels/.spawn.lock}"
-STAGGER_ACQUIRE_MAX="${CLAUDE_START_STAGGER_ACQUIRE:-60}"  # 락 대기 상한(초)
 STAGGER_SETTLE_MAX="${CLAUDE_START_STAGGER_SETTLE:-25}"    # 내 poller 안착(bot.pid) 대기 상한(초)
+# ★ACQUIRE 는 SETTLE 에서 유도한다★ — 고정 60 으로 두면 claude 멤버가 3명 이상일 때 마지막 멤버의
+#   대기가 (N-1)×SETTLE 로 상한을 넘겨 '락 미확보 → 경합 안고 진행' = 고치려던 그 경합으로 되돌아간다.
+#   (N-1)×SETTLE + 여유. N 은 claude 봇 LaunchAgent plist 수로 센다(없으면 2로 가정).
+#   ※ `ls … | wc -l` 로 세지 않는다 — 매칭 0건이면 ls 가 실패하고 set -o pipefail + set -e 때문에
+#     ★스크립트가 그 자리에서 죽는다★(기동 자체가 안 된다). 순수 glob 으로 센다.
+_claude_members=0
+for _p in "$HOME/Library/LaunchAgents/"*.claude-telegram-*.plist; do
+  [[ -e "$_p" ]] && _claude_members=$(( _claude_members + 1 ))
+done
+(( _claude_members < 2 )) && _claude_members=2
+STAGGER_ACQUIRE_MAX="${CLAUDE_START_STAGGER_ACQUIRE:-$(( (_claude_members - 1) * STAGGER_SETTLE_MAX + 20 ))}"
+STAGGER_STALE_CONFIRM="${CLAUDE_START_STAGGER_STALE_CONFIRM:-5}"  # 같은 죽은 pid 를 연속 관찰해야 하는 초
 _stagger_held=0
 _stagger_release() { [[ $_stagger_held -eq 1 ]] && rm -rf "$STAGGER_LOCK" 2>/dev/null || true; }
 
@@ -303,6 +314,8 @@ if [[ "${CLAUDE_START_NO_STAGGER:-}" == "1" || "${CLAUDE_START_NO_STAGGER:-}" ==
 else
   mkdir -p "$(dirname "$STAGGER_LOCK")" 2>/dev/null || true
   _waited=0
+  _stale_pid=""      # 연속 관찰 중인 '죽은 소유자' pid
+  _stale_seen=0      # 그 pid 를 연속 관찰한 횟수(초)
   while (( _waited < STAGGER_ACQUIRE_MAX )); do
     if mkdir "$STAGGER_LOCK" 2>/dev/null; then
       _stagger_held=1
@@ -310,13 +323,41 @@ else
       trap _stagger_release EXIT
       break
     fi
-    # stale 회수: 락 소유 프로세스가 이미 죽었으면(부팅 중 kill·크래시) 락을 회수한다.
-    #   pid 파일이 아직 안 쓰인 찰나일 수 있으므로 pid 가 읽히지 않는 동안은 기다린다(성급한 탈취 방지).
+    # ─ stale 회수 (부팅 중 크래시가 락을 영구 점유하지 않게) ─
+    # ★TOCTOU 를 막는다★: "pid 읽고 죽었으면 rm" 은 위험하다 — 읽고 rm 하는 사이에 원 소유자가
+    #   정상 release 하고 다른 멤버가 mkdir 로 획득하면 ★남의 살아있는 락을 지운다★(상호배제 붕괴).
+    #   그래서 두 겹으로 막는다:
+    #   ① 같은 죽은 pid 를 STAGGER_STALE_CONFIRM 초 ★연속★ 관찰해야 회수 후보가 된다.
+    #      살아있는 소유자나 새 획득자는 이 조건을 만들 수 없다(새 획득자는 자기 살아있는 pid 를 쓰므로
+    #      관찰이 리셋된다). 즉 '방금 갈아치워진 락' 은 후보에서 자동 탈락한다.
+    #   ② 회수는 rm 이 아니라 ★원자적 mv★ 로 들어낸 뒤, 들어낸 것의 pid 를 다시 확인한다. mv 는
+    #      주어진 디렉토리를 정확히 한 프로세스만 옮길 수 있다. 옮긴 게 알고 보니 살아있는 주인의
+    #      락이면 즉시 제자리로 되돌린다.
+    #   ③ 회수했다고 스스로 락을 주지 않는다 — 루프 위로 돌아가 mkdir 로 공정하게 다시 경쟁한다.
     _owner="$(cat "$STAGGER_LOCK/pid" 2>/dev/null || true)"
     if [[ -n "$_owner" ]] && ! kill -0 "$_owner" 2>/dev/null; then
-      echo "  Stagger     : stale 락 회수 (죽은 pid=$_owner)"
-      rm -rf "$STAGGER_LOCK" 2>/dev/null || true
-      continue
+      if [[ "$_owner" == "$_stale_pid" ]]; then
+        _stale_seen=$(( _stale_seen + 1 ))
+      else
+        _stale_pid="$_owner"; _stale_seen=1
+      fi
+      if (( _stale_seen >= STAGGER_STALE_CONFIRM )); then
+        _stale_dir="${STAGGER_LOCK}.stale.$$"
+        if mv "$STAGGER_LOCK" "$_stale_dir" 2>/dev/null; then
+          _moved_pid="$(cat "$_stale_dir/pid" 2>/dev/null || true)"
+          if [[ -n "$_moved_pid" ]] && kill -0 "$_moved_pid" 2>/dev/null; then
+            # 살아있는 주인의 락을 잘못 들어냈다 → 제자리로. 되돌리기 실패(그새 남이 획득)면 버린다.
+            mv "$_stale_dir" "$STAGGER_LOCK" 2>/dev/null || rm -rf "$_stale_dir" 2>/dev/null || true
+          else
+            rm -rf "$_stale_dir" 2>/dev/null || true
+            echo "  Stagger     : stale 락 회수 (죽은 pid=$_owner, ${_stale_seen}s 연속 확인)"
+          fi
+        fi
+        _stale_pid=""; _stale_seen=0
+      fi
+    else
+      # 소유자가 살아있다 / pid 파일이 아직 안 쓰인 찰나 → 관찰 리셋(성급한 탈취 방지)
+      _stale_pid=""; _stale_seen=0
     fi
     sleep 1
     _waited=$(( _waited + 1 ))
@@ -328,7 +369,7 @@ else
       echo "  Stagger     : 락 확보 (즉시) — 스폰 직렬화"
     fi
   else
-    echo "  ⚠ Stagger   : 락 대기 ${STAGGER_ACQUIRE_MAX}s 초과 — 경합 위험을 안고 계속 진행"
+    echo "  ⚠ Stagger   : 락 대기 ${STAGGER_ACQUIRE_MAX}s 초과(멤버 ${_claude_members}명 기준) — 경합 위험을 안고 계속 진행"
   fi
 fi
 

--- a/src/server/runtimes/claude/start-telegram-channel.sh
+++ b/src/server/runtimes/claude/start-telegram-channel.sh
@@ -274,12 +274,88 @@ else
   echo "  ⚠ MCP plugin enable 자동기록 실패(계속) — 안 붙으면 세션에서 /plugin 으로 수동 enable"
 fi
 
-# ★pre-warm/boot-mutex 제거(2026-07-25 하네스 4-way 확정)★: 이전엔 "콜드 `bun install` → CC 30s MCP 핸드셰이크 초과 →
+# ★pre-warm 제거는 유지(2026-07-25 하네스 4-way 확정)★: 이전엔 "콜드 `bun install` → CC 30s MCP 핸드셰이크 초과 →
 #   타임아웃"을 근본으로 보고 node_modules pre-warm + 버전락 mutex 를 뒀으나, ★실패 세션 MCP 로그에 `Starting connection`
 #   이 0건★ = 타임아웃이 아니라 부팅 MCP 열거에서 telegram 이 아예 빠진 것으로 반증됐다. 그 타임아웃이 애초에 없으므로
 #   pre-warm 은 헛수고이고, 오히려 매 스폰마다 공유 플러그인 캐시에서 `bun install` 을 돌려 형제 세션과 경합을 늘렸다 → 제거.
 #   진짜 복구는 activation 의 auto-reconnect(`/mcp reconnect`)가 담당한다.
+#   ⚠ 아래 stagger 는 그 pre-warm 의 부활이 아니다 — 공유 캐시를 ★건드리지 않는다★(bun install 없음). 스폰 순서만 직렬화한다.
+
+# ─── Spawn stagger (공유 플러그인 캐시 binlink 경합 가드) ────────────────────
+# 2026-07-30 실측(리사 28분 무응답): jane·lisa launchd 잡이 RunAtLoad 로 ★같은 초★(08:03:33)에 떠서
+#   두 세션의 claude 가 공유 플러그인 캐시(…/telegram/<ver>/)에 `bun run` 을 동시에 걸었다.
+#   bun 이 node_modules/.bin binlink 를 동시 생성 → 한쪽이 `error: Failed to link which: EEXIST` 로 죽고
+#   `MCP error -32000: Connection closed`(144ms) → bot.pid 미생성 → 그 멤버는 텔레그램을 아예 못 받는다.
+#   jane 은 경합을 이겨 정상, lisa 만 탈락 = 부팅마다 뽑기.
+# ★2026-07-25 케이스와 실패 서명이 다르다★: 그땐 MCP 로그에 `Starting connection` 0건(열거 누락),
+#   이번엔 `Starting connection` 있고 144ms 뒤 `Connection closed`(링크 실패). 그래서 다른 처방이 맞다.
+# 처방: 머신 단위 mutex 로 ★스폰만★ 직렬화하고, 새 세션의 poller 가 bot.pid 를 쓸 때까지 기다렸다 락을 놓는다.
+#   → 두 번째 멤버의 claude 는 캐시 링크가 끝난 뒤에 뜨므로 링크할 게 없다(경합 소멸).
+# flock(1) 은 macOS 기본 미포함 → mkdir 원자성으로 구현. 락 획득 실패는 ★기동을 막지 않는다★(경고 후 진행).
+STAGGER_LOCK="${CLAUDE_START_STAGGER_LOCK:-$HOME/.claude/channels/.spawn.lock}"
+STAGGER_ACQUIRE_MAX="${CLAUDE_START_STAGGER_ACQUIRE:-60}"  # 락 대기 상한(초)
+STAGGER_SETTLE_MAX="${CLAUDE_START_STAGGER_SETTLE:-25}"    # 내 poller 안착(bot.pid) 대기 상한(초)
+_stagger_held=0
+_stagger_release() { [[ $_stagger_held -eq 1 ]] && rm -rf "$STAGGER_LOCK" 2>/dev/null || true; }
+
+if [[ "${CLAUDE_START_NO_STAGGER:-}" == "1" || "${CLAUDE_START_NO_STAGGER:-}" == "true" ]]; then
+  echo "  Stagger     : OFF (CLAUDE_START_NO_STAGGER)"
+else
+  mkdir -p "$(dirname "$STAGGER_LOCK")" 2>/dev/null || true
+  _waited=0
+  while (( _waited < STAGGER_ACQUIRE_MAX )); do
+    if mkdir "$STAGGER_LOCK" 2>/dev/null; then
+      _stagger_held=1
+      echo "$$" > "$STAGGER_LOCK/pid" 2>/dev/null || true
+      trap _stagger_release EXIT
+      break
+    fi
+    # stale 회수: 락 소유 프로세스가 이미 죽었으면(부팅 중 kill·크래시) 락을 회수한다.
+    #   pid 파일이 아직 안 쓰인 찰나일 수 있으므로 pid 가 읽히지 않는 동안은 기다린다(성급한 탈취 방지).
+    _owner="$(cat "$STAGGER_LOCK/pid" 2>/dev/null || true)"
+    if [[ -n "$_owner" ]] && ! kill -0 "$_owner" 2>/dev/null; then
+      echo "  Stagger     : stale 락 회수 (죽은 pid=$_owner)"
+      rm -rf "$STAGGER_LOCK" 2>/dev/null || true
+      continue
+    fi
+    sleep 1
+    _waited=$(( _waited + 1 ))
+  done
+  if [[ $_stagger_held -eq 1 ]]; then
+    if (( _waited > 0 )); then
+      echo "  Stagger     : 락 확보 (앞 세션 대기 ${_waited}s) — 스폰 직렬화"
+    else
+      echo "  Stagger     : 락 확보 (즉시) — 스폰 직렬화"
+    fi
+  else
+    echo "  ⚠ Stagger   : 락 대기 ${STAGGER_ACQUIRE_MAX}s 초과 — 경합 위험을 안고 계속 진행"
+  fi
+fi
+
+_spawn_t0=$(date +%s)
 tmux new-session -d -s "$SESSION_NAME" -c "$WORKDIR" "$INNER_CMD"
+
+# 내 poller 가 bot.pid 를 ★새로★ 쓸 때까지 락을 쥔 채 기다린다(= 캐시 링크 완료 신호).
+#   기존 bot.pid 가 남아있을 수 있으므로 mtime 이 스폰 이후인지 본다(오래된 파일로 조기 통과 방지).
+#   bot.pid 를 미리 지우지 않는다 — 플러그인이 그 값으로 stale orphan poller 를 죽이기 때문(server.ts PID_FILE).
+if [[ $_stagger_held -eq 1 ]]; then
+  _settled=0
+  for (( i = 0; i < STAGGER_SETTLE_MAX; i++ )); do
+    if [[ -f "$STATE_DIR/bot.pid" ]]; then
+      _mt=$(stat -f %m "$STATE_DIR/bot.pid" 2>/dev/null || stat -c %Y "$STATE_DIR/bot.pid" 2>/dev/null || echo 0)
+      if (( _mt >= _spawn_t0 )); then _settled=1; break; fi
+    fi
+    sleep 1
+  done
+  if [[ $_settled -eq 1 ]]; then
+    echo "  Poller      : bot.pid 확인 ✓ (${i}s) — 다음 멤버 스폰 안전"
+  else
+    echo "  ⚠ Poller    : bot.pid 미확인 (${STAGGER_SETTLE_MAX}s) — MCP 미기동 가능, activation auto-reconnect 대상"
+  fi
+  _stagger_release
+  _stagger_held=0
+  trap - EXIT
+fi
 
 echo "Started tmux session: $SESSION_NAME"
 echo "  State dir   : $STATE_DIR"

--- a/src/server/runtimes/claude/start-telegram-channel.sh
+++ b/src/server/runtimes/claude/start-telegram-channel.sh
@@ -307,7 +307,19 @@ done
 STAGGER_ACQUIRE_MAX="${CLAUDE_START_STAGGER_ACQUIRE:-$(( (_claude_members - 1) * STAGGER_SETTLE_MAX + 20 ))}"
 STAGGER_STALE_CONFIRM="${CLAUDE_START_STAGGER_STALE_CONFIRM:-5}"  # 같은 죽은 pid 를 연속 관찰해야 하는 초
 _stagger_held=0
-_stagger_release() { [[ $_stagger_held -eq 1 ]] && rm -rf "$STAGGER_LOCK" 2>/dev/null || true; }
+# release 도 ★내 락인지 확인하고★ 지운다. 회수 로직이 창을 극단적으로 좁혔어도 완전히 닫지는
+#   못하므로(오회수 → 되돌리기 실패 경로가 이론상 남는다), 그 최악 결과가 '해제할 때 남의 락을
+#   지운다' 로 연쇄되는 걸 여기서 끊는다. 좁은 경합을 더 쫓는 대신 최악 결과를 없애는 쪽.
+#   (리사 리뷰 F1, 2026-07-30)
+_stagger_release() {
+  [[ $_stagger_held -eq 1 ]] || return 0
+  local _cur
+  _cur="$(cat "$STAGGER_LOCK/pid" 2>/dev/null || true)"
+  if [[ "$_cur" == "$$" ]]; then
+    rm -rf "$STAGGER_LOCK" 2>/dev/null || true
+  fi
+  return 0
+}
 
 if [[ "${CLAUDE_START_NO_STAGGER:-}" == "1" || "${CLAUDE_START_NO_STAGGER:-}" == "true" ]]; then
   echo "  Stagger     : OFF (CLAUDE_START_NO_STAGGER)"


### PR DESCRIPTION
> **작성: Jane (jane)** — gdstudio 팀 · 서비스 전략/기획 및 풀스택
> 리뷰: Lisa (lisa) 승인 완료 (버스 리뷰)
> ※ 이 PR 은 팀원 작업 계정 `gdb3rys` 로 작성됐습니다(b3os-github-workflow ⑤ — 작성자와 승인자가
> 달라야 리뷰 요건이 성립). 커밋 author 는 공용 계정이라 담당자가 드러나지 않으므로 실제 작업자는 위와 같습니다.
> 원 PR #132 은 `gd452`(승인 계정)로 만들어져 승인이 불가능했습니다 — 작성자는 변경할 수 없어 닫고 다시 열었습니다.

## 무슨 일이 있었나

2026-07-30 부팅. 팀장님이 "리사가 응답이 없어" 라고 알려주고 나서야 발견됐다. 리사 세션·프로세스는 멀쩡히 살아있었고, 죽은 건 텔레그램 MCP 채널이었다.

```
08:03:40.372  Starting connection with timeout of 30000ms
08:03:40.515  Server stderr: error: Failed to link which: EEXIST
08:03:40.515  Connection failed after 144ms (-32000): Connection closed
```
(`~/Library/Caches/claude-cli-nodejs/-Users-gd452-b3os-members-lisa/mcp-logs-plugin-telegram-telegram/`)

`jane`·`lisa` launchd 잡이 `RunAtLoad` 로 **같은 초(08:03:33)** 에 떠서, 두 세션의 claude 가 공유 플러그인 캐시(`…/telegram/0.0.6`)에 `bun run` 을 동시에 걸었다. bun 이 `node_modules/.bin` binlink 를 동시 생성 → 한쪽이 EEXIST 로 죽는다. jane 은 같은 시각 **322ms 에 connected** — 경합을 이겼다. lisa 는 `bot.pid` 가 안 생겨 **텔레그램을 아예 못 받는** 상태로 28분 방치됐다.

launchd 에는 순서·의존성 키가 없다(잡 5개 전부 RunAtLoad, 순서 제약 0). **부팅마다 뽑기다** — `00:12:38` 에도 같은 경합이 잡혔고 그때는 둘 다 30초 내 회복해서 아무도 몰랐다.

## 처방

머신 단위 mutex 로 **스폰만** 직렬화한다. 새 세션의 poller 가 `bot.pid` 를 쓸 때까지 락을 쥐고 있다 놓으므로, 두 번째 멤버의 claude 는 캐시 링크가 끝난 뒤에 뜬다 → **링크할 게 없어 경합이 성립하지 않는다.**

### ⚠️ 2026-07-25 에 제거한 pre-warm 의 부활이 아니다

리뷰어가 먼저 볼 지점이라 명시한다. 그때 제거된 것은 "매 스폰마다 공유 캐시에서 `bun install`" 이고, 그게 오히려 형제 세션과의 경합을 늘렸다는 게 제거 이유였다. **이 PR 은 공유 캐시를 건드리지 않는다 (`bun install` 없음).**

실패 서명도 다르다:
| | 2026-07-25 | 2026-07-30 (이 PR) |
|---|---|---|
| MCP 로그 | `Starting connection` **0건** | `Starting connection` 있음 |
| 고장 지점 | 부팅 MCP 열거 누락 | connection 열린 뒤 144ms 에 링크 실패 |
| 처방 | auto-reconnect | 스폰 직렬화 |

다른 고장이라 다른 처방이 맞다. 기존 pre-warm 제거 주석은 유지하고 그 아래에 이 구분을 적어뒀다.

## 안전 설계

- `flock(1)` 은 macOS 기본 미포함 → `mkdir` 원자성으로 구현
- **stale 락 회수**: 소유 pid 가 죽어 있으면 회수한다. 부팅 중 크래시가 영구 블록이 되지 않게. pid 파일이 아직 안 쓰인 찰나에는 기다린다(성급한 탈취 방지)
- **락 획득 실패가 기동을 막지 않는다** — 경고 후 진행. 가드가 서비스를 죽이면 안 된다
- `bot.pid` 를 미리 지우지 않는다 — 플러그인이 그 값으로 stale orphan poller 를 죽인다(`server.ts` PID_FILE)
- 기존 `bot.pid` 로 조기 통과하지 않게 mtime 이 스폰 이후인지 본다
- 탈출구 `CLAUDE_START_NO_STAGGER=1`, 대기 상한 2종 env 조정 가능

## 검증

`scripts/claude-start-stagger.test.sh` — **4/4 통과**

| 시나리오 | 무엇을 지키나 |
|---|---|
| 동시 기동 직렬화 | 늦은 `start` ≥ 이른 `bot.pid`. 두 멤버 다 bot.pid 생성 = 아무도 경합 탈락 안 함 |
| `CLAUDE_START_NO_STAGGER=1` | 탈출구 동작, 락 미생성 |
| stale 락 회수 | 죽은 pid 선점 상태에서 회수 후 정상 기동 |

FS 격리(infra-safety ④): `HOME` 을 `mktemp` 로 갈고 claude 는 stub. 실제 `~/.claude` 무접촉. tmux 세션명에 PID 를 붙이고 종료 시 kill.

전체 스위트: **1903 pass / 4 fail** — 4건은 `teamRouter.llm.test.ts`(EXAONE), ollama 미기동 환경 실패로 **clean main 에서 동일하게 4건 실패**(baseline 확인). typecheck 통과.

### `.gitignore` 변경 이유

`scripts/test-*.sh` 로 짰더니 `/scripts/*` 에 걸려 **git status 에 아예 안 나타났다.** 그대로 커밋하면 `!/scripts/*.test.ts` 주석이 경고하는 바로 그 사고 — "소스만 커밋되고 그 소스를 지키는 테스트는 리포에 없는 PR" — 가 셸에서 재현된다. 그 주석의 원칙대로 **클래스로** `!/scripts/*.test.sh` 를 열었다. 기존 GD 머신 전용 ops 테스트는 `test-*.sh` 라 이 패턴에 안 걸린다(공개 노출 없음).

## 남는 것 (이 PR 범위 밖)

이 PR 은 **경합을 없앤다**. 하지만 다른 이유로 poller 가 죽으면 여전히 되살릴 주체가 없다 (claude 봇 잡만 `KeepAlive=false`, 스포너라서 true 로 켜면 무한 재실행 루프). 그 안전망은 #team-op PR 이 담당한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

