### PR TITLE
fix(claude start): 락 관련 3가지 — 고아 락을 안 만들고, 스폰 직전 확인하고, 락 없이 뜨면 기록한다

### DIFF
--- a/scripts/claude-start-stagger.test.sh
+++ b/scripts/claude-start-stagger.test.sh
@@ -182,6 +182,9 @@ grep -q "경합 위험을 안고 계속 진행" <<<"$out" \
   && pass "상한까지 기다린 뒤 경고 경로 (기동은 막지 않음)" \
   || fail "예상한 상한 초과 경로가 아니다"
 [[ -d "$TMPROOT/spawn.lock" ]] && pass "선점 락이 그대로 남아있다" || fail "선점 락이 사라졌다"
+# ★락 없이 뜬 사실이 기록으로 남는가★ — 지금까지 이 경로는 launchd /tmp 로그 한 줄이 전부였다.
+#   보호장치가 꺼진 채 도는 상황을 ★나중에 재서 판단하려면★ 흔적이 남아야 한다. (codex 교차검증)
+[[ -s "$TMPROOT/.spawn-failopen.log" ]] && pass "fail-open 기록 남음" || fail "락 없이 떴는데 기록이 없다"
 kill "$LIVE_PID" 2>/dev/null || true
 tmux kill-session -t "claude-$A" 2>/dev/null || true
 

--- a/src/server/runtimes/claude/start-telegram-channel.sh
+++ b/src/server/runtimes/claude/start-telegram-channel.sh
@@ -330,9 +330,18 @@ else
   _stale_seen=0      # 그 pid 를 연속 관찰한 횟수(초)
   while (( _waited < STAGGER_ACQUIRE_MAX )); do
     if mkdir "$STAGGER_LOCK" 2>/dev/null; then
-      _stagger_held=1
-      echo "$$" > "$STAGGER_LOCK/pid" 2>/dev/null || true
-      trap _stagger_release EXIT
+      # ★pid 를 못 적으면 락을 쥔 채로 진행하지 않는다★ — 그 상태가 ★영구 고아 락★ 을 만든다.
+      #   아래 회수 로직은 pid 를 읽어 죽었는지 보는데, ★pid 가 없으면 그 판정이 성립하지 않는다.★
+      #   실측(2026-07-30 격리 재현): pid 없는 락 폴더 하나면 그 뒤 모든 기동이 상한까지 기다렸다가
+      #   ★경합을 안고 뜨고 폴더는 영구 잔존★ 한다. 우리 기계 기준 매 기동 120초 + 경합 무방비.
+      #   적기에 실패하면 ★내가 만든 폴더를 즉시 지우고★ 락 없이 간다 — 경합 위험은 감수하되 영구화는 막는다.
+      if echo "$$" > "$STAGGER_LOCK/pid" 2>/dev/null; then
+        _stagger_held=1
+        trap _stagger_release EXIT
+        break
+      fi
+      rm -rf "$STAGGER_LOCK" 2>/dev/null || true
+      echo "  ⚠ Stagger   : 락 pid 기록 실패 — 고아 락을 안 남기려 되돌리고 락 없이 진행합니다"
       break
     fi
     # ─ stale 회수 (부팅 중 크래시가 락을 영구 점유하지 않게) ─
@@ -382,6 +391,22 @@ else
     fi
   else
     echo "  ⚠ Stagger   : 락 대기 ${STAGGER_ACQUIRE_MAX}s 초과(멤버 ${_claude_members}명 기준) — 경합 위험을 안고 계속 진행"
