### PR TITLE
fix(team-os): 세션이 아직 없는 기동 창도 보호한다 — 유예가 재는 시작점이 달랐다

### DIFF
--- a/scripts/team-os
+++ b/scripts/team-os
@@ -184,10 +184,27 @@ session_age_sec() {  # session_age_sec <세션이름> — 못 구하면 빈 문�
 }
 
 # 갓 뜬 세션인가 (= 아직 poller 를 쓸 시간이 없었을 수 있다)
+# ★세션이 '아직 없는' 창도 기동 중이다★ (steve 교차검증, 2026-07-30)
+#   유예는 세션 생성 시각부터 잰다. 그런데 ★위험한 창은 세션이 생기기 전에 시작된다.★
+#   부팅 때 launchd 가 claude 멤버를 동시에 띄우면 런처가 스폰 mutex 로 직렬화하고,
+#   대기 상한은 (멤버수-1)×SETTLE+20 이다 — 우리 기계 5명 기준 ★최대 120초★.
+#   그동안 그 멤버는 ★tmux 세션이 아예 없는 상태로 락을 기다린다.★
+#   전에는 이 창이 'age 를 못 구함 → 기동 중 아님' 으로 떨어져 ★보호가 0★ 이었고,
+#   up 은 정확히 부팅 직후에 쓰는 도구라 오탐 인구가 거기 몰려 있었다.
+#   ★그런데 '세션 없음 = 항상 기동 중' 으로 두면 안 된다★ — 진짜 영구 다운을 영영 안 고치게 된다.
+#   그래서 ★그 멤버의 런처가 실제로 돌고 있는지★ 를 본다. 돌고 있으면 기다리는 중이고, 아니면 다운이다.
+launcher_running() {  # launcher_running <팀원이름> — 그 멤버의 런처 프로세스가 떠 있나
+  pgrep -f "start-telegram-channel\.sh.*[[:space:]]$1([[:space:]]|$)" >/dev/null 2>&1
+}
+
 member_booting() {  # member_booting <팀원이름>
   local age
   age="$(session_age_sec "claude-$1")"
-  [ -n "$age" ] || return 1
+  if [ -z "$age" ]; then
+    # 세션이 없다 — 런처가 돌고 있으면 '기동 중'(락 대기), 아니면 진짜 다운이다.
+    launcher_running "$1"
+    return $?
+  fi
   [ "$age" -lt "$POLLER_BOOT_GRACE" ]
 }
 

--- a/scripts/team-os-booting.test.sh
+++ b/scripts/team-os-booting.test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# member_booting 의 '세션 없는 창' 보호를 검증한다. ★서버는 안 띄운다.★
+#   판정 함수만 떼어 돌리고, 런처는 이름만 흉내낸 sleep 프로세스로 만든다.
+set -uo pipefail
+SRC="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/team-os}"
+TMP="$(mktemp)"; PIDS=""
+cleanup() { for p in $PIDS; do kill "$p" 2>/dev/null || true; done; rm -f "$TMP"; }
+trap cleanup EXIT
+
+sed -n '/^session_age_sec() {/,/^}/p'   "$SRC" >  "$TMP"
+sed -n '/^launcher_running() {/,/^}/p'  "$SRC" >> "$TMP"
+sed -n '/^member_booting() {/,/^}/p'    "$SRC" >> "$TMP"
+grep '^POLLER_BOOT_GRACE=' "$SRC"                >> "$TMP"
+# shellcheck disable=SC1090
+. "$TMP"
+
+FAIL=0
+ok(){ echo "  ✓ $1"; }; bad(){ echo "  ✗ $1"; FAIL=1; }
+
+echo "── T1: 세션 없음 + 런처 안 돎 → ★기동 중 아님★ (진짜 다운은 계속 고쳐야 한다) ──"
+if member_booting "nosuchmember$$"; then bad "보호됨 — 영구 다운을 영영 안 고치게 된다"; else ok "보호 안 함 (맞음)"; fi
+
+echo "── T2: 세션 없음 + ★런처가 돌고 있음★ → 기동 중 (락 대기 중이라 죽이면 안 됨) ──"
+NAME="fakemem$$"
+# 런처와 같은 모양의 명령줄을 가진 프로세스를 띄운다(실제 런처는 안 부른다)
+bash -c "exec -a 'bash /path/src/server/runtimes/claude/start-telegram-channel.sh $NAME' sleep 25" &
+PIDS="$PIDS $!"
+sleep 1
+if launcher_running "$NAME"; then ok "런처 감지됨"; else bad "★런처를 못 찾는다 — 보호가 작동 안 함★"; fi
+if member_booting "$NAME"; then ok "기동 중으로 판정 (보호됨)"; else bad "★보호 안 됨 — 락 대기 중인 멤버를 죽인다★"; fi
+
+echo "── T3: 이름이 비슷한 다른 멤버로 오인하지 않나 ──"
+if launcher_running "${NAME}x"; then bad "★다른 이름인데 매칭됨★"; else ok "다른 이름은 매칭 안 함"; fi
+if launcher_running "akemem$$"; then bad "★부분 문자열로 매칭됨★"; else ok "부분 문자열 매칭 안 함"; fi
+
+echo "── T4: 지금 살아있는 팀원 5명이 '기동 중' 으로 잘못 잡히지 않나 ──"
+# (세션이 오래 됐으므로 age >= 90 이라 기동 중이 아니어야 정상 — 고장나면 복구가 영영 안 돈다)
+for m in bill steve demis dbak lui; do
+  if member_booting "$m"; then bad "$m 이 '기동 중' 으로 잡힘 — 복구가 영영 안 걸린다"; else ok "$m 정상(기동 중 아님)"; fi
+done
+
+echo
+[ "$FAIL" -eq 0 ] && echo "ALL PASS" || echo "FAIL"
+exit "$FAIL"


