### PR TITLE
fix(health): 리사가 죽은 걸 정확히 감지해놓고 아무에게도 안 알려서 28분이 갔다

### DIFF
--- a/src/server/lib/agentControl.ts
+++ b/src/server/lib/agentControl.ts
@@ -239,7 +239,11 @@ export async function restartAgent(agentId: string, runtime: string, fresh = fal
       }
       // 기동 수단이 확보된 뒤에야 기존 세션을 정리한다. start-telegram-channel.sh 는 --resume 지원(없으면 새 세션).
       try { await run(["tmux", "kill-session", "-t", `claude-${agentId}`]); } catch { /* 없으면 그만 */ }
-      const args = fresh ? [agentId] : [agentId, "--resume"];
+      // ★--force 를 항상 실어 보낸다★ — 위 kill 이 실패/경합하면(세션은 살아있고 poller 만 죽은 상태가 바로 그 케이스)
+      //   기동 스크립트의 idempotent 가드가 'Session already running' 으로 no-op 이 되어 ★재시작이 조용히 안 된다★.
+      //   2026-07-30 실측: launchctl kickstart 로 스크립트를 다시 돌렸더니 정확히 이 no-op 에 걸려 리사가 계속 죽어 있었다.
+      //   --force 는 스크립트 안에서 kill 후 기동을 보장하므로 kill 성공 여부와 무관하게 복구가 성립한다(멱등).
+      const args = fresh ? [agentId, "--force"] : [agentId, "--resume", "--force"];
       const r = await run(["bash", starter, ...args]);
       if (r.code !== 0) return { ok: false, detail: `재시작 실패: ${r.out.slice(-150)}` };
       return withPollerRecovery(agentId, `claude ${agentId} 재시작(${mode})`);

