### PR TITLE
fix(dashboard/ci): 화면이 부르는 주소에 /api 가 빠져 CI 블록이 한 번도 동작하지 않았다

### DIFF
--- a/src/server/routes/ciStatus.test.ts
+++ b/src/server/routes/ciStatus.test.ts
@@ -1,4 +1,6 @@
 import { describe, test, expect } from "bun:test";
+import { Hono } from "hono";
+import { CI_URL } from "../../web/components/TeamOS";
 import { createCiStatusRoutes, normalizeRuns, parseRateLimit, RateLimitedError, parseRepoFromRemote, repoFromGitConfig, resolveCiRepo } from "./ciStatus";
 
 const sample = {
@@ -308,5 +310,23 @@ describe("미설정 방어는 2층이다", () => {
       if (prev === undefined) delete process.env.TEAM_CI_REPO;
       else process.env.TEAM_CI_REPO = prev;
     }
+  });
+});
+
+// ─── 화면이 부르는 주소가 실제로 이 라우트에 닿나 (2026-07-30) ──────────────────
+// ★상수를 상수와 비교하는 것으로는 부족하다.★ 화면이 `${apiBase()}/ci-status` 로 불러
+//   SPA 의 index.html 을 받고 있었고(라이브 실측), 서버·파싱·표시 테스트는 전부 통과했다.
+//   그래서 여기서는 ★index.ts 와 같은 방식으로 mount 한 뒤 그 주소로 실제 요청★ 을 보낸다.
+describe("화면이 쓰는 주소가 라우트에 닿는다", () => {
+  test("★CI_URL 로 요청하면 이 라우트가 응답한다★ — index.ts 와 같은 mount 구성", async () => {
+    const api = new Hono();
+    api.route("/", createCiStatusRoutes({ ciRepo: () => null }));  // index.ts:397
+    const app = new Hono();
+    app.route("/api", api);                                       // index.ts:473
+
+    const res = await app.request(CI_URL);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { configured?: boolean };
+    expect(body.configured).toBe(false); // 라우트가 실제로 답한 것(404 HTML 이 아니다)
   });
 });

--- a/src/web/components/TeamOS.ts
+++ b/src/web/components/TeamOS.ts
@@ -38,9 +38,16 @@ let _ciData: Parameters<typeof ciBlockHtml>[0] = null;
 
 /** CI 결과를 가져와 ★그 블록만★ 갈아끼운다(전체 재렌더 안 함 — 스크롤 튐 방지).
  *  ★실패해도 화면을 비우지 않는다★ — 서버가 ok:false 와 이유를 주고 블록이 빨간 줄로 보여준다. */
