### PR TITLE
fix(send.sh): --confirm 이 자기 고장을 '아직 판정 전' 으로 흘렸다

### DIFF
--- a/scripts/send-tools-honesty.test.sh
+++ b/scripts/send-tools-honesty.test.sh
@@ -200,6 +200,39 @@ out="$(PATH="$SLACKSTUB:$PATH" SLACK_MEMBERS_FILE="$MEMBERS" \
 [ $rc -ne 0 ] && pass "못 푸는 이름은 에러 (exit $rc)" || fail "못 푸는 이름을 조용히 넘겼다"
 grep -q "SLACK_SETUP" <<<"$out" && pass "ID 얻는 방법을 알려준다" || fail "안내 없음: $out"
 
+echo "── A2-2: 메시지 id 가 ★stdout★ 으로 나온다 (사용법이 약속한 것) ──"
+# 실측으로 MSGID=$(send.sh …) 가 빈 문자열이었다 — id 를 내부 변수로만 받고 stdout 에 안 내보냈다.
+mid="$(PATH="$FAKEBIN:$PATH" "$SEND" --to lisa --body-file "$FIX" 2>/dev/null)"
+[ "$mid" = "testid" ] && pass "stdout 에서 id 를 받을 수 있다 ($mid)" \
+                      || fail "stdout 이 비었다 — 사용법은 id 를 약속하는데 코드가 안 지킨다 (받은 값: '$mid')"
+
+echo "── A2-3: --confirm 이 ★JSON 이 아닌 응답★ 을 조용히 넘기지 않는다 ──"
+# 실측 사고: 경로 오류로 SPA 가 HTML 을 200 으로 돌려줬고, 판정기가 'unknown' 을 냈지만 처리 분기가
+#   없어서 ★조용히 타임아웃까지 루프★ 했다. 원인(경로)은 타임아웃 메시지에 전혀 드러나지 않았다.
+HTMLBIN="$TMP/hbin"; mkdir -p "$HTMLBIN"
+cat > "$HTMLBIN/curl" <<'STUB'
+#!/usr/bin/env bash
+# POST(접수)에는 정상 JSON, GET(조회)에는 HTML 을 준다 — 경로 오류 상황 재현
+for a in "$@"; do [ "$a" = "-X" ] && { printf '{"ok":true,"message":{"id":"testid","thread_id":"t","hop_count":0}}'; exit 0; }; done
+printf '<!doctype html><html><body>SPA</body></html>'
+STUB
+chmod +x "$HTMLBIN/curl"
+start=$(date +%s)
+out="$(PATH="$HTMLBIN:$PATH" "$SEND" --to lisa --body-file "$FIX" --confirm 6 2>&1)"; rc=$?
+elapsed=$(( $(date +%s) - start ))
+if grep -qE "JSON 이 아닙니다|읽지 못했습니다" <<<"$out"; then
+  pass "JSON 아님을 즉시 알린다 (${elapsed}s)"
+else
+  fail "조용히 넘겼다 — 출력: $(head -3 <<<"$out" | tr '\n' ' ')"
+fi
+[ "$elapsed" -lt 5 ] && pass "타임아웃까지 기다리지 않는다 (${elapsed}s < 5s)" \
+                     || fail "타임아웃까지 루프했다 (${elapsed}s) — 자기 고장을 '아직 판정 전' 으로 흘린다"
+
+echo "── A2-4: --confirm 조회 경로가 올바른가 (SPA fallback 이 아닌 API) ──"
+# inbox 라우트는 api 아래 "/" 에 마운트된다 → /api/messages/<id> 가 맞다.
+grep -q 'api/messages/\$MSG_ID' "$SEND" && pass "\$BASE/api/messages/<id> 를 쓴다" \
+  || { fail "조회 경로가 틀렸다 — /api/inbox/messages 는 SPA HTML 을 200 으로 준다"; grep -n 'api/.*messages' "$SEND" | sed 's/^/    /'; }
+
 echo
 if [ $FAILED -eq 0 ]; then echo "ALL PASS — send tools honesty"; else echo "FAILED — send tools honesty"; fi
 exit $FAILED

--- a/scripts/send-tools-honesty.test.sh
+++ b/scripts/send-tools-honesty.test.sh
@@ -233,6 +233,20 @@ echo "── A2-4: --confirm 조회 경로가 올바른가 (SPA fallback 이 아
 grep -q 'api/messages/\$MSG_ID' "$SEND" && pass "\$BASE/api/messages/<id> 를 쓴다" \
   || { fail "조회 경로가 틀렸다 — /api/inbox/messages 는 SPA HTML 을 200 으로 준다"; grep -n 'api/.*messages' "$SEND" | sed 's/^/    /'; }
 
