### PR TITLE
feat(bin): 사람이 치는 명령은 bin/ 에 둔다 — team-os 이동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ archiving/
 # (launchd·배포·테스트 하네스·실 로스터)와 내부 docs(PLAN/REVIEW/내부운영)는 로컬 워킹파일로 유지(untrack)한다.
 # 버전관리는 은퇴하는 private repo(내부 유지)가 계속 tracked 로 보존 → 유실 없음. 공개엔 명시 allowlist 만 싣는다.
 # (기본=제외 + `!` allowlist. 새 공개용 스크립트/문서는 여기 `!` 로 추가.)
+# bin/ = ★사람이 직접 치는 명령★ 만 둔다(팀장님 방침). scripts/ 와 달리 ignore 대상이 아니다 —
+#   여기 넣는 순간 공개된다. 자동화·테스트·내부 ops 는 scripts/ 에 남긴다.
 /scripts/*
 !/scripts/auto-heal-core.sh
 !/scripts/auto-heal-core-harness.sh
@@ -42,7 +44,6 @@ archiving/
 #   ★문서가 가리키는 도구가 리포에 없으면 그 안내는 거짓말이 된다★ (이 문서가 고치려던 바로 그 문제).
 # ★공개 사용자가 부팅 후 안 뜰 때 쓰는 도구★ — README 가 이 파일을 가리킨다.
 #   /scripts/* 가 전부 무시하므로 ★여기 없으면 조용히 빠진다★ (실제로 한 번 빠뜨렸다 — codex 가 잡음)
-!/scripts/team-os
 !/scripts/gen-test-map.sh
 !/scripts/test-map-nodescribe.txt
 # ★scripts 의 테스트는 ★클래스로★ 연다★ — /scripts/* 가 전부 무시하므로 .test.ts 를

--- a/README.md
+++ b/README.md
@@ -246,9 +246,9 @@ Slack은 **Socket Mode**로 붙습니다 — 공개 URL·웹훅 엔드포인트�
 **보통은 맥을 켜면 저절로 올라옵니다.** 아래는 그게 안 됐을 때만 씁니다.
 
 ```bash
-bash scripts/team-os up       # 올린다
-bash scripts/team-os doctor   # 왜 안 뜨는지 본다
-bash scripts/team-os down     # 내린다
+bash bin/team-os up       # 올린다
+bash bin/team-os doctor   # 왜 안 뜨는지 본다
+bash bin/team-os down     # 내린다
 ```
 
 **순서는 이렇게** — `up` 먼저, 그래도 안 되면 `doctor`.
@@ -320,7 +320,7 @@ bun run src/server/index.ts
 > - **자동실행 이름**(`com.<사용자>.…`)은 설치마다 다릅니다 →
 >   `~/Library/LaunchAgents/*.plist` 를 열어 안에 적힌 `Label` 을 그대로 읽습니다.
 > - **저장소 위치**도 설치마다 다릅니다 →
->   이 스크립트가 `<저장소>/scripts/team-os` 자리에 있으므로 **자기 위치에서 알아냅니다.**
+>   이 스크립트가 `<저장소>/bin/team-os` 자리에 있으므로 **자기 위치에서 알아냅니다.**
 >   바로가기(심링크)로 불러도 끝까지 따라갑니다.
 >
 > 스크립트를 저장소 밖으로 복사해서 쓰신다면 그때만 알려주세요:

--- a/bin/team-os
+++ b/bin/team-os
@@ -9,7 +9,7 @@
 set -uo pipefail
 
 # 저장소 위치를 짐작하지 않는다 — ★이 스크립트 자신이 저장소 안에 있다.★
-#   경로가 `<저장소>/scripts/team-os` 이므로 자기 위치의 한 단계 위가 저장소다.
+#   경로가 `<저장소>/bin/team-os` 이므로 자기 위치의 한 단계 위가 저장소다.
 #   짐작하면 틀린다: 우리는 ~/Development/ 밑에 두지만 공개 사용자는 README 대로
 #   아무 데서나 `git clone` 하므로 대개 홈 바로 밑이다. 그 경우 예전 기본값으로는
 #   ★자기 서비스를 하나도 못 찾는다.★ (팀장님이 잡으신 결함)
@@ -26,7 +26,7 @@ while [ -L "$_self" ] && [ "$_hops" -lt 40 ]; do
   _hops=$((_hops + 1))
 done
 #   pwd -P 로 심링크를 푼 실제 경로를 쓴다. 파일이 아니라 ★상위 폴더가 심링크★ 인 경우
-#   (예: ~/repo -> /실제/경로, 그 안의 scripts/team-os 는 일반 파일)
+#   (예: ~/repo -> /실제/경로, 그 안의 bin/team-os 는 일반 파일)
 #   위 while 은 걸리지 않고 pwd 는 심링크 경로를 그대로 준다.
 #   plist 에는 실제 경로가 적혀 있으니 그대로 두면 ★또 0건★ 이 된다. (codex 실측)
 # ★root 로 돌리지 않는다★ (GD 2026-07-30) — 경고가 아니라 거부한다.
@@ -48,7 +48,7 @@ fi
 REPO="${TEAM_OS_REPO:-$(cd "$(dirname "$_self")/.." 2>/dev/null && pwd -P)}"
 if [ -z "$REPO" ] || [ ! -d "$REPO/src/server" ] || [ ! -f "$REPO/package.json" ]; then
   echo "✗ 저장소를 못 찾았습니다 (찾은 곳: ${REPO:-없음})"
-  echo "  이 스크립트는 <저장소>/scripts/team-os 자리에 있어야 합니다."
+  echo "  이 스크립트는 <저장소>/bin/team-os 자리에 있어야 합니다."
   echo "  다른 데서 쓰시려면: TEAM_OS_REPO=<저장소 경로> team-os $*"
   exit 1
 fi

--- a/scripts/team-os-booting.test.sh
+++ b/scripts/team-os-booting.test.sh
@@ -2,7 +2,7 @@
 # member_booting 의 '세션 없는 창' 보호를 검증한다. ★서버는 안 띄운다.★
 #   판정 함수만 떼어 돌리고, 런처는 이름만 흉내낸 sleep 프로세스로 만든다.
 set -uo pipefail
-SRC="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/team-os}"
+SRC="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../bin/team-os}"
 TMP="$(mktemp)"; PIDS=""
 cleanup() { for p in $PIDS; do kill "$p" 2>/dev/null || true; done; rm -f "$TMP"; }
 trap cleanup EXIT

--- a/scripts/team-os-guards.test.sh
+++ b/scripts/team-os-guards.test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # team-os 의 두 가드(root 거부 · off 명단 존중)를 검증한다. ★서버 미기동·라이브 무접촉★
 set -uo pipefail
-SRC="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/team-os}"
+SRC="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../bin/team-os}"
 FAIL=0
 ok(){ echo "  ✓ $1"; }; bad(){ echo "  ✗ $1"; FAIL=1; }
 

--- a/scripts/team-os-poller.test.sh
+++ b/scripts/team-os-poller.test.sh
@@ -19,7 +19,7 @@ set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(cd "$HERE/.." && pwd)"
-SCRIPT="$HERE/team-os"
+SCRIPT="$HERE/../bin/team-os"
 [ -x "$SCRIPT" ] || { echo "FAIL: $SCRIPT 없음/실행권한 없음"; exit 1; }
 
 FAILED=0

--- a/scripts/team-os.test.sh
+++ b/scripts/team-os.test.sh
@@ -12,7 +12,7 @@
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TARGET="$HERE/team-os"
+TARGET="$HERE/../bin/team-os"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 

--- a/src/server/lib/pollerHealthDrift.test.ts
+++ b/src/server/lib/pollerHealthDrift.test.ts
@@ -1,4 +1,4 @@
-// ★드리프트 가드★ — scripts/team-os 의 셸 poller 판정이 정본(runtimeEssentials.ts)과 같은 답을 내나.
+// ★드리프트 가드★ — bin/team-os 의 셸 poller 판정이 정본(runtimeEssentials.ts)과 같은 답을 내나.
 //
 // 왜 두 곳에 같은 판정이 있나:
 //   team-os 는 ★서버가 죽었을 때★ 쓰는 복구 도구다. 서버 API 를 부를 수 없으니 셸로 다시 짤 수밖에
@@ -17,7 +17,7 @@ import { join } from "node:path";
 import { checkEssentialSettings, createRuntimeEssentialsRegistry } from "./runtimeEssentials";
 import type { AgentRecord } from "../types";
 
-const TEAM_OS = join(import.meta.dir, "../../../scripts/team-os");
+const TEAM_OS = join(import.meta.dir, "../../../bin/team-os");
 const NAME = "drifttest";
 
 /** 살아있는 pid — 이 테스트 프로세스 자신. 죽은 pid — 쓰이지 않을 큰 값. */

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -400,8 +400,10 @@ elif ! managed_by_this_install "$_srv_plist"; then
   warn "    서버를 내리려면 그 서버를 설치한 폴더에서 uninstall 하세요."
 else
   # team-os.sh 가 있으면 best-effort 로 호출(정지 시도). 없거나 실패해도 아래 bootout 이 실제 정지.
