### PR TITLE
fix(inbox/slack): 전송 도구가 실패를 성공으로 보고하던 3가지

### DIFF
--- a/docs/SLACK_SETUP.md
+++ b/docs/SLACK_SETUP.md
@@ -30,6 +30,42 @@ Slack 연결은 **선택**입니다(텔레그램만으로 충분합니다).
   부를 때는 Slack 의 멘션 자동완성을 쓰세요 — 이름을 글자로 적는 건 멘션이 아닙니다.
 - 토큰은 채팅·로그에 평문으로 남기지 마세요. 위저드에 붙여넣으면 서버가 권한 0600 파일로 보관합니다.
 - 팀원이 Slack 에 글을 올릴 때는 `skills/b3os-team-inbox` 의 `scripts/slack-post.sh` 를 씁니다.
+  `--mention <U…>` 으로 받을 사람을 지정하세요. 멘션이 없으면 게시 후 경고가 나옵니다.
+
+## 멘션에 쓸 멤버 ID 를 어디서 얻나
+
+위 규칙("이름을 글자로 적는 건 멘션이 아닙니다")을 지키려면 **member ID 가 필요합니다.**
+ID 없이 이름만 적어 올리면 **채널에는 보이지만 알림이 아무에게도 가지 않습니다** — 그리고 게시는
+성공하므로 보낸 쪽은 전달된 줄 압니다. `slack-post.sh` 는 이 경우 게시 후 경고를 냅니다.
+
+**ID 얻는 방법** (워크스페이스마다 값이 다릅니다):
+
+1. Slack 앱에서 대상 프로필 열기 → `⋯` → **"멤버 ID 복사"** (Copy member ID) → `U…` 형태
+2. 또는 채널에서 그 사람이 올린 메시지의 `bot_profile.name` / `user` 필드로 확인
+3. `users.list`·`users.info` API 는 **기본 스코프로는 막혀 있습니다.** 멘션만 하려고 스코프를
+   늘리는 것은 노출면을 넓히므로 권하지 않습니다 — 위 1번이 가장 간단합니다
+
+**ID 를 어디에 두나 — 저장소에 넣지 마세요.**
+member ID 는 워크스페이스 고유 값이고 공개 저장소에 둘 값이 아닙니다.
+`slack-post.sh` 는 `slack-tokens/members.env` 에서 이름→ID 를 읽습니다(이 폴더는 `.gitignore` 에
+있어 커밋되지 않습니다):
+
+```
+# slack-tokens/members.env  — 워크스페이스 전용, 커밋되지 않습니다
+maintainer=U01234567
+teammate-a=U89ABCDEF
+```
+
+그러면 ID 를 외울 필요 없이 이름으로 부를 수 있습니다:
+
+```
+slack-post.sh --channel C… --text-file note.md --mention maintainer
+slack-post.sh --channel C… --text-file note.md --mention U01234567   # 원시 ID 도 그대로 받습니다
+```
+
+- 채널 전체 알림은 본문에 `<!here>` 또는 `<!channel>` 을 넣으면 됩니다(멘션으로 인정됩니다).
+- `agents.json` 에는 두지 않습니다 — 그건 런타임 팀 registry 이고, 이 파일이 다루는 대상(다른
+  머신·다른 팀의 사람)은 거기에 들어갈 자리가 없습니다.
 
 ## 왜 내용을 바꿨나
 

