### PR TITLE
feat(send.sh): 슬랙 멘션을 옵션으로 받는다 — 알림 없이 나가던 경로

### DIFF
--- a/scripts/send-mention.test.sh
+++ b/scripts/send-mention.test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# send.sh --mention 검증. ★실제 발신 안 함★ — 멘션 해석·부착 로직만 떼어 돌린다.
+set -uo pipefail
+SRC="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/b3os-team-inbox/scripts/send.sh}"
+FAIL=0
+ok(){ echo "  ✓ $1"; }; bad(){ echo "  ✗ $1"; FAIL=1; }
+
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+cat > "$T/members.env" <<'EOF'
+# 주석은 무시된다
+lisa=U0BL1UYHLV7
+Jane=U0BKJR2G8MD
+EOF
+
+# resolve_mention 만 떼어낸다
+LIB="$T/lib.sh"
+sed -n '/^resolve_mention() {/,/^}/p' "$SRC" > "$LIB"
+MEMBERS_FILE="$T/members.env"; export MEMBERS_FILE
+# shellcheck disable=SC1090
+. "$LIB"
+
+echo "── T1: 이름 → ID ──"
+[ "$(resolve_mention lisa)" = "U0BL1UYHLV7" ] && ok "lisa" || bad "lisa: $(resolve_mention lisa)"
+[ "$(resolve_mention LISA)" = "U0BL1UYHLV7" ] && ok "대소문자 무시" || bad "대소문자"
+[ "$(resolve_mention jane)" = "U0BKJR2G8MD" ] && ok "사전 키가 대문자여도 찾음" || bad "jane"
+
+echo "── T2: 원시 ID 는 그대로 ──"
+[ "$(resolve_mention U0BL1UYHLV7)" = "U0BL1UYHLV7" ] && ok "U… 통과" || bad "U…"
+[ "$(resolve_mention '<@U0BL1UYHLV7>')" = "U0BL1UYHLV7" ] && ok "<@U…> 형태도 받음" || bad "<@U…>"
+
+echo "── T3: 모르는 이름은 빈 값(→ 스크립트가 에러로 멈춘다) ──"
+[ -z "$(resolve_mention nosuchperson)" ] && ok "빈 값" || bad "빈 값이 아님"
+
+echo "── T4: 사전 파일이 없으면 이름은 못 풀고, 원시 ID 는 여전히 통과 ──"
+MEMBERS_FILE="$T/none.env"
+[ -z "$(resolve_mention lisa)" ] && ok "이름 → 빈 값" || bad "파일 없는데 풀렸다"
+[ "$(resolve_mention U0BL1UYHLV7)" = "U0BL1UYHLV7" ] && ok "원시 ID 는 통과" || bad "원시 ID 실패"
+MEMBERS_FILE="$T/members.env"
+
+echo "── T5: 본문 부착 (중복 방지 포함) ──"
+# ★부착 로직을 손으로 베끼지 않는다★ — 베끼면 그 사본이 원본과 갈라져도 시험은 통과한다
+#   (#149 에서 같은 형태로 당했다: 대조 대상이 자기 복사본이었다).
+#   그래서 send.sh 의 for 루프를 ★그대로 떼어★ 쓴다.
+eval "prepend() {  # prepend <본문> <멘션들...>
+  local BODY=\"\$1\"; shift
+  local MENTIONS=\"\$*\"
+$(sed -n '/^for _m in \$MENTIONS; do$/,/^done$/p' "$SRC")
+  printf '%s' \"\$BODY\"
+}"
+r="$(prepend "본문" lisa)"
+[ "$r" = "$(printf '<@U0BL1UYHLV7>\n본문')" ] && ok "맨 앞 ★자기 줄★ 에 붙음" || bad "부착: $r"
+r="$(prepend "<@U0BL1UYHLV7> 이미 있음" lisa)"
+[ "$r" = "<@U0BL1UYHLV7> 이미 있음" ] && ok "★중복으로 안 붙임★" || bad "중복: $r"
+# ★코드블록이 깨지지 않는지★ — 여는 펜스가 줄 맨 앞에 그대로 있어야 한다
+r="$(prepend '```
+code
+```' lisa)"
+case "$r" in
+  "<@U0BL1UYHLV7>"*$'\n''```'*) ok "코드블록 여는 펜스가 줄 맨 앞에 유지됨" ;;
+  *) bad "★펜스가 밀렸다★: $(printf '%s' "$r" | head -2 | tr '\n' '|')" ;;
+esac
+r="$(prepend "본문" lisa jane)"
+case "$r" in *"<@U0BL1UYHLV7>"*) case "$r" in *"<@U0BKJR2G8MD>"*) ok "여러 명 부착" ;; *) bad "두 번째 누락" ;; esac ;; *) bad "첫 번째 누락" ;; esac
+
+echo
+[ "$FAIL" -eq 0 ] && echo "ALL PASS" || echo "FAIL"
+exit "$FAIL"