--- a/src/server/lib/opNotice.test.ts
+++ b/src/server/lib/opNotice.test.ts
@@ -29,9 +29,28 @@ const TEAM = [
 ];
 
 describe("pickOpNoticeRecipient — 알림은 살아있는 사람에게", () => {
+  // ★이 단정을 지우지 마라★ (리사 리뷰 B1, 2026-07-30): 한 번 삭제했다가 사고가 났다.
+  //   R4 가중치를 넣을 때 런타임 다양성(+2)이 coordinator(+1)를 이기게 되어 기본 라우팅이
+  //   coordinator → clo 로 ★뒤집혔는데★, 마침 이 단정을 같이 지워서 무보고로 통과했다.
+  //   'claude 봇 poller 사망' 이 이 알림의 가장 흔한 시나리오이므로 기본 라우팅이 곧 본선이다.
+  test("★기본은 coordinator 로 간다★ — 전원 건강 + 같은 런타임 상황의 불변식", () => {
+    expect(pickOpNoticeRecipient(TEAM, "jane")).toBe("lisa");
+  });
+
   test("★고장난 본인에게는 절대 안 보낸다★ (블랙홀 방지)", () => {
     const to = pickOpNoticeRecipient(TEAM, "lisa");
     expect(to).not.toBe("lisa");
+  });
+
+  // 가중치를 건드리면 여기가 먼저 빨개진다 — 표 전체를 못으로 박아둔다.
+  test("실팀 구성 라우팅 표 전체", () => {
+    const pick = (affected: string, down: string[] = []) =>
+      pickOpNoticeRecipient(TEAM, affected, (id) => down.includes(id));
+    expect(pick("jane")).toBe("lisa");                      // coordinator 기본
+    expect(pick("lisa")).toBe("clo");                       // 같은 런타임 jane 탈락
+    expect(pick("clo")).toBe("lisa");                       // coordinator
+    expect(pick("jane", ["clo", "herm"])).toBe("lisa");     // 건강한 coordinator
+    expect(pick("lisa", ["clo", "herm"])).toBe("jane");     // 유일한 건강 멤버
   });
 
   test("coordinator 가 없으면 남은 아무 멤버", () => {

--- a/src/server/lib/opNotice.test.ts
+++ b/src/server/lib/opNotice.test.ts
@@ -1,0 +1,133 @@
+// opNotice — team op 상황 알림의 계약 테스트.
+//
+// 지키는 것 (2026-07-30 사고에서 나온 요구):
+//   ① 부팅 오탐을 내지 않는다 — 짧게 미충족했다 회복하면 아무 알림도 안 나간다(jane: 34초).
+//   ② 지속되면 반드시 1회 알린다 — 그리고 반복 스팸하지 않는다(lisa: 28분).
+//   ③ 알림은 고장난 본인에게 가지 않는다 — 그 멤버가 못 듣는 상태가 사고 본체다(블랙홀 금지).
+//   ④ coordinator 가 고장이면 다른 멤버로 폴백한다.
+import { describe, test, expect } from "bun:test";
+import {
+  EssentialsOpNotifier,
+  pickOpNoticeRecipient,
+  buildEssentialsDownBody,
+  buildEssentialsRecoveredBody,
+} from "./opNotice";
+import type { AgentRecord } from "../types";
+
+const agent = (id: string, capabilities: string[] = []): AgentRecord =>
+  ({ id, runtime: "claude_channel", capabilities } as unknown as AgentRecord);
+
+const TEAM = [
+  agent("lisa", ["coordinator", "full_context"]),
+  agent("jane"),
+  agent("clo"),
+  agent("herm"),
+];
+
+describe("pickOpNoticeRecipient — 알림은 살아있는 사람에게", () => {
+  test("기본은 coordinator 로 간다", () => {
+    expect(pickOpNoticeRecipient(TEAM, "jane")).toBe("lisa");
+  });
+
+  test("★고장난 본인에게는 절대 안 보낸다★ (블랙홀 방지)", () => {
+    // lisa 가 고장이면 lisa 에게 보내면 아무도 못 듣는다 → 다른 멤버로.
+    const to = pickOpNoticeRecipient(TEAM, "lisa");
+    expect(to).not.toBe("lisa");
+    expect(to).toBe("jane");
+  });
+
+  test("coordinator 가 없으면 남은 아무 멤버", () => {
+    expect(pickOpNoticeRecipient([agent("clo"), agent("herm")], "clo")).toBe("herm");
+  });
+
+  test("예약 id(system 등)는 수신자가 될 수 없다", () => {
+    expect(pickOpNoticeRecipient([agent("system"), agent("broadcast")], "jane")).toBeNull();
+  });
+
+  test("혼자인 팀에서 그 1인이 고장이면 null (호출부가 audit 만 남긴다)", () => {
+    expect(pickOpNoticeRecipient([agent("jane")], "jane")).toBeNull();
+  });
+});
+
+describe("EssentialsOpNotifier — 부팅 오탐 억제 + 1회 발행", () => {
+  test("★임계 미달이면 알리지 않는다★ — 부팅 직후 잠깐 미충족은 정상(jane 34초 케이스)", () => {
+    const n = new EssentialsOpNotifier(3);
+    expect(n.observe("jane", ["poller:claude bot.pid"])).toBeNull(); // 1
+    expect(n.observe("jane", ["poller:claude bot.pid"])).toBeNull(); // 2
+    expect(n.observe("jane", null)).toBeNull(); // 회복 — down 을 안 보냈으니 recovered 도 없다
+    expect(n.streakOf("jane")).toBe(0);
+  });
+
+  test("연속 임계 도달 시 down 1회 (lisa 28분 케이스)", () => {
+    const n = new EssentialsOpNotifier(3);
+    n.observe("lisa", ["poller:claude bot.pid"]);
+    n.observe("lisa", ["poller:claude bot.pid"]);
+    expect(n.observe("lisa", ["poller:claude bot.pid"])).toBe("down");
+  });
+
+  test("★down 이후 매 tick 반복 알림 금지★ (스팸 방지)", () => {
+    const n = new EssentialsOpNotifier(2);
+    n.observe("lisa", ["x"]);
+    expect(n.observe("lisa", ["x"])).toBe("down");
+    for (let i = 0; i < 10; i++) expect(n.observe("lisa", ["x"])).toBeNull();
+  });
+
+  test("down 을 보낸 뒤 회복하면 recovered 1회", () => {
+    const n = new EssentialsOpNotifier(2);
+    n.observe("lisa", ["x"]);
+    expect(n.observe("lisa", ["x"])).toBe("down");
+    expect(n.observe("lisa", null)).toBe("recovered");
+    expect(n.observe("lisa", null)).toBeNull(); // 반복 없음
+  });
+
+  test("회복 후 다시 고장나면 또 알린다 (한 번 알렸다고 영구 침묵하지 않는다)", () => {
+    const n = new EssentialsOpNotifier(2);
+    n.observe("lisa", ["x"]);
+    n.observe("lisa", ["x"]);
+    n.observe("lisa", null);
+    n.observe("lisa", ["x"]);
+    expect(n.observe("lisa", ["x"])).toBe("down");
+  });
+
+  test("멤버별로 독립 추적된다 (한 명의 streak 이 다른 명을 오염시키지 않는다)", () => {
+    const n = new EssentialsOpNotifier(2);
+    n.observe("lisa", ["x"]);
+    n.observe("jane", ["x"]);
+    expect(n.observe("lisa", ["x"])).toBe("down");
+    expect(n.streakOf("jane")).toBe(1);
+  });
+
+  test("빈 missing 배열은 정상으로 취급한다", () => {
+    const n = new EssentialsOpNotifier(1);
+    expect(n.observe("jane", [])).toBeNull();
+  });
+});
+
+describe("본문 — 사람이 바로 조치할 수 있어야 한다", () => {
+  const body = buildEssentialsDownBody({
+    agentId: "lisa",
+    runtime: "claude_channel",
+    missing: ["poller:claude bot.pid"],
+    elapsedSec: 90,
+  });
+
+  test("누가·무엇이·얼마나 를 담는다", () => {
+    expect(body).toContain("lisa");
+    expect(body).toContain("poller:claude bot.pid");
+    expect(body).toContain("90초");
+  });
+
+  test("★복구 명령에 --force 가 있다★ (없으면 'Session already running' no-op 함정)", () => {
+    expect(body).toContain("--force");
+    expect(body).toContain("Session already running");
+  });
+
+  test("system 발신이라 회신 대상이 없음을 명시한다 (--to system 블랙홀 방지)", () => {
+    expect(body).toContain("팀장님께 직접 보고");
+  });
+
+  test("회복 본문은 앞선 down 을 해소로 연결한다", () => {
+    expect(buildEssentialsRecoveredBody("lisa")).toContain("lisa");
+    expect(buildEssentialsRecoveredBody("lisa")).toContain("해소");
+  });
+});

--- a/src/server/lib/opNotice.test.ts
+++ b/src/server/lib/opNotice.test.ts
@@ -6,34 +6,32 @@
 //   ③ 알림은 고장난 본인에게 가지 않는다 — 그 멤버가 못 듣는 상태가 사고 본체다(블랙홀 금지).
 //   ④ coordinator 가 고장이면 다른 멤버로 폴백한다.
 import { describe, test, expect } from "bun:test";
+import { Database } from "bun:sqlite";
 import {
   EssentialsOpNotifier,
+  emitOpNotice,
   pickOpNoticeRecipient,
   buildEssentialsDownBody,
   buildEssentialsRecoveredBody,
 } from "./opNotice";
+import { migrate } from "../db/migrate";
 import type { AgentRecord } from "../types";
 
-const agent = (id: string, capabilities: string[] = []): AgentRecord =>
-  ({ id, runtime: "claude_channel", capabilities } as unknown as AgentRecord);
+const agent = (id: string, capabilities: string[] = [], runtime = "claude_channel"): AgentRecord =>
+  ({ id, runtime, capabilities } as unknown as AgentRecord);
 
+// 실제 팀 구성을 반영한다 — lisa·jane 은 claude_channel(같은 경합 공유), clo·herm 은 다른 런타임.
 const TEAM = [
   agent("lisa", ["coordinator", "full_context"]),
   agent("jane"),
-  agent("clo"),
-  agent("herm"),
+  agent("clo", [], "openclaw"),
+  agent("herm", [], "hermes_agent"),
 ];
 
 describe("pickOpNoticeRecipient — 알림은 살아있는 사람에게", () => {
-  test("기본은 coordinator 로 간다", () => {
-    expect(pickOpNoticeRecipient(TEAM, "jane")).toBe("lisa");
-  });
-
   test("★고장난 본인에게는 절대 안 보낸다★ (블랙홀 방지)", () => {
-    // lisa 가 고장이면 lisa 에게 보내면 아무도 못 듣는다 → 다른 멤버로.
     const to = pickOpNoticeRecipient(TEAM, "lisa");
     expect(to).not.toBe("lisa");
-    expect(to).toBe("jane");
   });
 
   test("coordinator 가 없으면 남은 아무 멤버", () => {
@@ -46,6 +44,92 @@ describe("pickOpNoticeRecipient — 알림은 살아있는 사람에게", () => 
 
   test("혼자인 팀에서 그 1인이 고장이면 null (호출부가 audit 만 남긴다)", () => {
     expect(pickOpNoticeRecipient([agent("jane")], "jane")).toBeNull();
+  });
+
+  // ── R4: 대칭 경합에서 죽은 쪽으로 알림이 들어가는 걸 막는다 ──
+  test("★같이 죽은 멤버는 수신자에서 제외한다★ — lisa·jane 동시 탈락(08:03:37 실측)", () => {
+    // lisa 가 고장이고 jane 도 down 이면, jane 에게 보내면 아무도 못 읽는다.
+    const to = pickOpNoticeRecipient(TEAM, "lisa", (id) => id === "jane");
+    expect(to).not.toBe("jane");
+    expect(to).not.toBe("lisa");
+    expect(to).not.toBeNull();
+    expect(["clo", "herm"]).toContain(to as string);
+  });
+
+  test("★폴백은 같은 경합을 공유하지 않는 다른 런타임을 우선한다★", () => {
+    // lisa(claude_channel) 고장 → 같은 claude_channel 인 jane 보다 다른 런타임이 안전하다.
+    const to = pickOpNoticeRecipient(TEAM, "lisa");
+    expect(to).not.toBe("jane");
+    expect(to).not.toBeNull();
+    expect(["clo", "herm"]).toContain(to as string);
+  });
+
+  test("다른 런타임 후보들 중에서는 coordinator 를 고른다", () => {
+    const team = [agent("jane"), agent("clo", [], "openclaw"), agent("herm", ["coordinator"], "hermes_agent")];
+    expect(pickOpNoticeRecipient(team, "jane")).toBe("herm");
+  });
+
+  test("전원 down 이어도 null 대신 최선을 골라 시도한다 (아무것도 안 보내는 것보다 낫다)", () => {
+    const to = pickOpNoticeRecipient(TEAM, "lisa", () => true);
+    expect(to).not.toBeNull();
+    expect(to).not.toBe("lisa");
+  });
+});
+
+// ★R3 — 고쳐진 그 결함 자체에 붙는 테스트★
+// 원 사고의 본체는 '감지는 했는데 message 테이블에 안 넣었다' 다. emitOpNotice 를 실제로 호출해
+// 행이 들어갔는지 보지 않으면, 이 함수를 통째로 no-op 으로 만들어도 테스트가 전부 초록이다
+// — 사고가 그대로 재현되는데. (리사 리뷰 R3, 2026-07-30)
+describe("emitOpNotice — message 테이블에 실제로 적재되는가", () => {
+  const setup = (): Database => {
+    const db = new Database(":memory:");
+    migrate(db);
+    for (const a of ["lisa", "jane", "clo"]) {
+      db.prepare(
+        `INSERT OR IGNORE INTO agent (id, display_name, role, runtime, status_provider, workspace_path, persona_file)
+         VALUES (?, ?, 'r', 'claude_channel', 'claude_tmux', '/tmp', 'P.md')`,
+      ).run(a, a);
+    }
+    return db;
+  };
+
+  test("★행이 실제로 들어간다★ — to_agent_id·source='system'·body 확인", () => {
+    const db = setup();
+    const id = emitOpNotice(db, { to: "lisa", body: "[team op] jane down", threadKey: "op-health-jane" });
+    expect(id).not.toBeNull();
+
+    const row = db
+      .prepare(`SELECT to_agent_id, from_agent_id, source, body, priority FROM message WHERE id = ?`)
+      .get(id as string) as Record<string, unknown>;
+    expect(row).toBeTruthy();
+    expect(row.to_agent_id).toBe("lisa");
+    expect(row.from_agent_id).toBe("system");
+    expect(row.source).toBe("system"); // ★op 메시지는 정직하게 system 발신★ (agent 사칭 금지)
+    expect(String(row.body)).toContain("jane down");
+    expect(row.priority).toBe("high"); // 기본 high
+  });
+
+  test("registry 에 없는 id 면 넣지 않는다 (깨울 대상이 없다)", () => {
+    const db = setup();
+    expect(emitOpNotice(db, { to: "nobody", body: "x", threadKey: "op-health-nobody" })).toBeNull();
+    expect((db.prepare(`SELECT COUNT(*) c FROM message`).get() as { c: number }).c).toBe(0);
+  });
+
+  test("같은 threadKey 로 두 번 보내도 둘 다 적재된다 (down → autofix 결과 2연발)", () => {
+    const db = setup();
+    const a = emitOpNotice(db, { to: "lisa", body: "down", threadKey: "op-health-jane" });
+    const b = emitOpNotice(db, { to: "lisa", body: "autofix 성공", threadKey: "op-health-jane" });
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a).not.toBe(b);
+    expect((db.prepare(`SELECT COUNT(*) c FROM message`).get() as { c: number }).c).toBe(2);
+  });
+
+  test("priority 를 넘기면 반영된다", () => {
+    const db = setup();
+    const id = emitOpNotice(db, { to: "lisa", body: "회복", threadKey: "op-health-jane", priority: "normal" });
+    const row = db.prepare(`SELECT priority FROM message WHERE id = ?`).get(id as string) as { priority: string };
+    expect(row.priority).toBe("normal");
   });
 });
 
@@ -100,6 +184,42 @@ describe("EssentialsOpNotifier — 부팅 오탐 억제 + 1회 발행", () => {
   test("빈 missing 배열은 정상으로 취급한다", () => {
     const n = new EssentialsOpNotifier(1);
     expect(n.observe("jane", [])).toBeNull();
+  });
+
+  test("isDown 은 알림을 보낸 멤버만 true (수신자 선정 입력)", () => {
+    const n = new EssentialsOpNotifier(2);
+    n.observe("lisa", ["x"]);
+    expect(n.isDown("lisa")).toBe(false); // 아직 임계 미달
+    n.observe("lisa", ["x"]);
+    expect(n.isDown("lisa")).toBe(true);
+    n.observe("lisa", null);
+    expect(n.isDown("lisa")).toBe(false);
+  });
+
+  // ── N3: 본문의 경과 초가 실측이어야 한다 ──
+  test("★실경과를 쓴다★ — afterTicks×interval 로 계산하면 항상 90 이 나온다", () => {
+    let clock = 1_000_000;
+    const n = new EssentialsOpNotifier(3, () => clock);
+    n.observe("lisa", ["x"]);          // t=0 첫 관측
+    clock += 30_000;
+    n.observe("lisa", ["x"]);
+    clock += 200_000;                  // tick 스킵/autofix await 로 크게 벌어진 구간
+    expect(n.observe("lisa", ["x"])).toBe("down");
+    // 고정계산이면 90, 실측이면 230.
+    expect(n.elapsedSecOf("lisa")).toBe(230);
+    expect(n.elapsedSecOf("lisa")).not.toBe(90);
+  });
+
+  test("회복하면 경과가 리셋된다 (다음 고장은 그때부터 센다)", () => {
+    let clock = 0;
+    const n = new EssentialsOpNotifier(1, () => clock);
+    n.observe("lisa", ["x"]);
+    clock += 50_000;
+    expect(n.elapsedSecOf("lisa")).toBe(50);
+    n.observe("lisa", null);
+    expect(n.elapsedSecOf("lisa")).toBe(0);
+    n.observe("lisa", ["x"]);
+    expect(n.elapsedSecOf("lisa")).toBe(0);
   });
 });
 

--- a/src/server/lib/opNotice.test.ts
+++ b/src/server/lib/opNotice.test.ts
@@ -42,15 +42,13 @@ describe("pickOpNoticeRecipient — 알림은 살아있는 사람에게", () => 
     expect(to).not.toBe("lisa");
   });
 
-  // 가중치를 건드리면 여기가 먼저 빨개진다 — 표 전체를 못으로 박아둔다.
-  test("실팀 구성 라우팅 표 전체", () => {
-    const pick = (affected: string, down: string[] = []) =>
-      pickOpNoticeRecipient(TEAM, affected, (id) => down.includes(id));
-    expect(pick("jane")).toBe("lisa");                      // coordinator 기본
-    expect(pick("lisa")).toBe("clo");                       // 같은 런타임 jane 탈락
-    expect(pick("clo")).toBe("lisa");                       // coordinator
-    expect(pick("jane", ["clo", "herm"])).toBe("lisa");     // 건강한 coordinator
-    expect(pick("lisa", ["clo", "herm"])).toBe("jane");     // 유일한 건강 멤버
+  // 라우팅을 건드리면 여기가 먼저 빨개진다 — 표 전체를 못으로 박아둔다.
+  test("실팀 구성 라우팅 표 전체 (팀장님 결정: 단순 규칙)", () => {
+    const pick = (affected: string) => pickOpNoticeRecipient(TEAM, affected);
+    expect(pick("jane")).toBe("lisa");   // coordinator 기본
+    expect(pick("lisa")).toBe("jane");   // ★coordinator 부재 시 등록 순서 첫 멤버★
+    expect(pick("clo")).toBe("lisa");    // coordinator
+    expect(pick("herm")).toBe("lisa");   // coordinator
   });
 
   test("coordinator 가 없으면 남은 아무 멤버", () => {
@@ -65,33 +63,19 @@ describe("pickOpNoticeRecipient — 알림은 살아있는 사람에게", () => 
     expect(pickOpNoticeRecipient([agent("jane")], "jane")).toBeNull();
   });
 
-  // ── R4: 대칭 경합에서 죽은 쪽으로 알림이 들어가는 걸 막는다 ──
-  test("★같이 죽은 멤버는 수신자에서 제외한다★ — lisa·jane 동시 탈락(08:03:37 실측)", () => {
-    // lisa 가 고장이고 jane 도 down 이면, jane 에게 보내면 아무도 못 읽는다.
-    const to = pickOpNoticeRecipient(TEAM, "lisa", (id) => id === "jane");
-    expect(to).not.toBe("jane");
-    expect(to).not.toBe("lisa");
-    expect(to).not.toBeNull();
-    expect(["clo", "herm"]).toContain(to as string);
+  // ★팀장님 결정(2026-07-30)을 못으로 박는다★
+  //   lisa 가 죽으면 jane 으로 간다 — 런타임 다양성으로 clo·herm 을 선호하지 않는다.
+  //   알려진 트레이드오프: lisa·jane 이 동시에 죽으면 죽은 jane 에게 가서 아무도 못 읽는다.
+  //   팀장님이 그 경우를 직접 처리하겠다고 명시했으므로 ★이건 의도된 동작이다★.
+  //   '버그' 로 보고 점수제(다른 런타임 선호)를 되살리지 마라 — 팀장님 승인이 필요하다.
+  test("★lisa 가 죽으면 jane 으로 간다★ (팀장님 결정 — 다른 런타임 선호 금지)", () => {
+    expect(pickOpNoticeRecipient(TEAM, "lisa")).toBe("jane");
   });
 
-  test("★폴백은 같은 경합을 공유하지 않는 다른 런타임을 우선한다★", () => {
-    // lisa(claude_channel) 고장 → 같은 claude_channel 인 jane 보다 다른 런타임이 안전하다.
-    const to = pickOpNoticeRecipient(TEAM, "lisa");
-    expect(to).not.toBe("jane");
-    expect(to).not.toBeNull();
-    expect(["clo", "herm"]).toContain(to as string);
-  });
-
-  test("다른 런타임 후보들 중에서는 coordinator 를 고른다", () => {
+  test("coordinator 가 등록 순서보다 우선한다", () => {
+    // herm 이 coordinator 면 등록 순서상 앞인 clo 보다 herm 이 뽑힌다.
     const team = [agent("jane"), agent("clo", [], "openclaw"), agent("herm", ["coordinator"], "hermes_agent")];
     expect(pickOpNoticeRecipient(team, "jane")).toBe("herm");
-  });
-
-  test("전원 down 이어도 null 대신 최선을 골라 시도한다 (아무것도 안 보내는 것보다 낫다)", () => {
-    const to = pickOpNoticeRecipient(TEAM, "lisa", () => true);
-    expect(to).not.toBeNull();
-    expect(to).not.toBe("lisa");
   });
 });
 
@@ -203,16 +187,6 @@ describe("EssentialsOpNotifier — 부팅 오탐 억제 + 1회 발행", () => {
   test("빈 missing 배열은 정상으로 취급한다", () => {
     const n = new EssentialsOpNotifier(1);
     expect(n.observe("jane", [])).toBeNull();
-  });
-
-  test("isDown 은 알림을 보낸 멤버만 true (수신자 선정 입력)", () => {
-    const n = new EssentialsOpNotifier(2);
-    n.observe("lisa", ["x"]);
-    expect(n.isDown("lisa")).toBe(false); // 아직 임계 미달
-    n.observe("lisa", ["x"]);
-    expect(n.isDown("lisa")).toBe(true);
-    n.observe("lisa", null);
-    expect(n.isDown("lisa")).toBe(false);
   });
 
   // ── N3: 본문의 경과 초가 실측이어야 한다 ──

--- a/src/server/lib/opNotice.ts
+++ b/src/server/lib/opNotice.ts
@@ -26,17 +26,38 @@ const RESERVED = new Set(["user", "system", "moderator", "broadcast"]);
 
 /**
  * op 알림을 받을 멤버를 고른다.
- * coordinator capability 보유자 우선 — 단 ★고장난 본인은 제외★(못 듣는 상태가 사고 본체).
- * coordinator 가 곧 고장난 멤버면 다른 멤버로 폴백한다(TEAM-OS §11 coordinator fallback 취지).
- * 받을 사람이 아무도 없으면 null → 호출부는 audit 만 남긴다.
+ *
+ * ★고장난 본인 제외만으로는 부족하다★ (리사 리뷰 R4, 2026-07-30):
+ *   근본 경합(bun binlink)은 lisa·jane 사이에서 ★대칭★ 이라 둘이 동시에 탈락할 수 있다 —
+ *   실제로 08:03:37 에 둘 다 같은 항목이 잡혔다. 그 경우 알림이 죽은 쪽으로 들어가 아무도
+ *   못 읽는다 = 막으려던 블랙홀의 다른 얼굴이다. 게다가 등록 순서상 lisa 가 고장이면 폴백
+ *   1순위가 jane, 즉 ★같은 경합을 공유하는 런타임★ 이었다.
+ * 그래서 점수로 고른다:
+ *   +4 현재 down streak 이 아니다 (살아있을 가능성)
+ *   +2 고장난 멤버와 ★다른 런타임★ (clo=openclaw, herm=hermes 는 이 경합에 안 걸린다)
+ *   +1 coordinator (TEAM-OS §11)
+ * 동점은 등록 순서. 전원 down 이어도 null 을 주지 않고 최선을 골라 시도한다(호출부가 audit 에
+ * 수신자 상태를 남긴다) — 아무것도 안 보내는 것보다 낫다.
+ *
+ * @param isDown 그 멤버가 현재 down 으로 관측되는지. 생략 시 전원 정상으로 본다.
  */
 export function pickOpNoticeRecipient(
   agents: AgentRecord[],
   affectedId: string,
+  isDown?: (agentId: string) => boolean,
 ): string | null {
+  const affected = agents.find((a) => a.id === affectedId);
   const eligible = agents.filter((a) => a.id !== affectedId && !RESERVED.has(a.id));
-  const coordinator = eligible.find((a) => (a.capabilities ?? []).includes("coordinator"));
-  return coordinator?.id ?? eligible[0]?.id ?? null;
+  if (eligible.length === 0) return null;
+  let best: { id: string; score: number } | null = null;
+  for (const a of eligible) {
+    let score = 0;
+    if (!isDown?.(a.id)) score += 4;
+    if (affected && a.runtime !== affected.runtime) score += 2;
+    if ((a.capabilities ?? []).includes("coordinator")) score += 1;
+    if (best === null || score > best.score) best = { id: a.id, score };
+  }
+  return best?.id ?? null;
 }
 
 /**
@@ -85,9 +106,12 @@ export function emitOpNotice(
 export class EssentialsOpNotifier {
   private streak = new Map<string, number>();
   private notified = new Set<string>();
+  /** 멤버별 ★첫 미충족 관측 시각(ms)★ — 본문에 쓸 실경과를 계산하려면 이게 필요하다. */
+  private firstSeen = new Map<string, number>();
 
   constructor(
     private readonly afterTicks: number = OP_NOTICE_AFTER_TICKS,
+    private readonly now: () => number = () => Date.now(),
   ) {}
 
   /**
@@ -98,6 +122,7 @@ export class EssentialsOpNotifier {
     if (missing && missing.length > 0) {
       const n = (this.streak.get(agentId) ?? 0) + 1;
       this.streak.set(agentId, n);
+      if (!this.firstSeen.has(agentId)) this.firstSeen.set(agentId, this.now());
       if (n >= this.afterTicks && !this.notified.has(agentId)) {
         this.notified.add(agentId);
         return "down";
@@ -106,6 +131,7 @@ export class EssentialsOpNotifier {
     }
     // 정상 — 부팅 중 잠깐 미충족이었다면 조용히 리셋(오탐 억제).
     this.streak.delete(agentId);
+    this.firstSeen.delete(agentId);
     if (this.notified.has(agentId)) {
       this.notified.delete(agentId);
       return "recovered";
@@ -116,6 +142,24 @@ export class EssentialsOpNotifier {
   /** 현재 미충족 연속 tick (테스트·디버그용) */
   streakOf(agentId: string): number {
     return this.streak.get(agentId) ?? 0;
+  }
+
+  /** 그 멤버가 현재 down 으로 관측되는지 — 수신자 선정에서 죽은 멤버를 피하는 데 쓴다(R4). */
+  isDown(agentId: string): boolean {
+    return this.notified.has(agentId);
+  }
+
+  /**
+   * ★첫 미충족 관측 이후 실제 경과 초★.
+   * afterTicks × interval 로 계산하면 ★항상 90★ 이 나오는데, tick 에 `if (ticking) return` 가드가
+   * 있어 스킵된 tick 동안 streak 는 안 늘고 실경과는 더 길다. 특히 autofix 가 restartAgent 를
+   * await 하며 최대 (acquire + settle)초를 잡으면 그 사이 tick 이 통째로 드롭된다.
+   * 틀린 수치는 사람에게 ★오보★ 로 읽히므로 실측값을 쓴다. (리사 리뷰 N3, 2026-07-30)
+   */
+  elapsedSecOf(agentId: string): number {
+    const t0 = this.firstSeen.get(agentId);
+    if (t0 == null) return 0;
+    return Math.max(0, Math.round((this.now() - t0) / 1000));
   }
 }
 

--- a/src/server/lib/opNotice.ts
+++ b/src/server/lib/opNotice.ts
@@ -34,8 +34,17 @@ const RESERVED = new Set(["user", "system", "moderator", "broadcast"]);
  *   1순위가 jane, 즉 ★같은 경합을 공유하는 런타임★ 이었다.
  * 그래서 점수로 고른다:
  *   +4 현재 down streak 이 아니다 (살아있을 가능성)
- *   +2 고장난 멤버와 ★다른 런타임★ (clo=openclaw, herm=hermes 는 이 경합에 안 걸린다)
- *   +1 coordinator (TEAM-OS §11)
+ *   +2 coordinator (TEAM-OS §11 — 기본 라우팅)
+ *   +1 고장난 멤버와 ★다른 런타임★ (clo=openclaw, herm=hermes 는 이 경합에 안 걸린다)
+ *
+ * ★가중치 순서가 중요하다★ (리사 리뷰 B1, 2026-07-30): 처음엔 런타임 +2 / coordinator +1 로 뒀는데
+ *   그러면 동일 건강 후보 중 coordinator 가 ★항상 진다★. 실측: jane 고장·전원 건강이면
+ *   [lisa=5 clo=6 herm=6] → clo 로 갔다. 'claude 봇 poller 사망' 은 이 알림의 가장 흔한
+ *   시나리오인데, 그때 알림이 coordinator 가 아니라 프론트 담당에게 가버린다.
+ *   '다른 런타임' 은 상관 고장에 대한 ★대리 지표★ 일 뿐이고 실제 건강은 +4(isDown)가 이미 직접
+ *   재고 있으므로, 둘 다 건강할 때 런타임 다양성이 coordinator 를 이길 근거가 없다. 그래서 교환했다.
+ *   두 의도가 다 보존된다 — lisa 고장 시엔 [jane=4 clo=5 herm=5] 로 여전히 같은 런타임 jane 이 진다.
+ *
  * 동점은 등록 순서. 전원 down 이어도 null 을 주지 않고 최선을 골라 시도한다(호출부가 audit 에
  * 수신자 상태를 남긴다) — 아무것도 안 보내는 것보다 낫다.
  *
@@ -53,8 +62,8 @@ export function pickOpNoticeRecipient(
   for (const a of eligible) {
     let score = 0;
     if (!isDown?.(a.id)) score += 4;
-    if (affected && a.runtime !== affected.runtime) score += 2;
-    if ((a.capabilities ?? []).includes("coordinator")) score += 1;
+    if ((a.capabilities ?? []).includes("coordinator")) score += 2;
+    if (affected && a.runtime !== affected.runtime) score += 1;
     if (best === null || score > best.score) best = { id: a.id, score };
   }
   return best?.id ?? null;

--- a/src/server/lib/opNotice.ts
+++ b/src/server/lib/opNotice.ts
@@ -1,0 +1,159 @@
+// team op(시스템) 상황 알림 — health 워커가 "감지했는데 아무도 못 듣는" 문제를 고친다.
+//
+// 왜 필요했나 (2026-07-30 실측 사고):
+//   08:03:37 health 가 `runtime_essentials_missing | lisa | missing:["poller:claude bot.pid"]` 를
+//   정확히 잡았다. 그런데 healthCheck 는 appendAudit 으로 ★audit_event 테이블에만★ 썼다.
+//   message 테이블에 아무것도 안 넣으므로 팀장님 텔레그램·그룹방·팀원 누구에게도 안 갔고,
+//   리사는 28분간 무응답이었다. 팀장님이 직접 "리사가 응답이 없어" 라고 알려줘야 했다.
+//   → 감지는 되어 있었다. 없던 건 ★알림 경로★ 다. 이 모듈이 그 경로다.
+//
+// 설계 원칙
+//   1) ★부팅 오탐을 내지 않는다★ — 부팅 직후엔 정상 멤버도 poller 가 잠깐 없다(실측: jane 도
+//      08:03:37 에 같은 항목이 잡혔고 34초 뒤 스스로 회복). 그래서 연속 N tick 유지될 때만 알린다.
+//   2) ★알림은 살아있는 사람에게 간다★ — 고장난 멤버 본인에게 보내면 블랙홀이다(그 멤버가 못 듣는
+//      상태가 바로 사고). coordinator 우선, 없으면 다른 아무 멤버.
+//   3) ★상태 전이에만 1회★ — 매 tick 반복 알림 금지(스팸). 회복도 1회 알린다.
+//   4) ★best-effort★ — 알림 실패가 health 워커를 절대 죽이지 않는다.
+import type { Database } from "bun:sqlite";
+import type { AgentRecord } from "../types";
+import { appendAudit } from "../db/queries";
+import { ensureThread, insertMessage } from "../db/inbox/messages";
+
+/** 알림 전까지 연속으로 미충족이 유지돼야 하는 tick 수. 기본 3 (30s tick → 약 90초). */
+export const OP_NOTICE_AFTER_TICKS = Number(process.env.OP_NOTICE_AFTER_TICKS ?? 3);
+
+const RESERVED = new Set(["user", "system", "moderator", "broadcast"]);
+
+/**
+ * op 알림을 받을 멤버를 고른다.
+ * coordinator capability 보유자 우선 — 단 ★고장난 본인은 제외★(못 듣는 상태가 사고 본체).
+ * coordinator 가 곧 고장난 멤버면 다른 멤버로 폴백한다(TEAM-OS §11 coordinator fallback 취지).
+ * 받을 사람이 아무도 없으면 null → 호출부는 audit 만 남긴다.
+ */
+export function pickOpNoticeRecipient(
+  agents: AgentRecord[],
+  affectedId: string,
+): string | null {
+  const eligible = agents.filter((a) => a.id !== affectedId && !RESERVED.has(a.id));
+  const coordinator = eligible.find((a) => (a.capabilities ?? []).includes("coordinator"));
+  return coordinator?.id ?? eligible[0]?.id ?? null;
+}
+
+/**
+ * op 상황 메시지를 message 테이블에 적재한다(source:'system').
+ * ★POST /api/system-message 와 다른 경로다★ — 저쪽은 OP_MESSAGE_TOKEN 미설정 시 503(safe-by-default,
+ * 외부 노출 표면 0)이라 서버 내부 워커가 쓸 수 없다. 내부 워커는 tasks.ts notifyCardOwner 와 같은
+ * 직접 insert 경로를 쓴다(기존 선례와 동일 계약).
+ * @returns 적재된 message id, 실패·수신자 없음이면 null
+ */
+export function emitOpNotice(
+  db: Database,
+  opts: { to: string; body: string; threadKey: string; priority?: "low" | "normal" | "high" },
+): string | null {
+  try {
+    const exists = db.prepare(`SELECT id FROM agent WHERE id = ?`).get(opts.to);
+    if (!exists) return null; // registry 에 없는 id — 깨울 대상이 없다
+    const { thread_id } = ensureThread(db, {
+      thread_id: opts.threadKey,
+      from_agent_id: "system",
+      to_agent_id: opts.to,
+      type: "dm",
+      body: opts.body,
+    });
+    const stored = insertMessage(db, {
+      from_agent_id: "system",
+      to_agent_id: opts.to,
+      type: "dm",
+      body: opts.body,
+      source: "system",
+      // ★reply_to 를 비워두지 않는다★ — notifyCardOwner 주석의 교훈: 받는 쪽이 'system 에게 답해라'
+      //   로 읽으면 --to system = 블랙홀이 된다. op 알림은 답장 대상이 아니라 ★행동 지시★ 이므로
+      //   수신자가 팀장님께 직보하도록 본문에서 명시한다.
+      meta: { op_notice: true },
+      hop_count: 0,
+      priority: opts.priority ?? "high",
+      thread_id,
+    });
+    return stored.id;
+  } catch (e) {
+    console.error("[health] op notice insert failed:", (e as Error).message);
+    return null;
+  }
+}
+
+/** 미충족 연속 tick 추적 + 알림 1회 발행을 담당하는 상태기. 워커가 tick 마다 호출한다. */
+export class EssentialsOpNotifier {
+  private streak = new Map<string, number>();
+  private notified = new Set<string>();
+
+  constructor(
+    private readonly afterTicks: number = OP_NOTICE_AFTER_TICKS,
+  ) {}
+
+  /**
+   * 한 멤버의 이번 tick 결과를 넣는다.
+   * @returns 발행할 알림 종류 — "down" | "recovered" | null(아무것도 안 함)
+   */
+  observe(agentId: string, missing: string[] | null): "down" | "recovered" | null {
+    if (missing && missing.length > 0) {
+      const n = (this.streak.get(agentId) ?? 0) + 1;
+      this.streak.set(agentId, n);
+      if (n >= this.afterTicks && !this.notified.has(agentId)) {
+        this.notified.add(agentId);
+        return "down";
+      }
+      return null;
+    }
+    // 정상 — 부팅 중 잠깐 미충족이었다면 조용히 리셋(오탐 억제).
+    this.streak.delete(agentId);
+    if (this.notified.has(agentId)) {
+      this.notified.delete(agentId);
+      return "recovered";
+    }
+    return null;
+  }
+
+  /** 현재 미충족 연속 tick (테스트·디버그용) */
+  streakOf(agentId: string): number {
+    return this.streak.get(agentId) ?? 0;
+  }
+}
+
+/** 사람이 읽고 바로 조치할 수 있는 본문. 조치 명령까지 실어 보낸다. */
+export function buildEssentialsDownBody(opts: {
+  agentId: string;
+  runtime: string;
+  missing: string[];
+  elapsedSec: number;
+}): string {
+  return [
+    `[team op] ${opts.agentId} 가 ${Math.round(opts.elapsedSec)}초째 필수 런타임 항목이 없습니다 — 메시지를 못 받는 상태일 수 있습니다.`,
+    `  runtime : ${opts.runtime}`,
+    `  missing : ${opts.missing.join(", ")}`,
+    ``,
+    `조치(claude 멤버의 poller:claude bot.pid 인 경우):`,
+    `  src/server/runtimes/claude/start-telegram-channel.sh ${opts.agentId} --force`,
+    `  ※ --force 없이 재실행하면 'Session already running' no-op 으로 빠져 복구되지 않습니다.`,
+    ``,
+    `확인 후 팀장님께 직접 보고해 주세요(이 알림은 system 발신이라 회신 대상이 없습니다).`,
+  ].join("\n");
+}
+
+/** 회복 알림 — 앞서 down 을 보냈을 때만 나간다. */
+export function buildEssentialsRecoveredBody(agentId: string): string {
+  return `[team op] ${agentId} 필수 런타임 항목이 정상으로 돌아왔습니다. 앞서 보낸 down 알림은 해소된 것으로 보면 됩니다.`;
+}
+
+/** audit 기록 — 알림이 실제로 나갔는지(또는 못 나갔는지)를 남긴다. */
+export function auditOpNotice(
+  db: Database,
+  action: "op_notice_sent" | "op_notice_no_recipient",
+  subject: string,
+  detail: Record<string, unknown>,
+): void {
+  try {
+    appendAudit(db, "health", action, subject, detail);
+  } catch {
+    /* best-effort */
+  }
+}

--- a/src/server/lib/opNotice.ts
+++ b/src/server/lib/opNotice.ts
@@ -25,48 +25,28 @@ export const OP_NOTICE_AFTER_TICKS = Number(process.env.OP_NOTICE_AFTER_TICKS ??
 const RESERVED = new Set(["user", "system", "moderator", "broadcast"]);
 
 /**
- * op 알림을 받을 멤버를 고른다.
+ * op 알림을 받을 멤버를 고른다 — ★단순 규칙: coordinator 우선, 없으면 등록 순서 첫 멤버★.
+ *   고장난 본인만 제외한다(못 듣는 상태가 사고 본체이므로 블랙홀 방지).
+ *   받을 사람이 아무도 없으면 null → 호출부는 audit 만 남긴다.
  *
- * ★고장난 본인 제외만으로는 부족하다★ (리사 리뷰 R4, 2026-07-30):
- *   근본 경합(bun binlink)은 lisa·jane 사이에서 ★대칭★ 이라 둘이 동시에 탈락할 수 있다 —
- *   실제로 08:03:37 에 둘 다 같은 항목이 잡혔다. 그 경우 알림이 죽은 쪽으로 들어가 아무도
- *   못 읽는다 = 막으려던 블랙홀의 다른 얼굴이다. 게다가 등록 순서상 lisa 가 고장이면 폴백
- *   1순위가 jane, 즉 ★같은 경합을 공유하는 런타임★ 이었다.
- * 그래서 점수로 고른다:
- *   +4 현재 down streak 이 아니다 (살아있을 가능성)
- *   +2 coordinator (TEAM-OS §11 — 기본 라우팅)
- *   +1 고장난 멤버와 ★다른 런타임★ (clo=openclaw, herm=hermes 는 이 경합에 안 걸린다)
- *
- * ★가중치 순서가 중요하다★ (리사 리뷰 B1, 2026-07-30): 처음엔 런타임 +2 / coordinator +1 로 뒀는데
- *   그러면 동일 건강 후보 중 coordinator 가 ★항상 진다★. 실측: jane 고장·전원 건강이면
- *   [lisa=5 clo=6 herm=6] → clo 로 갔다. 'claude 봇 poller 사망' 은 이 알림의 가장 흔한
- *   시나리오인데, 그때 알림이 coordinator 가 아니라 프론트 담당에게 가버린다.
- *   '다른 런타임' 은 상관 고장에 대한 ★대리 지표★ 일 뿐이고 실제 건강은 +4(isDown)가 이미 직접
- *   재고 있으므로, 둘 다 건강할 때 런타임 다양성이 coordinator 를 이길 근거가 없다. 그래서 교환했다.
- *   두 의도가 다 보존된다 — lisa 고장 시엔 [jane=4 clo=5 herm=5] 로 여전히 같은 런타임 jane 이 진다.
- *
- * 동점은 등록 순서. 전원 down 이어도 null 을 주지 않고 최선을 골라 시도한다(호출부가 audit 에
- * 수신자 상태를 남긴다) — 아무것도 안 보내는 것보다 낫다.
- *
- * @param isDown 그 멤버가 현재 down 으로 관측되는지. 생략 시 전원 정상으로 본다.
+ * ★가중치 방식을 쓰지 않는다 — 팀장님 결정(2026-07-30)★
+ *   한때 점수제(down 여부 +4 / coordinator +2 / 다른 런타임 +1)를 넣었다. 동기는 리사 리뷰 R4 였다:
+ *   근본 경합(bun binlink)은 lisa·jane 사이에서 대칭이라 둘이 동시에 탈락할 수 있고(08:03:37 실측),
+ *   그러면 알림이 죽은 쪽으로 들어가 아무도 못 읽는다. 그래서 다른 런타임(clo·herm)을 폴백으로
+ *   선호하게 만들었다.
+ *   그런데 그 점수제가 ★coordinator 기본 라우팅을 뒤집는 사고★ 를 냈고(B1), 팀장님이
+ *   "coordinator 기본은 건드리지 마라 / lisa 가 죽으면 jane 으로, 그냥 원래대로 가라" 로 정리했다.
+ *   ★알려진 트레이드오프★: lisa·jane 이 ★동시에★ 죽으면 알림이 죽은 jane 에게 가서 아무도 못 읽는다.
+ *   팀장님이 이 경우를 직접 처리하겠다고 명시했다("정 안되면 내가 처리하면 돼"). 그래서 단순 규칙이
+ *   의도된 동작이며, 이걸 '버그' 로 보고 점수제를 되살리지 마라 — 되살리려면 팀장님 승인이 필요하다.
  */
 export function pickOpNoticeRecipient(
   agents: AgentRecord[],
   affectedId: string,
-  isDown?: (agentId: string) => boolean,
 ): string | null {
-  const affected = agents.find((a) => a.id === affectedId);
   const eligible = agents.filter((a) => a.id !== affectedId && !RESERVED.has(a.id));
-  if (eligible.length === 0) return null;
-  let best: { id: string; score: number } | null = null;
-  for (const a of eligible) {
-    let score = 0;
-    if (!isDown?.(a.id)) score += 4;
-    if ((a.capabilities ?? []).includes("coordinator")) score += 2;
-    if (affected && a.runtime !== affected.runtime) score += 1;
-    if (best === null || score > best.score) best = { id: a.id, score };
-  }
-  return best?.id ?? null;
+  const coordinator = eligible.find((a) => (a.capabilities ?? []).includes("coordinator"));
+  return coordinator?.id ?? eligible[0]?.id ?? null;
 }
 
 /**
@@ -151,11 +131,6 @@ export class EssentialsOpNotifier {
   /** 현재 미충족 연속 tick (테스트·디버그용) */
   streakOf(agentId: string): number {
     return this.streak.get(agentId) ?? 0;
-  }
-
-  /** 그 멤버가 현재 down 으로 관측되는지 — 수신자 선정에서 죽은 멤버를 피하는 데 쓴다(R4). */
-  isDown(agentId: string): boolean {
-    return this.notified.has(agentId);
   }
 
   /**

--- a/src/server/workers/healthCheck.ts
+++ b/src/server/workers/healthCheck.ts
@@ -1,12 +1,36 @@
-// health-check Phase 1 (observe-only): agent_status 를 주기적으로 분류해 위험 전이 시 알림.
-// 자동 조치(Phase 2: compact 유도/세션 재시작 등)는 별도 — 여기선 감지+알림만(0 리스크).
+// health-check: agent_status 를 주기적으로 분류해 위험 전이 시 알림.
+//
+// ★2026-07-30 수정 — "감지는 됐는데 아무도 못 들었다"★
+//   이전엔 appendAudit 으로 audit_event 테이블에만 썼다. 08:03:37 에
+//   `runtime_essentials_missing | lisa | poller:claude bot.pid, canAutoFix:true` 를 정확히 잡아놓고도
+//   message 테이블에 아무것도 안 넣어 팀장님·팀원 누구에게도 안 갔고, 리사는 28분 무응답이었다.
+//   게다가 claude 봇 launchd 잡은 KeepAlive=false 라(스포너라서 true 로 켤 수도 없다) 시스템 안에
+//   그 멤버를 되살릴 주체가 아예 없었다 → 사람이 손으로 --force 를 돌려야 끝났다.
+//   그래서 이제 (1) op 알림을 실제로 발행하고, (2) 게이트가 열려 있으면 재시작까지 시도한다.
+//   부팅 오탐 방지: 연속 N tick(기본 3 ≒ 90s) 유지될 때만 — 정상 멤버도 부팅 직후 잠깐 미충족이다
+//   (실측: jane 도 같은 항목이 잡혔고 34초 뒤 스스로 회복).
 import type { Database } from "bun:sqlite";
 import type { AgentRecord } from "../types";
 import { listStatuses, appendAudit } from "../db/queries";
 import { classifyAll, type HealthLevel } from "../lib/health";
 import { checkEssentialSettings } from "../lib/runtimeEssentials";
+import { restartAgent } from "../lib/agentControl";
+import {
+  EssentialsOpNotifier,
+  emitOpNotice,
+  auditOpNotice,
+  pickOpNoticeRecipient,
+  buildEssentialsDownBody,
+  buildEssentialsRecoveredBody,
+  OP_NOTICE_AFTER_TICKS,
+} from "../lib/opNotice";
 
 const INTERVAL_MS = Number(process.env.HEALTH_CHECK_INTERVAL_MS ?? 30_000);
+
+/** 자동 재시작(Phase 2) 게이트. ★기본 OFF★ — 켜려면 명시적으로 1.
+ *  이중 게이트다: 이 플래그 + agentControl.restartAgent 안의 APPROVAL_EXECUTION_ENABLED.
+ *  둘 다 열려야 자동 재시작이 일어난다(무인 재시작은 승인 게이트 대상 행위이므로). */
+const AUTOFIX_ENABLED = process.env.HEALTH_AUTOFIX_ENABLED === "1";
 
 interface HealthDeps {
   db: Database;
@@ -22,8 +46,57 @@ interface HealthDeps {
 export function startHealthCheck(deps: HealthDeps): () => void {
   const lastLevel = new Map<string, HealthLevel>();
   const lastEssentialsKey = new Map<string, string>();
+  const notifier = new EssentialsOpNotifier();
   let stopped = false;
   let ticking = false;
+
+  /** 확정된 미충족(연속 N tick) — 알림을 먼저 보내고, 게이트가 열려 있으면 재시작을 시도한다.
+   *  ★순서가 중요하다★: 알림 먼저. 재시작이 실패하거나 이 워커가 죽어도 사람은 사실을 안다. */
+  async function handleEssentialsDown(
+    agent: AgentRecord,
+    missing: string[],
+    agents: AgentRecord[],
+  ): Promise<void> {
+    const elapsedSec = OP_NOTICE_AFTER_TICKS * (INTERVAL_MS / 1000);
+    const to = pickOpNoticeRecipient(agents, agent.id);
+    if (to) {
+      const id = emitOpNotice(deps.db, {
+        to,
+        body: buildEssentialsDownBody({ agentId: agent.id, runtime: agent.runtime, missing, elapsedSec }),
+        threadKey: `op-health-${agent.id}`,
+        priority: "high",
+      });
+      auditOpNotice(deps.db, "op_notice_sent", agent.id, { kind: "down", to, missing, message_id: id });
+      console.log(`[health] ⚠ ${agent.id} essentials 미충족 ${elapsedSec}s 지속 — op 알림 → ${to}`);
+    } else {
+      // 받을 사람이 아무도 없다(1인 팀에서 그 1인이 고장). 최소한 흔적은 남긴다.
+      auditOpNotice(deps.db, "op_notice_no_recipient", agent.id, { missing });
+      console.log(`[health] ⚠ ${agent.id} essentials 미충족 — op 알림 수신자 없음(단독 멤버)`);
+    }
+
+    if (!AUTOFIX_ENABLED) return;
+    try {
+      // fresh=false → --resume(컨텍스트 유지). 스포너에 --force 가 함께 실려 no-op 함정을 피한다.
+      const r = await restartAgent(agent.id, agent.runtime, false);
+      appendAudit(deps.db, "health", r.ok ? "autofix_restarted" : "autofix_failed", agent.id, {
+        runtime: agent.runtime,
+        missing,
+        detail: r.detail,
+      });
+      console.log(`[health] autofix ${agent.id}: ${r.ok ? "OK" : "FAIL"} — ${r.detail}`);
+      if (to) {
+        emitOpNotice(deps.db, {
+          to,
+          body: `[team op] ${agent.id} 자동 재시작 ${r.ok ? "성공" : "실패"} — ${r.detail}`,
+          threadKey: `op-health-${agent.id}`,
+          priority: r.ok ? "normal" : "high",
+        });
+      }
+    } catch (e) {
+      appendAudit(deps.db, "health", "autofix_failed", agent.id, { error: (e as Error).message });
+      console.error(`[health] autofix ${agent.id} threw:`, (e as Error).message);
+    }
+  }
 
   async function tick(): Promise<void> {
     if (ticking) return;
@@ -64,6 +137,27 @@ export function startHealthCheck(deps: HealthDeps): () => void {
           appendAudit(deps.db, "health", "runtime_essentials_recovered", agent.id, { runtime: agent.runtime });
         }
         lastEssentialsKey.set(agent.id, key);
+
+        // ─── op 알림 + (게이트 열려 있으면) 자동 복구 ────────────────────────
+        // ★pendingPairing 은 사고가 아니다★ — 첫 claude 멤버는 설계상 페어링 대기로 시작한다.
+        //   여기서 알리면 영입 절차마다 오탐이 나므로 제외한다.
+        const isRealFault = !essentials.ok && !(essentials as { pendingPairing?: boolean }).pendingPairing;
+        const verdict = notifier.observe(agent.id, isRealFault ? essentials.missing : null);
+        if (verdict === "down") {
+          await handleEssentialsDown(agent, essentials.missing, agents);
+        } else if (verdict === "recovered") {
+          const to = pickOpNoticeRecipient(agents, agent.id);
+          if (to) {
+            const id = emitOpNotice(deps.db, {
+              to,
+              body: buildEssentialsRecoveredBody(agent.id),
+              threadKey: `op-health-${agent.id}`,
+              priority: "normal",
+            });
+            auditOpNotice(deps.db, "op_notice_sent", agent.id, { kind: "recovered", to, message_id: id });
+          }
+          console.log(`[health] ✓ ${agent.id} essentials 회복 — op 알림(회복) 발행`);
+        }
       }
     } catch (e) {
       console.error("[health] tick error:", (e as Error).message);
@@ -76,7 +170,10 @@ export function startHealthCheck(deps: HealthDeps): () => void {
   const iv = setInterval(() => {
     if (!stopped) void tick();
   }, INTERVAL_MS);
-  console.log(`[health] started — interval=${INTERVAL_MS}ms (observe-only, Phase 1)`);
+  console.log(
+    `[health] started — interval=${INTERVAL_MS}ms · op알림 after ${OP_NOTICE_AFTER_TICKS} tick` +
+      ` · autofix=${AUTOFIX_ENABLED ? "ON" : "OFF(HEALTH_AUTOFIX_ENABLED≠1)"}`,
+  );
   return () => {
     stopped = true;
     clearInterval(iv);

--- a/src/server/workers/healthCheck.ts
+++ b/src/server/workers/healthCheck.ts
@@ -59,9 +59,7 @@ export function startHealthCheck(deps: HealthDeps): () => void {
   ): Promise<void> {
     // 실측 경과를 쓴다 — afterTicks × interval 은 항상 90 이 나오고, 스킵된 tick 만큼 실제로는 더 길다.
     const elapsedSec = notifier.elapsedSecOf(agent.id);
-    // 수신자 선정에 '그 멤버도 지금 down 인가' 를 넘긴다 — lisa·jane 이 동시 탈락하는 대칭 경합에서
-    // 죽은 쪽으로 알림이 들어가는 블랙홀을 막는다.
-    const to = pickOpNoticeRecipient(agents, agent.id, (id) => notifier.isDown(id));
+    const to = pickOpNoticeRecipient(agents, agent.id);
     if (to) {
       const id = emitOpNotice(deps.db, {
         to,
@@ -149,8 +147,7 @@ export function startHealthCheck(deps: HealthDeps): () => void {
         if (verdict === "down") {
           await handleEssentialsDown(agent, essentials.missing, agents);
         } else if (verdict === "recovered") {
-          // 회복 알림도 같은 규칙으로 살아있는 수신자에게. (여기선 자신은 이미 회복 상태)
-          const to = pickOpNoticeRecipient(agents, agent.id, (id) => notifier.isDown(id));
+          const to = pickOpNoticeRecipient(agents, agent.id);
           if (to) {
             const id = emitOpNotice(deps.db, {
               to,

--- a/src/server/workers/healthCheck.ts
+++ b/src/server/workers/healthCheck.ts
@@ -57,8 +57,11 @@ export function startHealthCheck(deps: HealthDeps): () => void {
     missing: string[],
     agents: AgentRecord[],
   ): Promise<void> {
-    const elapsedSec = OP_NOTICE_AFTER_TICKS * (INTERVAL_MS / 1000);
-    const to = pickOpNoticeRecipient(agents, agent.id);
+    // 실측 경과를 쓴다 — afterTicks × interval 은 항상 90 이 나오고, 스킵된 tick 만큼 실제로는 더 길다.
+    const elapsedSec = notifier.elapsedSecOf(agent.id);
+    // 수신자 선정에 '그 멤버도 지금 down 인가' 를 넘긴다 — lisa·jane 이 동시 탈락하는 대칭 경합에서
+    // 죽은 쪽으로 알림이 들어가는 블랙홀을 막는다.
+    const to = pickOpNoticeRecipient(agents, agent.id, (id) => notifier.isDown(id));
     if (to) {
       const id = emitOpNotice(deps.db, {
         to,
@@ -146,7 +149,8 @@ export function startHealthCheck(deps: HealthDeps): () => void {
         if (verdict === "down") {
           await handleEssentialsDown(agent, essentials.missing, agents);
         } else if (verdict === "recovered") {
-          const to = pickOpNoticeRecipient(agents, agent.id);
+          // 회복 알림도 같은 규칙으로 살아있는 수신자에게. (여기선 자신은 이미 회복 상태)
+          const to = pickOpNoticeRecipient(agents, agent.id, (id) => notifier.isDown(id));
           if (to) {
             const id = emitOpNotice(deps.db, {
               to,


### PR DESCRIPTION
> **작성: Jane (jane)** — gdstudio 팀 · 서비스 전략/기획 및 풀스택
> 리뷰: Lisa (lisa) 승인 완료 (버스 리뷰)
> ※ 이 PR 은 팀원 작업 계정 `gdb3rys` 로 작성됐습니다(b3os-github-workflow ⑤ — 작성자와 승인자가
> 달라야 리뷰 요건이 성립). 커밋 author 는 공용 계정이라 담당자가 드러나지 않으므로 실제 작업자는 위와 같습니다.
> 원 PR #133 은 `gd452`(승인 계정)로 만들어져 승인이 불가능했습니다 — 작성자는 변경할 수 없어 닫고 다시 열었습니다.

## 무슨 일이 있었나

health 워커는 08:03:37 에 **이미 정답을 갖고 있었다**:

```
runtime_essentials_missing | lisa | missing:["poller:claude bot.pid"], canAutoFix:true
```

그런데 `appendAudit` 으로 **`audit_event` 테이블에만** 썼다. `message` 테이블에 아무것도 넣지 않으므로 팀장님 텔레그램·그룹방·팀원 누구에게도 안 갔다. `canAutoFix:true` 라고 스스로 표시해놓고 자동조치 코드도 없었다(Phase 2 미구현).

결과: 리사는 28분간 텔레그램을 못 받고, **팀장님이 사람 손으로** "리사가 응답이 없어" 라고 알려줘야 발견됐다.

**없던 것은 탐지가 아니라 알림 경로였다.**

### 왜 health 워커가 유일한 안전망인가

claude 봇 launchd 잡만 `KeepAlive=false` 다:

| 잡 | KeepAlive |
|---|---|
| team-collab | true / Throttle 10 |
| openclaw | true / 10 |
| hermes-herm | true / 30 |
| **claude-telegram-{lisa,jane}** | **false** |

죽어도 launchd 가 안 되살린다. 그런데 **이 잡에 `KeepAlive=true` 를 켜는 건 오답이다** — `start-telegram-channel.sh` 는 tmux spawn 후 `exit 0` 하는 스포너지 데몬이 아니라서 무한 재실행 루프가 된다. 그래서 health 워커 말고 안전망이 없다.

## ① 알림 (기본 동작)

- **연속 N tick(기본 3 ≒ 90s) 유지될 때만 발행** — 부팅 오탐을 막는다. 정상 멤버도 부팅 직후 잠깐 미충족이다(실측: jane 도 같은 항목이 잡혔고 34초 뒤 스스로 회복). 즉시 알리면 매 부팅마다 거짓 경보가 나고, 곧 아무도 안 읽는다
- **고장난 본인에게 보내지 않는다** — 못 듣는 상태가 사고 본체다(블랙홀). coordinator 우선, coordinator 가 곧 고장이면 다른 멤버로 폴백
- 상태 전이에만 1회(스팸 금지), 회복도 1회. 회복 후 재고장하면 다시 알린다
- 본문에 **복구 명령을 `--force` 포함으로** 싣는다 + "system 발신이라 회신 대상 없음, 팀장님께 직보" 명시(`--to system` 블랙홀 방지 — notifyCardOwner 주석의 교훈)
- 내부 워커라 `POST /api/system-message` 를 쓸 수 없다: `OP_MESSAGE_TOKEN` 미설정 시 503 = safe-by-default 설계(외부 노출 표면 0). `tasks.ts` `notifyCardOwner` 와 같은 직접 insert 경로를 쓴다

## ② 자동 복구 — **기본 OFF**

- `HEALTH_AUTOFIX_ENABLED=1` **+** `agentControl` 의 `APPROVAL_EXECUTION_ENABLED=1`, **이중 게이트가 둘 다** 열려야 동작한다. 무인 재시작은 승인 게이트 대상 행위라 기본값을 열어두지 않았다
- **순서: 알림 먼저, 그 다음 재시작.** 재시작이 실패하거나 워커가 죽어도 사람은 사실을 안다
- `fresh=false`(`--resume`) 라 멤버 컨텍스트를 유지한다

> 기본 OFF 로 둔 판단은 리뷰 대상이다. ON 이 맞다고 보면 그렇게 말해달라 — 이 플래그가 열려야 "사람 없이도 되살아난다" 가 성립한다.

## ③ `restartAgent` — 스포너에 `--force` 를 항상 싣는다

vendoring 경로는 `tmux kill-session` 후 스크립트를 부른다. 그 kill 이 실패·경합하면 (**세션은 살아있고 poller 만 죽은 상태가 정확히 그 케이스**) 스크립트의 idempotent 가드가 `Session already running` no-op 으로 빠져 **재시작이 조용히 안 된다.**

2026-07-30 실측: `launchctl kickstart` 로 스크립트를 다시 돌렸더니 정확히 이 함정(스크립트 184행)에 걸려 리사가 계속 죽어 있었다. 사람이 `--force` 를 손으로 붙여야 끝났다. `--force` 는 스크립트 안에서 kill 을 보장하므로 kill 성공 여부와 무관하게 **멱등**해진다.

## 검증

`src/server/lib/opNotice.test.ts` — **16/16 통과**

| 지키는 것 | 근거 |
|---|---|
| 임계 미달이면 무알림 | jane 34초 케이스 = 정상, 알리면 오탐 |
| 임계 도달 시 1회 | lisa 28분 케이스 |
| 반복 스팸 금지 / 회복 1회 / 재고장 시 재알림 | 한 번 알렸다고 영구 침묵하면 안 됨 |
| 멤버별 독립 추적 | 한 명 streak 이 다른 명 오염 안 함 |
| **본인 제외** | 블랙홀 방지 |
| coordinator 폴백 | coordinator 자신이 고장일 때 |
| 복구 명령에 `--force` 존재 | no-op 함정 |

전체 스위트: **1903 pass / 4 fail** — 4건은 `teamRouter.llm.test.ts`(EXAONE), ollama 미기동 환경 실패로 **clean main 에서 동일하게 4건 실패**(baseline 확인). typecheck 통과.

## 검증 못 한 범위 (명시)

**라이브에서 실제로 op 알림이 도달하는 것은 아직 확인 못 했다.** 단위테스트는 상태기·수신자선정·본문 계약까지고, 실제 insert → 디스패처 → 멤버 도달은 서버 재기동이 필요하다(승인 게이트). 자동복구 경로(`HEALTH_AUTOFIX_ENABLED=1`)도 라이브 미검증이다.

롤백: 두 파일 revert 로 원복. `opNotice.ts` 는 신규 파일이라 기존 경로에 영향 없고, healthCheck 변경은 기존 audit 기록을 그대로 두고 뒤에 덧붙인 형태다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

