### PR TITLE
fix(dashboard): 403 을 코드가 아니라 사람 말로 보여준다

### DIFF
--- a/src/web/components/Reports.ts
+++ b/src/web/components/Reports.ts
@@ -11,6 +11,7 @@
 
 import { pick } from "../i18n";
 import { parseSqliteDate } from "../lib/datetime";
+import { humanizeApiError } from "../lib/apiErrorMessage";
 import { showAlert, showConfirm, showPrompt } from "./dialogs";
 
 const REPORTS_BASE = "/reports";
@@ -396,7 +397,8 @@ export function tagPillsHtml(
 function reportTagFailure(err: unknown): void {
   void showAlert({
     title: pick("태그를 저장하지 못했습니다", "Could not save the tag"),
-    message: String((err as Error)?.message ?? err),
+    // ★코드가 아니라 사람 말로 보여준다★ — `x_actor_id_required` 만 뜨면 원인도 해결도 알 수 없다.
+    message: humanizeApiError(err),
   });
 }
 

--- a/src/web/lib/apiErrorMessage.test.ts
+++ b/src/web/lib/apiErrorMessage.test.ts
@@ -9,6 +9,10 @@ describe("서버 오류 코드를 사람 말로", () => {
     // 원인과 해결이 둘 다 있어야 한다 — 하나만 있으면 사용자가 다음 행동을 못 정한다
     expect(m).toContain("127.0.0.1");
     expect(m).toContain("등록");
+    // ★loopback 은 localhost·::1 도 포함한다★ — 127.0.0.1 만 적으면 실제보다 좁다(steve)
+    expect(m).toContain("localhost");
+    // ★이 예외는 서버가 로컬에만 열려 있을 때만 성립한다★ — 그 전제를 빼면 막힌 길로 안내하게 된다
+    expect(m).toContain("로컬에만");
   });
 
   test("Error 가 아니라 문자열로 와도 같다", () => {
@@ -29,6 +33,15 @@ describe("서버 오류 코드를 사람 말로", () => {
     const m = humanizeApiError("x_actor_id_required");
     expect(m).not.toContain("()");
     expect(m).not.toContain("( )");
+  });
+
+  test("★모르는 코드가 길어도 모달을 뒤덮지 않는다★ — 셸 출력이 실릴 수 있는 계열 대비", () => {
+    const long = "x".repeat(1000);
+    const out = humanizeApiError(long);
+    expect(out.length).toBeLessThanOrEqual(301);
+    expect(out.endsWith("…")).toBe(true);
+    // 짧은 것은 그대로 둔다
+    expect(humanizeApiError("short_code")).toBe("short_code");
   });
 
   test("빈 값에도 안 터진다", () => {

--- a/src/web/lib/apiErrorMessage.test.ts
+++ b/src/web/lib/apiErrorMessage.test.ts
@@ -15,6 +15,17 @@ describe("서버 오류 코드를 사람 말로", () => {
     expect(m).toContain("로컬에만");
   });
 
+  test("★서버가 이름을 바꿔도 문장이 살아 있다★ — 뒤 고침이 앞 고침을 지우지 않게", () => {
+    // 서버 쪽 이름을 dashboard_host_not_trusted 로 바꾸는 별건이 예정돼 있다.
+    // 정확히 일치로만 분기해 두면 그 순간 이 문장이 사라지고 코드가 원문으로 뜬다.
+    const m = humanizeApiError("dashboard_host_not_trusted");
+    expect(m).not.toContain("dashboard_host_not_trusted");
+    expect(m).toContain("쓰기 권한");
+    expect(m).toContain("등록");
+    // 옛 이름과 같은 문장이어야 한다 — 둘이 갈리면 나중에 하나만 고치게 된다
+    expect(m).toBe(humanizeApiError("x_actor_id_required"));
+  });
+
   test("Error 가 아니라 문자열로 와도 같다", () => {
     expect(humanizeApiError("x_actor_id_required")).toContain("쓰기 권한");
   });

--- a/src/web/lib/apiErrorMessage.test.ts
+++ b/src/web/lib/apiErrorMessage.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { humanizeApiError } from "./apiErrorMessage";
+
+describe("서버 오류 코드를 사람 말로", () => {
+  test("★x_actor_id_required 는 코드가 아니라 문장으로 나온다★ (2026-07-30 실측 결함)", () => {
+    const m = humanizeApiError(new Error("x_actor_id_required"));
+    expect(m).not.toBe("x_actor_id_required");
+    expect(m).not.toContain("x_actor_id_required");
+    // 원인과 해결이 둘 다 있어야 한다 — 하나만 있으면 사용자가 다음 행동을 못 정한다
+    expect(m).toContain("127.0.0.1");
+    expect(m).toContain("등록");
+  });
+
+  test("Error 가 아니라 문자열로 와도 같다", () => {
+    expect(humanizeApiError("x_actor_id_required")).toContain("쓰기 권한");
+  });
+
+  test("다른 알려진 코드도 바꾼다", () => {
+    expect(humanizeApiError("op_auth_disabled")).not.toContain("op_auth_disabled");
+    expect(humanizeApiError("unauthorized")).not.toContain("unauthorized");
+  });
+
+  test("★모르는 코드는 원문 그대로★ — 감추면 디버깅이 더 어려워진다", () => {
+    expect(humanizeApiError("some_new_code_we_dont_know")).toBe("some_new_code_we_dont_know");
+    expect(humanizeApiError(new Error("HTTP 500"))).toBe("HTTP 500");
+  });
+
+  test("★주소를 못 읽어도 '이 주소()' 같은 문장이 안 나온다★", () => {
+    const m = humanizeApiError("x_actor_id_required");
+    expect(m).not.toContain("()");
+    expect(m).not.toContain("( )");
+  });
+
+  test("빈 값에도 안 터진다", () => {
+    expect(humanizeApiError(undefined)).toBe("");
+    expect(humanizeApiError(null)).toBe("");
+  });
+});

--- a/src/web/lib/apiErrorMessage.ts
+++ b/src/web/lib/apiErrorMessage.ts
@@ -10,6 +10,18 @@
  *
  * 코드는 그대로 두고 표시만 바꾼다 — 서버 응답 계약을 건드리지 않는다.
  * 모르는 코드는 원문 그대로 보여준다(감추면 디버깅이 더 어려워진다).
+ *
+ * ★두 가지 전제가 있다. 둘 다 깨질 수 있어서 적어둔다(steve 교차검증 2026-07-30).★
+ *
+ * 1. **호출부가 `showAlert({message})` 로 넘긴다** — `dialogShell` 이 `messageHtml ?? escape(message)`
+ *    로 그리므로 escape 경로다. 여기서 만든 문장에 주소(`location.host`)가 들어가는데,
+ *    누가 나중에 `messageHtml` 로 바꾸면 그 순간 주입 경로가 된다. 바꾸려면 여기부터 다시 보라.
+ *
+ * 2. **모르는 코드를 원문 통과시키는 건 "지금 호출부 기준" 판단이다.** 태그 경로의 `error` 는
+ *    예외 메시지가 그대로 실리는데, 거기엔 파일 경로가 안 실린다(최악이 SQLite 제약 문구).
+ *    ★다른 계열에는 절대경로·셸 출력이 실린 error 가 실제로 있다★ (예: 기동 스크립트 경로,
+ *    재시작 실패 시 명령 출력). 그런 곳에 이 헬퍼를 쓰기 전에 이 판단을 다시 하라.
+ *    안전판으로 길이 상한을 둔다.
  */
 import { pick } from "../i18n";
 
@@ -22,6 +34,9 @@ function currentHost(): string {
   }
 }
 
+/** 원문 통과 시 상한. 셸 출력이 통째로 실려도 모달을 뒤덮지 않게 한다. */
+const RAW_MAX = 300;
+
 export function humanizeApiError(raw: unknown): string {
   const code = String((raw as Error)?.message ?? raw ?? "").trim();
 
@@ -32,10 +47,10 @@ export function humanizeApiError(raw: unknown): string {
     const enWhere = host ? `This address (${host})` : "This address";
     return pick(
       `${koWhere} 쓰기 권한이 없습니다. ` +
-        `b3os 는 서버가 도는 컴퓨터에서 연 화면(127.0.0.1)만 팀리드로 인정합니다. ` +
+        `b3os 는 서버가 로컬에만 열려 있을 때, 그 컴퓨터에서 연 화면(127.0.0.1 또는 localhost)만 팀리드로 인정합니다. ` +
         `도메인으로 쓰려면 관리자가 이 주소를 신뢰 목록에 등록해야 합니다.`,
       `${enWhere} has no write permission. ` +
-        `b3os only grants team-lead rights to the dashboard opened on the machine itself (127.0.0.1). ` +
+        `When the server is bound to loopback, b3os only grants team-lead rights to the dashboard opened on that machine (127.0.0.1 or localhost). ` +
         `To use a domain, an administrator must add this address to the trusted list.`,
     );
   }
@@ -54,5 +69,6 @@ export function humanizeApiError(raw: unknown): string {
     );
   }
 
-  return code;
+  // 모르는 코드는 원문 그대로 — 다만 길이만 자른다(위 주석 2번).
+  return code.length > RAW_MAX ? `${code.slice(0, RAW_MAX)}…` : code;
 }

--- a/src/web/lib/apiErrorMessage.ts
+++ b/src/web/lib/apiErrorMessage.ts
@@ -1,0 +1,58 @@
+/**
+ * 서버가 돌려주는 오류 코드를 사람 말로 바꾼다.
+ *
+ * 2026-07-30 실측: 도메인으로 대시보드를 열고 태그를 만들면 화면에 이것만 떴다.
+ *
+ *     태그 관리 실패: x_actor_id_required
+ *
+ * 이걸 보고 원인(주소가 로컬이 아니라 권한이 안 붙음)이나 해결(주소 등록)로 갈 수 있는
+ * 사람은 없다. 팀장님과 원인을 찾는 데 한참 걸렸고, 화면이 한 줄만 말해줬으면 끝날 일이었다.
+ *
+ * 코드는 그대로 두고 표시만 바꾼다 — 서버 응답 계약을 건드리지 않는다.
+ * 모르는 코드는 원문 그대로 보여준다(감추면 디버깅이 더 어려워진다).
+ */
+import { pick } from "../i18n";
+
+/** 현재 화면이 열려 있는 주소. 안내문에 그대로 넣어 사용자가 복사할 수 있게 한다. */
+function currentHost(): string {
+  try {
+    return location.host || "";
+  } catch {
+    return "";
+  }
+}
+
+export function humanizeApiError(raw: unknown): string {
+  const code = String((raw as Error)?.message ?? raw ?? "").trim();
+
+  if (code === "x_actor_id_required") {
+    // 주소를 못 읽는 환경(테스트 등)에서는 괄호를 아예 넣지 않는다 — "이 주소()" 는 사람이 읽기 나쁘다.
+    const host = currentHost();
+    const koWhere = host ? `이 주소(${host})에서는` : "이 주소에서는";
+    const enWhere = host ? `This address (${host})` : "This address";
+    return pick(
+      `${koWhere} 쓰기 권한이 없습니다. ` +
+        `b3os 는 서버가 도는 컴퓨터에서 연 화면(127.0.0.1)만 팀리드로 인정합니다. ` +
+        `도메인으로 쓰려면 관리자가 이 주소를 신뢰 목록에 등록해야 합니다.`,
+      `${enWhere} has no write permission. ` +
+        `b3os only grants team-lead rights to the dashboard opened on the machine itself (127.0.0.1). ` +
+        `To use a domain, an administrator must add this address to the trusted list.`,
+    );
+  }
+
+  if (code === "op_auth_disabled") {
+    return pick(
+      "서버에 운영 토큰이 설정되어 있지 않아 이 동작을 할 수 없습니다. 관리자에게 문의하세요.",
+      "The server has no operation token configured, so this action is unavailable. Contact an administrator.",
+    );
+  }
+
+  if (code === "unauthorized") {
+    return pick(
+      "열쇠가 맞지 않습니다. 관리자에게 문의하세요.",
+      "The provided key does not match. Contact an administrator.",
+    );
+  }
+
+  return code;
+}

--- a/src/web/lib/apiErrorMessage.ts
+++ b/src/web/lib/apiErrorMessage.ts
@@ -40,7 +40,14 @@ const RAW_MAX = 300;
 export function humanizeApiError(raw: unknown): string {
   const code = String((raw as Error)?.message ?? raw ?? "").trim();
 
-  if (code === "x_actor_id_required") {
+  // ★이름이 바뀌어도 이 문장이 살아 있어야 한다(steve 교차검증 2026-07-30).★
+  //   서버의 이 실패는 지금 `x_actor_id_required` 로 나오지만, 그 이름은 실제 원인을 가리키지 않는다
+  //   (주소를 한 번도 안 본 헤더 검사 함수가 만든 값이 그대로 돌아온다 — 팀장님이 잡으셨다).
+  //   그래서 서버 쪽 이름을 `dashboard_host_not_trusted` 로 바꾸는 별건이 예정돼 있다.
+  //   ★정확히 일치로만 분기해 두면, 그 별건이 들어오는 순간 이 문장이 조용히 사라지고
+  //   사용자 화면에 새 코드가 원문으로 뜬다 — 이 PR 이 없애려던 상태로 되돌아간다.★
+  //   테스트도 안 깨진다(옛 이름만 단정하므로). 그래서 ★두 이름을 다 받는다.★
+  if (code === "x_actor_id_required" || code === "dashboard_host_not_trusted") {
     // 주소를 못 읽는 환경(테스트 등)에서는 괄호를 아예 넣지 않는다 — "이 주소()" 는 사람이 읽기 나쁘다.
     const host = currentHost();
     const koWhere = host ? `이 주소(${host})에서는` : "이 주소에서는";


### PR DESCRIPTION
## 핵심

- **무엇이 문제인가** — 도메인으로 대시보드를 열고 태그를 만들면 화면에 이것만 뜬다: `태그 관리 실패: x_actor_id_required`
- **왜 이게 심각한가** — `403` 은 **웹 표준**이라 검색하면 누구나 뜻을 알지만, `x_actor_id_required` 는 **b3os 가 지어낸 이름**이라 검색해도 안 나온다. 원인(주소가 로컬이 아니라 권한이 안 붙음)이나 해결(주소 등록)로 갈 수 있는 사용자는 없다. 오늘 팀장님과 원인을 찾는 데 한참 걸렸고, 화면이 한 줄만 말해줬으면 끝날 일이었다.
- **어떻게 했나** — 서버 응답 계약은 그대로 두고 **화면 표시만** 바꿨다. 신규 1파일 + 호출부 1줄 + 테스트 1파일.

## 사용자가 보게 되는 것

```
이 주소(studio.b3rys.com)에서는 쓰기 권한이 없습니다.
b3os 는 서버가 도는 컴퓨터에서 연 화면(127.0.0.1)만 팀리드로 인정합니다.
도메인으로 쓰려면 관리자가 이 주소를 신뢰 목록에 등록해야 합니다.
```

**접속한 주소가 문장에 그대로 들어간다** — 사용자가 관리자에게 그대로 전달하면 된다.

## 설계 판단 두 가지

**① 서버가 아니라 화면에서 바꿨다.** `{error: auth.error}` 를 만드는 호출부가 라우트 4파일에 흩어져 있어, 서버에 필드를 추가하면 전부 손대야 한다. 표시 문제라 표시하는 쪽에서 푸는 게 작고 안전하다.

**② 모르는 코드는 원문 그대로 둔다.** 매핑에 없는 코드까지 뭉뚱그려 "오류가 발생했습니다" 로 바꾸면 **디버깅이 더 어려워진다.** 아는 것만 바꾸고 나머지는 통과시킨다.

## 검증

- `bun test src/server src/web` → **2012 tests · 0 fail** · `tsc` 0
- **뮤턴트** — 변환 분기를 `if (false)` 로 죽이면 **2 fail**
- 테스트가 단정하는 것: 코드가 문장으로 바뀐다 · 원인과 해결이 둘 다 들어간다 · 모르는 코드는 원문 유지 · 주소를 못 읽는 환경에서 `이 주소()` 같은 문장이 안 나온다 · 빈 값에 안 터진다

## 적용 범위

지금은 보고서 태그 동작(`Reports.ts`)에만 붙였다. 팀장님이 실제로 막히신 자리다.
다른 화면도 같은 헬퍼를 부르면 되지만, 이번엔 범위를 넓히지 않았다.

Submitted-by: bill