### PR TITLE
fix(mention): 슬랙 멘션을 본문에 박지 않고 릴레이 시점에 붙인다 — 텔레그램 방에 노출됐다

### DIFF
--- a/scripts/send-mention.test.sh
+++ b/scripts/send-mention.test.sh
@@ -37,30 +37,26 @@ MEMBERS_FILE="$T/none.env"
 [ "$(resolve_mention U0BL1UYHLV7)" = "U0BL1UYHLV7" ] && ok "원시 ID 는 통과" || bad "원시 ID 실패"
 MEMBERS_FILE="$T/members.env"
 
-echo "── T5: 본문 부착 (중복 방지 포함) ──"
-# ★부착 로직을 손으로 베끼지 않는다★ — 베끼면 그 사본이 원본과 갈라져도 시험은 통과한다
-#   (#149 에서 같은 형태로 당했다: 대조 대상이 자기 복사본이었다).
-#   그래서 send.sh 의 for 루프를 ★그대로 떼어★ 쓴다.
-eval "prepend() {  # prepend <본문> <멘션들...>
-  local BODY=\"\$1\"; shift
-  local MENTIONS=\"\$*\"
-$(sed -n '/^for _m in \$MENTIONS; do$/,/^done$/p' "$SRC")
-  printf '%s' \"\$BODY\"
-}"
-r="$(prepend "본문" lisa)"
-[ "$r" = "$(printf '<@U0BL1UYHLV7>\n본문')" ] && ok "맨 앞 ★자기 줄★ 에 붙음" || bad "부착: $r"
-r="$(prepend "<@U0BL1UYHLV7> 이미 있음" lisa)"
-[ "$r" = "<@U0BL1UYHLV7> 이미 있음" ] && ok "★중복으로 안 붙임★" || bad "중복: $r"
-# ★코드블록이 깨지지 않는지★ — 여는 펜스가 줄 맨 앞에 그대로 있어야 한다
-r="$(prepend '```
-code
-```' lisa)"
-case "$r" in
-  "<@U0BL1UYHLV7>"*$'\n''```'*) ok "코드블록 여는 펜스가 줄 맨 앞에 유지됨" ;;
-  *) bad "★펜스가 밀렸다★: $(printf '%s' "$r" | head -2 | tr '\n' '|')" ;;
-esac
-r="$(prepend "본문" lisa jane)"
-case "$r" in *"<@U0BL1UYHLV7>"*) case "$r" in *"<@U0BKJR2G8MD>"*) ok "여러 명 부착" ;; *) bad "두 번째 누락" ;; esac ;; *) bad "첫 번째 누락" ;; esac
+echo "── T5: ★본문을 오염시키지 않는다★ (broadcast 는 텔레그램 그룹방으로도 나간다) ──"
+# ★이 시험이 존재하는 이유★: 처음엔 send.sh 가 본문 맨 앞에 <@U…> 를 박았다.
+#   그 결과 ★텔레그램 단체방에 <@U0BL1UYHLV7> 이 그대로 찍혔다★(2026-07-30, 팀장님 발견).
+#   슬랙 문법은 슬랙에서만 뜻이 있다 — 그래서 지금은 ID 만 풀어 meta 로 넘기고,
+#   실제 부착은 슬랙으로 릴레이하는 서버가 한다.
+grep -q 'BODY="<@' "$SRC" && bad "★본문에 멘션을 박는 코드가 남아 있다★" || ok "본문 부착 코드 없음"
+grep -q "meta\['slack_mentions'\]" "$SRC" && ok "meta.slack_mentions 로 넘긴다" || bad "meta 전달 코드가 없다"
+grep -q 'MENTION_IDS="\$MENTION_IDS \$_id"' "$SRC" && ok "ID 로 풀어 모은다" || bad "ID 수집 코드가 없다"
+
+echo "── T6: 서버가 슬랙 릴레이에서만 붙이나 (소스 확인) ──"
+SRV="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/src/server/routes/inbox.ts"
+if [ -f "$SRV" ]; then
+  grep -q 'slack_mentions' "$SRV" && ok "릴레이가 meta 를 읽는다" || bad "서버가 meta 를 안 읽는다"
+  # 부착이 슬랙 send 블록 안에 있는지 — text: slackText 로 넘어가야 한다
+  grep -q 'text: slackText' "$SRV" && ok "슬랙 발신 text 에만 적용" || bad "슬랙 발신에 안 걸려 있다"
+  # 형식 검증: U/W 로 시작하는 것만 받아야 한다(임의 문자열 주입 방지)
+  grep -q 'UW\]\[A-Z0-9\]' "$SRV" && ok "ID 형식 검증 있음" || bad "★형식 검증 없음 — 임의 문자열이 붙는다★"
+else
+  bad "서버 소스를 못 찾음: $SRV"
+fi
 
 echo
 [ "$FAIL" -eq 0 ] && echo "ALL PASS" || echo "FAIL"

