### PR TITLE
fix(team-os): 세션이 살아있어도 봇이 안 들릴 수 있다 — up·doctor 가 그걸 못 본다

### DIFF
--- a/scripts/team-os
+++ b/scripts/team-os
@@ -108,19 +108,123 @@ member_of() {
 
 tmux_session_up() { tmux has-session -t "$1" 2>/dev/null; }
 
+# 런처 경로를 plist 에서 읽는다 — 여기 하드코딩하면 정본(launcher.ts CLAUDE_START_SCRIPT)과
+#   조용히 갈라진다. plist 가 실제로 부르는 것이 진실이다.
+member_script() { plist_val "$1" ProgramArguments:0; }
+
+# ─── 팀원 poller 판정 ──────────────────────────────────────────────────────
+# ★tmux 세션이 있는 것과 봇이 들리는 것은 다르다.★ 2026-07-30 실측: 리사 세션은 08:03:33 에
+#   정상 생성됐는데 poller(MCP 텔레그램 서버)가 링크 경합으로 죽어 bot.pid 가 없었다. 08:31 까지
+#   28분간 텔레그램을 한 통도 못 받았는데, 세션만 보면 ★정상★ 이다. 팀장님이 사람 손으로
+#   "리사가 응답이 없어" 라고 알려줘야 발견됐다. 세션만 보는 판정은 그 28분을 정상이라고 말한다.
+#
+# 판정 의미는 ★정본과 같아야 한다★ — src/server/lib/runtimeEssentials.ts 의 claude 분기:
+#     marker = readPidMarker(botPid);  marker == null        -> "poller:claude bot.pid"
+#                                      !pidAlive(marker.pid) -> "poller:claude bot.pid not alive"
+#   즉 (bot.pid 없음) OR (pid 죽음) => unhealthy. 여기 셸 구현이 그 의미를 재현한다.
+#   ※ 왜 재구현하나: 이 도구는 ★서버가 죽었을 때★ 쓴다. 서버 API 를 부를 수 없어 셸로 다시 짤 수밖에
+#     없다. 그래서 드리프트가 구조적으로 남는다 — scripts/team-os-poller.test.sh 가 두 판정이 같은
+#     케이스 표에서 같은 답을 내는지 못박는다. 한쪽만 고치면 그 테스트가 빨개진다.
+#   bot.pid 형식은 정본과 같이 두 가지를 받는다: 평문 정수, 또는 {"pid":123,...} JSON.
+poller_healthy() {  # poller_healthy <팀원이름>
+  local f raw pid
+  f="$HOME/.claude/channels/telegram-$1/bot.pid"
+  [ -f "$f" ] || return 1
+  raw="$(tr -d '[:space:]' < "$f" 2>/dev/null)"
+  [ -n "$raw" ] || return 1
+  case "$raw" in
+    [0-9]*) pid="$raw" ;;
+    *) pid="$(printf '%s' "$raw" | sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9]\{1,\}\).*/\1/p')" ;;
+  esac
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$pid" -gt 0 ] 2>/dev/null || return 1
+  kill -0 "$pid" 2>/dev/null   # 죽은 pid = unhealthy (정본 'not alive' 와 같은 의미)
+}
+
 # 지금 실제로 살아 있나. 서비스 종류마다 답이 다르다.
-#   런처 계열 = tmux 세션이 있나          (launchd 는 exit 0 인 채로 남는다)
+#   런처 계열 = tmux 세션이 있나 ★그리고 poller 가 들리나★  (launchd 는 exit 0 인 채로 남는다)
 #   상주 계열 = state = running 인가
 # ★last exit code 0 은 과거 사실이다.★ 그걸로 판정하면 tmux 가 죽은 뒤에도 정상으로 보인다 —
 #   이 도구가 잡으라고 만들어진 바로 그 상황을 놓친다. (codex 지적, 실제로 그렇게 짰다가 고침)