--- a/scripts/send-tools-honesty.test.sh
+++ b/scripts/send-tools-honesty.test.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# send.sh --body-file / slack-post.sh 멘션 경고 인수테스트.
+#
+# 무엇을 막나 (2026-07-30 실측, 하루에 4건):
+#   · 버스 본문의 백틱이 셸 명령치환돼 ★그 구절이 조용히 사라졌다★ — send 는 성공으로 떴다
+#   · 버스 본문의 홑따옴표가 문자열을 끊어 인자 파싱 오류로 죽었다 (죽어서 오히려 알아챌 수 있었다)
+#   · 슬랙 게시글 4건이 멘션 없이 올라가 ★아무에게도 알림이 가지 않았다★ — '✓ posted' 는 찍혔다
+#   전부 "실패가 성공으로 보인다" 한 계열이다.
+#
+# 이 테스트는 ★서버를 필요로 하지 않는 부분만★ 본다(인자 검증·본문 보존·경고 조건).
+#   실제 전송·배달 판정은 src/server/routes/inbox.messageRecipients.test.ts 와
+#   send.sh --confirm 수동 확인이 담당한다(서버 기동 필요).
+# 실행: scripts/send-tools-honesty.test.sh   (0=통과, 1=실패)
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+SEND="$REPO/skills/b3os-team-inbox/scripts/send.sh"
+SLACK="$REPO/skills/b3os-team-inbox/scripts/slack-post.sh"
+for f in "$SEND" "$SLACK"; do [ -f "$f" ] || { echo "FAIL: 없음 $f"; exit 1; }; done
+
+FAILED=0
+pass() { echo "  ✓ $1"; }
+fail() { echo "  ✗ $1"; FAILED=1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ★신원을 격리해서 명시한다★ — _me.sh 는 ★현재 폴더 ↔ team.db★ 로 발신자를 판별한다. worktree 에서
+#   돌리면 판별에 실패하고 스크립트가 curl 전에 죽는다. 그러면 "경고가 안 나왔다" 같은 ★부정 단정이
+#   전부 거짓 통과★ 한다(죽어서 출력이 없으니 grep 이 못 찾는다). 실제로 첫 실행에서 그렇게 통과했다.
+#   해결: 최소 registry 를 임시 DB 에 만들고 TEAM_DB_PATH 로 가리킨다.
+#   ★실 team.db 를 읽지 않는다★ (infra-safety ④) — 테스트는 실 파일시스템을 건드리지 않는다.
+export TEAM_DB_PATH="$TMP/registry.db"
+sqlite3 "$TEAM_DB_PATH" "CREATE TABLE agent (id TEXT PRIMARY KEY, tmux_session TEXT, workspace_path TEXT);
+                         INSERT INTO agent (id, tmux_session, workspace_path) VALUES ('jane','claude-jane','$TMP/ws');" 2>/dev/null
+export GD_AGENT_ID=jane
+# 준비단계 가드 — 신원 해석이 실제로 되는지 먼저 확인한다. 안 되면 이후 단정이 전부 무의미하다.
+if [ "$("$REPO/skills/b3os-team-inbox/scripts/_me.sh" 2>/dev/null)" = "jane" ]; then
+  pass "신원 해석 준비됨 (격리 registry)"
+else
+  fail "신원 해석이 안 된다 — 이후 단정은 신뢰할 수 없다"
+  echo "FAILED — send tools honesty"; exit 1
+fi
+
+# ★셸이 해석하면 훼손되는 문자를 전부 담은 픽스처★
+#   백틱 · 홑따옴표 · $(cmd) · $VAR · 여러 줄 · ★ · 리터럴 \n (이건 펴지면 안 된다)
+FIX="$TMP/body.txt"
+{
+  printf '%s\n' '백틱 `echo HACKED` 는 그대로 남아야 한다'
+  printf '%s\n' "홑따옴표 ' 하나가 있어도 죽지 않아야 한다"
+  printf '%s\n' '명령치환 $(echo HACKED) 도 문자 그대로'
+  printf '%s\n' '변수 $HOME 과 ${PATH} 도 확장되지 않는다'
+  printf '%s\n' '리터럴 백슬래시-n: a\nb  ← 이건 펴지면 안 된다'
+  printf '%s\n' '★ 유니코드 · 여러 줄'
+} > "$FIX"
+
+echo "── A1-1: --body 와 --body-file 동시 지정은 거절 ──"
+out="$("$SEND" --to lisa --body "x" --body-file "$FIX" 2>&1)"; rc=$?
+[ $rc -ne 0 ] && pass "거절됨 (exit $rc)" || fail "동시 지정을 통과시켰다"
+grep -q "동시에" <<<"$out" && pass "사유 설명 있음" || fail "사유 설명 없음: $out"
+
+echo "── A1-2: 없는 파일은 에러로 죽는다 (빈 본문으로 조용히 보내지 않는다) ──"
+out="$("$SEND" --to lisa --body-file "$TMP/nope.txt" 2>&1)"; rc=$?
+[ $rc -ne 0 ] && pass "죽었다 (exit $rc)" || fail "없는 파일인데 계속 진행했다"
+grep -qE "없습니다|경로" <<<"$out" && pass "경로 문제를 알려준다" || fail "메시지 불명확: $out"
+
+echo "── A1-3: 빈 파일도 에러 ──"
+: > "$TMP/empty.txt"
+out="$("$SEND" --to lisa --body-file "$TMP/empty.txt" 2>&1)"; rc=$?
+[ $rc -ne 0 ] && pass "빈 파일 거절 (exit $rc)" || fail "빈 본문으로 보내려 했다"
+
+echo "── A1-4: 디렉토리를 주면 에러 ──"
+out="$("$SEND" --to lisa --body-file "$TMP" 2>&1)"; rc=$?
+[ $rc -ne 0 ] && pass "디렉토리 거절 (exit $rc)" || fail "디렉토리를 본문으로 읽으려 했다"
+
+echo "── A1-5: ★본문이 문자 단위로 보존되는가★ (핵심) ──"
+# 서버 없이 검증하려면 페이로드 생성까지만 돌려야 한다 → curl 을 가짜로 바꿔 POST 를 가로챈다.
+FAKEBIN="$TMP/bin"; mkdir -p "$FAKEBIN"
+cat > "$FAKEBIN/curl" <<'STUB'
+#!/usr/bin/env bash
+# -d 다음 인자가 JSON 페이로드다. 그걸 파일로 떨어뜨리고 성공 응답을 흉내낸다.
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-d" ]; then printf '%s' "$a" > "$CAPTURE"; fi
+  prev="$a"
+done
+printf '{"ok":true,"message":{"id":"testid","thread_id":"t","hop_count":0}}'
+STUB
+chmod +x "$FAKEBIN/curl"
+export CAPTURE="$TMP/payload.json"
+PATH="$FAKEBIN:$PATH" "$SEND" --to lisa --body-file "$FIX" >/dev/null 2>&1
+if [ -s "$CAPTURE" ]; then
+  if CAPTURE="$CAPTURE" FIX="$FIX" python3 - <<'PY'
+import json, os, sys
+sent = json.load(open(os.environ["CAPTURE"]))["body"]
+want = open(os.environ["FIX"], encoding="utf-8").read()
+if want.endswith("\n"): want = want[:-1]   # 끝 개행 1개 절삭은 규격
+if sent == want:
+    sys.exit(0)
+print("  전송된 본문이 파일과 다르다", file=sys.stderr)
+for i,(a,b) in enumerate(zip(sent, want)):
+    if a != b:
+        print(f"    첫 불일치 {i}: 전송={a!r} 파일={b!r}", file=sys.stderr); break
+print(f"    길이 전송={len(sent)} 파일={len(want)}", file=sys.stderr)
+sys.exit(1)
+PY
+  then pass "파일 내용과 문자 단위로 동일 (백틱·홑따옴표·\$(cmd)·\$VAR·리터럴 \\n 전부 원문 보존)"
+  else fail "본문이 훼손됐다"
+  fi
+  grep -q "HACKED" "$CAPTURE" && pass "명령치환이 실행되지 않았다(문자로 남음)" \
+                              || fail "HACKED 가 사라졌다 = 셸이 실행해버렸다"
+else
+  fail "페이로드를 잡지 못했다(테스트 하네스 문제 — 아래 단정은 신뢰할 수 없다)"
+fi
+
+echo "── A2-1: 접수 문구가 '보냈다' 라고 단정하지 않는다 ──"
+out="$(PATH="$FAKEBIN:$PATH" "$SEND" --to lisa --body-file "$FIX" 2>&1)"
+grep -q "✓ sent" <<<"$out" && fail "아직 '✓ sent' 라고 단정한다" || pass "'✓ sent' 단정 제거됨"
+grep -qE "접수됨|배달 확인 전" <<<"$out" && pass "접수까지만 말한다" || fail "접수 문구 없음: $out"
+
+echo "── A3-1: 멘션 없으면 게시 후 경고 ──"
+SLACKSTUB="$TMP/sbin"; mkdir -p "$SLACKSTUB"
+cat > "$SLACKSTUB/curl" <<'STUB'
+#!/usr/bin/env bash
+printf '{"ok":true,"ts":"1.0"}'
+STUB
+chmod +x "$SLACKSTUB/curl"
+out="$(PATH="$SLACKSTUB:$PATH" "$SLACK" --channel C123 --text "Bill 확인 부탁드립니다" 2>&1)"
+grep -q "멘션 없음" <<<"$out" && pass "경고 나옴 (이름만 쓴 글)" || fail "경고가 안 나왔다: $out"
+
+echo "── A3-2: 멘션 있으면 경고 없음 ──"
+# ★부정 단정에는 반드시 '실제로 끝까지 갔다' 는 증거를 같이 본다★ — 스크립트가 중간에 죽어도
+#   "경고 없음" 은 참이 되어버린다. 첫 실행에서 그렇게 거짓 통과했다.
+out="$(PATH="$SLACKSTUB:$PATH" "$SLACK" --channel C123 --text "<@U01234567> 확인 부탁" 2>&1)"
+if grep -q "✓ posted" <<<"$out"; then
+  grep -q "멘션 없음" <<<"$out" && fail "멘션이 있는데 경고했다" || pass "경고 없음 (게시까지 도달 확인)"
+else
+  fail "게시 단계에 도달하지 못했다 — 이 단정은 무효: $out"
+fi
+
+echo "── A3-3: <!here> 도 멘션으로 인정 ──"
+out="$(PATH="$SLACKSTUB:$PATH" "$SLACK" --channel C123 --text "<!here> 공지" 2>&1)"
+if grep -q "✓ posted" <<<"$out"; then
+  grep -q "멘션 없음" <<<"$out" && fail "<!here> 를 멘션으로 안 봤다" || pass "<!here> 인정 (게시까지 도달 확인)"
+else
+  fail "게시 단계에 도달하지 못했다 — 이 단정은 무효: $out"
+fi
+
+echo "── A3-4: --mention 이 본문 앞에 붙는다 ──"
+export CAPTURE="$TMP/slackpayload.json"
+cat > "$SLACKSTUB/curl" <<'STUB'
+#!/usr/bin/env bash
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "-d" ]; then printf '%s' "$a" > "$CAPTURE"; fi
+  prev="$a"
+done
+printf '{"ok":true,"ts":"1.0"}'
+STUB
+chmod +x "$SLACKSTUB/curl"
+PATH="$SLACKSTUB:$PATH" "$SLACK" --channel C123 --text "본문" --mention U01234567 >/dev/null 2>&1
+if [ -s "$CAPTURE" ]; then
+  python3 -c "
+import json,os,sys
+t=json.load(open(os.environ['CAPTURE']))['text']
+sys.exit(0 if t.startswith('<@U01234567> ') else 1)
+" && pass "본문 맨 앞에 <@ID> 부착" || fail "부착 안 됨"
+else fail "슬랙 페이로드를 잡지 못했다"; fi
+
+echo "── A3-5: --text-file 도 원문 보존 ──"
+PATH="$SLACKSTUB:$PATH" "$SLACK" --channel C123 --text-file "$FIX" >/dev/null 2>&1
+python3 - <<'PY' && pass "--text-file 원문 보존" || fail "--text-file 본문 훼손"
+import json, os, sys
+t = json.load(open(os.environ["CAPTURE"]))["text"]
+sys.exit(0 if "`echo HACKED`" in t and "$(echo HACKED)" in t else 1)
+PY
+
+echo "── A3-6: --mention 이 ★이름★ 을 로컬 설정에서 ID 로 푼다 (저장소에 ID 를 두지 않는다) ──"
+MEMBERS="$TMP/members.env"
+printf '# comment\nmaintainer=U07654321\nOther-Person = U11112222\n' > "$MEMBERS"
+PATH="$SLACKSTUB:$PATH" SLACK_MEMBERS_FILE="$MEMBERS" \
+  "$SLACK" --channel C123 --text "본문" --mention maintainer >/dev/null 2>&1
+python3 -c "
+import json,os,sys
+t=json.load(open(os.environ['CAPTURE']))['text']
+sys.exit(0 if t.startswith('<@U07654321> ') else 1)
+" && pass "이름 → ID 해석됨" || fail "이름을 ID 로 풀지 못했다"
+# 대소문자 무시 + 공백 허용
+PATH="$SLACKSTUB:$PATH" SLACK_MEMBERS_FILE="$MEMBERS" \
+  "$SLACK" --channel C123 --text "본문" --mention OTHER-PERSON >/dev/null 2>&1
+python3 -c "
+import json,os,sys
+t=json.load(open(os.environ['CAPTURE']))['text']
+sys.exit(0 if t.startswith('<@U11112222> ') else 1)
+" && pass "대소문자 무시·공백 허용" || fail "대소문자/공백 처리 실패"
+# 못 풀면 ★조용히 넘기지 않고★ 죽는다 — 멘션 없는 글이 되면 알림이 안 가므로
+out="$(PATH="$SLACKSTUB:$PATH" SLACK_MEMBERS_FILE="$MEMBERS" \
+  "$SLACK" --channel C123 --text "본문" --mention nobody 2>&1)"; rc=$?
+[ $rc -ne 0 ] && pass "못 푸는 이름은 에러 (exit $rc)" || fail "못 푸는 이름을 조용히 넘겼다"
+grep -q "SLACK_SETUP" <<<"$out" && pass "ID 얻는 방법을 알려준다" || fail "안내 없음: $out"
+
+echo
+if [ $FAILED -eq 0 ]; then echo "ALL PASS — send tools honesty"; else echo "FAILED — send tools honesty"; fi
+exit $FAILED

