### PR TITLE
fix(security): 신뢰 호스트 등록이 한 번도 동작한 적 없던 것

### DIFF
--- a/src/server/lib/opAuth.ts
+++ b/src/server/lib/opAuth.ts
@@ -163,17 +163,22 @@ function isLoopbackDashboardRequest(request: Request): boolean {
     }
     return false;
   }
-  let urlHost = "";
-  try {
-    urlHost = new URL(request.url).hostname;
-  } catch {
-    return false;
-  }
+  // ★앞서 여기에 "url 의 host 도 loopback 이어야 한다" 는 조건이 하나 더 있었다.★
+  //   의도는 "요청이 진짜 이 서버 소켓에 닿았나" 였는데, ★그 둘은 같은 값이다.★
+  //   Bun 은 `request.url` 의 authority 를 ★Host 헤더로 만든다★ (2026-07-30 실측 — 최소 서버로 확인):
+  //     Host: dev.b3rys.com → req.url = http://dev.b3rys.com/x
+  //     Host: 127.0.0.1     → req.url = http://127.0.0.1:7999/x
+  //   그래서 두 조건이 ★서로 배타적★ 이었다 — 도메인으로 오면 앞이 거짓, 루프백으로 오면 뒤가 무의미.
+  //   ★즉 등록 기능은 켜질 수가 없었다.★ 문서·안내 페이지·팀 안내가 전부 안 되는 방법을 말하고 있었다.
+  //
+  //   "진짜 이 서버에 닿았나" 는 위의 TEAM_BIND 검사가 이미 답한다 — 루프백 바인딩이면 소켓 자체가
+  //   로컬에서만 연결을 받는다. 중복이었고, 그 중복이 기능을 죽였다. 그래서 뺀다.
+  //
+  //   ★Host 헤더가 아예 없으면 통과시킨다★ — 앞서와 같은 동작이다. HTTP/1.1 은 Host 를 요구하므로
+  //   실제로는 거의 없고, 있더라도 소켓이 로컬 전용이라 로컬에서 온 요청이다.
   const trusted = trustedDashboardHosts();
   const hostHeader = request.headers.get("host") ?? "";