+# ★같은 함정이 한 겹 안쪽에 또 있었다★: tmux 세션 존재도 '과거 사실' 에 가깝다 — 세션은 살아있는데
+#   그 안의 poller 만 죽는 조합이 실제로 났다(위 poller_healthy 주석). 그래서 둘 다 본다.
 service_healthy() {  # service_healthy <라벨> <plist>
   local m
   m="$(member_of "$2")"
   if [ -n "$m" ]; then
-    tmux_session_up "claude-$m"
+    tmux_session_up "claude-$m" || return 1
+    poller_healthy "$m"
     return $?
   fi
   launchctl print "gui/$(id -u)/$1" 2>/dev/null | grep -q "state = running"
+}
+
+# ─── 파괴적 복구 앞의 확인 단계 ───────────────────────────────────────────
+# ★수정 전에는 오판정이 무해했다. 수정 후에는 살아있는 세션을 죽인다.★ (리사 지적, 2026-07-30)
+#   전: 건강한 멤버를 unhealthy 로 잘못 봐도 kickstart 가 런처 가드에 no-op 되니 아무 일도 없었다.
+#   후: 복구가 --force 를 실으니 런처가 기존 세션을 kill 한다 → 오판정 1건 = 일하던 팀원 강제 종료.
+#   그리고 up 은 ★부팅 직후★ 에 쓰는 도구라, 아직 bot.pid 를 안 쓴 정상 기동 중인 멤버가 정확히
+#   그 오판정 대상이다 — 2026-07-30 08:03:37 에 jane 이 같은 항목으로 잡혔고 34초 뒤 스스로 회복했다.
+#   그 34초 창에 up 을 돌렸으면 멀쩡한 세션을 죽였다.
+# 그래서 두 겹으로 막는다:
+#   ① 세션이 갓 떴으면(기본 90초 이내) 복구하지 않는다 — '기동 중' 으로 보고만 한다. 오탐 인구가
+#      정확히 여기 몰려 있고, 이 게이트는 도구를 느리게 하지 않는다.
+#   ② 그래도 복구로 내려갈 때는 간격을 두고 재확인한다. 그 사이 poller 가 뜨면 자동 탈락한다.
+#      (#132 의 STALE_CONFIRM 과 같은 원리 — 한 번 본 상태로 남의 것을 없애지 않는다)
+POLLER_BOOT_GRACE="${TEAMOS_POLLER_BOOT_GRACE:-90}"   # 세션 나이가 이 안이면 '기동 중'
+POLLER_CONFIRM_TRIES="${TEAMOS_POLLER_CONFIRM_TRIES:-3}"
+POLLER_CONFIRM_GAP="${TEAMOS_POLLER_CONFIRM_GAP:-3}"
+
+session_age_sec() {  # session_age_sec <세션이름> — 못 구하면 빈 문자열
+  local c now
+  c="$(tmux display-message -p -t "$1" '#{session_created}' 2>/dev/null)"
+  case "$c" in ''|*[!0-9]*) printf '' ; return ;; esac
+  now="$(date +%s)"
+  printf '%s' "$(( now - c ))"
+}
+
+# 갓 뜬 세션인가 (= 아직 poller 를 쓸 시간이 없었을 수 있다)
+member_booting() {  # member_booting <팀원이름>
+  local age
+  age="$(session_age_sec "claude-$1")"
+  [ -n "$age" ] || return 1
+  [ "$age" -lt "$POLLER_BOOT_GRACE" ]
+}
+
+# 복구해도 되는가 — 간격을 두고 재확인해서 그 사이 살아나면 복구하지 않는다.
+poller_dead_confirmed() {  # poller_dead_confirmed <팀원이름>
+  local i=1
+  while [ "$i" -le "$POLLER_CONFIRM_TRIES" ]; do
+    poller_healthy "$1" && return 1     # 그 사이 떴다 → 복구 불필요
+    [ "$i" -lt "$POLLER_CONFIRM_TRIES" ] && sleep "$POLLER_CONFIRM_GAP"
+    i=$(( i + 1 ))
+  done
+  return 0
+}
+
+# ─── 팀원 복구 ────────────────────────────────────────────────────────────
+# ★launchctl kickstart 로는 이 상태를 복구할 수 없다.★ kickstart 는 plist 의 ProgramArguments 를
+#   그대로 다시 실행하는데 그 인자에 --force 가 없다. 그러면 런처의 idempotent 가드
+#   ("Session already running" -> exit 0)에 걸려 ★no-op★ 이 된다. 세션은 살아있고 poller 만
+#   죽은 상태가 정확히 그 케이스다 — 2026-07-30 08:28 에 실제로 kickstart 로 복구를 시도했다가
+#   이 가드에 걸려 아무 일도 일어나지 않았고, 사람이 --force 를 붙여야 끝났다.
+#   그래서 런처를 직접 부른다. env 는 plist 에서 읽어 kickstart 와 같은 환경을 준다.
+# ★--resume 를 --force 와 반드시 같이 싣는다★ (리사 지적): --force 만 실으면 세션을 죽이고 fresh 로
+#   띄워서 ★그 멤버의 작업 컨텍스트가 사라진다.★ 복구 도구가 작업 기억을 날리면 안 된다.
+#   정본도 같은 조합이다 — agentControl.restartAgent 는 fresh=false 에서 [id, --resume] 이고
+#   #133 이 여기에 --force 를 더해 [id, --resume, --force] 로 만든다. 여기도 같아야 한다.
+member_restart() {  # member_restart <plist> <팀원이름>
+  local sc _path _wd _b3
+  sc="$(member_script "$1")"
+  [ -n "$sc" ] && [ -f "$sc" ] || return 1
+  _path="$(plist_val "$1" EnvironmentVariables:PATH)"
+  _wd="$(plist_val "$1" EnvironmentVariables:WORKDIR)"
+  _b3="$(plist_val "$1" EnvironmentVariables:B3RYS_HOME)"
+  env HOME="$HOME" \
+      ${_path:+PATH="$_path"} \
+      ${_wd:+WORKDIR="$_wd"} \
+      ${_b3:+B3RYS_HOME="$_b3"} \
+      bash "$sc" "$2" --resume --force >/dev/null 2>&1
 }
 
 alive() { [ "$(curl -s -o /dev/null -m 3 -w '%{http_code}' "$URL" 2>/dev/null || echo 000)" = "200" ]; }