### PR DESCRIPTION
## 핵심 3줄

1. `#156` 의 기동 유예는 **세션이 있을 때만** 작동한다 — `session_age_sec` 가 세션을 못 찾으면 "기동 중 아님" 으로 떨어진다.
2. 그런데 부팅 때 스폰 mutex 가 멤버를 직렬화해서, **세션이 아예 없는 대기 창이 최대 120초**(우리 기계 5명 기준 `(5-1)×25+20`)다. `up` 은 정확히 그 시점에 쓰는 도구라 **오탐 인구가 유예 밖에 몰려 있었다.**
3. 세션이 없으면 **그 멤버의 런처가 돌고 있는지**를 본다 — 돌고 있으면 락 대기(보호), 아니면 진짜 다운(복구 대상).

## 무엇을 바꿨나

| 상태 | 전 | 후 |
|---|---|---|
| 세션 있음 · 90초 이내 | 기동 중(보호) | 그대로 |
| **세션 없음 · 런처 실행 중** | **기동 중 아님 → `--force` 복구** | **기동 중(보호)** |
| 세션 없음 · 런처 없음 | 기동 중 아님 → 복구 | 그대로 (진짜 다운은 계속 고친다) |

"세션 없음 = 항상 기동 중" 으로 두지 않았다. 그러면 **영구 다운을 영영 안 고친다.**

## 검증 — `scripts/team-os-booting.test.sh` 신설

판정 함수만 떼어 돌린다(**서버 미기동**, 실 tmux·실 `~/.claude` 무접촉):

| 시험 | 결과 |
|---|---|
| 세션 없음 + 런처 없음 → 보호 안 함 | ✓ |
| 세션 없음 + **런처 실행 중** → 보호함 | ✓ |
| 이름 유사·부분 문자열 오매칭 | ✓ 안 함 |
| 살아있는 팀원 5명이 "기동 중" 으로 오인되지 않음 | ✓ (오인되면 복구가 영영 안 걸린다) |

`bash -n` 통과.

## 근거

교차검증 2인이 서로 다른 답을 냈고, 그 차이가 이 PR 이다:
- **codex**: 배포 가 — 세션 존재를 전제로 `session_created` 기준 유예 90초를 확인
- **steve**: 고치고 배포 — **세션이 없는 창**은 유예가 0임을 실측

같은 가드를 다른 시작점에서 본 결과다. 심각도는 부팅 케이스에서 낮다(`--resume` 이 실려 컨텍스트는 안 날아가고, `#156` 이전 `kickstart -k` 도 대기 중 런처를 죽였으니 회귀는 아니다). 다만 **다른 복구 주체(대시보드 재시작·health autofix·주간 재시작)가 세션을 만드는 중**이면 두 주체가 서로의 새 세션을 `--force` 로 죽인다 — 유예가 막으라고 있는 상황이 정확히 그것이다.

## 남은 것 (별건)

`team-os` 가 의도적 off 명단(`var/agent-off.txt`)을 안 본다 · `sudo` 로 실행 시 `$HOME` 이 달라 전원 오탐 · bot.pid 판정 구현이 3곳(정본 2 + 셸 1, 드리프트 시험은 2개만 대조).

Submitted-by: bill
