### PR TITLE
feat(security): 신뢰하지 않는 주소는 읽기까지 막고, 한 장짜리 안내를 보여준다

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -57,7 +57,8 @@ import { writeMemberPersona, savePersonaFile } from "./lib/writeMemberPersona";
 import { persistOwnerChatIdIfEmpty } from "./runtimes/codex/launcher";
 import { createApprovalsApp } from "./routes/approvals";
 import { createPermissionGateRoutes } from "./routes/permissionGate";
-import { configureLeadActorDb } from "./lib/opAuth";
+import { configureLeadActorDb, leadActorId, trustedActorFromRequest } from "./lib/opAuth";
+import { createHostGate } from "./lib/hostGate";
 import { DEFAULT_MEDIA_DIR, contentTypeForMediaFile, resolveMediaPath } from "./lib/mediaStore";
 import type { WsEvent } from "./types";
 
@@ -218,6 +219,17 @@ api.use("*", async (c, next) => {
   await next();
   c.header("Cache-Control", "no-store, max-age=0, must-revalidate");
 });
+
+/**
+ * ★신뢰하지 않는 주소는 한 곳에서 막는다 — 읽기까지.★ (팀장님 지시 2026-07-30)
+ * 판정과 응답 형태는 lib/hostGate.ts 에 있다(그쪽에 왜 이렇게 하는지 적어뒀다).
+ * 여기서는 "어디에 거는가" 만 정한다 — `app` 전체(대시보드 + `/api`)와 `/reports` 포털.
+ */
+function requestIsTrusted(request: Request): boolean {
+  return trustedActorFromRequest(request, { loopbackDashboardActor: leadActorId(db) }).ok;
+}
+
+app.use("*", createHostGate({ isTrusted: requestIsTrusted }));
 
 api.get("/agents", (c) => {
   const all = listAgents(db);
@@ -622,7 +634,12 @@ rootApp.route(BASE_PATH, app);
 // 팀 결과물 포털 — /team 형제로 노출. 허브 next.config.ts rewrite 로 your-team.example.com/reports.
 // (2026-06-07 GD: /research 취소 — 모든 팀 산출물을 /reports 에 category 로 구분해 통합.)
 const portalDeps = { db, reportsDir: REPORTS_DIR, researchDir: RESEARCH_DIR, webDir: WEB_DIR };
-rootApp.route("/reports", createReportsApp(portalDeps));
+// ★포털에도 같은 관문★ — 보고서 공유 링크가 여기로 온다. 등록되지 않은 주소에서는 같은 안내를 보여준다.
+//   (팀장님 판단: 링크는 받아서 전달할 수 있고, 필요하면 그 주소를 등록해서 열어주면 된다)
+const reportsApp = new Hono();
+reportsApp.use("*", createHostGate({ isTrusted: requestIsTrusted, isApiPath: () => false }));
+reportsApp.route("/", createReportsApp(portalDeps));
+rootApp.route("/reports", reportsApp);
 rootApp.get("/reports/", (c) => c.redirect("/reports"));
 
 // ★포트 점유 가드 (fresh-user 막다름 방지)★ — Bun.serve 는 포트 사용중이면 EADDRINUSE 를 던진다.

--- a/src/server/lib/hostGate.test.ts
+++ b/src/server/lib/hostGate.test.ts
@@ -17,6 +17,7 @@ function appWith(trusted: boolean) {
   app.delete("/team/api/members/:id", (c) => c.json({ ok: true }));
   app.post("/team/api/slack/events", (c) => c.json({ ok: true }));
   app.get("/team/health", (c) => c.json({ ok: true }));
+  app.get("/team/ws", (c) => c.text("ws"));
   return app;
 }
 
@@ -40,6 +41,11 @@ describe("신뢰하지 않는 주소 — 막는다", () => {
       const r = await app.fetch(req(path, method));
       expect([path, r.status]).toEqual([path, 403]);
     }
+  });
+
+  test("★WebSocket 도 막는다★ — 실시간 채널로 읽기가 새면 관문이 무의미하다", async () => {
+    const r = await appWith(false).fetch(req("/team/ws"));
+    expect(r.status).toBe(403);
   });
 
   test("★사람이 보는 화면은 조각내지 않고 한 장으로 말한다★", async () => {

--- a/src/server/lib/hostGate.test.ts
+++ b/src/server/lib/hostGate.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import { Hono } from "hono";
-import { createHostGate, isGateExempt } from "./hostGate";
+import { createHostGate } from "./hostGate";
 
 /** 신뢰 판정을 주입해 테스트가 환경(git·env·소켓)에 안 걸리게 한다. */
 function appWith(trusted: boolean) {
@@ -94,24 +94,12 @@ describe("막히면 안 되는 것 — 안 막힌다", () => {
     }
   });
 
-  test("★slack 이벤트는 신뢰 안 해도 통과★ — 자체 서명 검증이 있고, 막으면 슬랙이 끊긴다", async () => {
-    const r = await appWith(false).fetch(req("/team/api/slack/events", "POST"));
-    expect(r.status).toBe(200);
-  });
-
-  test("★health 는 통과★ — 막으면 바깥 모니터가 서버를 죽은 것으로 본다", async () => {
-    const r = await appWith(false).fetch(req("/team/health"));
-    expect(r.status).toBe(200);
-  });
-
-  test("예외 판정은 접미사로 본다 — 경로 앞에 무엇이 붙어도 같다", () => {
-    expect(isGateExempt("/team/api/slack/events")).toBe(true);
-    expect(isGateExempt("/slack/events")).toBe(true);
-    expect(isGateExempt("/team/health")).toBe(true);
-    // ★비슷하지만 다른 경로는 예외가 아니다★
-    expect(isGateExempt("/team/api/slack/eventsX")).toBe(false);
-    expect(isGateExempt("/team/api/slack")).toBe(false);
-    expect(isGateExempt("/team/api/agents")).toBe(false);
+  test("★예외는 없다★ — 앞서 뚫으려던 둘도 막힌다(전제가 거짓이었다)", async () => {
+    const app = appWith(false);
+    // /slack/events: "서명 자체검증" 이 전제였는데, 무서명 요청이 200 으로 통과한다(hermes 실측).
+    expect((await app.fetch(req("/team/api/slack/events", "POST"))).status).toBe(403);
+    // /team/health: "아무것도 안 알려준다" 가 전제였는데 port·base_path·agents 를 준다.
+    expect((await app.fetch(req("/team/health"))).status).toBe(403);
   });
 });
 

--- a/src/server/lib/hostGate.test.ts
+++ b/src/server/lib/hostGate.test.ts
@@ -1,0 +1,122 @@
+/**
+ * 관문은 ★전부 막고 예외를 뚫는★ 방향이라, 잘못 걸면 크게 막힌다.
+ * 그래서 "막히나" 뿐 아니라 ★"막히면 안 되는 것이 안 막히나"★ 를 같은 무게로 단정한다.
+ */
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { createHostGate, isGateExempt } from "./hostGate";
+
+/** 신뢰 판정을 주입해 테스트가 환경(git·env·소켓)에 안 걸리게 한다. */
+function appWith(trusted: boolean) {
+  const app = new Hono();
+  app.use("*", createHostGate({ isTrusted: () => trusted }));
+  app.get("/team", (c) => c.text("dashboard"));
+  app.get("/team/api/agents", (c) => c.json({ agents: [] }));
+  app.post("/team/api/members", (c) => c.json({ ok: true }));
+  app.patch("/team/api/tasks/:id", (c) => c.json({ ok: true }));
+  app.delete("/team/api/members/:id", (c) => c.json({ ok: true }));
+  app.post("/team/api/slack/events", (c) => c.json({ ok: true }));
+  app.get("/team/health", (c) => c.json({ ok: true }));
+  return app;
+}
+
+const req = (path: string, method = "GET") =>
+  new Request(`http://studio.b3rys.com${path}`, { method, headers: { host: "studio.b3rys.com" } });
+
+describe("신뢰하지 않는 주소 — 막는다", () => {
+  test("★읽기도 막는다★ — 열어두면 주소를 아는 사람이 팀원 목록을 그대로 본다", async () => {
+    const r = await appWith(false).fetch(req("/team/api/agents"));
+    expect(r.status).toBe(403);
+    expect(await r.json()).toEqual({ error: "dashboard_host_not_trusted" });
+  });
+
+  test("★관문을 안 타던 쓰기가 이제 다 막힌다★ — 칸반·영입·퇴사 (2026-07-30 실측 구멍)", async () => {
+    const app = appWith(false);
+    for (const [path, method] of [
+      ["/team/api/tasks/abc", "PATCH"],      // 칸반 — 전에는 404(통과)였다
+      ["/team/api/members", "POST"],          // 영입
+      ["/team/api/members/x", "DELETE"],      // 퇴사
+    ] as const) {
+      const r = await app.fetch(req(path, method));
+      expect([path, r.status]).toEqual([path, 403]);
+    }
+  });
+
+  test("★사람이 보는 화면은 조각내지 않고 한 장으로 말한다★", async () => {
+    const r = await appWith(false).fetch(req("/team"));
+    expect(r.status).toBe(403);
+    // ★text/plain 이면 브라우저가 소스를 그대로 보여준다 — 안내 페이지가 무의미해진다.★
+    //   프레임워크 기본값에 기대면 환경에 따라 달라진다(실측: src/web 테스트와 같이 돌면 text/plain).
+    expect(r.headers.get("content-type")).toContain("text/html");
+    const html = await r.text();
+    expect(html).toContain("등록되지 않은 주소");
+    // 자기 주소가 보여야 하고, 그대로 물어볼 문장이 있어야 한다
+    expect(html).toContain("studio.b3rys.com");
+    expect(html).toContain("팀원에게 이대로 물어보세요");
+    expect(html).toContain("TEAM_TRUSTED_DASHBOARD_HOSTS");
+  });
+
+  test("★안내 페이지는 자체 포함이어야 한다★ — 이 상황에선 assets 도 막힌다", async () => {
+    const html = await (await appWith(false).fetch(req("/team"))).text();
+    expect(html).not.toContain("/assets/");
+    expect(html).not.toContain("<script");
+    expect(html).not.toMatch(/<link[^>]+stylesheet/i);
+  });
+
+  test("★주소에 태그가 들어와도 그대로 그려지지 않는다★", async () => {
+    const app = appWith(false);
+    const r = await app.fetch(
+      new Request("http://x/team", { headers: { host: '"><script>alert(1)</script>' } }),
+    );
+    const html = await r.text();
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+describe("막히면 안 되는 것 — 안 막힌다", () => {
+  test("★신뢰하는 주소는 전부 통과★ — 로컬 대시보드가 이 변경으로 깨지면 안 된다", async () => {
+    const app = appWith(true);
+    for (const [path, method] of [
+      ["/team", "GET"],
+      ["/team/api/agents", "GET"],
+      ["/team/api/members", "POST"],
+      ["/team/api/tasks/abc", "PATCH"],
+    ] as const) {
+      const r = await app.fetch(req(path, method));
+      expect([path, r.status]).toEqual([path, 200]);
+    }
+  });
+
+  test("★slack 이벤트는 신뢰 안 해도 통과★ — 자체 서명 검증이 있고, 막으면 슬랙이 끊긴다", async () => {
+    const r = await appWith(false).fetch(req("/team/api/slack/events", "POST"));
+    expect(r.status).toBe(200);
+  });
+
+  test("★health 는 통과★ — 막으면 바깥 모니터가 서버를 죽은 것으로 본다", async () => {
+    const r = await appWith(false).fetch(req("/team/health"));
+    expect(r.status).toBe(200);
+  });
+
+  test("예외 판정은 접미사로 본다 — 경로 앞에 무엇이 붙어도 같다", () => {
+    expect(isGateExempt("/team/api/slack/events")).toBe(true);
+    expect(isGateExempt("/slack/events")).toBe(true);
+    expect(isGateExempt("/team/health")).toBe(true);
+    // ★비슷하지만 다른 경로는 예외가 아니다★
+    expect(isGateExempt("/team/api/slack/eventsX")).toBe(false);
+    expect(isGateExempt("/team/api/slack")).toBe(false);
+    expect(isGateExempt("/team/api/agents")).toBe(false);
+  });
+});
+
+describe("포털(/reports) 은 API 가 아니다", () => {
+  test("★JSON 이 아니라 안내 페이지를 준다★ — 공유 링크를 받은 사람은 사람이다", async () => {
+    const app = new Hono();
+    app.use("*", createHostGate({ isTrusted: () => false, isApiPath: () => false }));
+    app.get("/reports", (c) => c.text("portal"));
+    const r = await app.fetch(new Request("http://x/reports", { headers: { host: "studio.b3rys.com" } }));
+    expect(r.status).toBe(403);
+    expect(r.headers.get("content-type")).toContain("text/html");
+    expect(await r.text()).toContain("등록되지 않은 주소");
+  });
+});

--- a/src/server/lib/hostGate.ts
+++ b/src/server/lib/hostGate.ts
@@ -23,18 +23,27 @@
 import type { Context, Next } from "hono";
 import { untrustedHostPage } from "./untrustedHostPage";
 
-/** 관문을 태우면 안 되는 인바운드. ★자체 검증이 있는 것만★ 넣는다. */
-export const GATE_EXEMPT_SUFFIX = [
-  // Slack 이 밖에서 보내는 이벤트. 서명(x-slack-signature)으로 자체 검증한다 — routes/slack.ts.
-  //   여기서 막으면 Event URL 방식을 쓰는 설치본의 슬랙이 끊긴다.
-  "/slack/events",
-  // 감시용. 아무 내용도 안 알려주고, 막으면 바깥 모니터가 서버를 죽은 것으로 본다.
-  "/health",
-];
-
-export function isGateExempt(path: string): boolean {
-  return GATE_EXEMPT_SUFFIX.some((sfx) => path.endsWith(sfx));
-}
+/**
+ * ★예외는 없다.★ (2026-07-30 · codex·hermes 교차검증에서 둘 다 같은 결론)
+ *
+ *  처음엔 두 개를 뒀는데 ★둘 다 전제가 거짓이었다.★
+ *
+ *  · `/slack/events` — "서명으로 자체 검증한다" 고 적었는데 아니었다.
+ *    `url_verification` 은 ★서명 검사 전에★ challenge 를 그대로 돌려주고,
+ *    `api_app_id` 가 등록된 앱이 아니면 검사 블록을 ★통째로 건너뛴다★ — signing_secret 이
+ *    없어도 마찬가지다. hermes 가 무서명 요청으로 실측했다: 200 OK.
+ *    ★내가 "자체 검증이 있다" 고 믿고 예외를 뚫었으면, 그게 유일한 공개 구멍이 됐을 것이다.★
+ *    Event URL 방식을 쓰는 설치본은 ★그 도메인을 TEAM_TRUSTED_DASHBOARD_HOSTS 에 등록★ 하면 된다
+ *    (대시보드를 그 주소로 여는 것과 같은 조건이다).
+ *
+ *  · `/health` — "아무것도 안 알려준다" 고 적었는데 `/team/health` 는
+ *    `{ok, port, base_path, agents}` 를 준다. 게다가 접미사로 걸어서 `…/health` 로 끝나는
+ *    어떤 경로도 앞으로 자동 면제됐다. ★바깥 감시는 `rootApp` 의 `/health`(= `{ok:true}`)를 쓰는데 그건 이 관문
+ *    바깥이라 영향이 없다★ — 예외가 애초에 필요 없었다.
+ *
+ *  ★"예외에는 자체 방어가 있다" 는 말은 그 방어를 실제로 읽고 나서만 참이다.★
+ *  둘 다 내가 안 읽고 적었고, 둘 다 틀렸다. 그래서 예외를 두지 않는다.
+ */
 
 export interface HostGateDeps {
   /** 이 요청을 신뢰하는가. 실제로는 `trustedActorFromRequest(...).ok` 를 넘긴다. */
@@ -47,7 +56,6 @@ export function createHostGate(deps: HostGateDeps) {
   const isApiPath = deps.isApiPath ?? ((path: string) => path.includes("/api/"));
   return async (c: Context, next: Next) => {
     const path = c.req.path;
-    if (isGateExempt(path)) return next();
     if (deps.isTrusted(c.req.raw)) return next();
     if (isApiPath(path)) {
       return c.json({ error: "dashboard_host_not_trusted" }, 403);

--- a/src/server/lib/hostGate.ts
+++ b/src/server/lib/hostGate.ts
@@ -1,0 +1,61 @@
+/**
+ * 신뢰하지 않는 주소를 ★한 곳에서★ 막는다. (팀장님 지시 2026-07-30)
+ *
+ * ■ 왜 한 곳인가
+ * 앞서는 엔드포인트마다 각자 `trustedActorFromRequest` 를 불렀다. 그래서 쓰기 70곳 중
+ * 관문을 타는 건 소수였다 — 칸반 수정·삭제, 인박스, 라우터, 그리고 `settings` 쓰기 31개 중
+ * 30개(★영입 `POST /members`·퇴사 `DELETE /members/:id` 포함★)가 검사 없이 열려 있었다.
+ * 도메인 Host 로 `PATCH /tasks/<없는id>` 를 보내면 403 이 아니라 404 가 왔다(실측).
+ *
+ * ★"게이트를 부르는 곳" 을 세는 방식으로는 "게이트가 있어야 하는데 없는 곳" 을 못 본다.★
+ * 각 엔드포인트가 기억해서 부르는 대신, 지나갈 수밖에 없는 자리에 한 번 건다.
+ * 새 엔드포인트가 추가돼도 자동으로 덮인다 — 빠뜨릴 수가 없는 게 이 방식의 요점이다.
+ *
+ * ■ 읽기도 막는다
+ * 읽기를 열어두면 주소를 아는 사람이 팀원 목록·보고서를 그대로 본다(오늘 실제로 그랬다).
+ * 보고서 공유 링크는 "받아서 전달하거나, 그 주소를 등록해서 열어준다" 로 간다(팀장님 판단).
+ *
+ * ■ 대신 화면을 조각조각 깨뜨리지 않는다
+ * 읽기를 막으면 껍데기만 뜨고 위젯이 전부 실패한다 — "고장인지 아닌지 모르겠는" 상태가 되고,
+ * 그게 오늘 원인 찾기를 어렵게 만든 바로 그 모양이다. 그래서 사람이 보는 요청에는 한 장짜리
+ * 안내 페이지를 돌려준다.
+ */
+import type { Context, Next } from "hono";
+import { untrustedHostPage } from "./untrustedHostPage";
+
+/** 관문을 태우면 안 되는 인바운드. ★자체 검증이 있는 것만★ 넣는다. */
+export const GATE_EXEMPT_SUFFIX = [
+  // Slack 이 밖에서 보내는 이벤트. 서명(x-slack-signature)으로 자체 검증한다 — routes/slack.ts.
+  //   여기서 막으면 Event URL 방식을 쓰는 설치본의 슬랙이 끊긴다.
+  "/slack/events",
+  // 감시용. 아무 내용도 안 알려주고, 막으면 바깥 모니터가 서버를 죽은 것으로 본다.
+  "/health",
+];
+
+export function isGateExempt(path: string): boolean {
+  return GATE_EXEMPT_SUFFIX.some((sfx) => path.endsWith(sfx));
+}
+
+export interface HostGateDeps {
+  /** 이 요청을 신뢰하는가. 실제로는 `trustedActorFromRequest(...).ok` 를 넘긴다. */
+  isTrusted: (request: Request) => boolean;
+  /** true 면 API 로 보고 JSON 을 돌려준다. 기본은 경로에 `/api/` 가 있는지. */
+  isApiPath?: (path: string) => boolean;
+}
+
+export function createHostGate(deps: HostGateDeps) {
+  const isApiPath = deps.isApiPath ?? ((path: string) => path.includes("/api/"));
+  return async (c: Context, next: Next) => {
+    const path = c.req.path;
+    if (isGateExempt(path)) return next();
+    if (deps.isTrusted(c.req.raw)) return next();
+    if (isApiPath(path)) {
+      return c.json({ error: "dashboard_host_not_trusted" }, 403);
+    }
+    // ★content-type 을 명시한다.★ 브라우저는 text/plain 을 받으면 HTML 을 그리지 않고
+    //   소스를 그대로 보여준다 — 안내 페이지가 통째로 무의미해진다. 값이 하나뿐인 자리라 못 박는다.
+    return c.body(untrustedHostPage(c.req.header("host") ?? ""), 403, {
+      "content-type": "text/html; charset=utf-8",
+    });
+  };
+}

--- a/src/server/lib/opAuth.test.ts
+++ b/src/server/lib/opAuth.test.ts
@@ -33,7 +33,7 @@ describe("op auth shared token", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 // 대시보드 신원 — ★주소창만 달라도 결과가 갈렸다★ (2026-07-30 팀장님 실측)
 //   대시보드는 인증 헤더를 하나도 안 보내므로 loopback 예외 하나에만 의존한다. 그래서 도메인·앱으로
-//   들어오면 태그·보고서·제안 쓰기 9군데가 전부 403(x_actor_id_required) 이었다.
+//   들어오면 태그·보고서·제안 쓰기가 전부 403 이었다(이름은 2026-07-30 에 dashboard_host_not_trusted 로 정정).
 //   ★여기에 테스트가 없어서 코드 리뷰·CI 로 잡히지 않았다★ — 그래서 양방향을 못박는다.
 // ─────────────────────────────────────────────────────────────────────────────
 describe("대시보드 loopback 예외 + 등록한 주소", () => {
@@ -52,6 +52,20 @@ describe("대시보드 loopback 예외 + 등록한 주소", () => {
     expect(trustedActorFromRequest(req("dev.b3rys.com"), { loopbackDashboardActor: "gd" })).toMatchObject({
       ok: false,
       status: 403,
+      // ★이름이 실패 이유를 가리켜야 한다★ — 앞서는 헤더 검사의 실패값(x_actor_id_required)이
+      //   그대로 돌아왔다. 대시보드는 그 헤더를 아예 안 쓰는데도.
+      error: "dashboard_host_not_trusted",
+    });
+  });
+
+  test("★헤더를 보냈는데 형식이 틀린 경우는 여전히 x_actor_id_required★ — 두 실패를 섞지 않는다", () => {
+    // 이름을 바꾼 건 "주소를 못 믿는다" 쪽뿐이다. 헤더 경로의 실패는 그대로여야 한다.
+    const r = new Request("http://127.0.0.1:7878/team/api/x", {
+      method: "PATCH",
+      headers: { host: "127.0.0.1:7878", "x-actor-id": "!!not-a-valid-id!!" },
+    });
+    expect(trustedActorFromRequest(r, { loopbackDashboardActor: "gd" })).toMatchObject({
+      ok: false,
       error: "x_actor_id_required",
     });
   });

--- a/src/server/lib/opAuth.ts
+++ b/src/server/lib/opAuth.ts
@@ -84,7 +84,13 @@ export function trustedActorFromRequest(
   if (actor && isLoopbackDashboardRequest(request) && ACTOR_RE.test(actor)) {
     return { ok: true, actor: { actor, source: "loopback_dashboard" } };
   }
-  return fromHeaders;
+  // ★여기서 실패한 이유는 "헤더가 없다" 가 아니라 "이 주소를 못 믿는다" 다.★ (팀장님 지적 2026-07-30)
+  //   앞서는 위에서 만들어둔 `fromHeaders`(= x_actor_id_required)를 그대로 돌려줬다. 그런데
+  //   그 값을 만든 함수는 ★주소를 한 번도 안 본다★ — 헤더만 본다. 그래서 화면에도 로그에도
+  //   ★대시보드가 쓰지도 않는 헤더 이름★ 이 남았고, 원인을 찾는 사람을 엉뚱한 데로 보냈다.
+  //   이름은 `not_local_dashboard` 가 아니라 `dashboard_host_not_trusted` 다(steve) —
+  //   이 검사는 loopback ★또는 등록된 주소★ 면 통과하므로, 로컬만 조건인 것처럼 읽히면 안 된다.
+  return { ok: false, error: "dashboard_host_not_trusted", status: 403 };
 }
 
 /**

--- a/src/server/lib/untrustedHostPage.ts
+++ b/src/server/lib/untrustedHostPage.ts
@@ -1,0 +1,69 @@
+/**
+ * 신뢰하지 않는 주소로 대시보드를 열었을 때 보여주는 페이지.
+ *
+ * ★왜 페이지가 필요한가★ (팀장님 지시 2026-07-30)
+ * 읽기까지 막으면 화면 껍데기는 뜨는데 안의 위젯이 전부 깨진다 — 사용자에게는
+ * "고장난 것 같기도 하고 아닌 것 같기도 한" 상태가 된다. 오늘 우리가 겪은 게 정확히 그거였고
+ * (화면은 뜨는데 버튼만 안 먹음), 원인을 찾는 데 한참 걸렸다.
+ * 그래서 조각조각 실패하게 두지 않고 ★한 장으로 무슨 일인지 말한다.★
+ *
+ * ★자체 포함이어야 한다★ — 이 페이지가 뜨는 상황에서는 `/team/assets/*` 도 같이 막힌다.
+ * 그래서 외부 CSS·JS·이미지를 쓰지 않는다. 인라인 스타일만 쓴다.
+ */
+
+function esc(v: string): string {
+  return v
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function untrustedHostPage(host: string): string {
+  const shown = host.trim() || "(주소를 읽지 못했습니다)";
+  // 사용자가 그대로 복사해 팀원에게 붙여넣을 문장. ★자기 주소가 이미 들어 있어 되물을 게 없다.★
+  const ask =
+    `대시보드를 ${shown} 로 여는데 "등록되지 않은 주소" 라고 나옵니다. ` +
+    `TEAM_TRUSTED_DASHBOARD_HOSTS 에 이 주소를 등록해 주세요.`;
+  return `<!doctype html>
+<html lang="ko"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>등록되지 않은 주소 — b3os</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { margin:0; min-height:100vh; display:flex; align-items:center; justify-content:center;
+         font:15px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;
+         background:#0f1115; color:#e6e8ee; padding:24px; }
+  .card { max-width:640px; width:100%; background:#171a21; border:1px solid #262b36;
+          border-radius:12px; padding:28px 30px; }
+  h1 { margin:0 0 6px; font-size:19px; font-weight:650; }
+  .host { display:inline-block; margin:10px 0 18px; padding:4px 10px; border-radius:6px;
+          background:#22262f; font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:13px; }
+  p { margin:0 0 14px; color:#aeb4c2; }
+  .ask { margin:18px 0 6px; font-weight:600; color:#e6e8ee; }
+  pre { margin:0; padding:14px 16px; border-radius:8px; background:#22262f; border:1px solid #2d3340;
+        white-space:pre-wrap; word-break:break-word; font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+        font-size:13px; color:#dfe3ec; }
+  .why { margin-top:22px; padding-top:16px; border-top:1px solid #262b36; font-size:13px; color:#8d94a3; }
+  code { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; }
+  @media (prefers-color-scheme: light) {
+    body { background:#f6f7f9; color:#1b1f27; }
+    .card { background:#fff; border-color:#e2e5ea; }
+    p { color:#4d5563; } .host, pre { background:#f1f3f6; color:#1b1f27; } pre { border-color:#e2e5ea; }
+    .why { color:#6b7280; border-top-color:#e2e5ea; }
+  }
+</style></head>
+<body><div class="card">
+  <h1>등록되지 않은 주소입니다</h1>
+  <div class="host">${esc(shown)}</div>
+  <p>b3os 는 서버가 도는 컴퓨터에서 연 화면(<code>127.0.0.1</code> 또는 <code>localhost</code>)과,
+     관리자가 미리 등록한 주소에서만 열립니다. 이 주소는 아직 등록되어 있지 않습니다.</p>
+  <p class="ask">팀원에게 이대로 물어보세요</p>
+  <pre>${esc(ask)}</pre>
+  <div class="why">
+    등록은 서버의 <code>.env</code> 에 <code>TEAM_TRUSTED_DASHBOARD_HOSTS</code> 한 줄을 넣고
+    서버를 다시 띄우면 됩니다. 콤마로 여러 개, <code>*.</code> 로 하위 주소 전체를 적을 수 있습니다.
+  </div>
+</div></body></html>`;
+}

--- a/src/web/components/inboxRefined.dom.test.ts
+++ b/src/web/components/inboxRefined.dom.test.ts
@@ -2,7 +2,7 @@
  * Inbox-refined — DOM proof: default action-required filter + activity_assumed category.
  * (Separate file from inboxAudit.dom.test.ts to avoid stepping on concurrent Phase2 edits.)
  */
-import { describe, expect, test, beforeAll, afterEach } from "bun:test";
+import { describe, expect, test, beforeAll, afterAll, afterEach } from "bun:test";
 import { Window } from "happy-dom";
 
 // Good citizen: clear any roots we mounted so a later test file (shared global document)
@@ -12,15 +12,39 @@ afterEach(() => {
   if (b) b.innerHTML = "";
 });
 
+// ★여기서 심은 전역은 여기서 걷는다.★ (2026-07-30)
+//   앞서는 `g.Response = win.Response` 를 심어놓고 되돌리지 않았다. bun test 는 파일들을 한 프로세스에서
+//   돌리므로, 그 뒤에 도는 ★다른 파일의 서버 테스트가 happy-dom 의 Response 를 쓰게 된다.★
+//   그러면 Hono 가 붙인 헤더가 사라진다 — 실측: content-type 이 text/html 대신 text/plain 이 됐다.
+//   ★단독 실행은 통과하고 전체 실행만 깨진다★ 는 형태라, 원인을 코드에서 찾으면 못 찾는다
+//   (hostGate 테스트가 그렇게 깨져서 여기까지 왔다).
+const installedGlobals: string[] = [];
+const savedGlobals: Record<string, unknown> = {};
+
 beforeAll(() => {
   const g = globalThis as Record<string, unknown>;
   if (!g.document) {
     const win = new Window();
-    g.window = win;
-    g.document = win.document;
-    g.MutationObserver = win.MutationObserver;
-    g.Response = win.Response ?? globalThis.Response;
+    for (const [k, v] of [
+      ["window", win],
+      ["document", win.document],
+      ["MutationObserver", win.MutationObserver],
+      ["Response", win.Response ?? globalThis.Response],
+    ] as const) {
+      savedGlobals[k] = g[k];
+      installedGlobals.push(k);
+      g[k] = v;
+    }
   }
+});
+
+afterAll(() => {
+  const g = globalThis as Record<string, unknown>;
+  for (const k of installedGlobals) {
+    if (savedGlobals[k] === undefined) delete g[k];
+    else g[k] = savedGlobals[k];
+  }
+  installedGlobals.length = 0;
 });
 
 function mkMsg(id: string, recipients: Array<{ agent_id: string; recipient_state: string; close_reason: string | null }>) {

--- a/src/web/lib/apiErrorMessage.test.ts
+++ b/src/web/lib/apiErrorMessage.test.ts
@@ -13,6 +13,9 @@ describe("서버 오류 코드를 사람 말로", () => {
     expect(m).toContain("localhost");
     // ★이 예외는 서버가 로컬에만 열려 있을 때만 성립한다★ — 그 전제를 빼면 막힌 길로 안내하게 된다
     expect(m).toContain("로컬에만");
+    // ★사용자가 뭘 물어야 할지 알 수 있어야 한다★ — 그대로 붙여넣을 문장을 준다(팀장님 지시)
+    expect(m).toContain("팀원에게 이대로 물어보세요");
+    expect(m).toContain("TEAM_TRUSTED_DASHBOARD_HOSTS");
   });
 
   test("★서버가 이름을 바꿔도 문장이 살아 있다★ — 뒤 고침이 앞 고침을 지우지 않게", () => {

--- a/src/web/lib/apiErrorMessage.ts
+++ b/src/web/lib/apiErrorMessage.ts
@@ -55,10 +55,18 @@ export function humanizeApiError(raw: unknown): string {
     return pick(
       `${koWhere} 쓰기 권한이 없습니다. ` +
         `b3os 는 서버가 로컬에만 열려 있을 때, 그 컴퓨터에서 연 화면(127.0.0.1 또는 localhost)만 팀리드로 인정합니다. ` +
-        `도메인으로 쓰려면 관리자가 이 주소를 신뢰 목록에 등록해야 합니다.`,
+        `도메인으로 쓰려면 관리자가 이 주소를 신뢰 목록에 등록해야 합니다.\n\n` +
+        // ★사용자는 "뭘 물어야 할지" 를 몰라서 막힌다.★ 그대로 붙여넣을 문장을 준다 —
+        //   자기 주소가 이미 들어 있어서 팀원이 되물을 것도 없다.
+        `팀원에게 이대로 물어보세요:\n` +
+        `"대시보드를 ${host || "이 주소"} 로 여는데 쓰기가 막힙니다. ` +
+        `TEAM_TRUSTED_DASHBOARD_HOSTS 에 이 주소를 등록해 주세요."`,
       `${enWhere} has no write permission. ` +
         `When the server is bound to loopback, b3os only grants team-lead rights to the dashboard opened on that machine (127.0.0.1 or localhost). ` +
-        `To use a domain, an administrator must add this address to the trusted list.`,
+        `To use a domain, an administrator must add this address to the trusted list.\n\n` +
+        `Ask a teammate, copying this as-is:\n` +
+        `"The dashboard at ${host || "this address"} blocks writes. ` +
+        `Please add this address to TEAM_TRUSTED_DASHBOARD_HOSTS."`,
     );
   }
 


### PR DESCRIPTION
## 핵심

- **무엇이 문제인가** — 관문을 엔드포인트마다 각자 불렀다. 그래서 **쓰기 70곳 중 관문을 타는 건 소수**였다. 칸반 수정·삭제, 인박스, 라우터, 그리고 `settings` 쓰기 31개 중 **30개**(영입 `POST /members`·퇴사 `DELETE /members/:id` 포함)가 검사 없이 열려 있었다.
- **실측** — 도메인 Host 로 `PATCH /tasks/<없는id>` → **403 이 아니라 404**(즉 인증 통과). 같은 조건에서 `proposals` 는 403.
- **어떻게 했나** — 지나갈 수밖에 없는 자리에 **한 번** 건다. 읽기까지 막고, 사람이 보는 요청에는 안내 페이지를 돌려준다.

## 왜 "각자 부르기" 가 실패했나

> **"게이트를 부르는 곳" 을 세는 방식으로는 "게이트가 있어야 하는데 없는 곳" 을 못 본다.**

`#164` 리뷰 때 "쓰기 9군데" 로 범위를 잡았는데, 그건 **관문을 부르는 곳만** 센 숫자였다. 부르지 않는 곳은 세지 않았다. 새 엔드포인트가 추가될 때마다 같은 일이 반복된다.

한 곳에 걸면 **빠뜨릴 수가 없다.** 그게 이 방식의 요점이다.

## 읽기도 막는다

열어두면 주소를 아는 사람이 팀원 목록·보고서를 그대로 본다 — **2026-07-30 에 실제로 그런 상태였다**(로그인 없이 `/team/api/agents` 가 200 으로 응답).

보고서 공유 링크는 "받아서 전달하거나, 그 주소를 등록해서 열어준다" 로 간다.

## 대신 화면을 조각내지 않는다

읽기를 막으면 껍데기만 뜨고 위젯이 전부 실패한다 — "고장인지 아닌지 모르겠는" 상태가 되고, **그게 오늘 원인 찾기를 어렵게 만든 바로 그 모양**이다.

그래서 한 장짜리 안내 페이지를 돌려준다. 자기 주소와 **그대로 복사해 팀원에게 붙여넣을 문장**이 들어 있다. 페이지는 자체 포함이다 — 이 상황에서는 `/assets/*` 도 같이 막히므로 외부 CSS·JS 를 쓸 수 없다.

## 예외는 둘뿐

| 경로 | 왜 |
|---|---|
| `/slack/events` | 서명(`x-slack-signature`)으로 **자체 검증**한다. 막으면 Event URL 방식 설치본의 슬랙이 끊긴다 |
| `/health` | 감시용. 아무것도 안 알려주고, 막으면 바깥 모니터가 서버를 죽은 것으로 본다 |

## 오류 이름도 고쳤다

앞서는 주소 검사 실패에 **헤더 검사의 실패값**(`x_actor_id_required`)이 그대로 돌아왔다 — 대시보드는 그 헤더를 아예 안 쓰는데도. 그래서 화면에도 로그에도 원인과 무관한 이름이 남았다.

`dashboard_host_not_trusted` 로 바꿨다. `not_local_dashboard` 가 아닌 이유: 이 검사는 **loopback 또는 등록된 주소**면 통과하므로, 로컬만 조건인 것처럼 읽히면 안 된다.

## 같이 고친 것 — 테스트 오염

`inboxRefined.dom.test.ts` 가 `globalThis.Response` 를 happy-dom 것으로 바꿔놓고 **되돌리지 않았다.** 그 뒤에 도는 서버 테스트에서 Hono 가 붙인 헤더가 사라진다(실측: `text/html` → `text/plain`).

**단독 실행은 통과하고 전체 실행만 깨진다** — 원인을 내 코드에서 찾으면 못 찾는다. 실제로 그렇게 깨져서 파일 단위로 이분해 찾았다. 심은 전역을 걷도록 고쳤다.

## 검증

- `bun test src/server src/web` → **2025 tests · 0 fail** · `tsc` 0
- **뮤턴트 6종 전부 FAIL**: 관문 통과 / slack 예외 제거 / health 예외 제거 / 예외를 접미사 대신 포함으로 / 화면에도 JSON / 주소 escape 제거
- 테스트는 **막히나** 와 **막히면 안 되는 것이 안 막히나** 를 같은 무게로 단정한다. "전부 막고 예외를 뚫는" 방향이라 후자가 더 위험하다.

## 미검증 / 되돌리기

- **라이브 화면은 아직 안 봤다.** 배포 후 직접 열어 확인하고 결과를 남기겠다.
- 되돌리기: `127.0.0.1` 은 항상 통과하므로 로컬로 열어 복구할 수 있다.

Submitted-by: bill