### PR TITLE
fix(health): 꺼둔 멤버는 검사하지 않는다 — 반복 알림의 원인

### DIFF
--- a/src/server/workers/healthCheck.ts
+++ b/src/server/workers/healthCheck.ts
@@ -124,6 +124,12 @@ export function startHealthCheck(deps: HealthDeps): () => void {
         lastLevel.set(v.agentId, v.level);
       }
       for (const agent of agents) {
+        // ★꺼둔 멤버는 고장이 아니다★ — 사람이 내린 결정이지 사고가 아니다.
+        //   이 갈래가 없어서, 오래전에 안 쓰게 된 멤버가 ★2분마다 high 알림★ 을 냈다(2026-07-30 brief).
+        //   설정이 아예 없는 멤버는 영원히 회복되지 않으므로 ★끝나지 않는 반복★ 이 된다.
+        //   registry 는 disabled 멤버도 목록에 남긴다(ambientAgents: enabled = a.enabled !== false)
+        //   → 여기서 명시적으로 건너뛰지 않으면 검사 대상에 그대로 들어온다.
+        if (agent.enabled === false) continue;
         const essentials = await checkEssentialSettings(agent);
         const key = essentials.ok ? "ok" : JSON.stringify({ runtime: agent.runtime, missing: essentials.missing });
         const prevKey = lastEssentialsKey.get(agent.id);


### PR DESCRIPTION
## 핵심 3줄

1. `#139` 헬스 알림이 **꺼둔 멤버까지 검사**한다 — 오늘 `brief` 가 **2분마다** high 알림을 냈다(코디네이터에게).
2. `brief` 는 openclaw 텔레그램 계정이 **애초에 없고** 마지막 발신이 **2026-05-20** 이다. 설정 부재라 **영원히 회복되지 않는다** → 끝나지 않는 반복.
3. 검사 루프에서 `enabled === false` 인 멤버를 건너뛴다. 한 줄.

## 무엇을 바꿨나

| 문제 | 고친 방법 |
|---|---|
| registry 가 disabled 멤버도 목록에 남기는데(`ambientAgents`: `enabled = a.enabled !== false`) 검사 루프에 필터가 없다 | 루프 첫 줄에서 `agent.enabled === false` 면 `continue` |

**꺼둔 멤버는 고장이 아니다** — 사람이 내린 결정이지 사고가 아니다.

## 왜 이 크기인가

근본은 "설정 부재와 생존 실패를 구분하지 못하는 것" 이지만, 그건 분류 체계 작업이다.
지금 실제로 일어나는 피해는 **꺼둔 멤버 하나가 반복 알림을 내는 것** 이고, 그건 이 한 줄로 멈춘다.
분류 개선은 필요하다는 증거가 더 모이면 그때 한다.

## 검증

- `tsc` 0 · `bun test src/server/workers/` **97 pass 0 fail**
- 워커 루프 자체를 도는 시험은 없다 — **이 갈래에 대한 직접 시험은 없다**(가드가 한 줄 조건이라 코드로 확인)
- 실동작 확인 방법: 배포 후 `brief` 를 disabled 로 두고 알림이 멎는지 본다

Submitted-by: bill