-  if [ -x "$SELF/scripts/team-os.sh" ] || [ -f "$SELF/scripts/team-os.sh" ]; then
-    bash "$SELF/scripts/team-os.sh" down >/dev/null 2>&1 || true
+  # ★이 조건은 오래 거짓이었다★ — 파일명이 team-os.sh 로 적혀 있었는데 실제 파일은 확장자가 없다.
+  #   그래서 이 "곱게 내리기" 단계는 한 번도 실행된 적이 없다(아래 bootout 이 실제로 내렸다).
+  if [ -f "$SELF/bin/team-os" ]; then
+    bash "$SELF/bin/team-os" down >/dev/null 2>&1 || true
   fi
   launchd_stop "$PREFIX.team-collab"
   rmf "$_srv_plist"


### PR DESCRIPTION
## 핵심 3줄

1. `scripts/` 에 **세 부류가 섞여 있었다** — 사람이 직접 치는 명령(`team-os`) · 자동화가 부르는 것 · 내부 전용. 구분은 `.gitignore` 예외 목록 한 줄뿐이었다.
2. `bin/` = **사람이 직접 치는 명령**만 둔다. `scripts/` 와 달리 ignore 대상이 아니라 **넣는 순간 공개**된다 — 디렉토리가 곧 의도 선언이 된다.
3. `git mv` + 참조 6곳. **동작 변경 없음.**

