### PR TITLE
fix(team-os): root 실행은 거부하고, 의도적으로 끈 멤버는 되살리지 않는다

### DIFF
--- a/scripts/team-os
+++ b/scripts/team-os
@@ -29,6 +29,22 @@ done
 #   (예: ~/repo -> /실제/경로, 그 안의 scripts/team-os 는 일반 파일)
 #   위 while 은 걸리지 않고 pwd 는 심링크 경로를 그대로 준다.
 #   plist 에는 실제 경로가 적혀 있으니 그대로 두면 ★또 0건★ 이 된다. (codex 실측)
+# ★root 로 돌리지 않는다★ (GD 2026-07-30) — 경고가 아니라 거부한다.
+#   이 도구의 판정은 전부 `$HOME` 기준이다: 팀원 상태는 `$HOME/.claude/channels/<이름>/bot.pid`,
+#   자동실행은 `$HOME/Library/LaunchAgents`. sudo 로 돌리면 HOME 이 /var/root 로 바뀌어
+#   ★팀원 5명 전원이 "poller 없음" 으로 잡히고 전원 --force 재시작 대상★ 이 된다.
+#   경고만 띄우면 사람이 지나친다. 애초에 그 상태로 판정을 시작하지 않는다.
+#   ★`id` 로 보지 않는다★ — PATH 로 가릴 수 있다(내 첫 시험이 실제로 그렇게 우회했다).
+#   bash 내장 EUID 는 PATH 와 무관하다. TEAMOS_FAKE_UID 는 ★시험 전용 시임★ 이다
+#   (root 를 흉내내 거부 경로를 확인하기 위한 것. 실제 방어는 EUID 가 한다).
+_TEAMOS_UID="${TEAMOS_FAKE_UID:-${EUID:-$(/usr/bin/id -u)}}"
+if [ "$_TEAMOS_UID" -eq 0 ]; then
+  echo "✗ team-os 는 root 로 실행하지 않습니다 (sudo 없이 그냥 실행하세요)."
+  echo "  이유: 팀원 상태를 \$HOME 기준으로 봅니다. root 로는 HOME 이 달라져"
+  echo "        ★팀원 전원이 고장으로 잡히고 전원 강제 재시작 대상★ 이 됩니다."
+  exit 1
+fi
+
 REPO="${TEAM_OS_REPO:-$(cd "$(dirname "$_self")/.." 2>/dev/null && pwd -P)}"
 if [ -z "$REPO" ] || [ ! -d "$REPO/src/server" ] || [ ! -f "$REPO/package.json" ]; then
   echo "✗ 저장소를 못 찾았습니다 (찾은 곳: ${REPO:-없음})"
@@ -197,6 +213,20 @@ launcher_running() {  # launcher_running <팀원이름> — 그 멤버의 런처
   pgrep -f "start-telegram-channel\.sh.*[[:space:]]$1([[:space:]]|$)" >/dev/null 2>&1
 }
 