--- a/skills/b3os-team-inbox/scripts/send.sh
+++ b/skills/b3os-team-inbox/scripts/send.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Send a message via the team-collab inbox.
-# Usage: send.sh --to <agent_id> --body "..." [--thread <id>] [--in-reply-to <msg_id>]
+# Usage: send.sh --to <agent_id> (--body "..." | --body-file <경로>) [--thread <id>] [--in-reply-to <msg_id>]
+#                [--confirm [초]]                  배달됐는지 실제로 확인하고 사실을 말한다.
+#                                                   ★본문에 홑따옴표·백틱·$(cmd)·$VAR 가 있으면 --body-file 을 쓰세요★
+#                                                   — --body 로 넘기면 셸이 해석해서 본문이 조용히 훼손됩니다(실측 2건).
+#                                                   stdout=메시지 id · stderr=사람이 읽는 결과(파싱하는 코드 없음, 2026-07-30 확인)
 #                [--type dm|reply] [--priority low|normal|high] [--hop <n>]
 #                [--direct-to-gd --source-thread <tg-...|group_id>] [--individual]
 #                                                   send ALL asks for one task on ONE --thread. The server
@@ -18,11 +22,18 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 BASE="${TEAM_BASE:-http://127.0.0.1:7878/team}"
 
 TO=""; BODY=""; THREAD=""; REPLY_TO=""; TYPE="dm"; PRIORITY="normal"; FROM=""; HOP=""; SYNC=""; DIRECT_TO_GD=""; SOURCE_THREAD=""; EXPECT_REPORT_BY=""; INDIVIDUAL=""; EPISODE=""
+BODY_FILE=""; BODY_SET=""; CONFIRM=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --to) TO="$2"; shift 2 ;;
-    --body) BODY="$2"; shift 2 ;;
+    --body) BODY="$2"; BODY_SET=1; shift 2 ;;
+    # ★--body-file — 본문을 셸 명령줄에 싣지 않는 경로★ (2026-07-30)
+    #   본문에 홑따옴표·백틱·$(cmd)·$VAR 가 있으면 셸이 그것을 해석한다. 실측 사고 2건:
+    #   · 백틱이 명령치환돼 본문 일부가 ★조용히 사라졌고★ send 는 성공으로 떴다
+    #   · 홑따옴표가 문자열을 끊어 인자 파싱 오류로 죽었다 — 이건 죽어서 오히려 알아챌 수 있었다
+    #   회피법(--body "$(cat 파일)")이 있었지만 ★아는 사람만 안전한 것은 고쳐진 게 아니다.★
+    --body-file) BODY_FILE="$2"; shift 2 ;;
     --thread) THREAD="$2"; shift 2 ;;
     --in-reply-to) REPLY_TO="$2"; shift 2 ;;
     --type) TYPE="$2"; shift 2 ;;
