### PR TITLE
fix(security): 관문을 들어오는 자리 한 곳으로 — 순서 때문에 /team/health 가 안 막혔다

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -211,7 +211,9 @@ watchRegistry(db, REGISTRY_PATH, (reloaded) => {
 
 const app = new Hono();
 
-app.get("/health", (c) => c.json({ ok: true, port: PORT, base_path: BASE_PATH, agents: agents.length }));
+
+
+
 
 const api = new Hono();
 
@@ -220,16 +222,7 @@ api.use("*", async (c, next) => {
   c.header("Cache-Control", "no-store, max-age=0, must-revalidate");
 });
 
-/**
- * ★신뢰하지 않는 주소는 한 곳에서 막는다 — 읽기까지.★ (팀장님 지시 2026-07-30)
- * 판정과 응답 형태는 lib/hostGate.ts 에 있다(그쪽에 왜 이렇게 하는지 적어뒀다).
- * 여기서는 "어디에 거는가" 만 정한다 — `app` 전체(대시보드 + `/api`)와 `/reports` 포털.
- */
-function requestIsTrusted(request: Request): boolean {
-  return trustedActorFromRequest(request, { loopbackDashboardActor: leadActorId(db) }).ok;
-}
 
-app.use("*", createHostGate({ isTrusted: requestIsTrusted }));
 
 api.get("/agents", (c) => {
   const all = listAgents(db);
@@ -628,18 +621,35 @@ bun run build</pre>
 }
 
 const rootApp = new Hono();
+
+// 바깥 감시용. ★관문 위에 둔다 — 이 한 줄이 유일한 예외이고, 예외라는 사실이 위치로 드러난다.★
 rootApp.get("/health", (c) => c.json({ ok: true }));
+
+/**
+ * ★신뢰하지 않는 주소는 여기 한 곳에서 막는다 — 읽기까지.★ (팀장님 지시 2026-07-30)
+ *
+ *  판정과 응답 형태는 lib/hostGate.ts 에 있다. 여기서는 "어디에 거는가" 만 정한다.
+ *
+ *  ★들어오는 모든 요청이 지나는 자리는 여기 하나다.★ 대시보드도 API 도 포털도 전부 이 아래에 붙는다.
+ *  앞서는 app 과 reports 두 군데에 각각 걸었는데, 그건 붙일 곳이 늘어날 때마다 또 붙여야 하는 모양이다.
+ *
+ *  ★순서가 곧 규칙이다.★ Hono 는 등록 순서대로 매칭하므로 이 줄 ★위★ 는 통과하고 ★아래★ 는 전부 막힌다.
+ *  2026-07-30 실측: `/health` 를 app 안에 두고 관문을 그 뒤에 뒀더니 배포 후에도 200 을 돌려줬다
+ *  (port·base_path·팀원 수 노출). ★시험도 교차검증 2인도 못 봤다★ — 시험은 자기 앱을 따로 만들고,
+ *  사람은 코드를 읽으면서 순서를 안 본다. 배포 후 라이브를 찔러서야 나왔다.
+ */
+function requestIsTrusted(request: Request): boolean {
+  return trustedActorFromRequest(request, { loopbackDashboardActor: leadActorId(db) }).ok;
+}
+
+rootApp.use("*", createHostGate({ isTrusted: requestIsTrusted }));
+
 rootApp.route(BASE_PATH, app);
 
 // 팀 결과물 포털 — /team 형제로 노출. 허브 next.config.ts rewrite 로 your-team.example.com/reports.
 // (2026-06-07 GD: /research 취소 — 모든 팀 산출물을 /reports 에 category 로 구분해 통합.)
 const portalDeps = { db, reportsDir: REPORTS_DIR, researchDir: RESEARCH_DIR, webDir: WEB_DIR };
-// ★포털에도 같은 관문★ — 보고서 공유 링크가 여기로 온다. 등록되지 않은 주소에서는 같은 안내를 보여준다.
-//   (팀장님 판단: 링크는 받아서 전달할 수 있고, 필요하면 그 주소를 등록해서 열어주면 된다)
-const reportsApp = new Hono();
-reportsApp.use("*", createHostGate({ isTrusted: requestIsTrusted, isApiPath: () => false }));
-reportsApp.route("/", createReportsApp(portalDeps));
-rootApp.route("/reports", reportsApp);
+rootApp.route("/reports", createReportsApp(portalDeps));
 rootApp.get("/reports/", (c) => c.redirect("/reports"));
 
 // ★포트 점유 가드 (fresh-user 막다름 방지)★ — Bun.serve 는 포트 사용중이면 EADDRINUSE 를 던진다.

--- a/src/server/lib/hostGate.test.ts
+++ b/src/server/lib/hostGate.test.ts
@@ -103,14 +103,45 @@ describe("막히면 안 되는 것 — 안 막힌다", () => {
   });
 });
 
-describe("포털(/reports) 은 API 가 아니다", () => {
-  test("★JSON 이 아니라 안내 페이지를 준다★ — 공유 링크를 받은 사람은 사람이다", async () => {
-    const app = new Hono();
-    app.use("*", createHostGate({ isTrusted: () => false, isApiPath: () => false }));
-    app.get("/reports", (c) => c.text("portal"));
-    const r = await app.fetch(new Request("http://x/reports", { headers: { host: "studio.b3rys.com" } }));
-    expect(r.status).toBe(403);
-    expect(r.headers.get("content-type")).toContain("text/html");
-    expect(await r.text()).toContain("등록되지 않은 주소");
+describe("관문은 ★한 곳★ 이고, 그 아래 붙는 것은 전부 덮인다", () => {
+  // ★이게 이 설계의 전부다.★ 실제 index.ts 와 같은 모양으로 조립해서, 하위 앱을 mount 해도
+  //   부모에 건 관문이 덮는지 확인한다. 앞서는 app·reports 두 곳에 각각 걸었는데(덧대기),
+  //   붙일 곳이 늘 때마다 또 붙여야 하는 모양이라 한 곳으로 합쳤다.
+  function rootLike() {
+    const dash = new Hono();          // = app (대시보드 + /api)
+    dash.get("/", (c) => c.text("dashboard"));
+    dash.get("/api/agents", (c) => c.json({ agents: [] }));
+
+    const portal = new Hono();        // = /reports 포털
+    portal.get("/", (c) => c.text("portal"));
+
+    const root = new Hono();
+    root.get("/health", (c) => c.json({ ok: true }));               // ★관문 위★ — 유일한 예외
+    root.use("*", createHostGate({ isTrusted: () => false }));      // ★관문★
+    root.route("/team", dash);                                      // 아래는 전부 덮인다
+    root.route("/reports", portal);
+    return root;
+  }
+
+  const hit = (p: string) =>
+    rootLike().fetch(new Request(`http://studio.b3rys.com${p}`, { headers: { host: "studio.b3rys.com" } }));
+
+  test("★관문 위에 등록된 /health 만 통과한다★", async () => {
+    expect((await hit("/health")).status).toBe(200);
+  });
+
+  test("★관문 아래 mount 된 하위 앱도 전부 덮인다★ — 대시보드·API·포털", async () => {
+    for (const p of ["/team", "/team/api/agents", "/reports"]) {
+      expect([p, (await hit(p)).status]).toEqual([p, 403]);
+    }
+  });
+
+  test("★기계는 JSON, 사람은 페이지★ — 포털은 사람이 여는 곳이라 페이지다", async () => {
+    const api = await hit("/team/api/agents");
+    expect(api.headers.get("content-type")).toContain("application/json");
+
+    const portal = await hit("/reports");
+    expect(portal.headers.get("content-type")).toContain("text/html");
+    expect(await portal.text()).toContain("등록되지 않은 주소");
   });
 });

--- a/src/server/lib/hostGate.ts
+++ b/src/server/lib/hostGate.ts
@@ -48,12 +48,14 @@ import { untrustedHostPage } from "./untrustedHostPage";
 export interface HostGateDeps {
   /** 이 요청을 신뢰하는가. 실제로는 `trustedActorFromRequest(...).ok` 를 넘긴다. */
   isTrusted: (request: Request) => boolean;
-  /** true 면 API 로 보고 JSON 을 돌려준다. 기본은 경로에 `/api/` 가 있는지. */
-  isApiPath?: (path: string) => boolean;
+}
+
+/** 기계가 부르는 자리인가 — 그러면 JSON, 아니면 사람이 읽을 페이지. */
+function isApiPath(path: string): boolean {
+  return path.includes("/api/");
 }
 
 export function createHostGate(deps: HostGateDeps) {
-  const isApiPath = deps.isApiPath ?? ((path: string) => path.includes("/api/"));
   return async (c: Context, next: Next) => {
     const path = c.req.path;
     if (deps.isTrusted(c.req.raw)) return next();


### PR DESCRIPTION
## 핵심

- **무엇이 문제인가** — `#171` 배포 후 라이브를 찔러보니 등록 안 된 주소에서 `/team/health` 가 **200** 이었다(`port`·`base_path`·팀원 수 노출).
- **원인** — Hono 는 **등록 순서대로** 매칭한다. 그 라우트가 관문보다 **20줄 위**에 있어서 관문을 아예 안 탔다.
- **왜 아무도 못 봤나** — 시험 2024개 통과, 교차검증 2인 통과. 시험은 **자기 앱을 따로 만들어** 관문을 맨 위에 두고 돌리고, 사람은 코드를 읽으면서 **순서를 안 본다.** 배포 후 실제로 찔러서야 나왔다.
- **어떻게 했나** — 관문을 **들어오는 자리 한 곳**으로 옮기고, 붙어 있던 군더더기를 걷었다.

## 지금 모양 — 이게 전부다

```ts
rootApp.get("/health", …)      // ← 관문 위. 유일한 예외이고, 예외라는 게 위치로 드러난다
rootApp.use("*", 관문)          // ← 여기 아래는 전부 막힌다
rootApp.route("/team", app)     // 대시보드 + /api
rootApp.route("/reports", 포털)
```

**순서가 곧 규칙이다.** 위는 통과, 아래는 전부 막힘.

## 걷어낸 것

| 무엇 | 왜 |
|---|---|
| `app` 쪽 관문 + `reportsApp` 쪽 관문 | 두 군데에 각각 걸면 **붙일 곳이 늘 때마다 또 붙여야 한다** |
| `app.get("/health")` | `rootApp` 것과 중복인데 운영 메타까지 줬다 |
| `isApiPath` 주입 옵션 | 관문이 한 곳이니 분기 하나면 된다 |
| `reportsApp` 껍데기 | 관문을 걸려고 만든 것이었다 |

## 테스트도 다시 짰다

앞선 테스트는 **자기 앱 하나**에 관문을 걸고 확인했다. 그래서 **조립 순서**를 못 봤다.

이제 `index.ts` 와 **같은 모양으로 조립**해서 단정한다:
- 관문 **위**의 `/health` 만 통과
- 관문 **아래** mount 된 하위 앱(대시보드·API·포털)은 전부 403
- 기계는 JSON, 사람은 페이지

**뮤턴트** — 관문을 `/health` **위로** 옮기면(예외가 사라짐) → **FAIL**. 라이브로 샜던 그 형태를 이제 시험이 잡는다.

## 검증

- `bun test src/server src/web` → **2026 tests · 0 fail** · `tsc` 0
- 배포 후 라이브 점검 13항목을 다시 돌려 결과를 남기겠다(이 결함을 잡아낸 그 점검이다)

Submitted-by: bill