--- a/skills/b3os-team-inbox/scripts/send.sh
+++ b/skills/b3os-team-inbox/scripts/send.sh
@@ -162,6 +162,12 @@ resolve_mention() {  # resolve_mention <원시ID|이름> -> ID 또는 빈 문자
     { k=$1; gsub(/^[[:space:]]+|[[:space:]]+$/, "", k); v2=$2; gsub(/^[[:space:]]+|[[:space:]]+$/, "", v2)
       if (tolower(k) == want) { print v2; exit } }' "$MEMBERS_FILE"
 }
+# ★본문에 넣지 않는다★ (2026-07-30 실측) — `--to broadcast` 는 슬랙만이 아니라
+#   ★텔레그램 그룹방으로도 나간다.★ 본문에 미리 `<@U…>` 를 박으면 그 문자열이
+#   ★단체방에 그대로 찍힌다★(팀장님이 발견). 슬랙 문법은 슬랙에서만 뜻이 있다.
+#   → ID 로 풀기만 하고 ★meta 로 넘긴다.★ 실제 부착은 ★슬랙으로 릴레이하는 서버★ 가 한다
+#     (채널마다 다른 것은 그 채널로 나갈 때 붙인다. 저장 본문은 채널 중립으로 둔다).
+MENTION_IDS=""
 for _m in $MENTIONS; do
   _id="$(resolve_mention "$_m")"
   if [ -z "$_id" ]; then
@@ -169,16 +175,11 @@ for _m in $MENTIONS; do
     echo "  원시 ID(U…)를 직접 주거나, $MEMBERS_FILE 에 '이름=U01234567' 을 추가하세요." >&2
     exit 1
   fi
-  case "$BODY" in *"<@$_id>"*) continue ;; esac   # 본문에 이미 있으면 중복으로 안 붙인다
-  # ★멘션은 자기 줄에 둔다★ (steve 지적) — 같은 줄에 붙이면 본문이 ``` 로 시작할 때
-  #   여는 펜스가 줄 맨 앞이 아니게 되어 멘션이 코드블록 안으로 끌려들어갈 수 있다.
-  #   사람이 쓰는 모양과도 같다.
-  BODY="<@$_id>
-$BODY"
+  MENTION_IDS="$MENTION_IDS $_id"
 done
 
 # Build JSON via python to handle escaping safely.