--- a/skills/b3os-team-inbox/scripts/send.sh
+++ b/skills/b3os-team-inbox/scripts/send.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Send a message via the team-collab inbox.
 # Usage: send.sh --to <agent_id> (--body "..." | --body-file <경로>) [--thread <id>] [--in-reply-to <msg_id>]
+#                [--mention <U…|이름>]              ★슬랙 스레드일 때만★ — 알림 받을 사람(반복 가능).
+#                                                   안 주면 슬랙엔 올라가도 알림이 아무에게도 안 갑니다(경고함).
+#                                                   이름 사전 = slack-tokens/members.env (slack-post.sh 와 공유)
 #                [--confirm [초]]                  배달됐는지 실제로 확인하고 사실을 말한다.
 #                                                   ★본문에 홑따옴표·백틱·$(cmd)·$VAR 가 있으면 --body-file 을 쓰세요★
 #                                                   — --body 로 넘기면 셸이 해석해서 본문이 조용히 훼손됩니다(실측 2건).
@@ -22,7 +25,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 BASE="${TEAM_BASE:-http://127.0.0.1:7878/team}"
 
 TO=""; BODY=""; THREAD=""; REPLY_TO=""; TYPE="dm"; PRIORITY="normal"; FROM=""; HOP=""; SYNC=""; DIRECT_TO_GD=""; SOURCE_THREAD=""; EXPECT_REPORT_BY=""; INDIVIDUAL=""; EPISODE=""
-BODY_FILE=""; BODY_SET=""; CONFIRM=""
+BODY_FILE=""; BODY_SET=""; CONFIRM=""; MENTIONS=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -34,6 +37,9 @@ while [ $# -gt 0 ]; do
     #   · 홑따옴표가 문자열을 끊어 인자 파싱 오류로 죽었다 — 이건 죽어서 오히려 알아챌 수 있었다
     #   회피법(--body "$(cat 파일)")이 있었지만 ★아는 사람만 안전한 것은 고쳐진 게 아니다.★
     --body-file) BODY_FILE="$2"; shift 2 ;;
+    # --mention <U…|이름>: 반복 가능. ★슬랙 스레드로 나갈 때만★ 본문 맨 앞에 <@ID> 를 붙인다.
+    #   slack-post.sh 와 ★같은 옵션 이름·같은 값 형식·같은 사전★ 이다(두 도구의 규약을 하나로).
+    --mention) MENTIONS="$MENTIONS $2"; shift 2 ;;
     --thread) THREAD="$2"; shift 2 ;;
     --in-reply-to) REPLY_TO="$2"; shift 2 ;;
     --type) TYPE="$2"; shift 2 ;;
@@ -136,6 +142,41 @@ if [ -z "$BODY_FILE" ]; then
   BODY=$(BODY="$BODY" python3 -c 'import os, sys; sys.stdout.write(os.environ["BODY"].replace("\\n", "\n").replace("\\t", "\t"))')
 fi
 