## 무엇을 옮겼나

| | 위치 | 이유 |
|---|---|---|
| `team-os` | `scripts/` → **`bin/`** | 사람이 치는 유일한 명령(`~/team-os` 심링크 대상) |
| `team-os*.test.sh` 4종 | `scripts/` 유지 | 시험은 사람이 치는 명령이 아니다 |

## 같이 고친 것 — `uninstall.sh` 의 죽은 참조

`uninstall.sh:403` 이 `scripts/team-os.sh` 를 찾았다. **그런 파일은 존재한 적이 없다**(실제 파일명은 확장자 없는 `team-os`). 조건이 항상 거짓이라 **"곱게 내리기" 단계가 한 번도 실행된 적이 없다** — 바로 아래 `bootout` 이 실제로 내려서 증상이 안 보였다. `bin/team-os` 로 고쳤다.

## 검증

| 항목 | 결과 |
|---|---|
| 셸 시험 4종(진입·기동창·가드·폴러) | **전부 PASS** (경로를 `../bin/team-os` 로 갱신) |
| 드리프트 시험(TS) | **13 pass** |
| `bin/team-os` 실행 — 인자 없이 → 설명, exit 0 | ✓ |
| 저장소 자기 탐지(`dirname/..`)가 `bin/` 에서도 맞나 | ✓ 서버·팀원 12명 인식 |
| 남은 `scripts/team-os` 참조 | **0건** |
| `git ls-files` 로 `bin/` 추적 확인 | ✓ (리사 경고 — `.gitignore` 가 조용히 삼키는지) |

## 배포 시 같이 해야 하는 것 (코드 밖)

`~/team-os` 심링크가 `b3rys-team-os/scripts/team-os` 를 가리킨다 — **배포 후 `bin/team-os` 로 다시 걸어야 한다.** 안 하면 팀장님이 `~/team-os` 를 쳤을 때 깨진다.

발견(디렉토리 분리 아이디어) = GD · 대기 조율 = 리사(gdstudio)

Submitted-by: bill
