### PR TITLE
fix(mention): meta 를 배열이라고 믿지 않는다 — 500 경로 + 알림 남용 방지

### DIFF
--- a/src/server/lib/relayMention.test.ts
+++ b/src/server/lib/relayMention.test.ts
@@ -1,0 +1,74 @@
+// 슬랙 릴레이의 멘션 부착 판정 — ★발신자가 채우는 meta 를 믿지 않는지★ 를 본다.
+//   실제 발신은 하지 않는다(사람에게 알림이 간다). 부착 문자열을 만드는 규칙만 검증한다.
+//   ★이 규칙이 서버 소스와 갈라지지 않게★ inbox.ts 에서 상수·정규식을 그대로 읽어 대조한다.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC = readFileSync(join(import.meta.dir, "../routes/inbox.ts"), "utf-8");
+
+/** inbox.ts 의 부착 규칙을 그대로 옮긴 것 — 아래 계약 시험이 원본과 일치함을 못박는다. */
+function slackPrefix(rawMentions: unknown, body: string, max = 10): string {
+  return (Array.isArray(rawMentions) ? rawMentions : [])
+    .filter((m): m is string => typeof m === "string" && /^[UW][A-Z0-9]+$/.test(m))
+    .filter((id, i, arr) => arr.indexOf(id) === i)
+    .filter((id) => !body.includes(`<@${id}>`))
+    .slice(0, max)
+    .map((id) => `<@${id}>`)
+    .join(" ");
+}
+
+describe("슬랙 멘션 부착 — meta 는 발신자가 채운다", () => {
+  test("★배열이 아니면 터지지 않고 무시한다★ (문자열·객체·null·숫자)", () => {
+    // codex 교차검증: "U123" 이나 {} 가 오면 .filter is not a function → 저장 뒤 POST 500.
+    for (const bad of ["U123", {}, null, undefined, 42, true]) {
+      expect(() => slackPrefix(bad, "본문")).not.toThrow();
+      expect(slackPrefix(bad, "본문")).toBe("");
+    }
+  });
+
+  test("정상 배열은 붙는다", () => {
+    expect(slackPrefix(["U0BL1UYHLV7"], "본문")).toBe("<@U0BL1UYHLV7>");
+  });
+
+  test("★형식이 아닌 값은 걸러낸다★ — 개행·슬랙 문법 주입 방지", () => {
+    expect(slackPrefix(["<!channel>", "U1\nX", "here", "u0bl1uyhlv7", ""], "본문")).toBe("");
+  });
+
+  test("★같은 사람을 두 번 부르지 않는다★", () => {
+    expect(slackPrefix(["U0BL1UYHLV7", "U0BL1UYHLV7"], "본문")).toBe("<@U0BL1UYHLV7>");
+  });
+
+  test("본문에 이미 있으면 중복으로 안 붙인다", () => {
+    expect(slackPrefix(["U0BL1UYHLV7"], "<@U0BL1UYHLV7> 이미 있음")).toBe("");
+  });
+
+  test("★개수 상한★ — 멘션 하나가 알림 하나다", () => {
+    const many = Array.from({ length: 30 }, (_, i) => `U${String(i).padStart(9, "0")}`);
+    expect(slackPrefix(many, "본문").split(" ").length).toBe(10);
+  });
+
+  test("여러 명은 한 줄에 모인다", () => {
+    expect(slackPrefix(["U0BL1UYHLV7", "U0BKJR2G8MD"], "본문")).toBe("<@U0BL1UYHLV7> <@U0BKJR2G8MD>");
+  });
+});
+
+describe("★계약★ — 위 규칙이 서버 소스와 갈라지지 않는다", () => {
+  // 손으로 베낀 사본은 원본이 바뀌어도 통과한다(#149 에서 당했다). 원본에 각 가드가 있는지 직접 센다.
+  test("배열 가드가 소스에 있다", () => {
+    expect(SRC).toContain("Array.isArray(rawMentions)");
+  });
+  test("ID 형식 검증이 소스에 있다", () => {
+    expect(SRC).toContain("/^[UW][A-Z0-9]+$/");
+  });
+  test("중복 제거가 소스에 있다", () => {
+    expect(SRC).toContain("arr.indexOf(id) === i");
+  });
+  test("개수 상한이 소스에 있고 이 시험의 기본값과 같다", () => {
+    const m = SRC.match(/MAX_MENTIONS\s*=\s*(\d+)/);
+    expect(m?.[1]).toBe("10");
+  });
+  test("부착 결과가 슬랙 send 의 text 로만 간다", () => {
+    expect(SRC).toContain("text: slackText");
+  });
+});

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -232,10 +232,17 @@ export function createInboxRoutes(deps: InboxRouteDeps): Hono {
           //   슬랙 문법은 슬랙에서만 뜻이 있고, 다른 채널에는 의미 없는 문자열이다.
           //   즉 ★채널마다 다른 것은 채널로 나갈 때 붙여야★ 한다. 저장되는 본문은 채널 중립으로 둔다.
           //   meta.slack_mentions = ["U…", …] (send.sh --mention 이 이름을 ID 로 풀어 넣는다)
-          const mentions = ((env as { meta?: { slack_mentions?: unknown } }).meta?.slack_mentions ?? []) as unknown[];
-          const prefix = mentions
+          // ★meta 는 발신자가 채우는 값이다 — 배열이라고 믿지 않는다★ (codex 교차검증).
+          //   `slack_mentions: "U123"` 이나 `{}` 가 오면 `.filter is not a function` 으로 ★POST 가 500★ 난다.
+          //   메시지는 이미 저장된 뒤라 ★"보냈는데 서버가 터진" 상태★ 가 된다. 배열이 아니면 조용히 무시한다.
+          const rawMentions = (env as { meta?: { slack_mentions?: unknown } }).meta?.slack_mentions;
+          // 개수 상한: 멘션 하나가 알림 하나다. 상한이 없으면 한 메시지로 워크스페이스 전체를 울릴 수 있다.
+          const MAX_MENTIONS = 10;
+          const prefix = (Array.isArray(rawMentions) ? rawMentions : [])
             .filter((m): m is string => typeof m === "string" && /^[UW][A-Z0-9]+$/.test(m))
+            .filter((id, i, arr) => arr.indexOf(id) === i)    // 같은 사람을 두 번 부르지 않는다
             .filter((id) => !env.body.includes(`<@${id}>`))   // 본문에 이미 있으면 중복 안 붙인다
+            .slice(0, MAX_MENTIONS)
             .map((id) => `<@${id}>`)
             .join(" ");
           // 멘션은 ★자기 줄에★ — 같은 줄이면 본문이 ``` 로 시작할 때 여는 펜스가 줄 맨 앞이 아니게 된다.


### PR DESCRIPTION
## 핵심 3줄

1. `#161` 이 슬랙 멘션을 `meta.slack_mentions` 로 받는데, **그건 발신자가 채우는 값이다.** 배열이 아니면(`"U123"`·`{}`) `.filter is not a function` 으로 **메시지는 저장된 뒤 POST 가 500** 난다.
2. 개수 상한·중복 제거도 없어서 한 메시지로 **워크스페이스 전체를 울릴 수 있다.**
3. 배열 가드 + 중복 제거 + 상한 10. 서버 3줄.

## 무엇을 바꿨나

| 문제 | 고친 방법 |
|---|---|
| `meta.slack_mentions` 가 배열이 아니면 **500** (저장은 됨 = "보냈는데 서버가 터진" 상태) | `Array.isArray` 아니면 **조용히 무시** |
| 같은 사람을 두 번 부름 | `indexOf === i` 로 중복 제거 |
| 개수 무제한 — **멘션 하나가 알림 하나다** | 상한 10 |

## 검증 — `src/server/lib/relayMention.test.ts` 신설

| 시험 | 결과 |
|---|---|
| **배열이 아니면 터지지 않고 무시**(문자열·객체·null·undefined·숫자·불리언) | ✓ |
| 형식 아닌 값 제거 — `<!channel>` · 개행 포함 · 소문자 · 빈 문자열 | ✓ |
| 중복 제거 · 본문에 이미 있으면 안 붙임 · 상한 10 · 여러 명 한 줄 | ✓ |
| **계약**: 소스에 배열 가드·정규식·중복 제거·상한이 실제로 있고, 결과가 `text: slackText` 로만 감 | ✓ |

- 뮤턴트: 배열 가드를 없애면 **계약 시험이 깨진다** ✓
- `tsc` 0

**시험이 규칙을 베껴 갖고 있어서**(#149 형태) 계약 절을 따로 뒀다 — 소스에서 상한 값을 읽어 시험 기본값과 대조하고, 각 가드가 소스에 있는지 직접 센다.

## 교차검증 결과 (#161 사후, 이 PR 의 근거)

- **codex**: 고치고 유지 — 위 500 경로가 블로커. 채널 분리·부착 위치는 맞음
- **hermes**: 유지 가 — 세 축(다른 채널 누출·부착 지점·슬랙 스레드 판정) 모두 새 유출 경로 없음. 정규식이 개행·`>`·공백을 거르는 것 Node 로 실측

**codex 가 함께 정정한 것**: "슬랙 스레드면 텔레그램엔 안 간다" 는 **그룹방에 한정**해야 정확하다 — `direct_to_gd` 는 분기 우선이라 슬랙 스레드여도 **팀장 DM 에는 간다**. 이 PR 범위 밖이지만 기록해 둔다.

발견 = codex(교차검증)

Submitted-by: bill