+# ★의도적으로 정지한 멤버는 되살리지 않는다★ (steve 교차검증, 2026-07-30)
+#   대시보드 /onoff 로 끈 멤버는 `var/agent-off.txt` 에 기록된다. agentControl 은 그 명단을 존중하는데
+#   team-os 는 안 봤다 — 그래서 사람이 끈 멤버를 up 이 ★--force 로 강제 기동★ 할 수 있었다.
+#   (지금 우리 명단은 비어 있어 노출 0이지만, 끄는 순간 살아난다.)
+#   형식은 정본과 같다: 공백·콤마로 구분된 id 목록(agentControl.isAgentOff).
+member_off() {  # member_off <팀원이름>
+  local f ids
+  f="${TEAMOS_AGENT_OFF_FILE:-$REPO/var/agent-off.txt}"
+  [ -f "$f" ] || return 1
+  ids="$(tr ',' ' ' < "$f" 2>/dev/null)"
+  case " $ids " in *" $1 "*) return 0 ;; esac
+  return 1
+}
+
 member_booting() {  # member_booting <팀원이름>
   local age
   age="$(session_age_sec "claude-$1")"
@@ -255,9 +285,18 @@ show() {
     echo "  ✗ 서버 응답 없음"
   fi
   # 팀원 이름을 고정하지 않는다 — 설치마다 다르다. 발견한 것 중 몇 개가 정상인지로 말한다.
-  local total=0 ok=0 lbl plist
+  local total=0 ok=0 off=0 lbl plist _mm
   while IFS='|' read -r lbl plist; do
     [ -n "$lbl" ] && [ "$lbl" != "!지원밖" ] || continue
+    # ★의도적으로 끈 멤버는 '고장' 이 아니다★ (hermes 교차검증) — 실패로 세면 doctor 가
+    #   "안 떴습니다 / up 하세요" 라고 말하고, 운영자는 자기가 끈 것을 고장으로 읽는다.
+    #   대신 ★끈 상태라고 보여준다★ — 그래야 되돌릴 수 있다.
+    _mm="$(member_of "$plist")"
+    if [ -n "$_mm" ] && member_off "$_mm"; then
+      echo "  · $lbl (정지됨 — 의도적 off)"
+      off=$((off + 1))
+      continue
+    fi
     total=$((total + 1))
     loaded "$lbl" && service_healthy "$lbl" "$plist" && ok=$((ok + 1))
   done < <(boot_services)
@@ -316,6 +355,13 @@ case "${1:-help}" in
         FAILED="$FAILED $(basename "$_plist")"
         continue
       fi
+      # ★off 검사는 loaded 분기보다 앞이다★ (hermes 교차검증) — 뒤에 두면 ★plist 가 bootout 된
+      #   off 멤버★ 가 아래 bootstrap 경로로 흘러가 ★다시 등록★ 된다. 끈 것을 되살리는 것이다.
+      _m0="$(member_of "$_plist")"
+      if [ -n "$_m0" ] && member_off "$_m0"; then
+        echo "  · $_lbl (정지됨 — 의도적 off, 건드리지 않음)"
+        continue
+      fi
       if loaded "$_lbl"; then
         # 등록돼 있다고 살아 있는 건 아니다. 실제 상태를 보고 죽었으면 다시 올린다.
         # ★런처의 '이미 떠 있으면 아무것도 안 한다' 가드를 안전장치로 믿으면 안 된다★ — 그 가드는
@@ -328,6 +374,7 @@ case "${1:-help}" in
         fi
         _m="$(member_of "$_plist")"
         if [ -n "$_m" ]; then
+          # (off 검사는 위에서 이미 했다)
           # 갓 뜬 세션은 건드리지 않는다 — 아직 poller 를 쓸 시간이 없었을 수 있다(오탐 인구).
           if member_booting "$_m"; then
             echo "  · $_lbl (기동 중 — poller 대기, 건드리지 않음)"

--- a/scripts/team-os-guards.test.sh
+++ b/scripts/team-os-guards.test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# team-os 의 두 가드(root 거부 · off 명단 존중)를 검증한다. ★서버 미기동·라이브 무접촉★
+set -uo pipefail
+SRC="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/team-os}"
+FAIL=0
+ok(){ echo "  ✓ $1"; }; bad(){ echo "  ✗ $1"; FAIL=1; }
+
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+
+echo "── T1: root 거부 ──"
+# ★PATH 로 `id` 를 가리는 방식은 더 이상 안 통한다★ — 가드가 bash 내장 EUID 를 쓴다(hermes 지적).
+#   그게 이 가드의 요점이라, ①PATH shadow 로는 판정이 안 바뀌는지 확인하고
+#   ②거부 경로 자체는 명시적 시임(TEAMOS_FAKE_UID)으로 확인한다.
+mkdir -p "$T/bin"
+printf '#!/bin/sh\n[ "$1" = "-u" ] && echo 0 || exec /usr/bin/id "$@"\n' > "$T/bin/id"
+chmod +x "$T/bin/id"
+SHADOW="$(PATH="$T/bin:$PATH" bash "$SRC" 2>&1)"
+case "$SHADOW" in
+  *"root 로 실행하지 않습니다"*) bad "★PATH 로 id 를 가려 판정을 바꿀 수 있다 = 방어가 우회 가능★" ;;
+  *) ok "PATH shadow 로는 판정이 안 바뀐다 (EUID 사용)" ;;
+esac
+OUT="$(TEAMOS_FAKE_UID=0 bash "$SRC" doctor 2>&1)"; RC=$?
+[ "$RC" -eq 1 ] && ok "종료코드 1" || bad "종료코드 $RC (1이어야 한다)"
+case "$OUT" in *"root 로 실행하지 않습니다"*) ok "거부 메시지" ;; *) bad "거부 메시지 없음: $OUT" ;; esac
+case "$OUT" in *"■ 점검"*|*"정상"*) bad "★거부했는데 판정이 돌았다★" ;; *) ok "판정 자체를 시작하지 않음" ;; esac
+
+echo "── T2: 일반 사용자면 그대로 동작 ──"
+OUT2="$(bash "$SRC" 2>&1)"; RC2=$?
+[ "$RC2" -eq 0 ] && ok "인자 없이 → 설명, 종료코드 0" || bad "종료코드 $RC2"
+case "$OUT2" in *"사용법: team-os"*) ok "설명 정상 출력" ;; *) bad "설명이 안 나옴" ;; esac
+
+echo "── T3: off 명단 판정 ──"
+# member_off 만 떼어 검증 (REPO 변수를 임시로 잡는다)
+LIB="$T/lib.sh"
+sed -n '/^member_off() {/,/^}/p' "$SRC" > "$LIB"
+mkdir -p "$T/repo/var"
+REPO="$T/repo"; export REPO
+# shellcheck disable=SC1090
+. "$LIB"
+printf 'steve, demis\n' > "$T/repo/var/agent-off.txt"
+member_off steve  && ok "steve 정지됨으로 인식" || bad "steve 를 못 읽음"
+member_off demis  && ok "demis 정지됨으로 인식(콤마 구분)" || bad "콤마 구분 실패"
+member_off bill   && bad "★bill 은 명단에 없는데 정지로 봤다★" || ok "bill 은 정상(명단 밖)"
+member_off stev   && bad "★부분 문자열로 매칭됐다★" || ok "부분 문자열 매칭 안 함"
+: > "$T/repo/var/agent-off.txt"
+member_off steve  && bad "★빈 명단인데 정지로 봤다★" || ok "빈 명단 = 아무도 정지 아님"
+rm -f "$T/repo/var/agent-off.txt"
+member_off steve  && bad "★파일이 없는데 정지로 봤다★" || ok "파일 없음 = 아무도 정지 아님"
+
+echo
+[ "$FAIL" -eq 0 ] && echo "ALL PASS" || echo "FAIL"
+exit "$FAIL"


