### PR TITLE
fix(reports): 태그 hover 아이콘이 안 보이는 상태에서도 눌리던 것

### DIFF
--- a/src/web/components/Reports.ts
+++ b/src/web/components/Reports.ts
@@ -372,11 +372,15 @@ export function tagPillsHtml(
   selected: Set<string>,
   pillCls: (active: boolean) => string,
 ): string {
+  // opacity 만으로 숨기면 안 보이는데 눌린다 — 투명해도 그 자리는 여전히 클릭을 받는다.
+  // 마우스가 없는 환경(터치·아이패드 웹뷰)에서 태그 옆을 탭하면 안 보이는 연필·휴지통이 눌려
+  // "누르지도 않은 창" 이 뜬다. pointer-events 를 같이 꺼서 숨김 상태에선 클릭 자체를 안 받게 한다.
+  const hoverOnlyCls = "opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto";
   const iconCls = "inline-flex h-6 w-6 items-center justify-center rounded-md border border-surface-3 bg-surface-1/70 text-slate-500 transition-colors";
   return tags.map((t) =>
     `<span class="group inline-flex items-center">
       <button class="${pillCls(selected.has(t.id))} reports-tag-pill" data-tag-id="${escape(t.id)}">#${escape(t.name)}<span class="ml-1.5 text-[11px] text-slate-500">${t.report_count ?? 0}</span></button>
-      <span class="ml-0.5 inline-flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+      <span class="ml-0.5 inline-flex items-center gap-0.5 ${hoverOnlyCls} transition-opacity">
         <button class="reports-tag-edit ${iconCls} hover:border-accent-green/40 hover:bg-accent-green/10 hover:text-accent-green" data-tag-id="${escape(t.id)}" data-tag-name="${escape(t.name)}" title="${pick("태그 이름 바꾸기", "Rename tag")}" aria-label="${pick("태그 이름 바꾸기", "Rename tag")}">
           <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
         </button>

--- a/src/web/components/reportsTagPills.test.ts
+++ b/src/web/components/reportsTagPills.test.ts
@@ -33,6 +33,14 @@ describe("tagPillsHtml", () => {
     expect(html).toContain("opacity-0 group-hover:opacity-100");
   });
 
+  test("★안 보일 때는 눌리지도 않는다★ — opacity 만으로는 클릭이 안 막힌다", () => {
+    // 투명한 요소도 그 자리는 클릭을 받는다. 마우스가 없는 환경(터치·아이패드 웹뷰)에서
+    // 태그 옆을 탭하면 안 보이는 연필·휴지통이 눌려 "누르지도 않은 창" 이 뜬다.
+    const html = tagPillsHtml([tag("t1", "a")], new Set(), pillCls);
+    expect(html).toContain("pointer-events-none");
+    expect(html).toContain("group-hover:pointer-events-auto");
+  });
+
   test("★태그 이름이 속성을 깨지 않는다★ — 이름은 사용자 입력이다", () => {
     const html = tagPillsHtml([tag("t1", '따옴표" <b>태그</b>')], new Set(), pillCls);
     // 원문 그대로 속성에 들어가면 data-tag-name 이 조기 종료돼 마크업이 깨진다.


### PR DESCRIPTION
## 핵심

- **무엇이 문제인가** — 보고서 태그의 hover 아이콘(연필·휴지통)을 `opacity-0` 으로만 숨겼다. **투명한 요소도 그 자리는 클릭을 받는다.**
- **누가 언제 겪나** — 마우스가 없는 환경(터치·아이패드 웹뷰)에서 태그 알약 **오른쪽을 탭하면** 안 보이는 버튼이 눌린다. 연필이면 이름 입력창이, 휴지통이면 삭제 확인창이 뜬다. 사용자에게는 "누르지도 않은 창이 떴다" 로 보인다. **조용히 지워지지는 않는다**(확인창이 한 번 더 뜬다).
- **어떻게 했나** — 숨김 상태에 `pointer-events-none`, hover 에 `pointer-events-auto`. 소스 1파일 · 테스트 1파일.

## 무엇을 바꿨나

| 파일 | 변경 |
|---|---|
| `src/web/components/Reports.ts` | hover 전용 클래스를 `hoverOnlyCls` 상수로 분리하고 `pointer-events` 쌍을 추가. 근거는 JS 주석 |
| `src/web/components/reportsTagPills.test.ts` | 숨김 상태에 두 클래스가 실리는지 단정하는 테스트 1종 |

## 왜 주석을 HTML 이 아니라 JS 로 두었나

처음엔 템플릿 리터럴 안에 `<!-- ... -->` 로 적었는데, 그러면 **렌더된 페이지 소스에 그대로 실려 나간다** — 태그 하나당 4줄이고, 내부 논의(누가 언제 잡았는지)가 퍼블릭 사용자에게 보인다. JS 주석은 브라우저로 안 나간다.

## 클래스 순서를 유지한 이유

기존 테스트가 `opacity-0 group-hover:opacity-100` 을 **연속된 문자열로** 단정한다. 사이에 끼워 넣으면 그 테스트가 깨진다. 두 클래스를 붙여 둔 채 뒤에 추가해서 기존 단정을 그대로 통과시켰다.

## 검증

- `bun test src/web src/server` → **1976 tests · 0 fail** (신규 1종 포함)
- `tsc --noEmit` → 0
- **뮤턴트** — `pointer-events-none group-hover:pointer-events-auto` 를 빼면 신규 테스트가 FAIL 한다(빼고 실제로 돌려 확인). 테스트가 이 가드를 실제로 보고 있다는 근거다.

## 미검증

- **실제 터치 기기에서 탭해 본 것은 아니다.** 코드가 단정하는 것은 "숨김 상태에 `pointer-events-none` 이 실린다" 까지다. 눌리지 않는다는 최종 확인은 육안·기기 확인이 필요하다.

## 배경

`#164` 머지 후 steve 자체점검에서 나왔다. 발견자가 직접 적어 넘긴 것을 그대로 옮겼다.

Submitted-by: bill