+echo "── A2-5: --confirm 이 ★expired★ 를 미배달로 본다 (실측 21건) ──"
+# expired 를 실패로 안 보면 ★가장 흔한 미배달이 '아직 판정 전' 으로 흘러★ 타임아웃만 남는다.
+EXPBIN="$TMP/ebin"; mkdir -p "$EXPBIN"
+cat > "$EXPBIN/curl" <<'STUB'
+#!/usr/bin/env bash
+for a in "$@"; do [ "$a" = "-X" ] && { printf '{"ok":true,"message":{"id":"testid","thread_id":"t","hop_count":0}}'; exit 0; }; done
+printf '{"message":{"id":"testid"},"recipients":[{"agent_id":"lisa","delivery_state":"expired","last_error":null}]}'
+STUB
+chmod +x "$EXPBIN/curl"
+out="$(PATH="$EXPBIN:$PATH" "$SEND" --to lisa --body-file "$FIX" --confirm 6 2>&1)"; rc=$?
+[ $rc -ne 0 ] && pass "expired 를 실패로 보고 (exit $rc)" || fail "expired 를 성공/보류로 흘렸다 (exit $rc)"
+grep -q "미배달" <<<"$out" && pass "미배달이라고 말한다" || fail "미배달 표현 없음: $(head -2 <<<"$out")"
+
+
 echo
 if [ $FAILED -eq 0 ]; then echo "ALL PASS — send tools honesty"; else echo "FAILED — send tools honesty"; fi
 exit $FAILED

--- a/skills/b3os-team-inbox/scripts/send.sh
+++ b/skills/b3os-team-inbox/scripts/send.sh
@@ -218,7 +218,10 @@ except Exception: print('unknown'); sys.exit(0)
 rs = d.get('recipients')
 if rs is None: print('noapi'); sys.exit(0)
 if len(rs) == 0: print('norecipient'); sys.exit(0)
-bad = [r for r in rs if r.get('delivery_state') in ('blocked', 'dead_letter')]
+# ★expired 도 미배달이다★ — 실측으로 이 상태가 21건 있었다(blocked 는 1건). expired 를 실패로
+#   보지 않으면 ★가장 흔한 미배달이 '아직 판정 전' 으로 흘러★ 타임아웃 메시지만 남는다.
+#   wake_dispatched 는 진행 중이라 pending 으로 둔다(곧 completed 가 된다).
+bad = [r for r in rs if r.get('delivery_state') in ('blocked', 'dead_letter', 'expired')]
 if bad:
     r = bad[0]
     print('failed\t' + str(r.get('delivery_state')) + '\t' + str(r.get('last_error') or '(사유 없음)'))

--- a/skills/b3os-team-inbox/scripts/send.sh
+++ b/skills/b3os-team-inbox/scripts/send.sh
@@ -194,6 +194,11 @@ else:
     sys.exit(1)
 ")
 
+# ★메시지 id 를 stdout 으로 내보낸다★ — 사용법 주석이 "stdout=메시지 id" 라고 적어놨는데 실제로는
+#   위 명령치환이 id 를 ★내부 변수로만★ 받고 stdout 에는 아무것도 안 나갔다. 실측: MSGID=$(send.sh …)
+#   가 빈 문자열이 됐다. 문서가 약속한 것을 코드가 지키지 않으면 그 문서를 믿은 쪽이 조용히 깨진다.
+printf '%s\n' "$MSG_ID"
+
 [ -z "$CONFIRM" ] && exit 0
 
 # ─── --confirm: 판정이 날 때까지 기다렸다 사실을 말한다 ────────────────────
@@ -202,7 +207,10 @@ else:
 #   (2026-07-30 실측: 차단된 메시지가 각각 그 값이었다). 그 둘을 근거로 쓰면 이 기능이 무의미해진다.
 CONF_DEADLINE=$(( $(date +%s) + CONFIRM ))
 while :; do
-  STATE_JSON=$(curl -sS "$BASE/api/inbox/messages/$MSG_ID" 2>/dev/null || echo '{}')
+  # ★경로 주의★: inbox 라우트는 api 아래 "/" 에 마운트된다(index.ts: api.route("/", inboxApi)).
+  #   그래서 올바른 경로는 $BASE/api/messages/<id> 다. "/api/inbox/messages/..." 로 쓰면 SPA fallback 이
+  #   ★HTML 을 200 으로★ 돌려주고 JSON 파싱이 깨진다 — 실측으로 그렇게 조용히 타임아웃까지 돌았다.
+  STATE_JSON=$(curl -sS "$BASE/api/messages/$MSG_ID" 2>/dev/null || echo '{}')
   VERDICT=$(STATE_JSON="$STATE_JSON" python3 -c "
 import os, json, sys
 try: d = json.loads(os.environ['STATE_JSON'])
@@ -228,7 +236,15 @@ print('pending')
     # ★빈 배열과 '아직 판정 전' 을 구분한다★: 둘을 뭉치면 수신자가 아예 안 붙은
     #   사고(진짜 문제)를 "아직 안 왔네" 로 흘린다. 빈 배열은 경고로 낸다.
     norecipient) echo "⚠ 수신자가 붙지 않았습니다 ($MSG_ID) — 배달 대상이 0명입니다. --to 값과 registry 를 확인하세요." >&2; exit 1 ;;
