### PR TITLE
fix(settings): PUT 이 모르는 키를 조용히 버리고 성공을 돌려줬다

### DIFF
--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -507,6 +507,65 @@ describe("settings: 머지 승인자 설정 쓰기", () => {
     expect((await app.request("/settings", put({ github_approver_account: null }))).status).toBe(400);
   });
 
+  // ★읽기만 구현돼 있던 키 (2026-07-30)★ — GET 은 값을 주는데 PUT 이 안 받아서, 보내면
+  //   ok:true 를 받고 저장이 안 됐다. 증상이 조용해서 호출자는 저장된 줄 알고 넘어간다.
+  test("★github_team_commit_email 을 쓰고 다시 읽을 수 있다★ (읽기만 열려 있던 키)", async () => {
+    const { app } = setup();
+    const r = await app.request("/settings", put({ github_team_commit_email: "1234+bot@users.noreply.github.com" }));
+    expect(r.status).toBe(200);
+    const j = await (await app.request("/settings")).json() as any;
+    expect(j.github_team_commit_email).toBe("1234+bot@users.noreply.github.com");
+  });
+
+  test("커밋 이메일 형식 검증 — 잘못된 값은 커밋 시점에야 드러나므로 여기서 막는다", async () => {
+    const { app } = setup();
+    expect((await app.request("/settings", put({ github_team_commit_email: "not-an-email" }))).status).toBe(400);
+    expect((await app.request("/settings", put({ github_team_commit_email: "a@b" }))).status).toBe(400);
+    expect((await app.request("/settings", put({ github_team_commit_email: 123 }))).status).toBe(400);
+    // 빈 문자열은 '해제' 로 허용
+    expect((await app.request("/settings", put({ github_team_commit_email: "" }))).status).toBe(200);
+  });
+});
+
+// ★모르는 키를 조용히 버리지 않는다 (2026-07-30)★
+//   핸들러가 아는 키만 골라 처리하고 나머지를 무시한 뒤 ok:true 를 돌려줬다. 그래서 오타·미구현 키·
+//   이름이 바뀐 키가 전부 ★성공으로 보였다.★ 실패는 고칠 수 있지만 조용한 성공은 고칠 기회가 없다.
+describe("settings: 모르는 키는 400 으로 거절한다", () => {
+  test("★오타 키가 성공으로 보이지 않는다★", async () => {
+    const { app } = setup();
+    const r = await app.request("/settings", put({ github_team_email: "x@y.com" }));  // 실제 키는 _commit_email
+    expect(r.status).toBe(400);
+    const j = await r.json() as any;
+    expect(j.error).toBe("unknown_settings_key");
+    expect(j.unknown).toContain("github_team_email");
+    expect(String(j.hint)).toContain("github_team_commit_email");   // 올바른 키를 알려준다
+  });
+
+  test("아는 키와 모르는 키를 같이 보내면 ★아무것도 저장되지 않는다★", async () => {
+    const { app } = setup();
+    await app.request("/settings", put({ team_name: "before" }));
+    const r = await app.request("/settings", put({ team_name: "after", bogus_key: "x" }));
+    expect(r.status).toBe(400);
+    const j = await (await app.request("/settings")).json() as any;
+    expect(j.team_name).toBe("before");   // 모르는 키 때문에 거절 → 아는 키도 안 바뀐다
+  });
+
+  test("쓰기 가능한 키는 전부 통과한다 (거절 목록이 과하지 않다)", async () => {
+    const { app } = setup();
+    const r = await app.request("/settings", put({
+      team_name: "t", tagline: "g", owner_name: "o", owner_chat_id: "123",
+      locale: "ko", dm_capture: true,
+      github_team_account: "acct", github_team_commit_email: "a@b.co",
+      github_approver_account: "appr", merge_approvers_normal: "bill",
+    }));
+    expect(r.status).toBe(200);
+  });
+
+  test("빈 본문은 거절하지 않는다 (바꿀 게 없는 요청은 유효하다)", async () => {
+    const { app } = setup();
+    expect((await app.request("/settings", put({}))).status).toBe(200);
+  });
+
   test("빈 문자열은 '해제' 로 허용 — 설정을 되돌릴 수 있어야 한다", async () => {
     const { app } = setup();
     await app.request("/settings", put({ github_approver_account: "gd452" }));

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -396,6 +396,29 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     } catch {
       return c.json({ error: "invalid_json" }, 400);
     }
+    // ★모르는 키를 조용히 버리지 않는다★ (2026-07-30)
+    //   이 핸들러는 아는 키만 골라 처리하고 나머지는 ★무시한 뒤 ok:true 를 돌려줬다.★ 그래서
+    //   ① 오타(`github_team_email`) ② 아직 구현 안 된 키 ③ 이름이 바뀐 키 가 전부 ★성공으로 보였다.★
+    //   실측: 읽기만 구현돼 있던 키를 PUT 했더니 ok:true 를 받고 저장이 안 됐다. 호출자는 저장된 줄 알고
+    //   넘어가고, 문제는 한참 뒤 다른 증상으로 나타난다.
+    //   ★쓰기 가능한 키를 여기 한 곳에 적고, 그 밖의 키는 400 으로 거절한다.★ 새 키를 추가하는 사람이
+    //   이 목록에 넣는 것을 잊으면 ★조용히 무시되는 대신 즉시 실패한다★ — 실패는 고칠 수 있다.
+    const WRITABLE_KEYS = new Set<string>([
+      "team_name", "lead_id", "tagline", "owner_name", "owner_chat_id", "locale", "dm_capture",
+      "github_team_account", "github_team_commit_email", "github_approver_account",
+      MERGE_APPROVERS_SETTING_KEY,
+    ]);
+    {
+      const unknown = Object.keys(body as Record<string, unknown>).filter((k) => !WRITABLE_KEYS.has(k));
+      if (unknown.length) {
+        return c.json({
+          error: "unknown_settings_key",
+          unknown,
+          hint: `쓸 수 없는 키입니다: ${unknown.join(", ")} — 쓰기 가능: ${[...WRITABLE_KEYS].join(", ")}`,
+        }, 400);
+      }
+    }
+
     const out: Record<string, string> = {};
     if (body.team_name !== undefined) {
       if (typeof body.team_name !== "string" || body.team_name.length > 20)
@@ -420,7 +443,16 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     //   읽고 다른 키까지 그렇다고 믿지 않도록 한정해서 적는다.★
     //   ★타입도 본다★: String() 강제 변환이라 숫자 123 이나 배열 ["bill"] 도 200 으로 저장됐다.
     {
-      const keys = ["github_team_account", "github_approver_account", MERGE_APPROVERS_SETTING_KEY] as const;
+      // ★github_team_commit_email 을 추가한다 (2026-07-30)★ — 이 키는 ★읽기만★ 구현돼 있었다.
+      //   GET 은 값을 돌려주는데 PUT 핸들러에 없어서, 보내면 ok:true 를 받고 ★저장되지 않았다.★
+      //   증상이 조용하다: 호출자는 성공 응답을 받고 저장된 줄 안다. 다음 커밋에서야 이메일이
+      //   설정되지 않은 채 나간다 — 그때는 원인이 여기라는 걸 알기 어렵다.
+      const keys = [
+        "github_team_account",
+        "github_team_commit_email",
+        "github_approver_account",
+        MERGE_APPROVERS_SETTING_KEY,
+      ] as const;
       const extra = body as Record<string, unknown>;
       const staged: Array<[string, string]> = [];
       for (const key of keys) {
@@ -436,6 +468,14 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
           if (bad.length)
             return c.json({ error: `${key}: 사용할 수 없는 이름 — ${bad.join(", ")} (영숫자·. _ - 만)` }, 400);
           staged.push([key, pool.join(",")]);
+        } else if (key === "github_team_commit_email") {
+          const v = raw.trim();
+          // 이메일 형식만 본다(빈 문자열은 '해제'). GitHub 는 noreply 형식도 받으므로 넓게 허용한다.
+          //   ★형식 검증을 여기서 하는 이유★: 잘못된 값은 커밋 시점에야 드러나고, 그때는
+          //   "push 가 거부됐다" 로만 보여 원인이 이 설정이라는 걸 찾기 어렵다.
+          if (v && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v))
+            return c.json({ error: `${key}: 이메일 형식이 아닙니다` }, 400);
+          staged.push([key, v]);
         } else {
           const v = raw.trim();
           // GitHub 사용자명 규칙: 영숫자·하이픈, 39자 이하. 빈 문자열은 '해제' 로 허용한다.


### PR DESCRIPTION
> **작성: Jane (jane)** — 서비스 전략/기획 및 풀스택
> ※ 커밋 계정은 팀 공용이라 author 로는 담당자가 드러나지 않습니다. 실제 작업자는 위와 같습니다.

## 사용자에게 무엇이 문제인가

`PUT /api/settings` 가 아는 키만 골라 처리하고 **나머지를 무시한 뒤 `ok:true` 를 돌려줍니다.**

**재현**
```bash
curl -X PUT http://127.0.0.1:7878/team/api/settings \
  -H 'Content-Type: application/json' -d '{"nonexistent_key":"v"}'
# → 200 {"ok":true, ...}   저장된 것은 없습니다
```

그래서 다음이 전부 성공으로 보입니다.
- 키 이름 오타 (`github_team_email` ← 실제 키는 `github_team_commit_email`)
- 아직 쓰기가 구현되지 않은 키
- 이름이 바뀐 키

호출자는 저장됐다고 믿고 넘어갑니다. 문제는 한참 뒤 **다른 증상**으로 나타나고, 그때 원인이 이
응답이었다는 것을 알기 어렵습니다.

---

## 두 가지를 고칩니다

### 1. 모르는 키는 400 으로 거절 (근본 수정)

쓰기 가능한 키 목록을 한 곳에 두고, 그 밖의 키가 오면 거절하며 **어떤 키가 문제인지와 쓸 수 있는
키 목록**을 함께 돌려줍니다.

새 키를 추가하는 사람이 이 목록에 넣는 것을 잊으면 **조용히 무시되는 대신 즉시 실패합니다.**
실패는 고칠 수 있지만 조용한 성공은 고칠 기회가 없습니다.

거절 시 **아는 키도 저장하지 않습니다.** 한 요청의 일부만 반영되면 호출자가 어느 쪽이 적용됐는지
알 수 없습니다. (기존 GitHub 키 블록이 같은 이유로 이미 원자적으로 처리하고 있습니다.)

### 2. `github_team_commit_email` 쓰기 추가

이 키는 GET 이 값을 돌려주는데 **PUT 핸들러에 없었습니다.** 위 1번의 실제 사례입니다 — 보내면
`ok:true` 를 받고 저장되지 않았습니다.

값이 비면 커밋이 전역 git 설정의 신원으로 나갑니다. 실측으로 그 상태에서 push 가
`push declined due to email privacy restrictions` 로 거부됐고, 원인을 이 설정과 연결짓기까지
시간이 걸렸습니다. 그래서 이메일 형식 검증도 **쓰는 시점에** 합니다(빈 문자열은 '해제' 로 허용).

---

## 검증 — 되돌려서 빨개지는지 확인

`src/server/routes/settings.test.ts` 에 6건 추가 (기존 100건 → **106건**, 기존 테스트 무변경 통과)

| 변이 | 결과 |
|---|---|
| 모르는 키 거절 제거 | **2건 실패** |
| `commit_email` 을 쓰기 목록에서 제거 | **2건 실패** |
| 원복 | 106건 전부 통과 |

거절 목록이 과하지 않은지도 단정합니다 — 쓰기 가능한 키 전부를 한 요청에 보내 200 을 확인하고,
빈 본문(`{}`)은 거절하지 않는 것도 확인합니다(바꿀 게 없는 요청은 유효합니다).

typecheck 통과.

## 반영 조건

서버 코드라 **pull + 서버 재시작** 후 적용됩니다. 재시작 전에는 이전 동작(조용히 무시)이 계속됩니다.

## 호환성 주의 (리뷰 시 봐주실 부분)

이전에는 모르는 키를 보내도 200 이었으므로, **알 수 없는 키를 함께 보내던 기존 호출부가 있으면
이제 400 을 받습니다.** 저장소 안에서는 그런 호출부를 찾지 못했지만, 외부 스크립트가 있다면 이
변경으로 드러납니다 — 그게 이 수정의 목적이기도 합니다(조용히 버려지던 것이 보이게 됨).

거절 대신 경고만 하는 선택지도 있었지만, 경고는 스크립트가 읽지 않으므로 같은 문제가 남습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