+# ─── 슬랙 멘션 ────────────────────────────────────────────────────────────
+# ★멘션이 없으면 슬랙에 글은 올라가도 알림이 아무에게도 안 간다.★
+#   실측(2026-07-30): 내가 이 경로로 올린 7건 중 6건이 멘션 없이 나갔고, 답을 기다리던 사람에게
+#   ★알림이 한 번도 안 갔다.★ slack-post.sh 에는 --mention 도 경고도 있는데 ★이 경로에만 없었다★ —
+#   즉 그 경고를 봐야 할 사람이 경고가 없는 쪽으로만 다녔다.
+#   ★막지는 않는다★: "슬랙에 정리해서 올려줘" 처럼 받는 사람이 없는 게시도 정당하다(slack-post 와 같은 판단).
+#   그래서 옵션은 선택이고, 안 줬을 때 ★알려만 준다★.
+#   ID 는 저장소에 두지 않는다 — slack-tokens/members.env(.gitignore)에서 이름→ID 를 찾고,
+#   원시 ID(U…/W…)는 그대로 받는다. slack-post.sh 와 ★같은 사전·같은 해석★ 이다.
+MEMBERS_FILE="${SLACK_MEMBERS_FILE:-$(cd "$HERE/../../.." && pwd)/slack-tokens/members.env}"
+resolve_mention() {  # resolve_mention <원시ID|이름> -> ID 또는 빈 문자열
+  local v="$1"
+  v="${v#<@}"; v="${v%>}"
+  case "$v" in [UW][A-Z0-9]*) printf '%s' "$v"; return 0 ;; esac
+  [ -f "$MEMBERS_FILE" ] || return 1
+  awk -F= -v want="$(printf '%s' "$v" | tr '[:upper:]' '[:lower:]')" '
+    /^[[:space:]]*#/ || !/=/ { next }
+    { k=$1; gsub(/^[[:space:]]+|[[:space:]]+$/, "", k); v2=$2; gsub(/^[[:space:]]+|[[:space:]]+$/, "", v2)
+      if (tolower(k) == want) { print v2; exit } }' "$MEMBERS_FILE"
+}
+for _m in $MENTIONS; do
+  _id="$(resolve_mention "$_m")"
+  if [ -z "$_id" ]; then
+    echo "ERROR: --mention '$_m' 을 member ID 로 풀 수 없습니다." >&2
+    echo "  원시 ID(U…)를 직접 주거나, $MEMBERS_FILE 에 '이름=U01234567' 을 추가하세요." >&2
+    exit 1
+  fi
+  case "$BODY" in *"<@$_id>"*) continue ;; esac   # 본문에 이미 있으면 중복으로 안 붙인다
+  # ★멘션은 자기 줄에 둔다★ (steve 지적) — 같은 줄에 붙이면 본문이 ``` 로 시작할 때
+  #   여는 펜스가 줄 맨 앞이 아니게 되어 멘션이 코드블록 안으로 끌려들어갈 수 있다.
+  #   사람이 쓰는 모양과도 같다.
+  BODY="<@$_id>
+$BODY"
+done
+
 # Build JSON via python to handle escaping safely.
 PAYLOAD=$(BODY="$BODY" FROM="$FROM" TO="$TO" THREAD="$THREAD" REPLY_TO="$REPLY_TO" TYPE="$TYPE" PRIORITY="$PRIORITY" HOP="$HOP" SYNC="$SYNC" DIRECT_TO_GD="$DIRECT_TO_GD" SOURCE_THREAD="$SOURCE_THREAD" EXPECT_REPORT_BY="$EXPECT_REPORT_BY" INDIVIDUAL="$INDIVIDUAL" EPISODE="$EPISODE" python3 -c "
 import json, os
@@ -198,6 +239,28 @@ else:
 #   위 명령치환이 id 를 ★내부 변수로만★ 받고 stdout 에는 아무것도 안 나갔다. 실측: MSGID=$(send.sh …)
 #   가 빈 문자열이 됐다. 문서가 약속한 것을 코드가 지키지 않으면 그 문서를 믿은 쪽이 조용히 깨진다.
 printf '%s\n' "$MSG_ID"
+
+# ★멘션이 없으면 알려준다★ — 실패로 만들지는 않는다.
+#   "슬랙에 정리해서 올려줘" 처럼 받는 사람이 없는 게시는 멘션이 없는 게 맞다(slack-post 와 같은 판단).
+#   문제는 ★받는 사람이 있는데 안 붙인 경우★ 이고, 그건 보낸 사람만 안다 — 판단을 대신하지 않고 사실만 알린다.
+#
+# ★슬랙인지 서버에 물어보지 않는다★ (steve 교차검증, 2026-07-30):
+#   처음엔 `GET /api/messages/<id>` 응답에 "slack 이 있는지" 로 판정했다. 그 응답에는
+#   ★슬랙을 뜻하는 필드가 아예 없다★ — 슬랙 발신 판단은 message 행이 아니라 디스패처가 런타임에 한다.
+#   실측 결과 판정이 ★정확히 뒤집혀 있었다★: thread_id 가 slack 으로 시작하는 평범한 팀 DM(라이브 16건)에는
+#   경고가 뜨고, ★진짜 슬랙 발신에서는 안 떴다.★ 즉 잔소리는 엉뚱한 데 하고 정작 막으려던 자리에선 침묵한다.
+#   알 수 없는 것을 아는 척하면 사람이 곧 경고를 무시하게 되고, 그게 이 기능을 무력화한다.
+#   → ★모르는 것은 흉내내지 않는다.★ 슬랙으로 릴레이되는 실제 경로(--to broadcast)에서 멘션이 없으면
+#     그냥 안내한다. 거짓 경보도 놓침도 사라지고, 조회 실패 시 침묵하는 문제도 같이 없어진다.
+if [ -z "$MENTIONS" ] && [ "$TO" = "broadcast" ]; then
+  case "$BODY" in
+    *"<@"*) : ;;   # 본문에 직접 넣었다 — 알릴 것 없음
+    *)
+      echo "⚠ 멘션이 없습니다 — 슬랙 스레드였다면 ★아무에게도 알림이 가지 않습니다★." >&2
+      echo "  받는 사람이 있으면: --mention <이름|U…>  (받는 사람 없는 공지면 그대로 두셔도 됩니다)" >&2
+      ;;
+  esac
+fi
 
 [ -z "$CONFIRM" ] && exit 0
 