### PR DESCRIPTION
## 핵심 3줄

1. `team-os` 는 판정을 전부 `$HOME` 기준으로 한다 — `sudo` 로 돌리면 **팀원 전원이 "poller 없음" 으로 잡히고 전원 `--force` 재시작 대상**이 된다.
2. 그리고 사람이 **의도적으로 끈 멤버**를 `up` 이 되살린다 — `var/agent-off.txt` 를 안 본다(`agentControl` 은 본다).
3. root 는 **경고가 아니라 거부**. off 멤버는 `up` 에서 건너뛰고 `doctor` 에서 **"정지됨" 으로 보여준다**.

## 무엇을 바꿨나

| 문제 | 고친 방법 |
|---|---|
| `sudo` 실행 시 전원 오탐 → 전원 강제 재시작 | `EUID` 가 0이면 **판정 시작 전에 거부**(exit 1) + 이유 출력 |
| 의도적 off 멤버를 `up` 이 `--force` 로 되살림 | off 검사를 **`loaded` 분기보다 앞**에 둔다 |
| off 멤버가 `doctor` 에서 **고장으로 집계** | 실패로 세지 않고 **"정지됨 — 의도적 off"** 로 표시 |

**`id` 가 아니라 `EUID` 인 이유**: `id` 는 PATH 로 가릴 수 있다 — **내 첫 시험이 실제로 그렇게 우회했다.** bash 내장 `EUID` 는 PATH 와 무관하다. (`TEAMOS_FAKE_UID` 는 거부 경로를 확인하기 위한 시험 전용 시임이고, 실제 방어는 `EUID` 가 한다.)

**off 검사가 `loaded` 분기보다 앞인 이유**: 뒤에 두면 **plist 가 bootout 된 off 멤버**가 아래 `bootstrap` 경로로 흘러가 **다시 등록**된다. 끈 것을 되살리는 것이다.

**`doctor` 가 off 를 보여줘야 하는 이유**: 안 보여주면 운영자가 자기가 끈 것을 고장으로 읽거나, 반대로 **진짜 고장을 off 뒤에 영구히 방치**하게 된다. off 는 desired state 이므로 감수하되, **보이게** 둔다.

## 검증 — `scripts/team-os-guards.test.sh` 신설

실제 `sudo` 를 쓰지 않는다.

| 시험 | 결과 |
|---|---|
| **PATH 로 `id` 를 가려도 판정이 안 바뀐다**(우회 불가) | ✓ |
| root(시임) → exit 1 · 거부 메시지 · **판정 자체를 시작 안 함** | ✓ |
| 일반 사용자 → 그대로 동작 | ✓ |
| off 명단: 공백/콤마 인식 · 명단 밖 정상 · **부분 문자열 오매칭 없음** · 빈 파일/파일 없음 = 아무도 정지 아님 | ✓ |

회귀 없음 — `team-os.test.sh` · `team-os-booting.test.sh` · `team-os-poller.test.sh` 전부 ALL PASS · `bash -n` 통과.

**검증 안 된 것**: `doctor` 의 off 표시를 실환경에서 눈으로 못 봤다 — 워크트리에서 돌리면 `boot_services` 가 저장소 경로로 plist 를 거르므로 라이브 plist 가 안 잡힌다(격리 특성). 로직은 `member_off` 시험으로만 확인됐다.

## 남은 것 (이번에 안 함)

`bot.pid` 판정 구현이 3곳(정본 2 + 셸 1)이고 드리프트 시험은 2곳만 대조한다 — 한 줄이 아니라 별건.

발견 = steve · 보완 = hermes(EUID 우회 · off 가드 위치 · doctor 표시) · 지시 = GD

Submitted-by: bill
