### PR TITLE
feat(server): SHARED.md 가 없으면 시작할 때 템플릿에서 만든다 — 기존 설치본까지 덮게

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { createBunWebSocket } from "hono/bun";
 import type { ServerWebSocket } from "bun";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync, copyFileSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 import { openDb, migrate } from "./db/migrate";
@@ -140,6 +140,24 @@ try {
   const claudeIds = agents.filter((a) => a.runtime === "claude_channel").map((a) => a.id);
   const rr = renderAndRepoint(ownerRow?.value ?? null, claudeIds);
   console.log(`[teamos-render] owner='${rr.owner}' repointed=${rr.repointed.join(",") || "none"}`);
+
+  // ★팀 학습 로그도 없으면 만든다★ — TEAM-OS.md 와 같은 방식(템플릿만 track, 실사용 파일은 생성).
+  //   #148 이 rules/SHARED.md 를 추적 제외하면서, 그 커밋을 pull 한 ★기존 설치본에서 파일이 삭제★ 됐다
+  //   (채워둔 팀은 git 이 막아주지만, 템플릿 그대로였던 팀은 fast-forward 로 지워진다).
+  //   그런데 문서화된 업데이트 절차는 `git pull → build → restart` 라 ★install.sh 를 다시 돌지 않는다★ →
+  //   설치 스크립트에만 생성 로직을 두면 기존 설치본은 영영 파일이 없고, TEAM-OS 의 "교훈은 SHARED.md 로"
+  //   안내가 없는 파일을 가리킨다. 재시작은 어차피 하므로 여기서 덮는다. (steve 교차검증)
+  //   ★이미 있으면 절대 건드리지 않는다★ — 팀이 쌓아온 기록이다.
+  try {
+    const sharedPath = join(RULES_DIR, "SHARED.md");
+    const sharedTemplate = join(RULES_DIR, "SHARED.template.md");
+    if (!existsSync(sharedPath) && existsSync(sharedTemplate)) {
+      copyFileSync(sharedTemplate, sharedPath);
+      console.log("[teamos-render] rules/SHARED.md 생성(템플릿 복사) — 팀 학습 로그, 추적되지 않습니다");
+    }
+  } catch (e) {
+    console.warn("[teamos-render] SHARED.md 생성 실패(계속):", e instanceof Error ? e.message : e);
+  }
   // 공개 빌드 부팅 백필(PUBLIC_BUILD 게이트) — 공개 사용자가 git 업데이트를 pull 한 뒤 재시작하면 기존
   //   멤버도 재영입 없이 최신을 받게. 라이브(PUBLIC_BUILD=false)는 글로벌 배선/실멤버 보호로 skip.
   if (PUBLIC_BUILD) {


### PR DESCRIPTION
## 핵심 3줄

1. `#150` 은 **신규 설치만** 고쳤다 — 생성 로직이 `install.sh` 에만 있는데, 문서화된 업데이트 절차(`b3os-ops-primer §11`)는 `git pull → build → restart` 라 **install.sh 를 다시 돌지 않는다.**
2. `#148` 을 pull 한 **기존 설치본**은 `rules/SHARED.md` 가 삭제된 상태 그대로다 → `TEAM-OS.template.md:80·95` 의 안내가 **없는 파일을 가리킨다.**
3. 서버 시작 시 없으면 템플릿에서 만든다 — `rules/TEAM-OS.md` 가 이미 쓰는 방식과 같은 자리, 같은 방법.

## 무엇을 바꿨나

| 문제 | 고친 방법 |
|---|---|
| 기존 설치본은 업데이트해도 `SHARED.md` 가 안 생긴다 | 서버 시작 블록에서 없으면 템플릿 복사 (재시작은 어차피 업데이트 절차에 있다) |
| 팀이 쌓은 기록을 덮을 위험 | **이미 있으면 건드리지 않는다** |
| 복사 실패가 부팅을 막을 위험 | `try/catch` — 경고만 남기고 계속 |

`renderAndRepoint`(TEAM-OS.md 렌더) 바로 아래에 붙였다. 같은 성격(템플릿만 track, 실사용 파일은 생성)이라 한자리에 모인다.

## 검증

- 실행 확인: 파일이 없는 트리에서 서버를 띄우니 `rules/SHARED.md` 가 생성되고 로그에 `[teamos-render] rules/SHARED.md 생성(템플릿 복사)` 가 찍혔다
- `tsc` 0
- 이미 있는 경우는 `existsSync` 분기라 복사 자체가 실행되지 않는다

## 배경 (실측)

`#148` 을 pull 할 때 팀 기록이 어떻게 되는지 임시 저장소로 재현했다:

| 상태 | 결과 |
|---|---|
| 팀이 채웠고 커밋 안 함 | pull 중단 — 파일·기록 보존 |
| 템플릿 그대로 | fast-forward 되고 **파일 삭제** ← 이 PR 이 덮는 경우 |
| 로컬 커밋해 둠 | 충돌로 보존 |

데이터 손실은 git 이 막아준다. 남는 문제는 **삭제된 채로 다시 안 생기는 것**이었다.

발견 = steve(교차검증)