@@ -51,12 +62,35 @@ while [ $# -gt 0 ]; do
     --expect-report-by) EXPECT_REPORT_BY="$2"; shift 2 ;;
     # comm-suite v3 결합키 — meta.episode 로 실림(기존 플래그 패턴 그대로, 서버 통과·마이그레이션 0).
     --episode) EPISODE="$2"; shift 2 ;;
+    # ★--confirm [초] — 실제 배달됐는지 확인한다★ (2026-07-30)
+    #   POST 응답은 '행이 들어갔다' 까지만 안다. 차단 판정은 그 뒤 dispatcher 가 비동기로 한다
+    #   (poll 1500ms). 그래서 POST 시점에 배달 여부를 아는 것은 ★구조적으로 불가능★ 하다.
+    #   이 플래그는 판정이 날 때까지 잠깐 기다렸다 사실을 말한다. 기본 5초(dispatcher 3틱).
+    --confirm) case "${2:-}" in ''|--*) CONFIRM=5 ;; *) CONFIRM="$2"; shift ;; esac; shift ;;
     *) echo "unknown arg: $1" >&2; exit 1 ;;
   esac
 done
 
 [ -z "$TO" ] && { echo "ERROR: --to required" >&2; exit 1; }
-[ -z "$BODY" ] && { echo "ERROR: --body required" >&2; exit 1; }
+
+# ─── 본문 확정: --body 또는 --body-file (둘 중 하나) ────────────────────────
+# ★둘 다 주면 거절한다★ — 어느 쪽이 이겼는지 조용히 정해지면, 보낸 사람은 자기가 보낸 줄 아는
+#   본문과 실제로 간 본문이 다를 수 있다. 오늘 사고가 전부 그 계열이라 여기서 애매함을 만들지 않는다.
+if [ -n "$BODY_FILE" ] && [ -n "$BODY_SET" ]; then
+  echo "ERROR: --body 와 --body-file 은 동시에 쓸 수 없습니다 (하나만 지정하세요)" >&2
+  exit 1
+fi
+if [ -n "$BODY_FILE" ]; then
+  # ★없거나 못 읽으면 죽는다.★ 빈 본문으로 조용히 보내면 '보냈다' 는 기록만 남고 내용이 사라진다.
+  [ -e "$BODY_FILE" ] || { echo "ERROR: --body-file 경로가 없습니다: $BODY_FILE" >&2; exit 1; }
+  [ -f "$BODY_FILE" ] || { echo "ERROR: --body-file 이 일반 파일이 아닙니다: $BODY_FILE" >&2; exit 1; }
+  [ -r "$BODY_FILE" ] || { echo "ERROR: --body-file 을 읽을 수 없습니다(권한): $BODY_FILE" >&2; exit 1; }
+  # 파일 내용을 ★그대로★ 읽는다. 셸 확장을 타지 않으므로 백틱·홑따옴표·$(cmd)·$VAR 가 원문 보존된다.
+  #   끝 개행 1개는 절삭한다(기존 회피법 --body "$(cat 파일)" 과 동일 동작 — 마이그레이션 0).
+  BODY="$(cat -- "$BODY_FILE")"
+  [ -n "$BODY" ] || { echo "ERROR: --body-file 이 비어 있습니다: $BODY_FILE" >&2; exit 1; }
+fi
+[ -z "$BODY" ] && { echo "ERROR: --body 또는 --body-file 이 필요합니다" >&2; exit 1; }
 
 
 
@@ -94,7 +128,13 @@ fi
 #   백슬래시+n 두 글자다★ → 그대로 JSON 에 실려 ★사람 눈에 "\n" 으로 보인다.★
 #   ★팀원을 탓할 게 아니라(그게 자연스러운 표기다) 여기서 받아주는 게 맞다.★
 #   \n · \t 만 편다 (\\ 는 안 건드린다 — 코드 붙여넣기를 망가뜨리지 않기 위해).
