### PR TITLE
fix(reports): 태그 아이콘이 항상 빈칸을 남기던 것 + 분류를 세 개로 + 태그를 목록에서 고르게

### DIFF
--- a/src/server/db/reports.ts
+++ b/src/server/db/reports.ts
@@ -1,4 +1,5 @@
 import type { Database } from "bun:sqlite";
+import { canonicalCategory, DEFAULT_REPORT_CATEGORY, REPORT_CATEGORIES } from "../lib/reportCategory";
 import { Buffer } from "node:buffer";
 import { nanoid } from "nanoid";
 
@@ -140,7 +141,7 @@ export function listReports(db: Database): ReportMeta[] {
   return attachTags(db, rows.map(rowToReport));
 }
 
-const DEFAULT_REPORT_CATEGORY = "보고서";
+// 기본 분류는 lib/reportCategory 의 정본을 쓴다 — 여기 따로 두면 두 곳이 갈린다(오늘 고치는 게 그 문제다).
 const CATEGORY_EXPR = `COALESCE(NULLIF(TRIM(category), ''), '${DEFAULT_REPORT_CATEGORY}')`;
 const MAX_REPORT_PAGE_SIZE = 100;
 type DbArg = string | number | boolean | null;
@@ -257,6 +258,15 @@ export function upsertReport(
   // date = 실제 작성일(있으면 created_at 으로). 없으면 INSERT 시 now / 갱신 시 기존값 유지.
   // created_at = 정렬·표시 기준(보고서 작성일). 등록시각은 updated_at 으로 충분.
   const date = input.date ?? null;
+  // ★분류는 세 개(보고서·리서치·교육자료)로만 저장한다★ (팀장님 지시 2026-07-30).
+  //   자유 문자열이던 탓에 같은 뜻이 표기별로 갈렸다 — 리서치/research/AI 리서치/AI Research 가
+  //   전부 따로 세어져 화면 알약이 9개로 늘었고, 팀장님이 그것을 태그로 오인하셨다.
+  //   ★db 층에 두는 이유★: 라우트 두 곳·정리 스크립트가 각자 접으면 또 갈린다. 넣는 문이 하나여야 한다.
+  //   모르는 표기는 기본값으로 접되 ★조용히 하지 않는다★ — 올린 사람이 자기 분류가 사라진 걸 모르면
+  //   그게 오늘 하루 우리를 괴롭힌 '무증상' 이다.
+  const category = canonicalCategory(input.category, (original) => {
+    console.warn(`[reports] 알 수 없는 분류 "${original}" → "${DEFAULT_REPORT_CATEGORY}" 로 저장합니다 (분류는 ${REPORT_CATEGORIES.join("·")} 만 씁니다)`);
+  });
   db.query(
     `INSERT INTO report (id, title, author, summary, category, forms_json, project, created_at)
      VALUES (?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')))
@@ -264,7 +274,7 @@ export function upsertReport(
        title=excluded.title, author=excluded.author, summary=excluded.summary,
        category=excluded.category, forms_json=excluded.forms_json, project=excluded.project,
        created_at=COALESCE(?, report.created_at), updated_at=datetime('now')`,
-  ).run(id, input.title, input.author ?? null, input.summary ?? null, input.category ?? null, forms_json, input.project ?? null, date, date);
+  ).run(id, input.title, input.author ?? null, input.summary ?? null, category, forms_json, input.project ?? null, date, date);
   return getReport(db, id)!;
 }
 