@@ -174,6 +278,11 @@ USAGE
 #   그때 설명 대신 기동이 시작되고 20초를 기다린다. 설명을 기대한 자리에서 시스템이 바뀌는 것은
 #   ★놀람★ 이고, 공개 사용자에게는 그게 첫인상이다.
 #   설명을 본 것은 잘못이 아니므로 exit 0 이다(모르는 명령을 친 경우만 exit 1).
+# ★판정 함수만 가져다 쓸 수 있게 한다★ — 이 아래는 서브커맨드 실행이라 source 하면 같이 돈다.
+#   드리프트 가드 테스트(pollerHealthDrift.test.ts)가 poller_healthy 를 정본과 대조하려면
+#   부작용 없이 함수만 로드해야 한다. 테스트가 못 부르는 판정은 조용히 갈라진다.
+[ -n "${TEAMOS_LIB_ONLY:-}" ] && return 0
+
 case "${1:-help}" in
   help|-h|--help)
     usage
@@ -192,12 +301,40 @@ case "${1:-help}" in
       fi
       if loaded "$_lbl"; then
         # 등록돼 있다고 살아 있는 건 아니다. 실제 상태를 보고 죽었으면 다시 올린다.
-        #   런처는 자기 안에 '이미 떠 있으면 아무것도 안 한다' 가드가 있어 다시 불러도 안전하다.
+        # ★런처의 '이미 떠 있으면 아무것도 안 한다' 가드를 안전장치로 믿으면 안 된다★ — 그 가드는
+        #   이미 건강한 경우엔 안전하지만, up 이 복구하려는 바로 그 케이스(세션 살아있고 poller 죽음)
+        #   에서는 그 '안전' 이 ★아무것도 안 함★ 이다. 그래서 복구는 --resume --force 로 런처를
+        #   직접 부른다(member_restart). 여기 kickstart 를 다시 넣으면 복구가 조용히 no-op 이 된다.
         if service_healthy "$_lbl" "$_plist"; then
           echo "  · $_lbl (정상)"
-        else
-          launchctl kickstart -k "gui/$(id -u)/$_lbl" >/dev/null 2>&1
+          continue
+        fi
+        _m="$(member_of "$_plist")"
+        if [ -n "$_m" ]; then
+          # 갓 뜬 세션은 건드리지 않는다 — 아직 poller 를 쓸 시간이 없었을 수 있다(오탐 인구).
+          if member_booting "$_m"; then
+            echo "  · $_lbl (기동 중 — poller 대기, 건드리지 않음)"
+            continue
+          fi
+          if ! poller_dead_confirmed "$_m"; then
+            echo "  · $_lbl (확인 중 살아남 — 복구 불필요)"
+            continue
+          fi
+          if member_restart "$_plist" "$_m" && service_healthy "$_lbl" "$_plist"; then
+            echo "  → $_lbl 다시 올림 ✓"
+          else
+            # ★복구했다고 거짓말하지 않는다.★ 확인해서 안 살아났으면 그렇게 말한다.
+            echo "  ✗ $_lbl 복구 실패 — 수동 확인 필요: $(member_script "$_plist") $_m --resume --force"
+            FAILED="$FAILED $_lbl"
+          fi
+          continue
+        fi
+        # 상주 서비스는 kickstart 가 맞다(런처 가드 문제가 없다).
+        if launchctl kickstart -k "gui/$(id -u)/$_lbl" >/dev/null 2>&1; then
           echo "  → $_lbl 다시 올림"