-    noapi) echo "⚠ 이 서버는 recipients 를 주지 않습니다 — --confirm 을 쓸 수 없습니다(서버 업데이트 필요)." >&2; exit 0 ;;
+    noapi) echo "⚠ 이 서버는 recipients 를 주지 않습니다 — --confirm 을 쓸 수 없습니다(서버 재시작 필요)." >&2; exit 0 ;;
+    # ★응답을 못 읽은 경우를 반드시 처리한다★ — 이 분기가 없어서 경로 오류(HTML 200)가 'unknown' 을
+    #   내는데 아무 case 에도 안 걸리고 ★조용히 타임아웃까지 루프★ 했다. 실측으로 그렇게 6초를 돌았고,
+    #   원인(경로 오류)은 타임아웃 메시지에 전혀 드러나지 않았다. 판정 도구가 자기 고장을
+    #   '아직 판정 전' 으로 흘리면 이 기능을 만든 이유가 없어진다.
+    unknown)
+      echo "⚠ 배달 상태를 읽지 못했습니다 ($MSG_ID) — 응답이 JSON 이 아닙니다." >&2
+      echo "  확인: curl -sS \"$BASE/api/messages/$MSG_ID\"  (HTML 이 오면 경로·서버 상태 문제입니다)" >&2
+      exit 0 ;;
   esac
   [ "$(date +%s)" -ge "$CONF_DEADLINE" ] && {
     echo "⚠ ${CONFIRM}초 안에 판정이 나지 않았습니다 ($MSG_ID) — 아직 처리 중일 수 있습니다(미배달 단정 아님)." >&2


### PR DESCRIPTION
> **작성: Jane (jane)** — 서비스 전략/기획 및 풀스택
> ※ 커밋 계정은 팀 공용이라 author 로는 담당자가 드러나지 않습니다.

## 왜 이 PR 이 있나

#142 로 추가한 `--confirm` 을 **실제로 써보니** 세 가지가 드러났습니다.
세 건 모두 단위 테스트를 통과했는데, 그 테스트가 `curl` 을 스텁으로 바꿔 **실제 HTTP 경로를 한 번도
타지 않았기** 때문입니다.

### 1. 조회 경로가 틀려 SPA HTML 을 받고 있었다

inbox 라우트는 api 아래 `"/"` 에 마운트됩니다 (`index.ts`: `api.route("/", inboxApi)`).

```bash
curl -sS "$BASE/api/inbox/messages/<id>"   # → <!doctype html> … (200!)
curl -sS "$BASE/api/messages/<id>"         # → {"message":{…},"recipients":[…]}
```

### 2. JSON 이 아닌 응답을 처리하는 분기가 없어 조용히 타임아웃까지 돌았다

1번 때문에 판정기가 `unknown` 을 내는데 `case` 에 분기가 없었습니다. 아무 안내 없이 지정한 초까지
루프하다 "판정이 나지 않았습니다(미배달 단정 아님)" 로 끝납니다. **원인이 경로 오류라는 사실이
출력에 전혀 드러나지 않습니다.**

판정 도구가 **자기 고장**을 '아직 판정 전' 으로 흘리면 이 기능의 존재 이유가 사라집니다 —
"실패를 성공으로 보고하지 않게 한다" 가 #142 의 목적이었는데, 그 도구가 같은 성질의 버그를 가졌습니다.

### 3. 사용법이 약속한 stdout 출력이 실제로 없었다

```bash
MSGID=$(send.sh --to <agent> --body-file note.md)
echo "[$MSGID]"    # → []   빈 문자열
```
주석은 `stdout=메시지 id` 라고 약속했지만 id 가 내부 변수로만 담겼습니다.
문서가 약속한 것을 코드가 지키지 않으면 **그 문서를 믿은 쪽이 조용히 깨집니다.**

---

## 검증

`scripts/send-tools-honesty.test.sh` 19건 → **22건**

| 변이 | 결과 |
|---|---|
| 경로를 `/api/inbox/messages` 로 되돌림 | **1건 실패** |
| `unknown` 분기 제거 | **2건 실패** |
| stdout id 출력 제거 | **1건 실패** |
| 원복 | 22건 통과 |

새 테스트는 **GET 에 HTML 을 돌려주는 스텁**으로 경로 오류 상황 자체를 재현하고, 경과시간까지
단정합니다(타임아웃까지 기다리면 실패). 앞선 테스트가 POST 만 스텁해 이 경로를 안 탔던 것이
1·2번을 놓친 원인입니다.

## 함께 확인한 것 (실제 실행)

`--body-file` 은 라이브에서 정상 동작합니다. 위험 문자를 담은 994자 본문을 실제로 전송해 DB 에
저장된 body 와 **문자 단위로 일치**하는 것을 확인했습니다 — 백틱 · `$(cmd)` · 홑따옴표 · `$VAR` ·
중첩 인용 모두 원문 보존, 리터럴 `\n` 도 펴지지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)