-BODY=$(BODY="$BODY" python3 -c 'import os, sys; sys.stdout.write(os.environ["BODY"].replace("\\n", "\n").replace("\\t", "\t"))')
+#   ★--body-file 에는 이 변환을 적용하지 않는다★ (2026-07-30): 파일 본문은 이미 진짜 개행을 갖고
+#   있고, 파일 안의 `\n` 은 ★글자 그대로 의도된 것★ 이다(코드·정규식·로그를 붙여넣는 경우).
+#   여기서 펴버리면 파일과 저장된 본문이 달라진다 — --body-file 을 만든 이유가 "원문 그대로 전달"
+#   인데 마지막 단계에서 원문을 바꾸면 앞의 노력이 무의미해진다.
+if [ -z "$BODY_FILE" ]; then
+  BODY=$(BODY="$BODY" python3 -c 'import os, sys; sys.stdout.write(os.environ["BODY"].replace("\\n", "\n").replace("\\t", "\t"))')
+fi
 
 # Build JSON via python to handle escaping safely.
 PAYLOAD=$(BODY="$BODY" FROM="$FROM" TO="$TO" THREAD="$THREAD" REPLY_TO="$REPLY_TO" TYPE="$TYPE" PRIORITY="$PRIORITY" HOP="$HOP" SYNC="$SYNC" DIRECT_TO_GD="$DIRECT_TO_GD" SOURCE_THREAD="$SOURCE_THREAD" EXPECT_REPORT_BY="$EXPECT_REPORT_BY" INDIVIDUAL="$INDIVIDUAL" EPISODE="$EPISODE" python3 -c "
@@ -136,13 +176,63 @@ print(json.dumps(p, ensure_ascii=False))
 ")
 
 RESP=$(curl -sS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$BASE/api/inbox")
-echo "$RESP" | python3 -c "
+
+# ★'✓ sent' 는 거짓이었다★ (2026-07-30): POST /api/inbox 는 ★행 삽입만★ 하고 ok 를 준다.
+#   차단 판정(핑퐁 상한·dead_letter 등)은 그 뒤 dispatcher 가 ★비동기로★ 한다(poll 1500ms).
+#   그래서 이 시점에 배달 여부를 아는 것은 구조적으로 불가능하다. 실측: 미배달 메시지에 '✓ sent' 가
+#   찍혔고, 보낸 사람은 전달된 줄 알았다 — 실제로 정정 메시지 한 건이 그렇게 사라졌다.
+#   알 수 없는 것을 안다고 말하지 않는다 — '접수됨'까지만 단정하고, 확인은 --confirm 이 한다.
+MSG_ID=$(echo "$RESP" | python3 -c "
 import sys, json
 d = json.load(sys.stdin)
 if d.get('ok'):
     m = d['message']
-    print(f'✓ sent {m[\"id\"]} thread={m[\"thread_id\"]} (hop={m[\"hop_count\"]})')
+    print(f'접수됨 {m[\"id\"]} thread={m[\"thread_id\"]} (hop={m[\"hop_count\"]}) — 배달 확인 전', file=sys.stderr)
+    print(m['id'])
 else:
-    print(f'✗ failed: {json.dumps(d, ensure_ascii=False)}')
+    print(f'✗ 접수 실패: {json.dumps(d, ensure_ascii=False)}', file=sys.stderr)
     sys.exit(1)
-"
+")
+
+[ -z "$CONFIRM" ] && exit 0
+
+# ─── --confirm: 판정이 날 때까지 기다렸다 사실을 말한다 ────────────────────
+# 판정 근거는 ★message_recipient.delivery_state★ 다.
+#   message.delivery_status 와 recipient_state 는 ★미배달에도 delivered/acknowledged 로 박힌다★
+#   (2026-07-30 실측: 차단된 메시지가 각각 그 값이었다). 그 둘을 근거로 쓰면 이 기능이 무의미해진다.
+CONF_DEADLINE=$(( $(date +%s) + CONFIRM ))
+while :; do
+  STATE_JSON=$(curl -sS "$BASE/api/inbox/messages/$MSG_ID" 2>/dev/null || echo '{}')
+  VERDICT=$(STATE_JSON="$STATE_JSON" python3 -c "
+import os, json, sys
+try: d = json.loads(os.environ['STATE_JSON'])
+except Exception: print('unknown'); sys.exit(0)
+rs = d.get('recipients')
+if rs is None: print('noapi'); sys.exit(0)
+if len(rs) == 0: print('norecipient'); sys.exit(0)
+bad = [r for r in rs if r.get('delivery_state') in ('blocked', 'dead_letter')]
+if bad:
+    r = bad[0]
+    print('failed\t' + str(r.get('delivery_state')) + '\t' + str(r.get('last_error') or '(사유 없음)'))
+    sys.exit(0)
+if all(r.get('delivery_state') in ('completed', 'delivered') for r in rs):
+    print('ok'); sys.exit(0)
+print('pending')
+")
+  case "${VERDICT%%$'\t'*}" in
+    ok) echo "✓ 배달 확인 ($MSG_ID)" >&2; exit 0 ;;
+    failed)
+      echo "✗ ★미배달★ ($MSG_ID) — $(echo "$VERDICT" | cut -f2): $(echo "$VERDICT" | cut -f3)" >&2
+      echo "  같은 스레드 왕복 상한이면 --in-reply-to 없이 ★새 스레드★ 로 다시 보내세요(카운터 리셋)." >&2
+      exit 1 ;;
+    # ★빈 배열과 '아직 판정 전' 을 구분한다★: 둘을 뭉치면 수신자가 아예 안 붙은
+    #   사고(진짜 문제)를 "아직 안 왔네" 로 흘린다. 빈 배열은 경고로 낸다.
+    norecipient) echo "⚠ 수신자가 붙지 않았습니다 ($MSG_ID) — 배달 대상이 0명입니다. --to 값과 registry 를 확인하세요." >&2; exit 1 ;;
+    noapi) echo "⚠ 이 서버는 recipients 를 주지 않습니다 — --confirm 을 쓸 수 없습니다(서버 업데이트 필요)." >&2; exit 0 ;;
+  esac
+  [ "$(date +%s)" -ge "$CONF_DEADLINE" ] && {
+    echo "⚠ ${CONFIRM}초 안에 판정이 나지 않았습니다 ($MSG_ID) — 아직 처리 중일 수 있습니다(미배달 단정 아님)." >&2
+    exit 0
+  }
+  sleep 1
+done

--- a/skills/b3os-team-inbox/scripts/slack-post.sh
+++ b/skills/b3os-team-inbox/scripts/slack-post.sh
@@ -2,19 +2,31 @@
 # Post a top-level message to a Slack channel as the current agent.
 # (Not a thread reply — for proactive announcements, weekly meeting starters, daily briefs, etc.)
 # Usage:
-#   slack-post.sh --channel <C...> --text "..."
+#   slack-post.sh --channel <C...> (--text "..." | --text-file <경로>)
+#   slack-post.sh --channel <C...> --text-file <경로> --mention <U…|이름>     # 알림 받을 사람(반복 가능)
 #   slack-post.sh --channel <C...> --text "..." --as <agent>     # impersonate (admin)
 #   slack-post.sh --channel <C...> --text "..." --thread <ts>    # reply in thread instead
+#
+# ★멘션이 없으면 채널에 올라가도 알림이 아무에게도 가지 않습니다★ — 게시 후 경고합니다.
+#   member ID 얻는 방법·보관 위치는 docs/SLACK_SETUP.md 참조 (저장소에 ID 를 두지 않습니다).
+# ★본문에 홑따옴표·백틱·$(cmd) 가 있으면 --text-file 을 쓰세요★ — --text 는 셸이 해석해 본문이 훼손됩니다.
 set -e
 HERE="$(cd "$(dirname "$0")" && pwd)"
 BASE="${TEAM_BASE:-http://127.0.0.1:7878/team}"
 
-CHANNEL=""; TEXT=""; AS=""; THREAD=""
+CHANNEL=""; TEXT=""; AS=""; THREAD=""; TEXT_FILE=""; TEXT_SET=""; MENTIONS=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --channel) CHANNEL="$2"; shift 2 ;;
-    --text)    TEXT="$2"; shift 2 ;;
+    --text)    TEXT="$2"; TEXT_SET=1; shift 2 ;;
+    # --text-file: 본문을 셸 명령줄에 싣지 않는다 (send.sh --body-file 과 같은 이유 — 홑따옴표·백틱·$(cmd)
+    #   가 셸에 해석돼 본문이 조용히 훼손된다. 실측 2건).
+    --text-file) TEXT_FILE="$2"; shift 2 ;;
+    # --mention <U…>: 반복 가능. 본문 맨 앞에 <@ID> 를 붙인다.
+    #   ★이게 없으면 게시는 되고 알림은 아무에게도 안 간다★ — 실측으로 게시글 4건이 그렇게
+    #   전달되지 않았고, 스크립트는 그때도 '✓ posted' 를 찍었다.
+    --mention) MENTIONS="$MENTIONS $2"; shift 2 ;;
     --as)      AS="$2"; shift 2 ;;
     --thread)  THREAD="$2"; shift 2 ;;
     *) echo "unknown arg: $1" >&2; exit 1 ;;