--- a/src/server/lib/reportCategory.test.ts
+++ b/src/server/lib/reportCategory.test.ts
@@ -1,0 +1,68 @@
+/**
+ * 분류는 세 개로만 — 보고서·리서치·교육자료. (팀장님 지시 2026-07-30)
+ *
+ * 왜 못 박나: `report.category` 가 자유 문자열이라 같은 뜻이 표기별로 갈렸다. 실측 48건에서
+ * 리서치 9 · research 4 · AI 리서치 1 · AI Research 1 이 ★각각 따로★ 세어져 화면 알약이 9개가 됐고,
+ * 팀장님이 그것을 태그로 오인해 "팀원이 등록한 태그는 내가 삭제/수정도 안돼" 로 신고하셨다.
+ * 표를 고치면 여기가 먼저 빨개진다.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  canonicalCategory,
+  knownCategoryAliases,
+  REPORT_CATEGORIES,
+  DEFAULT_REPORT_CATEGORY,
+} from "./reportCategory";
+
+describe("canonicalCategory", () => {
+  test("정본 세 개는 그대로 통과한다", () => {
+    for (const c of REPORT_CATEGORIES) expect(canonicalCategory(c)).toBe(c);
+  });
+
+  test("★같은 뜻의 표기를 하나로 접는다★ — 실제로 갈려 있던 값들", () => {
+    for (const v of ["리서치", "research", "AI 리서치", "AI Research", "ai리서치"]) {
+      expect(canonicalCategory(v), v).toBe("리서치");
+    }
+    for (const v of ["교육자료", "english-learning", "가이드"]) {
+      expect(canonicalCategory(v), v).toBe("교육자료");
+    }
+  });
+
+  test("대소문자·앞뒤공백·연속공백이 달라도 같게 본다", () => {
+    for (const v of ["  RESEARCH ", "AI  RESEARCH", "ai research"]) {
+      expect(canonicalCategory(v), JSON.stringify(v)).toBe("리서치");
+    }
+  });
+
+  test("빈 값은 기본 분류 — 분류를 안 적은 것은 정상이다", () => {
+    for (const v of ["", "   ", null, undefined]) {
+      expect(canonicalCategory(v as string | null | undefined)).toBe(DEFAULT_REPORT_CATEGORY);
+    }
+  });
+
+  test("★빈 값에는 경고 훅을 부르지 않는다★ — 미지의 표기와 다르다", () => {
+    const seen: string[] = [];
+    canonicalCategory("", (o) => seen.push(o));
+    canonicalCategory(null, (o) => seen.push(o));
+    expect(seen).toEqual([]);
+  });
+
+  test("★모르는 표기는 기본값으로 접되 조용히 하지 않는다★", () => {
+    const seen: string[] = [];
+    expect(canonicalCategory("마케팅", (o) => seen.push(o))).toBe(DEFAULT_REPORT_CATEGORY);
+    // 원본을 그대로 넘겨야 사람이 무엇이 사라졌는지 안다.
+    expect(seen).toEqual(["마케팅"]);
+  });
+
+  test("표에 등록된 별칭은 모두 정본 세 개 중 하나로만 간다", () => {
+    for (const [alias, target] of knownCategoryAliases()) {
+      expect(REPORT_CATEGORIES as readonly string[], alias).toContain(target);
+      // 별칭 키는 소문자·공백정리된 형태여야 한다 — 아니면 영원히 매칭되지 않는다.
+      expect(alias, alias).toBe(alias.trim().toLowerCase().replace(/\s+/g, " "));
+    }
+  });
+
+  test("정본이 세 개다 (늘리려면 팀장님 결정이 필요하다)", () => {
+    expect(REPORT_CATEGORIES).toEqual(["보고서", "리서치", "교육자료"]);
+  });
+});

--- a/src/server/lib/reportCategory.ts
+++ b/src/server/lib/reportCategory.ts
@@ -1,0 +1,73 @@
+/**
+ * 보고서 분류를 ★세 개로만★ 둔다 — 보고서 · 리서치 · 교육자료. (팀장님 지시 2026-07-30)
+ *
+ * ■ 왜 필요했나
+ * `report.category` 가 ★자유 문자열★ 이었다. 올리는 사람이 아무 값이나 적을 수 있어서 같은 뜻이
+ * 표기별로 갈렸다 — 실측(48건): 리서치 9 · research 4 · AI 리서치 1 · AI Research 1 · 교육자료 5 ·
+ * english-learning 1 · 가이드 1 · 보고서 2 · ★빈 값 24★. 화면에 알약이 9개로 늘어 두 줄을 먹었고,
+ * 팀장님이 그것을 태그로 오인해 "팀원이 등록한 태그는 내가 삭제/수정도 안돼" 로 신고하셨다.
+ * (분류는 보고서에서 집계되는 값이라 지울 실체가 없다 — 그래서 아이콘도 안 붙는다.)
+ *
+ * ■ 왜 표인가
+ * 분기를 늘리는 대신 ★별칭 표★ 하나를 둔다. 새 표기가 생기면 표에 한 줄 추가하면 되고, 판정 코드는
+ * 바뀌지 않는다. 그리고 ★읽는 쪽·쓰는 쪽·과거 데이터 정리가 모두 같은 표를 쓴다★ — 세 곳이 갈리면
+ * 오늘 같은 상태로 다시 돌아간다.
+ *
+ * ■ 모르는 값은 '보고서' 로 넣지만 ★조용히 하지 않는다★
+ * 팀장님 방침이 "세 개로만" 이라 미지의 값은 보고서로 모은다. 다만 조용히 바꾸면 올린 사람은 자기
+ * 분류가 사라진 걸 모른다 — 오늘 하루 우리를 괴롭힌 게 정확히 그 '무증상' 이다. 그래서 한 줄 남긴다.
+ */
+
+export const REPORT_CATEGORIES = ["보고서", "리서치", "교육자료"] as const;
+export type ReportCategory = (typeof REPORT_CATEGORIES)[number];
+
+/** 기본 분류 — 빈 값·미지의 값이 모이는 곳. */
+export const DEFAULT_REPORT_CATEGORY: ReportCategory = "보고서";
+
+/**
+ * 별칭 → 정본. 키는 ★소문자·공백정리된 형태★ 로 둔다(비교 전에 같은 방식으로 다듬는다).
+ * 새 표기를 만나면 여기 한 줄만 추가한다.
+ */
+const CATEGORY_ALIASES: Record<string, ReportCategory> = {
+  "보고서": "보고서",
+  "report": "보고서",
+  "reports": "보고서",
+  "가이드": "교육자료",        // 가르치는 성격이라 교육자료로 본다 (팀장님 확인 요청해 둠)
+  "guide": "교육자료",
+  "교육자료": "교육자료",
+  "education": "교육자료",
+  "english-learning": "교육자료",
+  "리서치": "리서치",
+  "research": "리서치",
+  "ai 리서치": "리서치",
+  "ai research": "리서치",
+  "ai리서치": "리서치",
+};
+
+function normalizeKey(raw: string): string {
+  // 전각 공백·연속 공백까지 하나로 — "AI  Research" 와 "ai research" 가 갈리지 않게.
+  return raw.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+/**
+ * 어떤 문자열이든 세 분류 중 하나로 접는다.
+ * @param raw 사용자·스크립트가 넣은 원본(빈 값·null 허용)
+ * @param onFallback 표에 없어서 기본값으로 접을 때 부르는 훅(로그·감사용). 빈 값에는 부르지 않는다 —
+ *                   빈 값은 '분류를 안 적었다' 는 정상 상태이고 미지의 표기와 다르다.
+ */
+export function canonicalCategory(
+  raw: string | null | undefined,
+  onFallback?: (original: string) => void,
+): ReportCategory {
+  const key = normalizeKey(String(raw ?? ""));
+  if (!key) return DEFAULT_REPORT_CATEGORY;
+  const hit = CATEGORY_ALIASES[key];
+  if (hit) return hit;
+  onFallback?.(String(raw));
+  return DEFAULT_REPORT_CATEGORY;
+}
+
+/** 표에 등록된 별칭 전부 — 과거 데이터 정리 스크립트가 무엇을 덮는지 보여줄 때 쓴다. */
+export function knownCategoryAliases(): Array<[string, ReportCategory]> {
+  return Object.entries(CATEGORY_ALIASES);
+}

--- a/src/web/components/Reports.ts
+++ b/src/web/components/Reports.ts
@@ -56,6 +56,11 @@ let _root: HTMLElement | null = null;
 let _all: Report[] = [];
 let _loaded = false;
 let _loading = false;
+// ★목록을 다시 받는 중인지 — 로딩 띠 전용 플래그★
+//   _loading 을 그대로 쓸 수 없다: loadReportsPage 가 그것을 ★재진입 가드★ 로도 쓰고(`if (_loading) return`),
+//   값을 켜는 시점도 renderList 다음이다. 그래서 _loading 으로 띠를 그리면 ★첫 페인트에 꺼져 있고,
+//   미리 켜면 로딩 자체가 막힌다.★ 신호가 판정부에 도달하지 않는 그 형태라 플래그를 따로 둔다.
+let _reloading = false;
 let _loadError: string | null = null;
 let _hasMore = false;
 let _nextCursor: string | null = null;
@@ -287,8 +292,13 @@ async function reloadList(opts: { preserveScroll?: boolean; restoreSearchFocus?:
   _nextCursor = null;
   _hasMore = false;
   _loaded = false;
+  _reloading = true;
   renderList();
-  await loadReportsPage(true);
+  try {
+    await loadReportsPage(true);
+  } finally {
+    _reloading = false;
+  }
   if (opts.restoreSearchFocus) _restoreSearchFocus = true;
   renderList();
   if (opts.restoreSearchFocus) {
@@ -671,6 +681,13 @@ function renderList(): void {
     <div class="text-xs text-slate-500 mb-4">${escape(_loadError || "unknown error")}</div>
     <button id="reports-retry" class="px-3 py-1.5 rounded-lg border border-surface-3 bg-surface-2 text-sm text-slate-200 hover:bg-surface-3">${pick("다시 시도", "Retry")}</button>
   </div>`;
+  // ★분류·태그를 누르면 목록을 다시 받아오는데, 그 사이 화면이 예전 목록을 그대로 보여줬다★
+  //   (팀장님: "카테고리를 누르거나 하면 느린데.. 로딩되는 바도 좀 넣어봐"). 눌렀는데 아무 반응이 없으면
+  //   사람은 안 눌린 줄 알고 또 누른다 — 오늘 우리가 계속 만난 '무증상' 과 같은 모양이다.
+  //   새 키프레임을 만들지 않고 이미 쓰는 animate-pulse 로 얇은 띠 하나만 둔다.
+  const loadingBar = _reloading
+    ? `<div class="mb-3 h-0.5 w-full overflow-hidden rounded-full bg-surface-3"><div class="h-full w-full animate-pulse bg-accent-green"></div></div>`
+    : "";
   const loadMore = items.length
     ? `<div class="py-4 text-center text-[12px] text-slate-500" data-reports-page-status>${_loading ? pick("더 불러오는 중…", "Loading more…") : _hasMore ? pick("아래로 스크롤하면 더 불러옵니다", "Scroll down to load more") : pick("마지막 보고서입니다", "End of reports")}</div>`
     : "";
@@ -693,7 +710,10 @@ function renderList(): void {
           <input id="reports-q" type="search" placeholder="${pick("제목·작성자·요약 검색", "Search title · author · summary")}" value="${escape(_query)}"
             class="w-full bg-surface-2 border border-surface-3 rounded-xl text-sm text-slate-200 pl-9 pr-3 py-2.5 outline-none focus:border-accent-green/40 placeholder:text-slate-600" />
         </div>
+        ${loadingBar}
+        <div class="${_reloading ? "opacity-50 transition-opacity" : "transition-opacity"}">
         ${_loadError ? error : items.length ? `<div class="flex flex-col gap-2.5">${cards}</div>${loadMore}` : empty}
+        </div>
       </div>
     </div>`;
   const scroller = _root.querySelector<HTMLElement>("[data-reports-list-scroll]");

--- a/src/web/components/Reports.ts
+++ b/src/web/components/Reports.ts
@@ -12,7 +12,7 @@
 import { pick } from "../i18n";
 import { parseSqliteDate } from "../lib/datetime";
 import { humanizeApiError } from "../lib/apiErrorMessage";
-import { showAlert, showConfirm, showPrompt } from "./dialogs";
+import { showAlert, showConfirm, showForm, showPrompt } from "./dialogs";
 
 const REPORTS_BASE = "/reports";
 const DEFAULT_CAT = "보고서";
@@ -329,33 +329,64 @@ async function mutateJson(path: string, method: string, body?: unknown): Promise
   if (!r.ok || j?.ok === false) throw new Error(j?.error || "HTTP " + r.status);
   return j;
 }
+/**
+ * 보고서에 붙일 태그를 ★목록에서 골라★ 정한다.
+ *
+ * ★왜 바꿨나★ (팀장님 실측 2026-07-30): 전에는 쉼표로 이름을 적는 칸 하나였다.
+ * "이미 추가된 태그가 없으니 외워서 넣기도 그렇고.. 이 추가된 태그를 좀 보여주면 좋지 안나? 선택해서 넣을 수 있게?"
+ * ★맞는 지적이다.★ 있는 것을 보여주지 않으면 사람은 외워야 하고, 오타를 내면 같은 뜻의 태그가 하나 더 생긴다
+ * (오늘 카테고리에서 리서치/research/AI 리서치/AI Research 로 갈린 것이 그 결과다).
+ *
+ * 체크박스를 쓴 이유: 칩을 눌러 켜고 끄려면 이벤트를 걸어야 하는데, shell 은 본문에 리스너를 안 걸어준다.
+ * `peer` + 숨긴 checkbox 면 ★자바스크립트 없이★ 켜짐/꺼짐이 되고, 확인 시 :checked 만 읽으면 된다.
+ */
+export function tagChoiceBodyHtml(all: ReportTag[], selected: Set<string>): string {
+  const chip = "inline-flex cursor-pointer items-center rounded-full border border-surface-3 bg-surface-2 px-2.5 py-1 text-xs text-slate-400 transition-colors peer-checked:border-accent-green/50 peer-checked:bg-accent-green/10 peer-checked:text-accent-green";
+  const choices = all.length
+    ? all.map((t) => `<label class="inline-flex">
+        <input type="checkbox" class="peer sr-only" data-tag-choice value="${escape(t.id)}"${selected.has(t.id) ? " checked" : ""} />
+        <span class="${chip}">#${escape(t.name)}</span>
+      </label>`).join("")
+    : `<span class="text-xs text-slate-600">${pick("아직 만들어진 태그가 없습니다. 아래에 이름을 적으면 새로 만들어집니다.", "No tags yet. Type a name below to create one.")}</span>`;
+  return `<div class="mt-3 flex flex-wrap gap-1.5">${choices}</div>
+    <input type="text" data-tag-new class="mt-3 w-full rounded-md border border-surface-3 bg-surface-2 px-3 py-2 text-sm text-slate-100 outline-none focus:border-accent-green/40 placeholder:text-slate-600"
+      placeholder="${escape(pick("새 태그로 만들 이름 (쉼표로 여러 개)", "New tag names (comma separated)"))}" />`;
+}
+
+/** 위 본문에서 고른 태그 id 와 새로 만들 이름을 읽어낸다. */
+export function collectTagChoice(root: HTMLElement): { ids: string[]; newNames: string[] } {
+  const ids = [...root.querySelectorAll<HTMLInputElement>("input[data-tag-choice]")]
+    .filter((el) => el.checked)
+    .map((el) => el.value);
+  const raw = root.querySelector<HTMLInputElement>("input[data-tag-new]")?.value ?? "";
+  const newNames = [...new Set(raw.split(",").map((x) => x.trim()).filter(Boolean))];
+  return { ids, newNames };
+}
+
 async function editReportTags(report: Report): Promise<void> {
-  const current = (report.tags ?? []).map((t) => t.name).join(", ");
-  // ★네이티브 prompt() 를 쓰지 않는다★ — 앱 웹뷰에서 억제되면 눌러도 아무 일이 없다(2026-07-30 실측).
-  //   문구 원칙: 범위('이 보고서')를 먼저, 기호는 우리말 이름과 함께, 결과를 말한다(팀장님 피드백).
-  const raw = await showPrompt({
+  const selected = new Set((report.tags ?? []).map((t) => t.id));
+  const picked = await showForm<{ ids: string[]; newNames: string[] }>({
     title: pick("이 보고서의 태그", "Tags for this report"),
     message: pick(
-      "붙일 태그 이름을 쉼표(,)로 구분해 적어 주세요.\n\n칸에서 이름을 지우면 그 태그가 이 보고서에서만 떨어집니다. 태그 자체와 보고서는 그대로 있습니다.\n목록에 없는 이름을 적으면 그 이름의 태그가 새로 만들어집니다.",
-      "List the tag names for this report, separated by commas (,).\n\nRemoving a name only unlabels this report — the tag and the report both stay.\nA name that isn't in the list yet becomes a new tag.",
+      "붙일 태그를 눌러서 켜고 끄세요. 끄면 이 보고서에서만 떨어집니다 — 태그 자체와 보고서는 그대로 있습니다.",
+      "Tap tags to turn them on or off. Turning one off only unlabels this report — the tag and the report both stay.",
     ),
-    placeholder: pick("예: 주간보고, 인프라", "e.g. weekly, infra"),
-    defaultValue: current,
+    bodyHtml: tagChoiceBodyHtml(_tags, selected),
+    collect: collectTagChoice,
     okLabel: pick("저장", "Save"),
   });
-  if (raw == null) return;
-  const names = [...new Set(raw.split(",").map((s) => s.trim()).filter(Boolean))];
+  if (picked == null) return;
+  const ids = [...picked.ids];
   const known = new Map(_tags.map((t) => [t.name.toLocaleLowerCase(), t]));
-  for (const name of names) {
-    if (!known.has(name.toLocaleLowerCase())) {
-      const created = (await mutateJson("/api/tags", "POST", { name })).tag as ReportTag;
-      _tags.push(created);
-      known.set(created.name.toLocaleLowerCase(), created);
-    }
+  for (const name of picked.newNames) {
+    const hit = known.get(name.toLocaleLowerCase());
+    if (hit) { if (!ids.includes(hit.id)) ids.push(hit.id); continue; }
+    const created = (await mutateJson("/api/tags", "POST", { name })).tag as ReportTag;
+    _tags.push(created);
+    known.set(created.name.toLocaleLowerCase(), created);
+    ids.push(created.id);
   }
-  await mutateJson(`/api/${encodeURIComponent(report.id)}/tags`, "PUT", {
-    tag_ids: names.map((name) => known.get(name.toLocaleLowerCase())!.id),
-  });
+  await mutateJson(`/api/${encodeURIComponent(report.id)}/tags`, "PUT", { tag_ids: [...new Set(ids)] });
 }
 /**
  * 태그 알약 + ★마우스 올리면 나오는 이름바꾸기·삭제 아이콘★ (팀장님 지시 2026-07-30).
@@ -377,11 +408,18 @@ export function tagPillsHtml(
   // 마우스가 없는 환경(터치·아이패드 웹뷰)에서 태그 옆을 탭하면 안 보이는 연필·휴지통이 눌려
   // "누르지도 않은 창" 이 뜬다. pointer-events 를 같이 꺼서 숨김 상태에선 클릭 자체를 안 받게 한다.
   const hoverOnlyCls = "opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto";
-  const iconCls = "inline-flex h-6 w-6 items-center justify-center rounded-md border border-surface-3 bg-surface-1/70 text-slate-500 transition-colors";
+  // ★자리를 차지하지 않게 띄운다★ (팀장님 실측 2026-07-30: "너무 떨어져 있어. 이럴 바엔 예전 UI 가 더 나아")
+  //   처음엔 아이콘을 알약 옆에 ★흐름 안에★ 두고 opacity 로만 숨겼다. 그러면 마우스를 올리지 않아도
+  //   태그마다 아이콘 두 개 만큼의 빈칸이 ★항상 남는다.★ 쉬는 상태가 흉해진다.
+  //   ★그리고 우리 검증이 그걸 통과시켰다★ — 확인 항목이 "아이콘이 나타날 때 줄이 흔들리지 않는다" 였고,
+  //   흔들리지 않는 이유가 바로 "자리를 미리 비워둬서" 였다. 기준을 통과했는데 기준이 부족했다.
+  //   absolute 로 흐름에서 빼면 ★쉬는 상태는 예전 UI 와 동일★ 하고 hover 에서도 줄이 흔들리지 않는다.
+  //   대신 hover 중에는 옆 알약 위로 떠서 겹치므로 배경을 불투명하게 두고 z-10 을 준다.
+  const iconCls = "inline-flex h-6 w-6 items-center justify-center rounded-md border border-surface-3 bg-surface-1 text-slate-500 transition-colors";
   return tags.map((t) =>
-    `<span class="group inline-flex items-center">
+    `<span class="group relative inline-flex items-center">
       <button class="${pillCls(selected.has(t.id))} reports-tag-pill" data-tag-id="${escape(t.id)}">#${escape(t.name)}<span class="ml-1.5 text-[11px] text-slate-500">${t.report_count ?? 0}</span></button>
-      <span class="ml-0.5 inline-flex items-center gap-0.5 ${hoverOnlyCls} transition-opacity">
+      <span class="absolute left-full top-1/2 z-10 ml-1 -translate-y-1/2 inline-flex items-center gap-0.5 ${hoverOnlyCls} transition-opacity">
         <button class="reports-tag-edit ${iconCls} hover:border-accent-green/40 hover:bg-accent-green/10 hover:text-accent-green" data-tag-id="${escape(t.id)}" data-tag-name="${escape(t.name)}" title="${pick("태그 이름 바꾸기", "Rename tag")}" aria-label="${pick("태그 이름 바꾸기", "Rename tag")}">
           <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
         </button>
@@ -641,8 +679,12 @@ function renderList(): void {
     <div data-reports-list-scroll class="h-full overflow-y-auto">
       <div class="max-w-3xl mx-auto px-4 md:px-6 py-5 pb-20">
         <div class="text-sm text-slate-500 mb-4">${pick("b3rys 팀 보고서 — 클릭하면 본문을 봅니다.", "b3rys team reports — click to read the full text.")}</div>
-        <div class="flex gap-2 flex-wrap mb-3">${pills}</div>
         <div class="flex items-center gap-2 flex-wrap mb-3">
+          <span class="shrink-0 text-[11px] font-semibold text-slate-500">${pick("분류", "Category")}</span>
+          ${pills}
+        </div>
+        <div class="flex items-center gap-2 flex-wrap mb-3">
+          <span class="shrink-0 text-[11px] font-semibold text-slate-500">${pick("태그", "Tags")}</span>
           ${tagPills || `<span class="text-xs text-slate-600">${pick("등록된 태그 없음", "No tags yet")}</span>`}
           <button id="reports-manage-tags" class="ml-auto px-3 py-1.5 rounded-full text-xs font-semibold border border-surface-3 bg-surface-2 text-slate-400 hover:text-slate-200">＋ ${pick("태그 만들기", "New tag")}</button>
         </div>

--- a/src/web/components/dialogs.ts
+++ b/src/web/components/dialogs.ts
@@ -22,9 +22,13 @@ interface DialogOptions {
 interface PromptOptions extends DialogOptions {
   defaultValue?: string;
   placeholder?: string;
+  /** form 모드 전용 — 본문에 그대로 넣을 마크업. 호출부가 만든다. */
+  bodyHtml?: string;
+  /** form 모드 전용 — 확인을 눌렀을 때 모달 DOM 에서 결과를 읽어낸다. */
+  collect?: (root: HTMLElement) => unknown;
 }
 
-type DialogMode = "alert" | "confirm" | "prompt";
+type DialogMode = "alert" | "confirm" | "prompt" | "form";
 
 /** 모드별 차이를 분기 대신 표로 둔다 — 모드가 늘 때 고칠 곳이 한 군데다. */
 const MODE_SPEC: Record<DialogMode, {
@@ -39,6 +43,8 @@ const MODE_SPEC: Record<DialogMode, {
   confirm: { title: () => pick("확인", "Confirm"), okLabel: () => pick("확인", "Confirm"), cancel: true, cancelValue: false },
   // prompt 의 취소는 false 가 아니라 ★null★ 이다 — 빈 문자열 입력("지우기")과 취소를 구분해야 한다.
   prompt: { title: () => pick("입력", "Input"), okLabel: () => pick("확인", "Confirm"), cancel: true, cancelValue: null },
+  // form 도 취소는 null 이다 — "아무것도 안 고름"(빈 배열)과 "취소"를 구분해야 한다.
+  form: { title: () => pick("선택", "Select"), okLabel: () => pick("저장", "Save"), cancel: true, cancelValue: null },
 };
 
 function dialogShell(opts: PromptOptions, mode: DialogMode): Promise<boolean | string | null> {
@@ -56,7 +62,7 @@ function dialogShell(opts: PromptOptions, mode: DialogMode): Promise<boolean | s
     const inputHtml = mode === "prompt"
       ? `<input type="text" data-dialog-input value="${escape(opts.defaultValue ?? "")}" placeholder="${escape(opts.placeholder ?? "")}"
            class="mt-3 w-full rounded-md border border-surface-3 bg-surface-2 px-3 py-2 text-sm text-slate-100 outline-none focus:border-accent-green/40 placeholder:text-slate-600" />`
-      : "";
+      : mode === "form" ? (opts.bodyHtml ?? "") : "";
 
     overlay.innerHTML = `
       <div class="w-full max-w-md rounded-md border border-surface-3 bg-surface-1 p-4 shadow-2xl" role="dialog" aria-modal="true" aria-labelledby="app-dialog-title">
@@ -86,11 +92,15 @@ function dialogShell(opts: PromptOptions, mode: DialogMode): Promise<boolean | s
       resolve(value);
     };
     // 확인을 눌렀을 때 무엇을 돌려주나 — prompt 는 입력값, 나머지는 true.
-    const accept = () => done(mode === "prompt" ? (input?.value ?? "") : true);
+    const accept = () => {
+      if (mode === "form") { done((opts.collect?.(overlay) ?? null) as string | null); return; }
+      done(mode === "prompt" ? (input?.value ?? "") : true);
+    };
     const cancel = () => done(spec.cancelValue);
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") cancel();
-      if (e.key === "Enter" && mode !== "confirm") accept();
+      // form 은 안에 입력칸·체크가 섞여 있어 Enter 로 즉시 확정하면 실수가 난다(confirm 과 같이 제외).
+      if (e.key === "Enter" && mode !== "confirm" && mode !== "form") accept();
     };
     overlay.addEventListener("click", (e) => { if (e.target === overlay) cancel(); });
     overlay.querySelectorAll("[data-dialog-cancel]").forEach((el) => el.addEventListener("click", cancel));
@@ -119,4 +129,21 @@ export async function showAlert(opts: DialogOptions | string): Promise<void> {
  */
 export function showPrompt(opts: PromptOptions | string): Promise<string | null> {
   return dialogShell(typeof opts === "string" ? { message: opts } : opts, "prompt") as Promise<string | null>;
+}
+
+/**
+ * 본문 마크업을 호출부가 만들고, 확인 시 그 DOM 에서 결과를 읽어오는 모달.
+ *
+ * ★왜 필요했나★ (팀장님 실측 2026-07-30): 보고서에 태그를 붙이는 창이 ★쉼표로 이름을 적는 칸★ 이었다.
+ * "이미 추가된 태그가 없으니 외워서 넣기도 그렇고" — 있는 태그를 보여주지 않으면 사람은 외워야 한다.
+ * 목록을 보여주고 눌러서 고르게 하려면 본문에 마크업이 필요한데, shell 은 문자열 한 줄만 받았다.
+ *
+ * shell(overlay·Escape·바깥클릭·settled·포커스)은 그대로 재사용하고 ★본문과 수집만 주입★ 한다.
+ * showConfirm·showAlert·showPrompt 시그니처는 건드리지 않았다.
+ * @returns collect 의 반환값, 취소 시 null. ★빈 선택과 취소는 다르다.★
+ */
+export function showForm<T>(
+  opts: DialogOptions & { bodyHtml: string; collect: (root: HTMLElement) => T },
+): Promise<T | null> {
+  return dialogShell(opts as PromptOptions, "form") as Promise<T | null>;
 }

--- a/src/web/components/reportsTagPills.test.ts
+++ b/src/web/components/reportsTagPills.test.ts
@@ -29,8 +29,25 @@ describe("tagPillsHtml", () => {
 
   test("hover 로만 보이게 하는 클래스가 실려 있다 (group + opacity 전환)", () => {
     const html = tagPillsHtml([tag("t1", "a")], new Set(), pillCls);
-    expect(html).toContain('class="group inline-flex');
+    // ★클래스를 붙어 있는 순서로 단정하지 않는다★ — 사이에 하나 끼우면 깨진다(실제로 깨졌다).
+    //   'group' 이 있고 'opacity-0 group-hover:opacity-100' 쌍이 있다는 것만 본다.
+    const wrapper = html.slice(0, html.indexOf(">") + 1);
+    expect(wrapper).toContain("group");
     expect(html).toContain("opacity-0 group-hover:opacity-100");
+  });
+
+  test("★아이콘이 자리를 차지하지 않는다★ — 쉬는 상태에 빈칸이 생기면 안 된다", () => {
+    // 팀장님 실측(2026-07-30): "너무 떨어져 있어. 이럴 바엔 예전 UI 가 더 나아."
+    //   흐름 안에 두고 opacity 로만 숨기면 마우스를 안 올려도 아이콘 두 개 만큼 빈칸이 항상 남는다.
+    //   ★그리고 우리 검증은 "줄이 흔들리지 않는다" 를 통과시켰다★ — 흔들리지 않는 이유가 그 빈칸이었다.
+    //   absolute 로 흐름에서 빼야 쉬는 상태가 예전 UI 와 같아진다.
+    const html = tagPillsHtml([tag("t1", "a")], new Set(), pillCls);
+    const wrapper = html.slice(0, html.indexOf(">") + 1);
+    expect(wrapper, "아이콘을 띄우려면 래퍼가 relative 여야 한다").toContain("relative");
+    const iconBox = html.slice(html.indexOf("<span", html.indexOf("</button>")));
+    expect(iconBox, "아이콘 묶음이 absolute 가 아니면 자리를 차지한다").toContain("absolute");
+    // 흐름 안에 두던 옛 방식의 흔적(알약 뒤 margin) 이 남아 있으면 빈칸이 다시 생긴다.
+    expect(iconBox).not.toContain("ml-0.5 inline-flex");
   });
 
   test("★안 보일 때는 눌리지도 않는다★ — opacity 만으로는 클릭이 안 막힌다", () => {


### PR DESCRIPTION
## 핵심 3줄

1. 배포된 태그 UI가 **마우스를 올리지 않아도 태그마다 빈칸을 남겨** 화면이 벌어졌고, 분류와 태그가 구분되지 않아 팀장님이 분류를 태그로 오인하셨고, 태그를 붙일 때 **있는 태그를 보여주지 않아 외워서 쳐야** 했다.
2. **팀장님이 오늘 배포본에서 직접 겪으셨다** — "너무 떨어져 있어. 이럴 바엔 예전 UI 가 더 나아", "팀원이 등록한 태그는 내가 삭제/수정도 안돼", "외워서 넣기도 그렇고". 대시보드를 쓰는 모든 사용자가 대상이다.
3. 아이콘을 흐름에서 빼고, 두 줄에 라벨을 붙이고, 태그를 목록에서 고르게 하고, 분류를 세 개로 접었다. **소스 5파일 · 테스트 2파일 · 커밋 3개**.

## 무엇을 바꿨나

| 문제 | 고친 방법 |
|---|---|
| 아이콘을 흐름 안에서 `opacity` 로만 숨겨 **쉬는 상태에도 빈칸이 항상 남음** | `absolute` 로 흐름에서 제거 — 쉬는 상태가 이전 UI와 동일. hover 시에도 줄이 밀리지 않음 |
| 분류 알약과 태그 알약이 같은 모양으로 나란히 있어 **구분 불가** | 두 줄 앞에 `분류` / `태그` 라벨 |
| 보고서에 태그를 붙일 때 **있는 태그를 보여주지 않음** (외워서 입력) | 태그 목록을 칩으로 보여주고 눌러서 켜고 끔. 없는 이름은 아래 칸에 적으면 새로 만들어 함께 붙음 |
| 분류가 자유 문자열이라 같은 뜻이 **표기별로 갈림** (알약 9개, 두 줄) | 별칭 표 하나(`lib/reportCategory.ts`)로 `보고서·리서치·교육자료` 세 개로 접음. **넣는 문을 db 층 하나로** |
| 분류·태그를 눌러 목록을 다시 받는 동안 **화면이 이전 목록을 그대로 보여줌** | 얇은 로딩 띠 + 목록 흐리게 (기존 `animate-pulse` 재사용) |

---

## 상세

### ① 검증이 통과시킨 결함 — 기준 자체가 부족했다

배포 전 육안 항목이 **"아이콘이 나타날 때 줄이 흔들리지 않는다"** 였고, 저와 Bill 둘 다 좌표를 재서 통과로 판정했다. 그런데 **흔들리지 않는 이유가 바로 "자리를 미리 비워둬서"** 였다. 쉬는 상태가 어떻게 보이는지는 아무도 확인하지 않았다.

그래서 이번엔 그 성질을 단정으로 넣었다 — 래퍼가 `relative` 인지, 아이콘 묶음이 `absolute` 인지, 흐름 안에 두던 옛 방식의 흔적(`ml-0.5 inline-flex`)이 남아 있지 않은지.

### ② 분류는 왜 갈렸나

실측 48건: `리서치 9 · research 4 · AI 리서치 1 · AI Research 1 · 교육자료 5 · english-learning 1 · 가이드 1 · 보고서 2 · 빈 값 24`. 같은 뜻이 네 표기로 갈려 **각각 따로 세어졌다.**

**분기를 늘리는 대신 별칭 표**를 뒀다. 새 표기가 생기면 표에 한 줄 추가하고 판정 코드는 바뀌지 않는다. 그리고 **읽는 쪽·쓰는 쪽·과거 데이터 정리가 같은 표를 쓴다** — 세 곳이 갈리면 지금 상태로 되돌아간다.

`canonicalCategory` 를 라우트가 아니라 **db 층(`upsertReport`)** 에 뒀다. 라우트 두 곳이 각자 접으면 또 갈린다. 그리고 `db/reports.ts` 에 이미 있던 `DEFAULT_REPORT_CATEGORY` 지역 상수를 지우고 정본을 쓰게 했다 — **같은 값이 두 곳에 있었고, 그게 이 PR이 고치는 문제의 축소판이다.**

모르는 표기는 기본값으로 모으지만 **조용히 하지 않는다** — 원본을 담아 경고를 남긴다. 조용히 바꾸면 올린 사람은 자기 분류가 사라진 걸 모른다. 빈 값에는 경고하지 않는다(분류를 안 적은 것은 정상이고 미지의 표기와 다르다).

### ③ 로딩 띠 — 안 보일 코드였다

처음엔 기존 `_loading` 으로 조건을 걸었다. 그런데 `loadReportsPage` 가 그것을 ①**재진입 가드**(`if (_loading) return`)로 쓰고 ②`renderList` **다음에** 켠다. 첫 페인트에는 꺼져 있어 띠가 안 뜨고, 미리 켜면 로딩 자체가 막힌다 — **어느 쪽이든 동작하지 않는다.** `_reloading` 을 따로 두고 `try/finally` 로 처리했다.

### 데이터 정리 (이미 적용)

기존 48건을 세 분류로 정리했다. 백업(`team.db.bak-category-20260730-215512`)과 id별 전/후 CSV를 남겼다.

```
적용 후: 보고서 26 · 리서치 15 · 교육자료 7   (합 48 — 총 수 불변)
정본 밖 값 0건 · 빈 값/NULL 0건
```

라이브 화면에서 **분류가 한 줄로 줄어든 것을 확인**했다 (`전체 48 · ★13 · 보고서 26 · 교육자료 7 · 리서치 15`).

### 검증

- `tsc --noEmit` 0 · `bun test src/server src/web` → **2015 pass · 0 fail**
- 신규 테스트 **10종**: 분류 별칭 8(정본 통과 / 실제로 갈려 있던 표기 접힘 / 대소문자·공백 / 빈 값 / 빈 값엔 훅 미호출 / 미지값 접고 훅 호출 / 별칭 키 정규화 형태 / 정본이 셋) · 아이콘 자리 차지 안 함 2
- 브리틀했던 인접 클래스 단정 제거 — 사이에 클래스 하나 끼우면 깨졌다(실제로 깨졌다)

### 미검증

- **hover 아이콘이 실제로 겹치지 않는지는 배포 후 육안이 필요하다.** `absolute` 라서 hover 중에는 아이콘이 옆 알약 위로 떠오른다. 배경을 불투명하게 두고 `z-10` 을 줬지만, 보기 좋은지는 사람이 봐야 한다.
- 로딩 띠가 눈에 보이는지도 실측이 필요하다(느린 순간을 잡아야 한다). 단위 테스트로는 배선을 못 잡는다 — ③이 그 증거다.

Submitted-by: steve