### PR DESCRIPTION
## 핵심 3줄

1. `send.sh` 로 슬랙 스레드에 답하면 **글은 올라가도 알림이 아무에게도 안 간다** — 실측: 오늘 이 경로로 올린 **7건 중 6건**이 그랬고, 답을 기다리던 사람에게 알림이 한 번도 안 갔다.
2. `slack-post.sh` 에는 `--mention` 도 경고도 **이미 있다**. 이 경로에만 없었다 — **그 경고를 봐야 할 사람이 경고가 없는 쪽으로만 다녔다.**
3. `--mention <이름|U…>` 을 **`slack-post.sh` 와 같은 규약**으로 추가한다. 옵션은 선택이고, 안 주면 **알려만 준다**(막지 않음).

## 무엇을 바꿨나

| | 내용 |
|---|---|
| 옵션 | `--mention <U…\|이름>` · **반복 가능** · 본문 맨 앞에 `<@ID>` 부착 · 이미 있으면 중복 부착 안 함 |
| 사전 | `slack-tokens/members.env` — **`slack-post.sh` 와 같은 파일·같은 해석**(`.gitignore` 라 커밋 안 됨) |
| 부착 위치 | **멘션을 자기 줄에** 둔다 — 같은 줄이면 본문이 ``` 로 시작할 때 여는 펜스가 줄 맨 앞이 아니게 되어 멘션이 코드블록에 끌려들어갈 수 있다 |
| 경고 | 멘션 없이 `--to broadcast` 로 보낸 경우 한 줄. 팀원 간 DM 엔 영향 없음 |

**슬랙인지 서버에 물어보지 않는 이유**: 처음엔 `GET /api/messages/<id>` 응답에 `"slack` 이 있는지로 판정했는데, **그 응답에는 슬랙을 뜻하는 필드가 아예 없다**(슬랙 발신 판단은 message 행이 아니라 디스패처가 런타임에 한다). 실측 결과 판정이 **정확히 뒤집혀 있었다** — `thread_id` 가 `slack` 으로 시작하는 평범한 팀 DM(라이브 16건)에는 경고가 뜨고 **진짜 슬랙 발신에서는 안 떴다**. 알 수 없는 것을 아는 척하면 사람이 곧 경고를 무시하게 된다. → **모르는 것은 흉내내지 않는다.** 릴레이되는 실제 경로(`--to broadcast`)만 보고, 조회 자체를 없앴다(조회 실패 시 침묵하는 문제도 같이 사라진다).

**막지 않는 이유**: "슬랙에 정리해서 올려줘" 처럼 **받는 사람이 없는 게시는 멘션이 없는 게 맞다.** 문제는 받는 사람이 있는데 안 붙인 경우이고, 그건 보낸 사람만 안다 — 그래서 판단을 대신하지 않고 사실만 알린다. (`slack-post.sh` 주석의 판단과 동일: "알림 없는 게시가 정당한 경우도 있다")

## 검증 — `scripts/send-mention.test.sh` 신설

실제 발신 없이 해석·부착 로직만 돌린다.

| 시험 | 결과 |
|---|---|
| 이름 → ID · 대소문자 무시 · 사전 키 대소문자 무관 | ✓ |
| 원시 `U…` 통과 · `<@U…>` 형태도 받음 | ✓ |
| 모르는 이름 → 빈 값(스크립트가 에러로 멈춤) | ✓ |
| **사전 파일이 없어도 원시 ID 는 통과** | ✓ |
| 본문 맨 앞 **자기 줄**에 부착 · **중복 부착 안 함** · 여러 명 | ✓ |
| **코드블록으로 시작하는 본문**에서 여는 펜스가 줄 맨 앞에 유지 | ✓ |

회귀 없음 — `send-tools-honesty.test.sh` ALL PASS · `bash -n` 통과.

**검증 안 된 것**: 실제 슬랙 발신으로 알림이 가는지는 확인하지 않았다(발신은 사람에게 알림을 보내는 행위라 시험으로 돌리지 않는다). 다음 실제 답글에서 확인한다.

## 배경

이 경로가 어떤 원인으로 새는지는 오늘 팀장님이 슬랙 글을 보고 잡아주셨다. 원인을 좁히니 **경고가 있는 경로와 없는 경로가 갈려 있었고, 알아야 할 사람이 없는 쪽으로만 다녔다.**

시험이 부착 로직을 **손으로 베끼지 않고 원본 루프를 그대로 떼어 쓴다** — 베낀 사본은 원본과 갈라져도 통과한다(`#149` 에서 같은 형태로 당했다).

지시 = GD("본문 검사보다 받는이를 파라미터로") · 발견 = GD · 경고 판정 정정 = steve(교차검증)

Submitted-by: bill