@@ -22,7 +34,45 @@ while [ $# -gt 0 ]; do
 done
 
 [ -z "$CHANNEL" ] && { echo "ERROR: --channel required (Slack channel id, starts with C)" >&2; exit 1; }
-[ -z "$TEXT" ]    && { echo "ERROR: --text required" >&2; exit 1; }
+
+if [ -n "$TEXT_FILE" ] && [ -n "$TEXT_SET" ]; then
+  echo "ERROR: --text 와 --text-file 은 동시에 쓸 수 없습니다 (하나만 지정하세요)" >&2; exit 1
+fi
+if [ -n "$TEXT_FILE" ]; then
+  [ -f "$TEXT_FILE" ] || { echo "ERROR: --text-file 경로가 없거나 일반 파일이 아닙니다: $TEXT_FILE" >&2; exit 1; }
+  [ -r "$TEXT_FILE" ] || { echo "ERROR: --text-file 을 읽을 수 없습니다(권한): $TEXT_FILE" >&2; exit 1; }
+  TEXT="$(cat -- "$TEXT_FILE")"
+  [ -n "$TEXT" ] || { echo "ERROR: --text-file 이 비어 있습니다: $TEXT_FILE" >&2; exit 1; }
+fi
+[ -z "$TEXT" ] && { echo "ERROR: --text 또는 --text-file 이 필요합니다" >&2; exit 1; }
+
+# --mention 을 본문 맨 앞에 붙인다 (이미 본문에 있으면 중복으로 붙이지 않는다)
+#   ★member ID 는 저장소에 두지 않는다★ — 워크스페이스 고유 값이라 공개 저장소에 박을 값이 아니다.
+#   원시 ID(U…/W…)를 그대로 받고, 그 밖의 값은 이름으로 보고 slack-tokens/members.env 에서 찾는다
+#   (그 폴더는 .gitignore 에 있다). 형식: 이름=U01234567 한 줄씩.
+MEMBERS_FILE="${SLACK_MEMBERS_FILE:-$(cd "$HERE/../../.." && pwd)/slack-tokens/members.env}"
+resolve_mention() {  # resolve_mention <원시ID|이름> -> ID 또는 빈 문자열
+  local v="$1"
+  v="${v#<@}"; v="${v%>}"                      # 사용자가 <@U…> 형태로 줘도 받아준다
+  case "$v" in [UW][A-Z0-9]*) printf '%s' "$v"; return 0 ;; esac
+  [ -f "$MEMBERS_FILE" ] || return 1
+  # KEY=VALUE, 대소문자 무시, 주석·빈 줄 무시
+  awk -F= -v want="$(printf '%s' "$v" | tr '[:upper:]' '[:lower:]')" '
+    /^[[:space:]]*#/ || !/=/ { next }
+    { k=$1; gsub(/^[[:space:]]+|[[:space:]]+$/, "", k); v2=$2; gsub(/^[[:space:]]+|[[:space:]]+$/, "", v2)
+      if (tolower(k) == want) { print v2; exit } }' "$MEMBERS_FILE"
+}
+for _m in $MENTIONS; do
+  _id="$(resolve_mention "$_m")"
+  if [ -z "$_id" ]; then
+    echo "ERROR: --mention '$_m' 을 member ID 로 풀 수 없습니다." >&2
+    echo "  원시 ID(U…)를 직접 주거나, $MEMBERS_FILE 에 '이름=U01234567' 을 추가하세요." >&2
+    echo "  ID 얻는 방법: Slack 프로필 → ⋯ → '멤버 ID 복사' (docs/SLACK_SETUP.md)" >&2
+    exit 1
+  fi
+  case "$TEXT" in *"<@$_id>"*) continue ;; esac
+  TEXT="<@$_id> $TEXT"
+done
 
 AGENT="${AS:-$($HERE/_me.sh)}"
 
@@ -47,3 +97,13 @@ else:
     print(f'✗ {json.dumps(d, ensure_ascii=False)}')
     sys.exit(1)
 "
+
+# ★게시 성공 ≠ 누가 읽는다★ (2026-07-30 실측)
+#   멘션이 없는 글은 채널에 올라가지만 ★아무에게도 알림이 가지 않는다.★ 실측 게시글 4건이
+#   그렇게 전달되지 않았고, 스크립트는 그때도 '✓ posted' 만 찍었다. 게시 여부와 도달 여부는 다른 사실이다.
+#   그래서 게시 뒤에 ★경고★ 한다(실패로 만들지는 않는다 — 알림 없는 게시가 정당한 경우도 있다).
+#   `<!here>`·`<!channel>`·`<!subteam^…>` 도 알림을 만드므로 멘션으로 인정한다.
+if ! printf '%s' "$TEXT" | grep -qE '<@[UW][A-Z0-9]+>|<!(here|channel)(\|[^>]*)?>|<!subteam\^'; then
+  echo "⚠ 멘션 없음 — 채널에 게시됐지만 ★알림은 아무에게도 가지 않았습니다★." >&2
+  echo "   받을 사람을 지정하려면: --mention <U…|이름>  (ID 얻는 방법 = docs/SLACK_SETUP.md)" >&2
+fi

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -466,7 +466,22 @@ export function createInboxRoutes(deps: InboxRouteDeps): Hono {
       )
       .get(id) as Record<string, unknown> | undefined;
     if (!m) return c.json({ error: "not_found", id }, 404);
-    return c.json({ message: m });
+    // ★수신자별 배달 상태를 함께 준다★ (2026-07-30) — send.sh --confirm 의 판정 근거.
+    //   POST /api/inbox 는 행 삽입만 하고 ok 를 주므로 그 시점엔 배달 여부를 알 수 없다(차단 판정은
+    //   dispatcher 가 비동기로 한다). 보낸 사람이 사실을 확인할 경로가 없어서 미배달이 '성공' 으로
+    //   보였다 — 실측으로 메시지가 그렇게 사라졌다.
+    //   ★delivery_state 를 준다. delivery_status·recipient_state 는 주지 않는다★ — 그 둘은 미배달에도
+    //   각각 delivered·acknowledged 로 박혀 있어(같은 행에서 실측) 판정 근거로 쓰면 거짓말을 되풀이한다.
+    //   last_error 를 같이 주는 이유: 차단 사유가 거기에만 있다(예: pingpong_limit_exceeded:rounds=8).
+    const recipients = deps.db
+      .prepare(
+        `SELECT agent_id, delivery_state, last_error, retry_count
+         FROM message_recipient WHERE message_id = ? ORDER BY agent_id`,
+      )
+      .all(id) as Array<Record<string, unknown>>;
+    // recipients 는 ★항상 배열★ 이다. 빈 배열은 '수신자가 0명' 이라는 사실이며 '모름' 이 아니다 —
+    //   호출부가 그 둘을 구분할 수 있어야 수신자 미연결 사고를 '아직 안 왔음' 으로 흘리지 않는다.
+    return c.json({ message: m, recipients });
   });
 
   return r;