+        else
+          echo "  ✗ $_lbl 다시 올리기 실패"
+          FAILED="$FAILED $_lbl"
         fi
         continue
       fi

--- a/scripts/team-os-poller.test.sh
+++ b/scripts/team-os-poller.test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# team-os 의 팀원 poller 판정·복구 인수테스트.
+#
+# 무엇을 막나 (2026-07-30 실측 사고):
+#   리사 tmux 세션은 08:03:33 에 정상 생성됐는데 poller 가 죽어 bot.pid 가 없었다. 28분간
+#   텔레그램을 한 통도 못 받았는데 세션만 보면 정상이다. team-os 는 세션만 봤으므로
+#   그 28분 동안 "리사 정상" 이라고 말했다.
+#
+# ★양방향을 다 본다★ — 한쪽만 보면 다음 사람이 반대쪽을 최적화로 걷어낸다:
+#   T1 세션 살아있고 bot.pid 없음        -> unhealthy 로 봐야 한다 (D1)
+#   T2 세션 살아있고 bot.pid 살아있음    -> healthy, ★세션을 죽이지 않아야 한다★ (오판정 = 강제종료)
+#   T3 갓 뜬 세션 + bot.pid 없음         -> '기동 중' 으로 건드리지 않아야 한다 (부팅 오탐)
+#   T4 복구 인자에 --resume --force 가   -> 둘 다 실려야 한다 (--force 만이면 컨텍스트 소실,
+#      실리나                               --resume 만이면 런처 가드에 no-op)
+#
+# FS 격리: HOME 을 mktemp 로 갈고 tmux 세션명에 PID 를 붙인다. 실제 ~/.claude·팀원 세션 무접촉.
+# 실행: scripts/team-os-poller.test.sh   (0=통과, 1=실패)
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+SCRIPT="$HERE/team-os"
+[ -x "$SCRIPT" ] || { echo "FAIL: $SCRIPT 없음/실행권한 없음"; exit 1; }
+
+FAILED=0
+pass() { echo "  ✓ $1"; }
+fail() { echo "  ✗ $1"; FAILED=1; }
+
+TMPROOT="$(mktemp -d)"
+NAME="pollertest$$"
+SESSION="claude-$NAME"
+
+cleanup() {
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  rm -rf "$TMPROOT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+STATE="$TMPROOT/home/.claude/channels/telegram-$NAME"
+mkdir -p "$STATE"
+
+# 판정 함수만 로드해서 부른다. TEAM_OS_REPO 를 줘야 한다 — source 하면 $0 이 스크립트 경로가
+#   아니라서 저장소 자동탐색이 실패하고 함수 정의 전에 exit 1 한다(그러면 전부 unhealthy 로 보인다).
+judge() {  # judge -> 0=healthy 1=unhealthy
+  HOME="$TMPROOT/home" TEAM_OS_REPO="$REPO" \
+    bash -c 'TEAMOS_LIB_ONLY=1 . "$1" >/dev/null 2>&1; poller_healthy "$2"' _ "$SCRIPT" "$NAME"
+}
+booting() {
+  HOME="$TMPROOT/home" TEAM_OS_REPO="$REPO" \
+    bash -c 'TEAMOS_LIB_ONLY=1 . "$1" >/dev/null 2>&1; member_booting "$2"' _ "$SCRIPT" "$NAME"
+}
+
+# 로딩 가드 — 이게 깨지면 아래 unhealthy 단정들이 전부 거짓 통과한다.
+if HOME="$TMPROOT/home" TEAM_OS_REPO="$REPO" \
+     bash -c 'TEAMOS_LIB_ONLY=1 . "$1" >/dev/null 2>&1; type poller_healthy >/dev/null 2>&1' _ "$SCRIPT"; then
+  pass "판정 함수 로드됨 (크래시가 unhealthy 로 위장하지 않는다)"
+else
+  fail "판정 함수를 로드하지 못했다 — 이후 단정은 신뢰할 수 없다"
+  echo "FAILED — team-os poller"; exit 1
+fi
+
+echo "── T1: 세션 살아있고 bot.pid 없음 → unhealthy (2026-07-30 리사 상태) ──"
+tmux new-session -d -s "$SESSION" -c "$TMPROOT" "sleep 300" 2>/dev/null
+rm -f "$STATE/bot.pid"
+tmux has-session -t "$SESSION" 2>/dev/null \
+  && pass "세션은 살아있다 (사고 상황 재현)" || fail "세션 생성 실패"
+judge && fail "★세션만 보고 healthy 라고 했다 — 사고 재현★" || pass "unhealthy 로 판정"
+
+echo "── T2: 세션 살아있고 bot.pid 살아있음 → healthy (★세션을 죽이면 안 된다★) ──"
+echo $$ > "$STATE/bot.pid"      # 이 테스트 프로세스 = 확실히 살아있는 pid
+judge && pass "healthy 로 판정" || fail "살아있는 poller 를 unhealthy 로 봤다 (오판정 = 강제종료 위험)"
+tmux has-session -t "$SESSION" 2>/dev/null \
+  && pass "판정이 세션을 건드리지 않았다" || fail "판정 중 세션이 죽었다"
+
+echo "── T3: 죽은 pid → unhealthy ──"
+echo "999999" > "$STATE/bot.pid"
+judge && fail "죽은 pid 를 healthy 라고 했다" || pass "죽은 pid = unhealthy (정본 'not alive' 와 동일)"
+
+echo "── T4: 갓 뜬 세션은 '기동 중' 으로 보호된다 (부팅 오탐 방지) ──"
+# 방금 만든 세션이므로 나이가 유예(기본 90초) 안이다.
+rm -f "$STATE/bot.pid"
+booting && pass "갓 뜬 세션을 '기동 중' 으로 인식 (복구로 안 내려간다)" \
+        || fail "갓 뜬 세션을 즉시 복구 대상으로 봤다 — 정상 기동 중인 멤버를 죽인다"
+# 유예를 0 으로 주면 더 이상 보호하지 않아야 한다(게이트가 실제로 값에 반응하는지)
+if HOME="$TMPROOT/home" TEAM_OS_REPO="$REPO" TEAMOS_POLLER_BOOT_GRACE=0 \
+     bash -c 'TEAMOS_LIB_ONLY=1 . "$1" >/dev/null 2>&1; member_booting "$2"' _ "$SCRIPT" "$NAME"; then
+  fail "유예 0 인데도 '기동 중' 이라고 했다 (게이트가 값에 반응하지 않는다)"
+else
+  pass "유예 0 이면 보호하지 않는다 (게이트가 값에 반응한다)"
+fi
+
+echo "── T5: 복구 인자에 --resume 와 --force 가 둘 다 실린다 ──"
+# --force 만이면 fresh 로 떠서 멤버 컨텍스트가 사라진다. --resume 만이면 런처 가드에 no-op 이다.
+if grep -qE '"\$sc" "\$2" --resume --force' "$SCRIPT"; then
+  pass "member_restart 가 --resume --force 를 함께 싣는다"
+else
+  fail "복구 인자가 --resume --force 조합이 아니다"
+  grep -nE 'bash "\$sc"' "$SCRIPT" | sed 's/^/    /'
+fi
+# 팀원 복구가 member_restart 를 타는지, 그리고 실행 코드의 kickstart 가 상주 서비스용 1곳만인지.
+#   ★주석을 세면 안 된다★ — 이 파일 주석에 'kickstart' 가 설명으로 여러 번 나온다(왜 안 쓰는지가
+#   기록이므로 지우면 안 된다). 그래서 주석을 지운 뒤 ★실행 코드만★ 센다.
+_exec_only="$(sed 's/#.*//' "$SCRIPT")"
+if grep -q 'member_restart "\$_plist" "\$_m"' <<<"$_exec_only"; then
+  pass "팀원 복구가 member_restart 를 탄다"
+else
+  fail "팀원 복구가 member_restart 를 타지 않는다"
+fi
+_kick="$(grep -c 'kickstart' <<<"$_exec_only")"
+if [ "$_kick" -eq 1 ]; then
+  pass "실행 코드의 kickstart 는 1곳(상주 서비스용)뿐이다"
+else
+  fail "실행 코드에 kickstart 가 ${_kick}곳 — 팀원 복구에 남아있으면 런처 가드에 no-op 된다"
+  grep -n 'kickstart' <<<"$_exec_only" | sed 's/^/    /'
+fi
+
+echo
+if [ $FAILED -eq 0 ]; then echo "ALL PASS — team-os poller"; else echo "FAILED — team-os poller"; fi
+exit $FAILED

--- a/src/server/lib/pollerHealthDrift.test.ts
+++ b/src/server/lib/pollerHealthDrift.test.ts
@@ -1,0 +1,132 @@
+// ★드리프트 가드★ — scripts/team-os 의 셸 poller 판정이 정본(runtimeEssentials.ts)과 같은 답을 내나.
+//
+// 왜 두 곳에 같은 판정이 있나:
+//   team-os 는 ★서버가 죽었을 때★ 쓰는 복구 도구다. 서버 API 를 부를 수 없으니 셸로 다시 짤 수밖에
+//   없다. 그래서 드리프트가 ★구조적으로★ 남는다 — 한쪽만 고치면 헬스 도구가 조용히 갈라진다.
+//   조용히 갈라진 헬스 도구는 없는 것보다 나쁘다(정상이라고 거짓말하므로).
+//   이 테스트가 두 판정을 같은 케이스 표에 태워 답이 같은지 못박는다. (리사 요구 #3, 2026-07-30)
+//
+// 실제 사고: 2026-07-30 리사 세션은 살아있는데 poller 가 죽어 28분 무응답. 정본은 그 상태를
+//   unhealthy 로 판정했지만(runtime_essentials_missing 기록됨) team-os 는 tmux 세션만 보고
+//   healthy 라고 했다. 도구가 정본보다 느슨했다.
+import { describe, test, expect } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkEssentialSettings, createRuntimeEssentialsRegistry } from "./runtimeEssentials";
+import type { AgentRecord } from "../types";
+
+const TEAM_OS = join(import.meta.dir, "../../../scripts/team-os");
+const NAME = "drifttest";
+
+/** 살아있는 pid — 이 테스트 프로세스 자신. 죽은 pid — 쓰이지 않을 큰 값. */
+const ALIVE_PID = process.pid;
+const DEAD_PID = 999_999;
+
+interface Case {
+  label: string;
+  /** bot.pid 파일 내용. null 이면 파일을 만들지 않는다. */
+  content: string | null;
+  expectHealthy: boolean;
+}
+
+const CASES: Case[] = [
+  { label: "bot.pid 없음 (2026-07-30 리사 상태)", content: null, expectHealthy: false },
+  { label: "빈 파일", content: "", expectHealthy: false },
+  { label: "공백만", content: "   \n", expectHealthy: false },
+  { label: "평문 pid, 살아있음", content: String(ALIVE_PID), expectHealthy: true },
+  { label: "평문 pid, 죽음", content: String(DEAD_PID), expectHealthy: false },
+  { label: "평문 pid + 개행, 살아있음", content: `${ALIVE_PID}\n`, expectHealthy: true },
+  { label: "JSON pid, 살아있음", content: JSON.stringify({ pid: ALIVE_PID, agentId: NAME }), expectHealthy: true },
+  { label: "JSON pid, 죽음", content: JSON.stringify({ pid: DEAD_PID, agentId: NAME }), expectHealthy: false },
+  { label: "쓰레기 값", content: "not-a-pid", expectHealthy: false },
+  { label: "pid 0", content: "0", expectHealthy: false },
+  { label: "음수 pid", content: "-1", expectHealthy: false },
+];
+
+/** 격리된 가짜 HOME 에 bot.pid 상태를 만든다. 실제 ~/.claude 는 건드리지 않는다. */
+function makeHome(content: string | null): string {
+  const home = mkdtempSync(join(tmpdir(), "pollerdrift-"));
+  const stateDir = join(home, ".claude", "channels", `telegram-${NAME}`);
+  mkdirSync(stateDir, { recursive: true });
+  if (content !== null) writeFileSync(join(stateDir, "bot.pid"), content);
+  return home;
+}
+
+const REPO_ROOT = join(import.meta.dir, "../../..");
+
+/** 셸 판정 — team-os 의 poller_healthy 를 함수만 로드해서 부른다(서브커맨드 실행 없음).
+ *  ★TEAM_OS_REPO 를 반드시 준다★: source 하면 $0 이 스크립트 경로가 아니라 셸의 $0 이라서
+ *  team-os 의 저장소 자동탐색이 실패하고 ★함수를 정의하기 전에 exit 1★ 한다. 그러면 이 함수가
+ *  항상 false 를 리턴해서 "unhealthy" 로 보인다 — 즉 ★판정을 안 부르고도 unhealthy 케이스가
+ *  전부 통과한다.★ 실제로 그렇게 짰다가 9건이 거짓 통과했고, healthy 케이스 3건만 빨개져서
+ *  겨우 알았다. 그래서 아래 loadsOk() 로 로딩 자체를 따로 단정한다. */
+function shellVerdict(home: string): boolean {
+  const r = spawnSync(
+    "bash",
+    ["-c", `TEAMOS_LIB_ONLY=1 . "$1" >/dev/null 2>&1; poller_healthy "$2"`, "_", TEAM_OS, NAME],
+    { env: { ...process.env, HOME: home, TEAM_OS_REPO: REPO_ROOT }, encoding: "utf8" },
+  );
+  return r.status === 0;
+}
+
+/** 셸 함수가 실제로 로드됐나 — 크래시가 'unhealthy' 로 위장하는 것을 막는 가드. */
+function loadsOk(home: string): boolean {
+  const r = spawnSync(
+    "bash",
+    ["-c", `TEAMOS_LIB_ONLY=1 . "$1" >/dev/null 2>&1; type poller_healthy >/dev/null 2>&1`, "_", TEAM_OS],
+    { env: { ...process.env, HOME: home, TEAM_OS_REPO: REPO_ROOT }, encoding: "utf8" },
+  );
+  return r.status === 0;
+}
+
+/** 정본 판정 — claude_channel 분기의 poller 항목만 본다.
+ *  ★deps 는 registry 로 주입한다★ — checkEssentialSettings 의 2번째 인자는 deps 가 아니라 registry 다.
+ *  거기에 {home} 을 넘기면 registry["claude_channel"] 이 undefined 라서 ★조용히 okResult()★ 가 나온다
+ *  (= 전부 healthy). 실제로 그렇게 짰다가 12건 전부 통과해버렸다 — 판정을 안 부르고 초록이 된 것이다. */
+async function canonicalVerdict(home: string): Promise<boolean> {
+  const agent = { id: NAME, runtime: "claude_channel" } as unknown as AgentRecord;
+  const registry = createRuntimeEssentialsRegistry({ home });
+  const res = await checkEssentialSettings(agent, registry);
+  return !res.missing.some((m) => m.startsWith("poller:claude bot.pid"));
+}
+
+describe("poller 판정 — 셸(team-os)과 정본(runtimeEssentials)이 갈라지지 않는다", () => {
+  // ★이 단정을 먼저 둔다★ — 셸 로딩이 깨지면 아래 unhealthy 케이스들이 전부 거짓 통과한다.
+  test("셸 판정 함수가 실제로 로드된다 (크래시가 unhealthy 로 위장하지 못하게)", () => {
+    const home = makeHome(null);
+    try {
+      expect(loadsOk(home)).toBe(true);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  for (const c of CASES) {
+    test(`${c.label} → ${c.expectHealthy ? "healthy" : "unhealthy"} (양쪽 동일)`, async () => {
+      const home = makeHome(c.content);
+      try {
+        const shell = shellVerdict(home);
+        const canon = await canonicalVerdict(home);
+        // ① 기대값과 맞나
+        expect(shell).toBe(c.expectHealthy);
+        expect(canon).toBe(c.expectHealthy);
+        // ② ★서로 같나★ — 이게 드리프트 가드의 본체다
+        expect(shell).toBe(canon);
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+    });
+  }
+
+  test("★핵심 케이스: bot.pid 만 없으면 양쪽 다 unhealthy★ (세션 존재와 무관하게)", async () => {
+    const home = makeHome(null);
+    try {
+      expect(shellVerdict(home)).toBe(false);
+      expect(await canonicalVerdict(home)).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## 핵심 3줄

1. `team-os up`·`doctor` 가 claude 팀원을 **tmux 세션 존재만으로** 판정한다 — 세션은 살아있고 봇이 안 들리는 상태를 **정상이라고 답한다.**
2. 그 상태는 **실측 17회** 발생했다(`runtime_essentials_missing`). 한 번은 팀원이 **28분간** 메시지를 받지 못했고, 그때 이 도구를 돌렸다면 "정상" 이라고 답했다. 영향: 부팅 후 복구가 필요한 모든 사용자.
3. 판정에 `bot.pid` 존재+생존을 추가하고, 복구를 no-op 이 아닌 경로로 바꿨다 — **실코드 80줄** + 테스트 2종.

## 무엇을 바꿨나

| 문제 | 고친 방법 |
|---|---|
| `service_healthy` 가 세션만 본다 (`bot.pid` 검사 0건) | poller 판정 추가 — `bot.pid` 없음 **또는** pid 미생존 → unhealthy |
| 복구가 `launchctl kickstart` → plist 인자에 `--force` 가 없어 런처 가드에 **no-op** | 런처를 `--resume --force` 로 직접 호출 |
| 복구 후 확인 없이 "다시 올림" 출력 | 복구 후 재판정 — 안 살아났으면 **실패로 보고** |
| 판정이 정본(`runtimeEssentials.ts`)보다 느슨 — 조용히 갈라질 수 있다 | 두 판정을 같은 케이스 표로 대조하는 드리프트 가드 |
| (수정이 만드는 새 위험) 오판정 1건 = 살아있는 세션 강제 종료 | 갓 뜬 세션 유예(90초) · 간격 재확인 · `--resume` 로 컨텍스트 보존 |

---

## 실측 근거

```
grep -c 'bot\.pid' scripts/team-os            → 0     (판정에 poller 검사가 없다)
service_healthy(): tmux_session_up "claude-$m" 만 보고 return
복구 경로: launchctl kickstart -k … → echo "다시 올림"   (--force 없음)
audit_event: runtime_essentials_missing 17회 (07-26 ~ 07-30)
```

정본은 이미 제대로 한다 — `runtimeEssentials.ts` 는 pid 마커를 읽고 `pidAlive` 까지 본다.
**도구가 정본보다 느슨했다.**

`kickstart` 가 왜 no-op 인가: plist `ProgramArguments` 는 `[런처, <이름>]` 이고 `--force` 가 없다.
런처의 idempotent 가드(`Session already running` → `exit 0`)에 걸린다. 세션은 살아있고 poller 만
죽은 상태가 **정확히 그 케이스**다.

## 왜 이 크기인가

`service_healthy` 한 줄만 고치면 **상태가 더 나빠진다.** 판정이 unhealthy 로 바뀌어 복구 경로로
내려가고, `up` 이 "다시 올림" 을 출력하면서 실제로는 아무것도 복구하지 않는다.
지금은 "정상" 이라고 잘못 말하고, 판정만 고치면 **"복구했다" 고 잘못 말한다.**
그래서 판정·복구·확인 세 곳이 한 묶음이다.

오판정 비용도 함께 바뀐다. 지금은 복구가 no-op 이라 오판정이 무해하지만, 복구가 실제로 동작하면
**오판정 1건 = 일하던 팀원 세션 강제 종료**다. `up` 은 부팅 직후에 쓰는 도구라 아직 `bot.pid` 를
쓰지 않은 정상 기동 중인 멤버가 정확히 그 대상이다(실측: 34초 뒤 스스로 회복한 사례). 그래서
유예·재확인·`--resume` 을 같이 넣었다.

## 검증

| 테스트 | 내용 |
|---|---|
| `scripts/team-os-poller.test.sh` (11건) | 양방향 — 세션+`bot.pid`없음 → unhealthy / 세션+살아있는 pid → healthy **세션이 죽지 않는다** / 죽은 pid → unhealthy / 갓 뜬 세션 보호 / 복구 인자 `--resume --force` |
| `src/server/lib/pollerHealthDrift.test.ts` (13건) | 셸 판정과 정본을 **같은 11개 케이스 표**로 대조 |

전체 스위트 **1981 pass / 4 fail** — 4건은 `teamRouter.llm.test.ts`(로컬 LLM 미기동)이며 이 변경과
무관하다(clean main 동일). typecheck 통과.
`scripts/claude-start-stagger.test.sh`(#141 로 갱신된 락 테스트)도 통과 — 리베이스가 그쪽을 깨지 않았다.

## 뮤턴트

| 변이 | 결과 |
|---|---|
| 셸 poller 판정을 `return 0`(항상 healthy)으로 | 드리프트 가드 **8건 실패** |

FS 격리: `HOME` 을 `mktemp` 로 갈고 `claude` 는 stub. 실제 설정 무접촉. tmux 세션명에 PID 부여 후 정리.

Submitted-by: Jane