+    # ★락 없이 뜬 사실을 흔적으로 남긴다★ — 지금까지 이 경로는 launchd 의 /tmp 로그 한 줄이 전부였다.
+    #   고아 락 하나로 이 경로가 ★상시화★ 될 수 있는데(위 재현), 그러면 보호장치가 사실상 꺼진 채
+    #   아무도 모른다. 파일 한 줄이면 doctor·헬스체크가 나중에 주워갈 수 있다. (codex 교차검증)
+    printf '%s %s acquire_timeout=%ss members=%s\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$BOT_NAME" "$STAGGER_ACQUIRE_MAX" "$_claude_members" \
+      >> "$(dirname "$STAGGER_LOCK")/.spawn-failopen.log" 2>/dev/null || true
+  fi
+  # ★스폰 직전에 '내가 아직 주인인가' 를 한 번 더 본다★ (codex HIGH1).
+  #   회수 절차가 락을 mv 로 들어내는 순간 경로가 잠깐 빈다. 그 틈에 제3자가 mkdir 로 선점하면
+  #   ★원 소유자와 선점자가 동시에 스폰★ 한다 — 이 장치가 막으려던 바로 그 상황이다.
+  #   처음 잡을 때만 확인하면 이 창을 못 막는다. 확인 지점을 ★쓰기 직전★ 으로 한 번 더 둔다.
+  #   내 것이 아니면 홀더 자격을 내려놓는다(그래야 뒤에서 남의 락을 지우지도 않는다).
+  if [[ $_stagger_held -eq 1 ]] && [[ "$(cat "$STAGGER_LOCK/pid" 2>/dev/null || true)" != "$$" ]]; then
+    _stagger_held=0
+    trap - EXIT
+    echo "  ⚠ Stagger   : 스폰 직전 확인 결과 락이 남의 것으로 바뀌었습니다 — 홀더 자격을 내려놓고 진행합니다"
   fi
 fi
 


### PR DESCRIPTION
## 핵심 3줄

1. 봇 두 개가 같은 순간 뜨면 공유 플러그인 캐시 링크를 다퉈 한쪽 텔레그램이 죽는다 → #138 이 "락 가진 하나만 스폰" 을 넣었다(오늘 라이브).
2. 그 락에 구멍 셋 — **주인 없는 락은 회수 불가 · 소유권을 처음 잡을 때만 확인 · 락 없이 뜬 사실이 기록에 안 남음.**
3. **생성 차단 + 관측**만 넣었다(실제 코드 15줄). 회수 로직은 넣지 않았다 — 아래 실측 근거.

## 무엇을 바꿨나

| 문제 | 고친 방법 |
|---|---|
| `mkdir` 후 pid 를 적기 전에 죽으면 그 락은 **회수 조건 자체가 성립하지 않아** 영구 잔존 | pid 쓰기 실패 시 **방금 만든 디렉토리를 즉시 제거**하고 락 없이 진행 — 고아가 생길 여지를 없앤다 |
| 소유권을 **획득 시점에만** 확인 → 회수 절차가 만드는 빈 창에서 락이 넘어가도 모르고 스폰 = 동시 스폰 | **스폰 직전에 pid 재확인.** 내 것이 아니면 홀더 자격을 내려놓는다 |
| 락 없이 뜬 사실이 **launchd /tmp 로그 한 줄**이 전부 | `.spawn-failopen.log` 에 시각·멤버·상한 기록 |

## 범위를 이 크기로 정한 근거

회수 로직(25줄)은 넣지 않았다. **발생 0회**로 실측된다:

- 이 락 기능은 오늘 11:02 머지 · 11:04 라이브인데 그 뒤 팀원을 새로 띄운 적이 없다(5명 `bot.pid` mtime 08:18~08:32 = 반영 전). **아직 실행된 적이 없다.**
- 락 디렉토리도 fail-open 기록도 존재하지 않는다.
- 고아 상태가 되려면 `mkdir` 직후 **파일 한 줄 쓰기 전 구간**에서 프로세스가 죽어야 한다.

생성을 차단하면 회수 대상이 없어진다. 그 구간의 강제 종료로 발생하면 fail-open 기록에 남으므로 관측 후 판단한다.

## 검증

- 기존 T1~T4 전부 통과(살아있는 락 보호 포함) · T4 에 fail-open 기록 확인 추가
- `bash -n` 통과 · 라이브 트리 무수정 · CI verify pass

발견 = codex(교차검증)
