### PR TITLE
fix(reports): 태그 편집을 팝업으로 — hover 아이콘은 두 번 다 못 쓰는 물건이었다

### DIFF
--- a/src/web/components/Reports.ts
+++ b/src/web/components/Reports.ts
@@ -414,30 +414,15 @@ export function tagPillsHtml(
   selected: Set<string>,
   pillCls: (active: boolean) => string,
 ): string {
-  // opacity 만으로 숨기면 안 보이는데 눌린다 — 투명해도 그 자리는 여전히 클릭을 받는다.
-  // 마우스가 없는 환경(터치·아이패드 웹뷰)에서 태그 옆을 탭하면 안 보이는 연필·휴지통이 눌려
-  // "누르지도 않은 창" 이 뜬다. pointer-events 를 같이 꺼서 숨김 상태에선 클릭 자체를 안 받게 한다.
-  const hoverOnlyCls = "opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto";
-  // ★자리를 차지하지 않게 띄운다★ (팀장님 실측 2026-07-30: "너무 떨어져 있어. 이럴 바엔 예전 UI 가 더 나아")
-  //   처음엔 아이콘을 알약 옆에 ★흐름 안에★ 두고 opacity 로만 숨겼다. 그러면 마우스를 올리지 않아도
-  //   태그마다 아이콘 두 개 만큼의 빈칸이 ★항상 남는다.★ 쉬는 상태가 흉해진다.
-  //   ★그리고 우리 검증이 그걸 통과시켰다★ — 확인 항목이 "아이콘이 나타날 때 줄이 흔들리지 않는다" 였고,
-  //   흔들리지 않는 이유가 바로 "자리를 미리 비워둬서" 였다. 기준을 통과했는데 기준이 부족했다.
-  //   absolute 로 흐름에서 빼면 ★쉬는 상태는 예전 UI 와 동일★ 하고 hover 에서도 줄이 흔들리지 않는다.
-  //   대신 hover 중에는 옆 알약 위로 떠서 겹치므로 배경을 불투명하게 두고 z-10 을 준다.
-  const iconCls = "inline-flex h-6 w-6 items-center justify-center rounded-md border border-surface-3 bg-surface-1 text-slate-500 transition-colors";
+  // ★알약은 오직 필터다.★ 이름 바꾸기·지우기는 "태그 편집" 버튼 → 팝업으로 간다.
+  //
+  // 여기 hover 아이콘을 붙였다가 두 번 실패하고 걷어냈다(팀장님 실측 2026-07-30):
+  //   1차 — 흐름 안에 두니 ★마우스를 안 올려도 아이콘 두 개 만큼 빈칸이 항상 남았다★
+  //   2차 — absolute 로 빼니 알약과 아이콘 사이 4px 틈에서 hover 가 풀려 ★누를 수가 없었다★
+  // ★두 번 다 마크업 시험은 통과했다.★ "자리를 차지하나" 는 잴 수 있어도 "실제로 누를 수 있나" 는
+  // 마크업만 봐서는 못 잰다. hover 로만 나타나는 조작은 그 간극이 구조적으로 크므로 쓰지 않는다.
   return tags.map((t) =>
-    `<span class="group relative inline-flex items-center">
-      <button class="${pillCls(selected.has(t.id))} reports-tag-pill" data-tag-id="${escape(t.id)}">#${escape(t.name)}<span class="ml-1.5 text-[11px] text-slate-500">${t.report_count ?? 0}</span></button>
-      <span class="absolute left-full top-1/2 z-10 ml-1 -translate-y-1/2 inline-flex items-center gap-0.5 ${hoverOnlyCls} transition-opacity">
-        <button class="reports-tag-edit ${iconCls} hover:border-accent-green/40 hover:bg-accent-green/10 hover:text-accent-green" data-tag-id="${escape(t.id)}" data-tag-name="${escape(t.name)}" title="${pick("태그 이름 바꾸기", "Rename tag")}" aria-label="${pick("태그 이름 바꾸기", "Rename tag")}">
-          <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
-        </button>
-        <button class="reports-tag-del ${iconCls} hover:border-red-400/40 hover:bg-red-400/10 hover:text-txt-red" data-tag-id="${escape(t.id)}" data-tag-name="${escape(t.name)}" title="${pick("태그 삭제", "Delete tag")}" aria-label="${pick("태그 삭제", "Delete tag")}">
-          <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v5"/><path d="M14 11v5"/></svg>
-        </button>
-      </span>
-    </span>`
+    `<button class="${pillCls(selected.has(t.id))} reports-tag-pill" data-tag-id="${escape(t.id)}" data-tag-name="${escape(t.name)}">#${escape(t.name)}<span class="ml-1.5 text-[11px] text-slate-500">${t.report_count ?? 0}</span></button>`
   ).join("");
 }
 
