### PR TITLE
chore(gitignore): 손으로 보관한 리포트 폴더를 제외한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ var/
 .DS_Store
 .tmp
 reports/
+# 리포트를 사람이 손으로 보관한 폴더. 내용은 reports/ 와 같은 계열이라 같이 제외한다.
+.archived-reports/
 
 slack-tokens/
 __pycache__/


### PR DESCRIPTION
## 무엇이 문제인가

`release-preflight.sh --mode post-merge` 가 라이브 트리에서 `rc=1` 로 멈춘다. `worktree not clean` 에 걸린다.

원인은 추적되지 않은 `.archived-reports/` 다. `reports/` 의 내용을 사람이 옮겨 보관한 폴더인데, `reports/` 는 제외 대상이고 이 폴더는 아니다.

## 왜 그 검사에 걸리나

post-merge 가 실제로 보는 것은 `origin/main` tip 의 author·committer 이메일이라 작업 트리와 무관하다. 앞단 공통 검사가 트리 청결을 먼저 요구해서 걸린다.

이 PR 은 트리 쪽만 정리한다. 공통 검사의 범위 문제는 별건이다.

## 어떻게 했나

`.gitignore` 에 `.archived-reports/` 를 추가했다. `reports/` 바로 아래에 둔다.

## 검증

```
git check-ignore -v --no-index .archived-reports/anything
  .gitignore:12:.archived-reports/   .archived-reports/anything
```

파일 삭제 없음. 이미 추적되지 않던 폴더라 이력에 영향이 없다.