-PAYLOAD=$(BODY="$BODY" FROM="$FROM" TO="$TO" THREAD="$THREAD" REPLY_TO="$REPLY_TO" TYPE="$TYPE" PRIORITY="$PRIORITY" HOP="$HOP" SYNC="$SYNC" DIRECT_TO_GD="$DIRECT_TO_GD" SOURCE_THREAD="$SOURCE_THREAD" EXPECT_REPORT_BY="$EXPECT_REPORT_BY" INDIVIDUAL="$INDIVIDUAL" EPISODE="$EPISODE" python3 -c "
+PAYLOAD=$(MENTION_IDS="$MENTION_IDS" BODY="$BODY" FROM="$FROM" TO="$TO" THREAD="$THREAD" REPLY_TO="$REPLY_TO" TYPE="$TYPE" PRIORITY="$PRIORITY" HOP="$HOP" SYNC="$SYNC" DIRECT_TO_GD="$DIRECT_TO_GD" SOURCE_THREAD="$SOURCE_THREAD" EXPECT_REPORT_BY="$EXPECT_REPORT_BY" INDIVIDUAL="$INDIVIDUAL" EPISODE="$EPISODE" python3 -c "
 import json, os
 p = {
   'from_agent_id': os.environ['FROM'],
@@ -211,6 +212,11 @@ if os.environ.get('INDIVIDUAL'):
 #   판정기가 json_extract(meta_json,'\$.episode') 로 그 수집만 묶는다(measure=deploy·codex-d).
 if os.environ.get('EPISODE', '').strip():
     meta['episode'] = os.environ['EPISODE'].strip()
+# slack_mentions: 슬랙으로 릴레이될 때만 서버가 본문 앞에 <@ID> 를 붙인다.
+#   ★본문에 직접 넣지 않는 이유★ — broadcast 는 텔레그램 그룹방으로도 나가고, 거기선 이 문법이
+#   의미 없는 문자열로 그대로 보인다(실측). 채널별 표현은 그 채널로 나갈 때 붙인다.
+if os.environ.get('MENTION_IDS', '').strip():
+    meta['slack_mentions'] = os.environ['MENTION_IDS'].split()
 if meta:
     p['meta'] = meta
 print(json.dumps(p, ensure_ascii=False))

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -227,11 +227,24 @@ export function createInboxRoutes(deps: InboxRouteDeps): Hono {
       if (slackMeta) {
         const creds = loadAgentCreds(env.from_agent_id);
         if (creds) {
+          // ★슬랙 멘션은 여기서 붙인다★ (2026-07-30) — 발신 스크립트가 본문에 미리 넣으면
+          //   `<@U…>` 가 ★텔레그램 그룹방에도 그대로 찍힌다★(실측: 팀장님이 단체방에서 발견).
+          //   슬랙 문법은 슬랙에서만 뜻이 있고, 다른 채널에는 의미 없는 문자열이다.
+          //   즉 ★채널마다 다른 것은 채널로 나갈 때 붙여야★ 한다. 저장되는 본문은 채널 중립으로 둔다.
+          //   meta.slack_mentions = ["U…", …] (send.sh --mention 이 이름을 ID 로 풀어 넣는다)
+          const mentions = ((env as { meta?: { slack_mentions?: unknown } }).meta?.slack_mentions ?? []) as unknown[];
+          const prefix = mentions
+            .filter((m): m is string => typeof m === "string" && /^[UW][A-Z0-9]+$/.test(m))
+            .filter((id) => !env.body.includes(`<@${id}>`))   // 본문에 이미 있으면 중복 안 붙인다
+            .map((id) => `<@${id}>`)
+            .join(" ");
+          // 멘션은 ★자기 줄에★ — 같은 줄이면 본문이 ``` 로 시작할 때 여는 펜스가 줄 맨 앞이 아니게 된다.
+          const slackText = prefix ? `${prefix}\n${env.body}` : env.body;
           void getChannel("slack")
             .send({
               botToken: creds.bot_token,
               target: slackMeta.channel,
-              text: env.body,
+              text: slackText,
               threadRef: slackMeta.thread_ts,
             })
             .then((r) => {


### PR DESCRIPTION
## 핵심 3줄

1. `#160` 이 넣은 멘션이 **본문에 박혀서 텔레그램 단체방에 `<@U0BL1UYHLV7>` 이 그대로 찍혔다**(팀장님이 실측 발견).
2. `--to broadcast` 는 슬랙만이 아니라 **텔레그램 그룹방으로도 나간다**. 슬랙 문법은 슬랙에서만 뜻이 있고 다른 채널엔 의미 없는 문자열이다.
3. 발신 스크립트는 **ID 로 풀어 `meta` 로만 넘기고**, 실제 부착은 **슬랙으로 릴레이하는 서버**가 한다.

## 무엇을 바꿨나

| | 전 | 후 |
|---|---|---|
| `send.sh` | 본문 맨 앞에 `<@ID>` **박음** | ID 로 풀어 `meta.slack_mentions` 로 **전달만** |
| 저장되는 본문 | 슬랙 문법 오염 | **채널 중립** |
| 부착 시점 | 발신 시 | **슬랙 릴레이 시** (`routes/inbox.ts`) |
| 텔레그램 그룹방 | `<@U…>` 노출 | 깨끗 |

서버 쪽 부착은 `U`/`W` 로 시작하는 형식만 받고, 본문에 이미 있으면 중복 부착하지 않으며, 멘션을 **자기 줄에** 둔다(코드블록 펜스 보호 — `#160` 에서 넣은 것 유지).

## 원칙

**채널마다 다른 것은 그 채널로 나갈 때 붙인다.** 저장되는 본문은 채널 중립으로 둔다.
`#160` 은 발신 시점에 붙여서 **한 채널의 문법을 모든 채널에 실어 보냈다.**

## 검증

| 시험 | 결과 |
|---|---|
| `send.sh` 에 본문 부착 코드가 **없다** | ✓ |
| `meta.slack_mentions` 로 넘긴다 · 이름→ID 해석은 그대로 | ✓ |
| 서버가 **슬랙 발신 `text` 에만** 적용 | ✓ |
| ID 형식 검증(`U`/`W`) 있음 — 임의 문자열 주입 방지 | ✓ |
| 이름→ID · 대소문자 · 원시 ID · 사전 없어도 원시 ID 통과 | ✓ |

`tsc` 0 · `bash -n` 통과.

**검증 안 된 것**: 실제 슬랙 발신으로 알림이 뜨는지, 그리고 그때 텔레그램 그룹방이 깨끗한지는 **배포 후 실제 발신으로 확인해야 한다**. `#160` 의 결함이 정확히 그 지점에서 드러났다(시험은 통과했는데 실제 방에서 보였다).

발견 = GD(단체방 스크린샷)

Submitted-by: bill