-  // urlHost 는 여전히 loopback 이어야 한다 — 요청이 실제로 이 서버 소켓에 닿았다는 뜻이다.
-  //   등록된 주소는 ★Host 헤더★ 쪽에서만 허용한다(터널이 남기는 이름이 그것뿐이다).
-  return isLoopbackHost(urlHost) && (!hostHeader || isTrustedDashboardHost(hostHeaderName(hostHeader), trusted));
+  return !hostHeader || isTrustedDashboardHost(hostHeaderName(hostHeader), trusted);
 }
 
 function hostHeaderName(value: string): string {

--- a/src/server/lib/opAuth.ts
+++ b/src/server/lib/opAuth.ts
@@ -174,11 +174,21 @@ function isLoopbackDashboardRequest(request: Request): boolean {
   //   "진짜 이 서버에 닿았나" 는 위의 TEAM_BIND 검사가 이미 답한다 — 루프백 바인딩이면 소켓 자체가
   //   로컬에서만 연결을 받는다. 중복이었고, 그 중복이 기능을 죽였다. 그래서 뺀다.
   //
-  //   ★Host 헤더가 아예 없으면 통과시킨다★ — 앞서와 같은 동작이다. HTTP/1.1 은 Host 를 요구하므로
-  //   실제로는 거의 없고, 있더라도 소켓이 로컬 전용이라 로컬에서 온 요청이다.
+  //   ★Host 헤더가 없으면 url 에서 읽는다. 둘 다 없으면 통과시키지 않는다.★
+  //   앞선 판에서 `!hostHeader || …` 로 뒀다가 ★없으면 무조건 통과★ 가 됐다 —
+  //   손으로 만든 Request 는 Host 헤더가 안 붙어서, `http://example.com/…` 요청이 통과했다
+  //   (proposals 테스트가 잡았다). 실제 서버에서는 Host 가 늘 있으므로 평소 동작은 같지만,
+  //   "없으면 믿는다" 는 방향이 틀렸다 — 모르면 안 믿는 쪽이다.
   const trusted = trustedDashboardHosts();
-  const hostHeader = request.headers.get("host") ?? "";
-  return !hostHeader || isTrustedDashboardHost(hostHeaderName(hostHeader), trusted);
+  let host = request.headers.get("host") ?? "";
+  if (!host) {
+    try {
+      host = new URL(request.url).host;
+    } catch {
+      return false;
+    }
+  }
+  return !!host && isTrustedDashboardHost(hostHeaderName(host), trusted);
 }
 
 function hostHeaderName(value: string): string {


### PR DESCRIPTION
## 핵심

- **무엇이 문제인가** — `TEAM_TRUSTED_DASHBOARD_HOSTS` 가 **한 번도 동작한 적이 없다.** 판정의 두 조건이 서로 배타적이었다.
- **왜 아무도 못 봤나** — 이 기능의 테스트가 **실제 서버가 만들 수 없는 요청**(`url=루프백` + `Host=도메인`)을 쓴다. 그래서 통과했다. hermes 3회전 검증도, 나도 오늘 여러 번 "도메인은 403" 을 보고 **정상 동작으로 읽었다.**
- **얼마나 퍼졌나** — 문서(`.env.example`)·안내 페이지·팀 안내·GD 께 드린 설명이 **전부 안 되는 방법을 말하고 있었다.**

## 두 조건이 왜 배타적인가

```
isLoopbackHost(urlHost) && isTrustedDashboardHost(hostHeader, trusted)
```

Bun 은 `request.url` 의 authority 를 **Host 헤더로 만든다.** 최소 서버로 실측:

```
Host: dev.b3rys.com → req.url = http://dev.b3rys.com/x    urlHost = dev.b3rys.com
Host: 127.0.0.1     → req.url = http://127.0.0.1:7999/x   urlHost = 127.0.0.1
```

**두 값은 실제 서버에서 항상 같다.** 도메인으로 오면 앞이 거짓, 루프백으로 오면 뒤가 무의미.

앞 조건의 의도는 *"요청이 진짜 이 서버 소켓에 닿았나"* 였는데, **그건 위의 `TEAM_BIND` 검사가 이미 답한다** — 루프백 바인딩이면 소켓 자체가 로컬에서만 연결을 받는다. 중복이었고, 그 중복이 기능을 죽였다.

## 실제 Bun 서버로 확인했다 (손으로 만든 Request 아님)

| Host | 고치기 전 | 고친 뒤 |
|---|---|---|
| `127.0.0.1` / `localhost` | 200 | 200 |
| `dev.b3rys.com` (등록됨) | **403** | **200** |
| `studio.b3rys.com` (등록됨) | **403** | **200** |
| `b3rys.com` (맨 도메인, 미등록) | 403 | 403 |
| `evilb3rys.com` | 403 | 403 |
| `b3rys.com.attacker.net` | 403 | 403 |
| `not-registered.example.com` | 403 | 403 |

**미등록 기본 설치본**도 확인 — 로컬 200, 도메인 403. 기존과 같다.

## 두 번째 커밋 — 내가 만든 결함을 테스트가 잡았다

첫 수정에서 `!hostHeader || …` 로 둬서 **Host 가 없으면 무조건 통과**가 됐다. 실제 서버에서는 Host 가 늘 있어 안 드러나지만, 손으로 만든 `Request` 는 Host 가 안 붙는다 — `proposals.test.ts` 의 `http://example.com/…` 요청이 그래서 통과했다(403 기대, 409).

Host 가 없으면 url 에서 읽고, **둘 다 없으면 거절**한다. 모르면 안 믿는 쪽이다.

## 테스트는 steve 가 다시 짠다

지금 테스트가 이 버그를 가린 장본인이라, **실제 `Bun.serve` 에 진짜 요청을 보내는** 모양으로 steve 가 재작성한다(분담 합의). 뮤턴트로 — 이 수정을 되돌렸을 때 새 테스트가 FAIL 하는지 먼저 확인하기로 했다.

## 검증

- `bun test src/server src/web` → **2040 tests · 0 fail** · `tsc` 0
- 실제 Bun 서버 8케이스 (위 표)

Submitted-by: bill