@@ -456,22 +441,93 @@ function reportTagFailure(err: unknown): void {
  * 예전에는 이 팝업 하나가 만들기·이름바꾸기·삭제를 다 받았고, 그래서 한 입력칸에 문법 세 가지가
  * 섞여 있었다("이름" / "기존 -> 새이름" / "-이름"). 팀장님 실측(2026-07-30)에서 `aaa->bbb` 가
  * 이름 변경이 아니라 ★그 이름의 새 태그★ 로 만들어졌다 — 화살표를 U+2192 한 종류만 봤기 때문이다.
- * 이름 바꾸기·삭제를 ★태그 옆 아이콘★ 으로 옮기면서 여기서 문법을 없앴다. 이제 입력은 항상
- * ★이름 그대로★ 다. `aaa->bbb` 를 적으면 그 이름의 태그가 만들어지는 게 맞는 동작이 된다.
+ * 지금은 ★고르는 것과 적는 것을 분리★ 했다(무엇을 할지는 고르고, 이름만 적는다). 그래서 여기 들어오는
+ * 값은 항상 ★이름 그대로★ 다 — `aaa->bbb` 를 적으면 그 이름의 태그가 만들어지는 게 맞는 동작이 된다.
  */
-async function createTag(): Promise<void> {
-  const name = await showPrompt({
-    title: pick("태그 만들기", "New tag"),
-    message: pick(
-      "만들 태그 이름을 적어 주세요.\n\n이름 바꾸기와 삭제는 태그에 마우스를 올리면 나오는 아이콘으로 합니다.",
-      "Type the name for the new tag.\n\nTo rename or delete, hover a tag and use the icons that appear.",
-    ),
-    placeholder: pick("예: 주간보고", "e.g. weekly"),
-    okLabel: pick("만들기", "Create"),
-  });
-  if (!name?.trim()) return;
+async function createTag(name: string): Promise<void> {
+  if (!name.trim()) return;
   await mutateJson("/api/tags", "POST", { name: name.trim() });
   await reloadList();
+}
+
+/**
+ * ★태그 편집 — 한 팝업에서 만들기·이름 바꾸기·지우기를 다 받는다.★ (팀장님 지시 2026-07-30)
+ *
+ * ■ 왜 hover 아이콘을 버렸나
+ * 태그 옆에 연필·휴지통을 띄우는 방식을 두 번 고쳤는데 두 번 다 못 쓰는 물건이 나왔다.
+ *   1차 — 아이콘을 흐름 안에 두니 ★마우스를 안 올려도 빈칸이 항상 남았다★ ("이럴 바엔 예전 UI 가 더 나아")
+ *   2차 — 흐름 밖으로 빼니 알약과 아이콘 사이 4px 틈에서 hover 가 풀려 ★도달 자체가 불가능했다★
+ *          ("옆에 태그가 없어도 마우스를 옮기면 바로 삭제/수정이 없어짐")
+ * ★두 번 다 우리 시험은 통과한 상태였다.★ 마크업만 보는 시험은 "자리를 차지하나" 는 재도
+ * "사람이 실제로 누를 수 있나" 는 재지 못한다. 그래서 hover 에 기대는 UI 자체를 그만둔다 —
+ * 팝업은 마우스 위치와 무관해서 이 실패 모드가 아예 없다.
+ */
+export function tagEditBodyHtml(all: ReportTag[]): string {
+  const chip = "inline-flex cursor-pointer items-center rounded-full border border-surface-3 bg-surface-2 px-2.5 py-1 text-xs text-slate-400 transition-colors peer-checked:border-accent-green/50 peer-checked:bg-accent-green/10 peer-checked:text-accent-green";
+  // ★작은 회색 글씨를 쓰지 않는다★ (팀장님 상시 규칙) — 이 라벨은 "무엇을 하는 칸인가" 를 알려주는
+  // 핵심 안내다. 흐리게 두면 고를 것만 보이고 무엇을 고르는지가 안 보인다.
+  // uppercase·tracking 도 뺐다 — 한글에는 효과가 없고 ①② 같은 기호는 11px 에서 읽히지 않았다(실측).
+  const label = "text-xs font-semibold text-slate-300";
+  const tagChoices = all.length
+    ? all.map((t, i) => `<label class="inline-flex">
+        <input type="radio" name="tag-edit-target" class="peer sr-only" data-tag-target value="${escape(t.id)}" data-tag-name="${escape(t.name)}"${i === 0 ? " checked" : ""} />
+        <span class="${chip}">#${escape(t.name)}</span>
+      </label>`).join("")
+    : `<span class="text-xs text-slate-600">${escape(pick("아직 만들어진 태그가 없습니다.", "No tags yet."))}</span>`;
+  const action = (value: string, ko: string, en: string, checked: boolean) =>
+    `<label class="inline-flex">
+      <input type="radio" name="tag-edit-action" class="peer sr-only" data-tag-action value="${value}"${checked ? " checked" : ""} />
+      <span class="${chip}">${escape(pick(ko, en))}</span>
+    </label>`;
+  return `<div class="mt-4 space-y-4 text-left">
+      <div>
+        <div class="${label}">${escape(pick("어떤 태그를", "Which tag"))}</div>
+        <div class="mt-1.5 flex flex-wrap gap-1.5">${tagChoices}</div>
+      </div>
+      <div>
+        <div class="${label}">${escape(pick("어떻게 할까요", "Do what"))}</div>
+        <div class="mt-1.5 flex flex-wrap gap-1.5">
+          ${action("rename", "이름 바꾸기", "Rename", true)}
+          ${action("delete", "지우기", "Delete", false)}
+        </div>
+      </div>
+      <div class="border-t border-surface-3 pt-3">
+        <div class="${label}">${escape(pick("또는 — 새 태그 만들기", "Or — create a new tag"))}</div>
+        <input type="text" data-tag-new class="mt-1.5 w-full rounded-md border border-surface-3 bg-surface-2 px-3 py-2 text-sm text-slate-100 outline-none focus:border-accent-green/40 placeholder:text-slate-600"
+          placeholder="${escape(pick("여기에 이름을 적으면 위 선택 대신 새로 만듭니다", "Type a name here to create one instead"))}" />
+      </div>
+    </div>`;
+}
+
+/** 위 본문에서 고른 태그·동작과 새로 적은 이름을 읽어낸다. */
+export function collectTagEdit(root: HTMLElement): { tagId: string; tagName: string; action: string; newName: string } {
+  const target = root.querySelector<HTMLInputElement>("input[data-tag-target]:checked");
+  const action = root.querySelector<HTMLInputElement>("input[data-tag-action]:checked");
+  return {
+    tagId: target?.value ?? "",
+    tagName: target?.dataset.tagName ?? "",
+    action: action?.value ?? "",
+    newName: (root.querySelector<HTMLInputElement>("input[data-tag-new]")?.value ?? "").trim(),
+  };
+}
+
+async function manageTags(): Promise<void> {
+  const picked = await showForm<{ tagId: string; tagName: string; action: string; newName: string }>({
+    title: pick("태그 편집", "Edit tags"),
+    message: pick(
+      "태그를 고르고 무엇을 할지 고르세요. 새로 만들려면 맨 아래에 이름만 적으면 됩니다.",
+      "Pick a tag and what to do with it. To create one instead, just type a name at the bottom.",
+    ),
+    bodyHtml: tagEditBodyHtml(_tags),
+    collect: collectTagEdit,
+    okLabel: pick("다음", "Next"),
+  });
+  if (picked == null) return;
+  // ★새 이름을 적었으면 그게 우선★ — 태그가 하나도 없을 때는 고를 것 자체가 없다.
+  if (picked.newName) { await createTag(picked.newName); return; }
+  if (!picked.tagId) return;
+  if (picked.action === "delete") { await deleteTag(picked.tagId, picked.tagName); return; }
+  await renameTag(picked.tagId, picked.tagName);
 }
 
 /** 태그 이름 바꾸기 — 지금 이름을 채워서 띄운다(다시 타이핑하지 않게). */
@@ -703,7 +759,7 @@ function renderList(): void {
         <div class="flex items-center gap-2 flex-wrap mb-3">
           <span class="shrink-0 text-[11px] font-semibold text-slate-500">${pick("태그", "Tags")}</span>
           ${tagPills || `<span class="text-xs text-slate-600">${pick("등록된 태그 없음", "No tags yet")}</span>`}
-          <button id="reports-manage-tags" class="ml-auto px-3 py-1.5 rounded-full text-xs font-semibold border border-surface-3 bg-surface-2 text-slate-400 hover:text-slate-200">＋ ${pick("태그 만들기", "New tag")}</button>
+          <button id="reports-manage-tags" class="ml-auto px-3 py-1.5 rounded-full text-xs font-semibold border border-surface-3 bg-surface-2 text-slate-400 hover:text-slate-200">${pick("태그 편집", "Edit tags")}</button>
         </div>
         <div class="relative mb-4">
           <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
@@ -729,13 +785,6 @@ function renderList(): void {
       void reloadList();
     });
   });