--- a/src/server/routes/messageRecipients.test.ts
+++ b/src/server/routes/messageRecipients.test.ts
@@ -1,0 +1,121 @@
+// GET /api/inbox/messages/:id 가 수신자별 배달 상태를 준다 — send.sh --confirm 의 판정 근거.
+//
+// 왜 필요했나 (2026-07-30 실측): POST /api/inbox 는 행 삽입만 하고 ok 를 주고, 차단 판정은 그 뒤
+//   dispatcher 가 비동기로 한다. 보낸 사람이 사실을 확인할 경로가 ★없어서★ 미배달이 '성공' 으로
+//   보였다 — 리사의 정정 메시지가 그렇게 사라졌고 send.sh 는 '✓ sent' 를 찍었다.
+import { describe, test, expect } from "bun:test";
+import { Database } from "bun:sqlite";
+import { migrate } from "../db/migrate";
+import { createInboxRoutes } from "./inbox";
+
+function setup(): { db: Database; app: ReturnType<typeof createInboxRoutes> } {
+  const db = new Database(":memory:");
+  migrate(db);
+  for (const a of ["jane", "lisa"]) {
+    db.prepare(
+      `INSERT OR IGNORE INTO agent (id, display_name, role, runtime, status_provider, workspace_path, persona_file)
+       VALUES (?, ?, 'r', 'claude_channel', 'claude_tmux', '/tmp', 'P.md')`,
+    ).run(a, a);
+  }
+  db.prepare(
+    `INSERT INTO thread (id, title, kind, participants_json, opened_by) VALUES ('t1','t','dm','[]','jane')`,
+  ).run();
+  const app = createInboxRoutes({
+    db,
+    broadcast: () => {},
+    registeredAgentIds: () => new Set(["jane", "lisa"]),
+  } as unknown as Parameters<typeof createInboxRoutes>[0]);
+  return { db, app };
+}
+
+/** message + message_recipient 를 직접 심는다 — dispatcher 를 돌리지 않고 상태를 만든다. */
+function seed(
+  db: Database,
+  id: string,
+  recipients: Array<{ agent: string; state: string; err?: string | null; status?: string; rstate?: string }>,
+): void {
+  db.prepare(
+    `INSERT INTO message (id, thread_id, from_agent_id, to_agent_id, type, body, source, delivery_status)
+     VALUES (?, 't1', 'jane', 'lisa', 'dm', 'b', 'agent', ?)`,
+  ).run(id, recipients[0]?.status ?? "delivered");
+  for (const r of recipients) {
+    db.prepare(
+      `INSERT INTO message_recipient (message_id, agent_id, delivery_state, last_error, recipient_state)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(id, r.agent, r.state, r.err ?? null, r.rstate ?? "acknowledged");
+  }
+}
+
+const get = async (app: ReturnType<typeof createInboxRoutes>, id: string) =>
+  await (await app.request(`/messages/${id}`)).json();
+
+describe("GET /api/inbox/messages/:id — recipients", () => {
+  test("★수신자별 delivery_state 와 last_error 를 준다★", async () => {
+    const { db, app } = setup();
+    seed(db, "m1", [{ agent: "lisa", state: "blocked", err: "blocked:pingpong_limit_exceeded:rounds=8,max=8" }]);
+    const body = (await get(app, "m1")) as { recipients: Array<Record<string, unknown>> };
+    expect(Array.isArray(body.recipients)).toBe(true);
+    expect(body.recipients).toHaveLength(1);
+    expect(body.recipients[0]!.agent_id).toBe("lisa");
+    expect(body.recipients[0]!.delivery_state).toBe("blocked");
+    expect(String(body.recipients[0]!.last_error)).toContain("pingpong_limit_exceeded");
+  });
+
+  test("정상 배달은 completed 로 보인다", async () => {
+    const { db, app } = setup();
+    seed(db, "m2", [{ agent: "lisa", state: "completed" }]);
+    const body = (await get(app, "m2")) as { recipients: Array<Record<string, unknown>> };
+    expect(body.recipients[0]!.delivery_state).toBe("completed");
+  });
+
+  test("★수신자가 없으면 빈 배열★ — '모름' 과 구분되어야 한다", async () => {
+    const { db, app } = setup();
+    db.prepare(
+      `INSERT INTO message (id, thread_id, from_agent_id, to_agent_id, type, body, source)
+       VALUES ('m3','t1','jane','lisa','dm','b','agent')`,
+    ).run();
+    const body = (await get(app, "m3")) as { recipients: unknown[] };
+    expect(Array.isArray(body.recipients)).toBe(true);
+    expect(body.recipients).toHaveLength(0);
+  });
+
+  test("여러 수신자 전부 준다 (broadcast)", async () => {
+    const { db, app } = setup();
+    seed(db, "m4", [
+      { agent: "jane", state: "completed" },
+      { agent: "lisa", state: "blocked", err: "blocked:x" },
+    ]);
+    const body = (await get(app, "m4")) as { recipients: unknown[] };
+    expect(body.recipients).toHaveLength(2);
+  });
+
+  test("없는 id 는 404", async () => {
+    const { app } = setup();
+    const res = await app.request("/messages/nope");
+    expect(res.status).toBe(404);
+  });
+
+  // ─── 사실 고정 (리사 요구 (b)) ───────────────────────────────────────────
+  // ★변이 테스트가 아니라 '사실 고정' 이다★ — 두 컬럼이 실제로 어긋난다는 것 자체를 못박는다.
+  //   나중에 누가 "delivery_status 로 충분한데?" 라고 할 때 이 단정이 근거가 된다.
+  test("★같은 행에서 delivery_status='delivered' 인데 delivery_state='blocked' 다★ (실측 재현)", async () => {
+    const { db, app } = setup();
+    // 2026-07-30 차단된 메시지 l5T94re0n3p- 의 실제 값 조합을 그대로 재현한다.
+    seed(db, "m5", [
+      { agent: "jane", state: "blocked", err: "blocked:pingpong_limit_exceeded:rounds=8,max=8",
+        status: "delivered", rstate: "acknowledged" },
+    ]);
+    const row = db.prepare(`SELECT delivery_status FROM message WHERE id='m5'`).get() as { delivery_status: string };
+    const rec = db.prepare(`SELECT delivery_state, recipient_state FROM message_recipient WHERE message_id='m5'`)
+      .get() as { delivery_state: string; recipient_state: string };
+    expect(row.delivery_status).toBe("delivered");        // ★거짓★
+    expect(rec.recipient_state).toBe("acknowledged");     // ★거짓★ (받은 적 없다)
+    expect(rec.delivery_state).toBe("blocked");           // ✅ 진실
+
+    // 그리고 API 는 ★진실만★ 노출한다 — 거짓 컬럼을 응답에 넣지 않는다.
+    const body = (await get(app, "m5")) as { recipients: Array<Record<string, unknown>> };
+    expect(body.recipients[0]!.delivery_state).toBe("blocked");
+    expect(body.recipients[0]).not.toHaveProperty("delivery_status");
+    expect(body.recipients[0]).not.toHaveProperty("recipient_state");
+  });
+});


### PR DESCRIPTION
> **작성: Jane (jane)** — 서비스 전략/기획 및 풀스택
> ※ 커밋 계정은 팀 공용이라 author 로는 담당자가 드러나지 않습니다. 실제 작업자는 위와 같습니다.

## 사용자에게 무엇이 문제인가

b3os 의 전송 도구 3가지가 **실패했는데 성공을 출력합니다.** 보낸 사람은 메시지가 전달된 줄 알지만
받는 쪽에는 아무것도 도착하지 않습니다. 세 건 모두 별도 도구 없이 재현됩니다.

---

### 1. 본문에 백틱·홑따옴표가 있으면 조용히 훼손된다

**재현**
```bash
send.sh --to <agent> --body "코드 `echo hi` 참고"
```
백틱 안이 셸 명령치환으로 실행되고 **그 구절이 본문에서 사라집니다.** 그런데 종료코드는 0 이고
`✓ sent` 가 출력됩니다. 홑따옴표를 넣으면 문자열이 끊겨 인자 파싱 오류로 죽습니다(이건 죽으므로 알 수 있음).

우회법(`--body "$(cat 파일)"`)은 존재했지만 **아는 사람만 안전한 것은 고쳐진 상태가 아닙니다.**

**수정** — `--body-file <경로>` 추가. 본문이 셸 명령줄을 거치지 않습니다.
- `--body` 와 동시 지정 거절 (어느 쪽이 이겼는지 조용히 정해지면 안 됨)
- 파일 없음 · 디렉토리 · 권한 없음 · 빈 파일 → 에러 종료. **빈 본문으로 조용히 보내지 않습니다**
- 끝 개행 1개만 절삭 (기존 우회법과 동일 동작 → 마이그레이션 없음)
- **리터럴 `\n` 변환을 `--body-file` 에는 적용하지 않습니다.** 파일 안의 `\n` 은 글자 그대로 의도된
  것입니다(코드·정규식·로그 붙여넣기). 여기서 펴면 파일과 저장 본문이 달라져 이 기능의 목적이 사라집니다

### 2. `✓ sent` 가 배달을 보장하지 않는다

`POST /api/inbox` 는 **행 삽입만** 하고 `ok` 를 돌려줍니다. 차단 판정(스레드 왕복 상한 등)은 그 뒤
dispatcher 가 **비동기로** 합니다. 즉 POST 시점에 배달 여부를 아는 것은 구조적으로 불가능한데
스크립트는 `✓ sent` 라고 단정했습니다.

**수정**
- 문구를 사실로 — `접수됨 <id> … (배달 확인 전)`. 아는 것까지만 말합니다
- `--confirm [초]` 추가(기본 5초). 판정이 날 때까지 기다려 결과를 보고합니다
- `GET /api/inbox/messages/:id` 응답에 `recipients[]` 추가 (`agent_id`, `delivery_state`, `last_error`, `retry_count`)

판정 근거는 **`message_recipient.delivery_state`** 입니다.
`message.delivery_status` 와 `recipient_state` 는 **미배달에도 각각 `delivered`·`acknowledged` 로
남아 있어** 근거로 쓸 수 없습니다. 같은 행에서 그 불일치가 실제로 관측되며, 테스트로 고정해뒀습니다.

`--confirm` 은 **수신자 목록이 빈 경우**(수신자가 안 붙은 실제 사고 → 경고)와 **아직 판정 전**
(정상 → 미배달로 단정하지 않음)을 구분합니다. 뭉치면 진짜 사고가 "아직 안 왔음" 으로 묻힙니다.

기존 `GET /api/bus/flow` 를 쓰지 않은 이유: 최근 40건 윈도우라 그 밖으로 밀린 메시지를 **조용히
못 찾습니다.** 판정 도구가 "못 찾음" 을 "문제 없음" 으로 흘리면 만드는 의미가 없습니다.

### 3. 멘션 없는 Slack 게시는 아무에게도 알림이 가지 않는다

Slack 은 `<@U…>` 없이 올린 글에 알림을 보내지 않습니다. 이름을 글자로 적는 것은 멘션이 아닙니다.
게시는 성공하므로 `✓ posted` 가 출력되고 올린 쪽은 전달된 줄 압니다.
`docs/SLACK_SETUP.md` 에 이미 경고가 있었지만 **문서만으로는 막히지 않았습니다** — 실측 게시글
4건이 그렇게 전달되지 않았습니다.

**수정**
- 본문에 `<@U…>` · `<!here>` · `<!channel>` · `<!subteam^…>` 가 없으면 **게시 후 경고**
  (실패로 만들지 않습니다 — 알림 없는 게시가 정당한 경우도 있습니다)
- `--mention <U…|이름>` 추가(반복 가능) → 본문 맨 앞에 `<@ID>` 부착
- `--text-file <경로>` 추가 (1번과 같은 이유)

**member ID 를 저장소에 넣지 않았습니다.** 워크스페이스 고유 값이므로 원시 ID 는 그대로 받고,
그 밖의 값은 이름으로 보아 `slack-tokens/members.env`(`.gitignore` 대상)에서 찾습니다.
못 풀면 조용히 넘기지 않고 종료하며 ID 얻는 방법을 안내합니다 — 조용히 넘기면 멘션 없는 글이 되어
같은 문제로 되돌아갑니다. 문서에는 ID 값 대신 **얻는 방법과 보관 위치**를 적었습니다.

---

## 검증 — 항목마다 되돌려서 빨개지는지 확인

`scripts/send-tools-honesty.test.sh` (19건) · `src/server/routes/messageRecipients.test.ts` (6건)

| 변이 | 결과 |
|---|---|
| `--body-file` 처리 제거 | **3건 실패** |
| 문구를 `✓ sent` 로 되돌림 | **1건 실패** |
| 멘션 경고 조건 제거 | **1건 실패** |
| `delivery_status` 를 노출 | **3건 실패** |
| 원복 | 전부 통과 |

서버 없이 도는 부분은 `curl` 을 스텁으로 바꿔 전송 페이로드를 검사합니다. 신원 해석은 임시 registry
로 격리해 실제 설정을 건드리지 않습니다.

**테스트가 거짓 통과한 것을 2회 겪어 가드를 넣었습니다.** 스크립트가 신원 해석 실패로 조기 종료하면
"경고가 없다" 같은 부정 단정이 전부 참이 됩니다(출력이 없으니 grep 이 못 찾음) — 첫 실행에서 9건이
그렇게 통과했습니다. 그래서 ① 신원 해석이 되는지 ② 게시 단계까지 실제로 도달했는지를 따로 단정합니다.

전체: **1961 pass / 4 fail**. 4건은 `teamRouter.llm.test.ts`(로컬 LLM 미기동 환경 실패)이며 이 변경과
무관합니다 — clean main 에서 동일하게 실패합니다. typecheck 통과.

## 반영 조건

이 PR 은 **스크립트 + 서버 라우트** 를 함께 건드립니다.
- `send.sh` · `slack-post.sh` → pull 만으로 즉시 적용
- `src/server/routes/inbox.ts` (`recipients[]`) → **서버 재시작 후** 적용. 재시작 전에는 `--confirm` 이
  "이 서버는 recipients 를 주지 않습니다" 로 안내하고 **종료코드 0** 으로 끝납니다(구버전 서버에서
  오탐하지 않도록)

## 검증 못 한 범위

`--confirm` 이 실제 차단 상황에서 `blocked` 를 읽어 실패로 보고하는 것은 **서버 재시작 후 라이브에서
확인 예정**입니다. 현재는 단위 테스트(고정된 DB 상태)까지 검증했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