+/** ★API 주소는 `${apiBase()}/api/...` 다★ — `apiBase()` 는 BASE_PATH(`/team`) 만 준다.
+ *  앞선 판은 `${apiBase()}/ci-status` 로 불러 ★SPA 의 index.html 을 받았다★. 그래서 화면은
+ *  줄곧 `✖ 확인 불가 · Unexpected token '<'` 였다 — ★이 블록은 한 번도 동작한 적이 없다.★
+ *  서버·파싱·표시 테스트는 전부 통과했고 교차검증도 코드를 읽어 "화면이 이유를 보여준다" 로 봤다.
+ *  ★부르는 주소를 실제로 부른 사람이 없었다.★ 그래서 아래 CI_URL 을 테스트가 직접 단정한다. */
+export const CI_URL = "/api/ci-status";
+
 async function loadCi(root: HTMLElement): Promise<void> {
   try {
-    const r = await fetch(`${apiBase()}/ci-status`);
+    const r = await fetch(`${apiBase()}${CI_URL}`);
     _ciData = await r.json();
   } catch (e) {
     _ciData = { ok: false, reason: e instanceof Error ? e.message : String(e), runs: [], fetched_at: null };

--- a/src/web/components/teamOsCi.test.ts
+++ b/src/web/components/teamOsCi.test.ts
@@ -6,7 +6,7 @@
  * (초록으로 위장하지 않는다 / 미설정은 오류가 아니다) 여기서 못 박는다.
  */
 import { describe, expect, test } from "bun:test";
-import { ciBlockHtml } from "./TeamOS";
+import { CI_URL, ciBlockHtml } from "./TeamOS";
 
 const base = {
   ok: false,
@@ -60,5 +60,16 @@ describe("빈 결과를 초록으로 위장하지 않는다", () => {
     const html = ciBlockHtml({ ...base, reason: '<img src=x onerror="alert(1)">' });
     expect(html).not.toContain("<img");
     expect(html).toContain("&lt;img");
+  });
+});
+
+describe("CI 를 부르는 주소", () => {
+  // ★이 한 줄이 없어서 블록이 한 번도 동작하지 않았다★ (2026-07-30 라이브 실측)
+  //   `${apiBase()}/ci-status` 는 SPA 의 index.html 을 받아온다 → JSON 파싱 실패 →
+  //   화면에 `✖ 확인 불가 · Unexpected token '<'`. 서버·표시 테스트가 전부 통과하는데도 그랬다.
+  //   부르는 주소는 ★그 주소로 실제 요청이 가는지★ 를 봐야 알 수 있다.
+  test("★/api 접두가 있어야 한다★ — 저장소의 다른 호출과 같은 규칙", () => {
+    expect(CI_URL.startsWith("/api/")).toBe(true);
+    expect(CI_URL).toBe("/api/ci-status");
   });
 });


### PR DESCRIPTION
## 핵심

- **무엇이 문제인가** — 화면이 `${apiBase()}/ci-status` 로 부른다. `apiBase()` 는 `/team` 만 주므로 이 주소는 **SPA 의 index.html** 을 돌려준다. JSON 파싱이 실패해 화면은 줄곧 `✖ 확인 불가 · Unexpected token '<'` 였다.
- **얼마나 오래** — `#118` 이 이 블록을 만든 뒤 **한 번도 동작한 적이 없다.** 오늘 배포 후 라이브 화면을 열어서 발견했다.
- **어떻게 했나** — 주소를 `CI_URL` 상수로 빼고 `/api` 를 붙였다. 소스 1파일 + 테스트 2파일.

## 라이브 실측

```
/team/api/ci-status → 200 JSON   (서버는 정상 — 실행 10건)
/team/ci-status     → 200 HTML   (화면이 부르던 주소)
```

저장소의 다른 호출은 전부 `${apiBase()}/api/...` 다(`AgentSlack.ts` 4곳). 여기만 규칙에서 벗어나 있었다.

## 왜 아무도 못 봤나

서버 테스트·파싱 테스트·표시 테스트가 **전부 통과**했고, 교차검증도 코드를 읽어 "화면이 이유를 보여준다" 로 판단했다. 실제로 화면은 이유를 보여주고 있었다 — **다만 그 이유가 JSON 파싱 오류였다.**

**부르는 주소를 실제로 부른 사람이 없었다.**

## 그래서 테스트를 두 층으로 넣었다

| 어디 | 무엇을 단정하나 |
|---|---|
| 화면 | `CI_URL` 에 `/api` 접두가 있다 |
| 서버 | `index.ts` 와 **같은 방식으로 mount** 한 뒤 `CI_URL` 로 **실제 요청**을 보내 라우트가 응답한다 |

상수를 상수와 비교하는 것만으로는 이 결함을 못 잡는다 — 틀린 주소를 쓴 사람은 틀린 단정도 같이 쓴다. 그래서 **주소가 실제로 어디에 닿는지**를 서버 쪽에서 확인한다.

## 검증

- `bun test src/server src/web` → **2006 tests · 0 fail** · `tsc` 0
- **뮤턴트** — `CI_URL` 에서 `/api` 를 빼면 **화면 테스트 1 fail · 서버 mount 테스트 1 fail**

## 미검증

- 고친 뒤의 화면은 **아직 라이브에서 안 봤다.** 머지·배포 후 직접 열어 확인하고 결과를 남기겠다.

Submitted-by: bill