### PR TITLE
chore(release): 0.5.1 → 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team-collab",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/src/web/components/LiveBadge.ts
+++ b/src/web/components/LiveBadge.ts
@@ -5,7 +5,7 @@
 
 const LIVE_HOSTS = new Set(["dev.b3rys.com"]);
 // b3os 제품 버전. package.json version과 맞춰 관리.
-export const APP_VERSION = "0.5.1";
+export const APP_VERSION = "0.6.0";
 
 export function shouldShowLiveBadge(hostname: string): boolean {
   return LIVE_HOSTS.has(hostname);


### PR DESCRIPTION
## 핵심 3줄

1. 오늘 main 에 **15건**이 들어갔고 그중 **동작이 바뀐 것이 3건**이다 — 패치가 아니라 **minor** 다.
2. `0.5.1` → **`0.6.0`**. 버전은 `package.json` 과 `LiveBadge.ts` 두 곳에 손으로 적혀 있고, 어긋나면 깨지는 시험이 이미 있다.
3. 코드 변경 없음. 두 숫자만.

## 왜 minor 인가 — 쓰던 사람 동작이 바뀐 것

| PR | 바뀐 동작 |
|---|---|
| `#140` | `team-os` 를 인자 없이 치면 **`up` 실행 → 설명 출력** 으로 바뀐다 |
| `#143` | 설정 PUT 이 모르는 키를 **조용히 무시 → 400 거절** 로 바뀐다 |
| `#135` | 실패한 반복 잡이 **영구 정지 → 다음 슬롯 재시도(연속 3회면 정지)** 로 바뀐다 |

나머지 12건은 결함 수정·시험·문서라 동작 호환이다.

## 오늘 들어간 것 (15건)

- **스케줄러/대시보드**: `#135` 실패 잡 재예약 + 죽은 잡 표시 · `#137` 꺼둔 잡 거짓 밀림 · `#136` UTC 계약 가드 허용목록
- **기동/헬스**: `#138` 봇 동시기동 직렬화 · `#141` 락 3가지 · `#139` 미충족 감지 후 알림
- **전송 도구**: `#142` 실패를 성공으로 보고하던 3가지 · `#144` `--confirm` 자기 고장 · `#146` 타임아웃 문구
- **설정/규칙**: `#143` PUT 키 검증 · `#149` 저장 되읽기 시험 · `#148`+`#150` SHARED.md 팀 로컬화
- **UX/절차**: `#140` `team-os` 설명 · `#145` PR 작성 규칙

## 검증

- `bun test src/web/components/LiveBadge.test.ts` → **3 pass** (버전 일치 시험 포함)
- 라이브 트리 무수정(worktree 격리)