-  // 태그 옆 아이콘 — 알약(필터 토글)과 형제라 stopPropagation 은 필요 없지만, 실패는 인페이지 창으로 알린다.
-  _root.querySelectorAll<HTMLButtonElement>(".reports-tag-edit").forEach((el) => {
-    el.addEventListener("click", () => void renameTag(el.dataset.tagId || "", el.dataset.tagName || "").catch(reportTagFailure));
-  });
-  _root.querySelectorAll<HTMLButtonElement>(".reports-tag-del").forEach((el) => {
-    el.addEventListener("click", () => void deleteTag(el.dataset.tagId || "", el.dataset.tagName || "").catch(reportTagFailure));
-  });
   _root.querySelectorAll<HTMLButtonElement>(".reports-tag-filter").forEach((el) => {
     el.addEventListener("click", (e) => {
       e.preventDefault(); e.stopPropagation();
@@ -744,7 +793,7 @@ function renderList(): void {
     });
   });
   _root.querySelector<HTMLButtonElement>("#reports-manage-tags")?.addEventListener("click", () => {
-    void createTag().catch(reportTagFailure);
+    void manageTags().catch(reportTagFailure);
   });
   _root.querySelectorAll<HTMLElement>(".reports-card").forEach((el) => {
     el.addEventListener("click", () => { rememberListScroll(); _curId = el.dataset.id || null; if (_curId) setDetailHash(_curId); _curType = null; _view = "detail"; renderDetail(); });

--- a/src/web/components/reportsTagPills.test.ts
+++ b/src/web/components/reportsTagPills.test.ts
@@ -1,76 +1,53 @@
 /**
- * 태그 알약 마크업 — ★이름 바꾸기·삭제가 태그 옆에 실제로 붙는지★ (팀장님 지시 2026-07-30).
+ * 태그 UI — ★알약은 필터, 편집은 팝업★ (팀장님 지시 2026-07-30)
  *
- * 왜 마크업을 시험하나: 이 UI 는 ★마우스를 올렸을 때만 보인다.★ 나는 브라우저를 띄워 확인하지 못했고
- * (그래서 PR 에 '미검증' 으로 적었다), 오늘 이미 ★시험은 통과했는데 실제 화면이 깨진 일★ 을
- * 팀 전체가 네 번 겪었다. 최소한 "버튼이 존재하고 어느 태그를 가리키는가" 는 코드로 못 박는다.
- * 육안 확인(아이콘이 실제로 hover 에 나타나는지)은 사람이 따로 해야 끝난다.
+ * ■ 이 파일이 왜 다시 쓰였나
+ * 앞선 두 판은 태그 옆 hover 아이콘을 시험했고, ★두 판 다 통과한 상태로 실제로는 못 쓰는 물건이었다.★
+ *   1차 — "줄이 흔들리지 않는다" 를 통과. 흔들리지 않은 이유가 ★빈칸을 미리 비워둬서★ 였다.
+ *   2차 — "자리를 차지하지 않는다(absolute)" 를 통과. 그런데 알약과 아이콘 사이 4px 틈에서
+ *          hover 가 풀려 ★손이 닿기 전에 사라졌다.★
+ * 마크업 시험은 "무엇이 있나" 는 재도 "사람이 닿을 수 있나" 는 못 잰다. 그래서 UI 를 바꿨고,
+ * 시험도 ★조작이 hover 에 걸려 있지 않다★ 는 것을 직접 단정하도록 바꾼다.
  */
 import { describe, expect, test } from "bun:test";
-import { tagPillsHtml } from "./Reports";
+import { collectTagEdit, tagEditBodyHtml, tagPillsHtml } from "./Reports";
 
 const pillCls = (active: boolean) => (active ? "ACTIVE" : "IDLE");
 const tag = (id: string, name: string, count = 0) => ({ id, name, color: "blue", report_count: count });
 
-describe("tagPillsHtml", () => {
-  test("태그마다 ★이름바꾸기·삭제 버튼이 하나씩★ 붙는다", () => {
+describe("tagPillsHtml — 알약은 필터 하나만 한다", () => {
+  test("★조작이 hover 에 걸려 있지 않다★ — 이게 두 번 무너진 지점이다", () => {
     const html = tagPillsHtml([tag("t1", "주간보고", 3), tag("t2", "인프라")], new Set(), pillCls);
-    expect((html.match(/reports-tag-edit/g) ?? []).length).toBe(2);
-    expect((html.match(/reports-tag-del/g) ?? []).length).toBe(2);
-    expect((html.match(/reports-tag-pill/g) ?? []).length).toBe(2);
+    // hover 로만 나타나는 요소가 있으면 "보이는데 못 누르는" 상태가 다시 생길 수 있다.
+    expect(html, "hover 로만 보이는 조작이 남아 있으면 안 된다").not.toContain("group-hover");
+    expect(html).not.toContain("opacity-0");
+    // 알약 밖으로 띄우는 배치(4px 틈이 생기던 그 배치)도 없어야 한다.
+    expect(html).not.toContain("left-full");
+    expect(html).not.toContain("absolute");
   });
 
-  test("★어느 태그인지 버튼이 알고 있다★ — id·이름이 둘 다 실린다", () => {
+  test("이름 바꾸기·지우기 버튼은 알약 옆에 없다 (팝업으로 갔다)", () => {
     const html = tagPillsHtml([tag("t1", "주간보고")], new Set(), pillCls);
-    expect(html).toContain('class="reports-tag-edit');
-    expect(html).toContain('data-tag-id="t1"');
-    expect(html).toContain('data-tag-name="주간보고"');
-  });
-
-  test("hover 로만 보이게 하는 클래스가 실려 있다 (group + opacity 전환)", () => {
-    const html = tagPillsHtml([tag("t1", "a")], new Set(), pillCls);
-    // ★클래스를 붙어 있는 순서로 단정하지 않는다★ — 사이에 하나 끼우면 깨진다(실제로 깨졌다).
-    //   'group' 이 있고 'opacity-0 group-hover:opacity-100' 쌍이 있다는 것만 본다.
-    const wrapper = html.slice(0, html.indexOf(">") + 1);
-    expect(wrapper).toContain("group");
-    expect(html).toContain("opacity-0 group-hover:opacity-100");
-  });
-
-  test("★아이콘이 자리를 차지하지 않는다★ — 쉬는 상태에 빈칸이 생기면 안 된다", () => {
-    // 팀장님 실측(2026-07-30): "너무 떨어져 있어. 이럴 바엔 예전 UI 가 더 나아."
-    //   흐름 안에 두고 opacity 로만 숨기면 마우스를 안 올려도 아이콘 두 개 만큼 빈칸이 항상 남는다.
-    //   ★그리고 우리 검증은 "줄이 흔들리지 않는다" 를 통과시켰다★ — 흔들리지 않는 이유가 그 빈칸이었다.
-    //   absolute 로 흐름에서 빼야 쉬는 상태가 예전 UI 와 같아진다.
-    const html = tagPillsHtml([tag("t1", "a")], new Set(), pillCls);
-    const wrapper = html.slice(0, html.indexOf(">") + 1);
-    expect(wrapper, "아이콘을 띄우려면 래퍼가 relative 여야 한다").toContain("relative");
-    const iconBox = html.slice(html.indexOf("<span", html.indexOf("</button>")));
-    expect(iconBox, "아이콘 묶음이 absolute 가 아니면 자리를 차지한다").toContain("absolute");
-    // 흐름 안에 두던 옛 방식의 흔적(알약 뒤 margin) 이 남아 있으면 빈칸이 다시 생긴다.
-    expect(iconBox).not.toContain("ml-0.5 inline-flex");
-  });
-
-  test("★안 보일 때는 눌리지도 않는다★ — opacity 만으로는 클릭이 안 막힌다", () => {
-    // 투명한 요소도 그 자리는 클릭을 받는다. 마우스가 없는 환경(터치·아이패드 웹뷰)에서
-    // 태그 옆을 탭하면 안 보이는 연필·휴지통이 눌려 "누르지도 않은 창" 이 뜬다.
-    const html = tagPillsHtml([tag("t1", "a")], new Set(), pillCls);
-    expect(html).toContain("pointer-events-none");
-    expect(html).toContain("group-hover:pointer-events-auto");
+    expect(html).not.toContain("reports-tag-edit");
+    expect(html).not.toContain("reports-tag-del");
+    expect((html.match(/reports-tag-pill/g) ?? []).length).toBe(1);
   });
 
   test("★태그 이름이 속성을 깨지 않는다★ — 이름은 사용자 입력이다", () => {
     const html = tagPillsHtml([tag("t1", '따옴표" <b>태그</b>')], new Set(), pillCls);
-    // 원문 그대로 속성에 들어가면 data-tag-name 이 조기 종료돼 마크업이 깨진다.
     expect(html).not.toContain('data-tag-name="따옴표" <b>');
     expect(html).toContain("&quot;");
     expect(html).toContain("&lt;b&gt;");
   });
 
-  test("선택된 태그는 pillCls(true) 를 받는다 (필터 토글 표시 유지)", () => {
-    const html = tagPillsHtml([tag("t1", "a"), tag("t2", "b")], new Set(["t2"]), pillCls);
-    const first = html.slice(0, html.indexOf("t2"));
-    expect(first).toContain("IDLE");
-    expect(html.slice(html.indexOf('data-tag-id="t2"') - 200)).toContain("ACTIVE");
+  test("선택된 태그는 pillCls(true) 를 받는다 (필터 표시 유지)", () => {
+    // ★알약 단위로 잘라서 본다★ — 앞선 판에서는 "id 위치에서 200자 앞" 으로 잘랐는데, 마크업이
+    //   짧아지자 그 값이 음수가 돼 slice 가 ★문자열 끝에서★ 잘랐다(시험이 엉뚱한 곳을 봤다).
+    const pills = tagPillsHtml([tag("t1", "a"), tag("t2", "b")], new Set(["t2"]), pillCls)
+      .split("</button>").filter(Boolean);
+    expect(pills.length).toBe(2);
+    expect(pills.find((p) => p.includes('data-tag-id="t1"'))).toContain("IDLE");
+    expect(pills.find((p) => p.includes('data-tag-id="t2"'))).toContain("ACTIVE");
   });
 
   test("보고서 수를 보여준다 (없으면 0)", () => {
@@ -80,5 +57,71 @@ describe("tagPillsHtml", () => {
 
   test("태그가 없으면 빈 문자열 (호출부가 '등록된 태그 없음' 을 띄운다)", () => {
     expect(tagPillsHtml([], new Set(), pillCls)).toBe("");
+  });
+});
+
+describe("tagEditBodyHtml — 팝업이 고를 것을 다 보여준다", () => {
+  test("있는 태그를 전부 보여준다 — ★외워서 적게 하지 않는다★", () => {
+    const html = tagEditBodyHtml([tag("t1", "주간보고"), tag("t2", "인프라")]);
+    expect(html).toContain("#주간보고");
+    expect(html).toContain("#인프라");
+    expect((html.match(/data-tag-target/g) ?? []).length).toBe(2);
+  });
+
+  test("★첫 태그가 미리 골라져 있다★ — 아무것도 안 고른 채 확인을 눌러 허탕치지 않게", () => {
+    const html = tagEditBodyHtml([tag("t1", "주간보고"), tag("t2", "인프라")]);
+    expect((html.match(/ checked/g) ?? []).length).toBe(2); // 태그 1 + 동작(이름 바꾸기) 1
+    expect(html.slice(0, html.indexOf("t2"))).toContain("checked");
+  });
+
+  test("동작은 이름 바꾸기·지우기 두 개고 ★이름 바꾸기가 기본★ (실수로 지우지 않게)", () => {
+    const html = tagEditBodyHtml([tag("t1", "a")]);
+    expect(html).toContain('value="rename"');
+    expect(html).toContain('value="delete"');
+    const renameIdx = html.indexOf('value="rename"');
+    expect(html.slice(renameIdx, renameIdx + 60)).toContain("checked");
+    expect(html.slice(html.indexOf('value="delete"'), html.indexOf('value="delete"') + 60)).not.toContain("checked");
+  });
+
+  test("태그가 하나도 없어도 새로 만들 칸은 있다", () => {
+    const html = tagEditBodyHtml([]);
+    expect(html).toContain("아직 만들어진 태그가 없습니다");
+    expect(html).toContain("data-tag-new");
+    expect(html).not.toContain("data-tag-target");
+  });
+
+  test("★태그 이름이 속성을 깨지 않는다★", () => {
+    const html = tagEditBodyHtml([tag("t1", '따옴표" <b>')]);
+    expect(html).not.toContain('data-tag-name="따옴표" <b>');
+    expect(html).toContain("&quot;");
+  });
+});
+
+describe("collectTagEdit — 팝업에서 고른 것을 읽어낸다", () => {
+  /** happy-dom 없이 필요한 부분만 흉내낸다 — querySelector 만 쓰므로 충분하다. */
+  const rootWith = (fields: { target?: { value: string; name: string }; action?: string; newName?: string }) =>
+    ({
+      querySelector: (sel: string) => {
+        if (sel.includes("data-tag-target")) {
+          return fields.target ? { value: fields.target.value, dataset: { tagName: fields.target.name } } : null;
+        }
+        if (sel.includes("data-tag-action")) return fields.action ? { value: fields.action } : null;
+        if (sel.includes("data-tag-new")) return { value: fields.newName ?? "" };
+        return null;
+      },
+    }) as unknown as HTMLElement;
+
+  test("고른 태그와 동작을 그대로 돌려준다", () => {
+    const got = collectTagEdit(rootWith({ target: { value: "t1", name: "주간보고" }, action: "delete" }));
+    expect(got).toEqual({ tagId: "t1", tagName: "주간보고", action: "delete", newName: "" });
+  });
+
+  test("새 이름은 ★앞뒤 공백을 떼서★ 돌려준다 (' 주간 ' 이 새 태그가 되지 않게)", () => {
+    const got = collectTagEdit(rootWith({ target: { value: "t1", name: "a" }, action: "rename", newName: "  새태그  " }));
+    expect(got.newName).toBe("새태그");
+  });
+
+  test("아무것도 안 고른 상태는 빈 값 — 호출부가 아무 일도 하지 않는 근거가 된다", () => {
+    expect(collectTagEdit(rootWith({}))).toEqual({ tagId: "", tagName: "", action: "", newName: "" });
   });
 });


### PR DESCRIPTION
팀장님 지시(2026-07-30): "그냥 기존처럼 오른쪽을 태그편집으로 바꾸고 팝업에서 이전에 한 방식으로 가자"

## 왜

태그 옆 hover 아이콘을 두 번 고쳤고 **두 번 다 못 쓰는 물건이 나왔다.**

| | 무엇을 했나 | 팀장님 실측 |
|---|---|---|
| 1차 (#164/#165) | 아이콘을 흐름 안에 두고 opacity 로 숨김 | "너무 떨어져 있어. 이럴 바엔 예전 UI 가 더 나아" — 마우스를 안 올려도 빈칸이 항상 남는다 |
| 2차 (#169) | `absolute left-full` 로 흐름에서 뺌 | "옆에 태그가 없어도 마우스를 옮기면 바로 삭제/수정이 없어짐" — 알약과 아이콘 사이 4px 틈에서 hover 가 풀려 **도달 자체가 불가능** |

**두 번 다 우리 마크업 시험은 통과한 상태였다.** 마크업 시험은 "자리를 차지하나" 는 재도
"사람이 실제로 누를 수 있나" 는 못 잰다. 그래서 hover 에 기대는 조작 자체를 그만둔다 —
팝업은 마우스 위치와 무관해서 이 실패 모드가 아예 없다.

## 무엇을

- 알약은 **필터만** 한다 — hover 아이콘·`group`·`absolute` 전부 제거
- 오른쪽 버튼 `＋ 태그 만들기` → **`태그 편집`**, 한 팝업에서 만들기·이름 바꾸기·지우기
- **문법을 다시 만들지 않는다** — 고르는 것(태그·동작)과 적는 것(새 이름)을 분리.
  예전 한 칸 팝업의 `기존 -> 새이름` 문법이 `aaa->bbb` 라는 태그를 만들어낸 그 사고를 구조적으로 막는다
- 라벨에 **작은 회색 글씨를 쓰지 않는다**(팀장님 상시 규칙). `①②` 기호는 11px 에서 안 읽혀 뺐다 — 렌더해서 확인
- 기본값은 **이름 바꾸기** — 실수로 지우지 않게

## 검증

- `tsc` 0 · `bun test src/server src/web` **2034 pass 0 fail**
- `vite build` 통과, 새로 쓴 유틸리티(`space-y-4`·`sr-only`·`peer-checked` 등)가 실제 CSS 에 생성된 것 확인
- **팝업을 실제로 렌더해 눈으로 확인** — 그 과정에서 `①②` 가독성 문제를 잡아 고쳤다
- 시험을 바꿨다: "hover 로만 보이는 조작이 없다"(`group-hover`·`opacity-0`·`left-full`·`absolute` 부재)를 단정.
  **값이 아니라 도달 가능성을 단정한다** — 앞선 두 판이 통과했던 지점이다

## 미검증

라이브에서 팝업을 실제로 눌러 만들기·이름 바꾸기·지우기가 도는 것은 배포 후 확인이 필요하다.