### PR TITLE
fix(health): 음수 오프셋과 소문자 z 를 읽지 못하던 것

### DIFF
--- a/src/server/lib/health.test.ts
+++ b/src/server/lib/health.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { classifyAll, classifyHealth } from "./health";
+import { classifyAll, classifyHealth, parseUtc } from "./health";
 import type { AgentStatus, AgentRecord } from "../types";
 
 const claudeAgent = {
@@ -194,5 +194,30 @@ describe("classifyAll", () => {
     expect(verdicts.find((v) => v.agentId === "demis")?.level).toBe("ok");
     expect(verdicts.find((v) => v.agentId === "demis")?.reasons.join(" ")).not.toContain("Claude 한도 대기");
     expect(verdicts.find((v) => v.agentId === "codex")?.level).toBe("ok");
+  });
+});
+
+describe("parseUtc — 시간대 표시자", () => {
+  const iso = (v: string) => { const n = parseUtc(v); return n == null ? null : new Date(n).toISOString(); };
+
+  test("표시자가 없으면 UTC 로 읽는다", () => {
+    expect(iso("2026-07-30 18:10:00")).toBe("2026-07-30T18:10:00.000Z");
+    expect(iso("2026-07-30T18:10:00")).toBe("2026-07-30T18:10:00.000Z");
+  });
+
+  test("음수 오프셋과 소문자 z 도 읽는다 — 앞서는 null 이었다", () => {
+    expect(iso("2026-07-30T18:10:00-05:00")).toBe("2026-07-30T23:10:00.000Z");
+    expect(iso("2026-07-30T18:10:00z")).toBe("2026-07-30T18:10:00.000Z");
+  });
+
+  test("양수 오프셋과 Z 는 그대로", () => {
+    expect(iso("2026-07-30T18:10:00+09:00")).toBe("2026-07-30T09:10:00.000Z");
+    expect(iso("2026-07-30T18:10:00Z")).toBe("2026-07-30T18:10:00.000Z");
+  });
+
+  test("빈 값과 파싱 실패는 null", () => {
+    expect(parseUtc(null)).toBe(null);
+    expect(parseUtc("")).toBe(null);
+    expect(parseUtc("not-a-date")).toBe(null);
   });
 });

--- a/src/server/lib/health.ts
+++ b/src/server/lib/health.ts
@@ -67,11 +67,19 @@ function runtimeBlockedReason(line: string | null | undefined): { level: HealthL
 }
 
 // sqlite datetime('now') 은 "YYYY-MM-DD HH:MM:SS" UTC (Z 없음) — UTC 로 파싱.
-function parseUtc(ts: string | null): number | null {
+// 저장소 관행은 "2026-07-24 13:31:36" (UTC, 표시자 없음) 이다.
+//
+// 판정 기준은 시간대 표시자(`Z` 또는 `±HH:MM`)의 유무다.
+// `/[Z+]/` 는 두 가지를 놓쳤다:
+//   · 음수 오프셋 — `…-05:00` 에 `Z` 도 `+` 도 없어 `Z` 가 덧붙고 파싱이 실패한다
+//   · 소문자 `z` — 같은 이유로 파싱이 실패한다
+// 표시자가 없는 문자열은 `Date.parse` 가 로컬 시각으로 읽으므로, 표시자를 붙여야 한다.
+export function parseUtc(ts: string | null): number | null {
   if (!ts) return null;
-  const iso = ts.includes("T") ? ts : ts.replace(" ", "T");
-  const withZ = /[Z+]/.test(iso) ? iso : iso + "Z";
-  const n = Date.parse(withZ);
+  const trimmed = ts.trim();
+  const iso = trimmed.includes("T") ? trimmed : trimmed.replace(" ", "T");
+  const withZone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(iso) ? iso : `${iso}Z`;
+  const n = Date.parse(withZone);
   return Number.isNaN(n) ? null : n;
 }
 


### PR DESCRIPTION
## 무엇이 문제인가

`parseUtc` 가 음수 오프셋과 소문자 `z` 를 읽지 못한다.

```
2026-07-30T18:10:00-05:00 → null
2026-07-30T18:10:00z      → null
```

`null` 이면 `probed_at` 의 오래됨 판정을 건너뛴다. 오래된 프로브가 경고로 잡히지 않는다.

## 왜 그렇게 되나

표시자 유무를 `/[Z+]/` 로 판정했다. 음수 오프셋에는 `Z` 도 `+` 도 없어 표시자가 없다고 보고 `Z` 를 덧붙인다.

```
"…18:10:00-05:00" + "Z" → Date.parse 실패 → null
```

## 어떻게 고쳤나

판정을 시간대 표시자(`Z` 또는 `±HH:MM`, 대소문자 무시) 유무로 바꿨다. 표시자 없는 문자열에 `Z` 를 붙이는 기존 동작은 그대로다.

## 검증

- `bun test scripts src/server src/web` → **2066 tests · 0 fail** · `tsc` 0
- 뮤턴트(옛 판정 `/[Z+]/` 복원) → FAIL

Submitted-by: bill
