### PR TITLE
fix: require and balance proposal peer review

### DIFF
--- a/src/server/bus/expiryNotice.test.ts
+++ b/src/server/bus/expiryNotice.test.ts
@@ -17,6 +17,8 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { recipientAlreadyAnswered } from "./wakeDispatcher";
 
 const SRC = readFileSync(join(import.meta.dir, "wakeDispatcher.ts"), "utf8");
 
@@ -49,5 +51,20 @@ describe("★만료 통지 — 요청자가 영원히 기다리지 않게★", (
   it("★재시도는 여전히 안 한다★ (통지를 넣었다고 재시도를 되살리면 중복 팬아웃이 난다)", () => {
     expect(SRC).toMatch(/\["hermes_agent", "expire_no_retry"\]/);
     expect(SRC).toMatch(/\["openclaw", "expire_no_retry"\]/);
+  });
+
+  it("명시 답변으로 닫힌 recipient는 늦게 끝난 wake 실패가 무응답으로 덮지 않는다", () => {
+    const db = new Database(":memory:");
+    db.exec(
+      `CREATE TABLE message_recipient (
+        message_id TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        recipient_state TEXT NOT NULL
+      )`,
+    );
+    db.prepare("INSERT INTO message_recipient VALUES ('ask-1','devon','completed')").run();
+    expect(recipientAlreadyAnswered(db, "ask-1", "devon")).toBe(true);
+    db.prepare("UPDATE message_recipient SET recipient_state='open'").run();
+    expect(recipientAlreadyAnswered(db, "ask-1", "devon")).toBe(false);
   });
 });

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -1401,6 +1401,14 @@ function notifyRequesterOfExpiry(
   }
 }
 
+export function recipientAlreadyAnswered(db: Database, messageId: string, agentId: string): boolean {
+  const current = db.prepare(
+    `SELECT recipient_state FROM message_recipient
+      WHERE message_id = ? AND agent_id = ?`,
+  ).get(messageId, agentId) as { recipient_state: string } | undefined;
+  return Boolean(current && current.recipient_state !== "open");
+}
+
 function recordDispatchOutcome(
   db: Database,
   row: PendingDispatchRow,
@@ -1421,6 +1429,13 @@ function recordDispatchOutcome(
     // the exception path was the last retry gap; the !result.ok path below already expires no-retry).
     // Same policy: expire (no retry), leave the bus message in the inbox for next-turn/manual collection.
     if (wakeFailurePolicy(targetAgent.runtime) === "expire_no_retry") {
+      if (recipientAlreadyAnswered(db, row.message_id, row.agent_id)) {
+        appendAudit(db, "bus_dispatcher", "late_wake_failure_ignored_after_reply", row.message_id, {
+          agent_id: row.agent_id,
+          detail: `exception:${errMsg}`.slice(0, 200),
+        });
+        return;
+      }
       db.prepare(
         `UPDATE message_recipient
          SET delivery_state = 'expired',
@@ -1507,6 +1522,13 @@ function recordDispatchOutcome(
     // OpenClaw gateway failures are ambiguous: the turn may already be queued or partially
     // visible to the native session. Retrying creates duplicate Codex turns, so expire and
     // leave the bus message in the inbox for manual/next-turn collection.
+    if (recipientAlreadyAnswered(db, row.message_id, row.agent_id)) {
+      appendAudit(db, "bus_dispatcher", "late_wake_failure_ignored_after_reply", row.message_id, {
+        agent_id: row.agent_id,
+        detail: lastError,
+      });
+      return;
+    }
     db.prepare(
       `UPDATE message_recipient
        SET delivery_state = 'expired',

--- a/src/server/db/proposal.ts
+++ b/src/server/db/proposal.ts
@@ -114,9 +114,16 @@ function eligiblePeerReviewerCapacity(db: Database, proposer: string): number {
   return rows.filter((r) => !skip.has(r.id)).length;
 }
 
-// GD 심플 모델: 팀장 보고 전 review는 필수. 단, 제안자 제외 리뷰 후보가 0명이면 gd_report 직행.
+// blocked 상태를 포함한 실제 공식 팀원 수. 실제 1인 팀인지 판정할 때만 사용한다.
+function actualPeerReviewerCapacity(db: Database, proposer: string): number {
+  const skip = reviewSkipIds();
+  const rows = db.prepare("SELECT id FROM agent WHERE id != ?").all(proposer) as { id: string }[];
+  return rows.filter((r) => !skip.has(r.id)).length;
+}
+
+// GD 심플 모델: 팀장 보고 전 review는 필수. 단, 실제 공식 팀원이 제안자 1명뿐이면 gd_report 직행.
 function requiredPeerReviewCount(db: Database, proposer: string): number {
-  return eligiblePeerReviewerCapacity(db, proposer) >= 1 ? 1 : 0;
+  return actualPeerReviewerCapacity(db, proposer) >= 1 ? 1 : 0;
 }
 
 // GD 모델: pm_review 는 2+ 팀(제안자 제외 후보 1명+)에서 1건 필요.
@@ -251,6 +258,9 @@ export function transitionProposal(
     // 사람: proposer 본인만(가로채기 방지). 자동화: SYSTEM_ACTOR 허용(생성=즉시 진입/sweeper 대리 제출).
     if (actor !== row.proposer_agent && actor !== SYSTEM_ACTOR) {
       return { ok: false, error: `draft → ${toStatus} 제출은 proposer_agent 또는 system만 가능(현재 actor=${actor}, proposer=${row.proposer_agent})` };
+    }
+    if (toStatus === "gd_report" && actualPeerReviewerCapacity(db, row.proposer_agent) > 0) {
+      return { ok: false, error: "draft → gd_report 직행은 실제 1인 팀에서만 가능" };
     }
   }
   // revise_requested→draft는 proposer-only이되, proposer 무응답/rate-limited 시 coordinator가

--- a/src/server/db/proposal.ts
+++ b/src/server/db/proposal.ts
@@ -228,7 +228,7 @@ export function updateProposal(
 
 /** 상태 전이 — 상태기계 밖 전이 금지 + 단계별 가드 + decision_log 자동 기록.
  *  Codex 교차검토 가드(2026-06-12):
- *   - peer→gd_report: 리뷰 1건 의무(팀장보고 전 review 생략 방지). emergency_override로만 예외(사유 기록).
+ *   - peer→gd_report: 리뷰 1건 의무(팀장보고 전 review 생략 방지). emergency_override도 우회 불가.
  *   - gd_report→accepted/rejected: team lead actor만(감사 무결성). PM은 pm-stage 리뷰로 recommend만. */
 export function transitionProposal(
   db: Database, id: string, actor: string, toStatus: string, reason: string,
@@ -262,7 +262,8 @@ export function transitionProposal(
   }
 
   // Guard A — review 의무: peer_review→gd_report는 실제 peer review 1건 이상 필요.
-  if (from === "peer_review" && toStatus === "gd_report" && !opts.emergency_override) {
+  // 팀장 결정 화면에는 검토를 마친 제안만 올라가야 하므로 emergency override도 이 가드를 우회하지 못한다.
+  if (from === "peer_review" && toStatus === "gd_report") {
     const requiredPeer = requiredPeerReviewCount(db, row.proposer_agent);
     const peerCount = eligiblePeerReviewCount(db, id, row.proposer_agent);
     if (peerCount < requiredPeer) {

--- a/src/server/routes/proposalAutomation.test.ts
+++ b/src/server/routes/proposalAutomation.test.ts
@@ -141,17 +141,28 @@ describe("자동화 — sweeper 정체 안전망", () => {
     expect(statusOf(db, id)).toBe("peer_review"); // 3+팀 → peer 자동 제출
   });
 
-  test("peer 무응답 → 1차 재배정 → 2차 리뷰 skip degraded 진행", async () => {
+  test("peer 무응답 → 1차 재배정 → 재대기 후에도 리뷰 없으면 blocked 유지", async () => {
     const { app, db } = setup();
     const { id } = (await (await create(app)).json()) as { id: string };
     expect(statusOf(db, id)).toBe("peer_review");
+    const firstOwner = (db.prepare(
+      "SELECT owner FROM proposal_followup_task WHERE proposal_id = ? AND status LIKE 'peer_review:%' ORDER BY created_at LIMIT 1",
+    ).get(id) as { owner: string }).owner;
     ageProposal(db, id, 40);
     const r1 = sweepStaleProposals(db, ambientAgents());
     expect(r1.reassigned).toContain(id);
     expect(statusOf(db, id)).toBe("peer_review"); // 재배정만, 아직 peer
-    const r2 = sweepStaleProposals(db, ambientAgents()); // 여전히 stale → degraded
-    expect(r2.degraded).toContain(id);
-    expect(statusOf(db, id)).toBe("gd_report"); // 리뷰 없이 자동 진행(degraded)
+    const reassignedOwner = (db.prepare(
+      "SELECT owner FROM proposal_followup_task WHERE proposal_id = ? AND status LIKE 'peer_review:%' AND closed_at IS NULL",
+    ).get(id) as { owner: string }).owner;
+    expect(reassignedOwner).not.toBe(firstOwner);
+    const immediate = sweepStaleProposals(db, ambientAgents());
+    expect(immediate.blocked).not.toContain(id); // 재배정 시 대기시계가 초기화된다
+    ageProposal(db, id, 40);
+    const r2 = sweepStaleProposals(db, ambientAgents());
+    expect(r2.degraded).toEqual([]);
+    expect(r2.blocked).toContain(id);
+    expect(statusOf(db, id)).toBe("peer_review"); // 리뷰 없이 gd_report 금지
   });
 
   test("정체 아닌(최근) 제안은 sweeper가 건드리지 않는다", async () => {
@@ -244,14 +255,16 @@ describe("자동화 — 교차검토 결함 회귀 방어", () => {
     expect(statusOf(db, id)).toBe("draft"); // 가로채기 실패
   });
 
-  test("P1: sweeper degraded는 risk_level=high 제안을 자동 진행하지 않는다", () => {
+  test("P1: sweeper는 risk와 무관하게 리뷰 없는 제안을 자동 진행하지 않는다", () => {
     const { db } = setup();
     const id = createProposal(db, { ...VALID_NEW, risk_level: "high" }).id!;
     advanceProposalIfCurrent(db, { proposalId: id, expectedFrom: "draft", to: "peer_review", actionKey: "k", kind: "t" });
     ageProposal(db, id, 40);
     sweepStaleProposals(db, ambientAgents()); // 1차 재배정
-    const r2 = sweepStaleProposals(db, ambientAgents()); // 2차: high-risk → skip
+    ageProposal(db, id, 40);
+    const r2 = sweepStaleProposals(db, ambientAgents());
     expect(r2.degraded).not.toContain(id);
+    expect(r2.blocked).toContain(id);
     expect(statusOf(db, id)).toBe("peer_review"); // 사람 리뷰 대기(무검토 승격 안 함)
   });
 });

--- a/src/server/routes/proposals.test.ts
+++ b/src/server/routes/proposals.test.ts
@@ -1031,6 +1031,21 @@ describe("proposals — GD 심플 모델 (팀 크기별 라우팅)", () => {
     expect(statusOf(db, id)).toBe("accepted");
   });
 
+  test("다인 팀의 다른 팀원이 모두 blocked면 무검토 gd_report 대신 peer_review blocked 유지", async () => {
+    const { app, db } = setupTeam(["alice", "bob", "carol"], { coordinator: "bob" });
+    db.prepare("INSERT INTO agent_status (agent_id, state) VALUES (?, 'blocked')").run("bob");
+    db.prepare("INSERT INTO agent_status (agent_id, state) VALUES (?, 'blocked')").run("carol");
+
+    const id = await createBy(app, "alice");
+    expect(statusOf(db, id)).toBe("peer_review");
+    expect((await transition(app, id, "gd_report", "alice")).status).toBe(409);
+    const task = db.prepare(
+      "SELECT description FROM task WHERE id IN (SELECT task_id FROM proposal_followup_task WHERE proposal_id = ?)",
+    ).get(id) as { description: string };
+    expect(task.description).toContain("blocked:");
+    expect(task.description).toContain("무검토 gd_report 직행 금지");
+  });
+
   test("LEAD_ACTOR_ID 설정은 리뷰 후보 계산에 관여하지 않는다", async () => {
     process.env.LEAD_ACTOR_ID = "lead";
     const { app, db } = setupTeam(["lead", "alice", "bob"], { coordinator: "bob" });

--- a/src/server/routes/proposals.test.ts
+++ b/src/server/routes/proposals.test.ts
@@ -190,6 +190,29 @@ describe("proposals — 상태기계 + Guard", () => {
     expect(r.status).toBe(409);
   });
 
+  test("authz: loopback dashboard는 현재 배정된 reviewer 명의의 리뷰만 등록할 수 있다", async () => {
+    const current = await fresh();
+    const assigned = current.db.prepare(
+      "SELECT owner FROM proposal_followup_task WHERE proposal_id = ? AND status LIKE 'peer_review:%' AND closed_at IS NULL",
+    ).get(current.id) as { owner: string };
+    const ok = await current.app.request(`/proposals/${current.id}/reviews`, json({
+      reviewer_agent: assigned.owner,
+      stage: "peer",
+      verdict: "concern",
+      comments: "팀 공통 이슈 여부 검토",
+    }));
+    expect(ok.status).toBe(201);
+
+    const next = await fresh();
+    const unassigned = ["steve", "demis", "devon"].find((id) => id !== next.followup?.owner)!;
+    const denied = await next.app.request(`/proposals/${next.id}/reviews`, json({
+      reviewer_agent: unassigned,
+      stage: "peer",
+      verdict: "approve",
+    }));
+    expect(denied.status).toBe(403);
+  });
+
   test("PATCH /proposals/:id updates draft text fields through standard API", async () => {
     const { app, db } = setup();
     const id = createProposalRow(db, {
@@ -365,7 +388,7 @@ describe("proposals — 상태기계 + Guard", () => {
     expect(openTasks.c).toBe(0);
   });
 
-  test("peer review는 제안자를 제외하고 나머지 팀원 중 랜덤 1명에게 보낸다", async () => {
+  test("peer review는 제안자를 제외하고 현재 부담이 가장 적은 1명에게 보낸다", async () => {
     const { app, db } = setup();
     seedAgent(db, "lui");
     seedAgent(db, "hermes");
@@ -376,11 +399,11 @@ describe("proposals — 상태기계 + Guard", () => {
       author_agent: "lui",
     })).json()) as { id: string };
 
-    // 생성=peer 진입 시점에 peer 1명(랜덤) 배정.
+    // 생성=peer 진입 시점에 peer 1명 배정.
     const peerTasks = db.prepare(
       "SELECT owner, status FROM proposal_followup_task WHERE proposal_id = ? AND status LIKE 'peer_review:%' ORDER BY owner",
     ).all(id) as { owner: string; status: string }[];
-    expect(peerTasks).toHaveLength(1); // 새 모델: peer 1명(랜덤)
+    expect(peerTasks).toHaveLength(1);
     expect(peerTasks[0]!.owner).not.toBe("lui"); // 제안자 제외
     expect(peerTasks[0]!.owner).toBeTruthy();
   });
@@ -584,8 +607,11 @@ describe("proposals — 상태기계 + Guard", () => {
     const { app, db, id } = await fresh();
     await transition(app, id, "peer_review", "codex");
     const before = db.prepare("SELECT COUNT(*) AS c FROM task WHERE description LIKE ?").get(`%proposal:${id} status:peer_review%`) as { c: number };
-    const r = await transition(app, id, "gd_report", "bill", { emergency_override: true });
-    expect(r.status).toBe(200);
+    const assigned = db.prepare(
+      "SELECT owner FROM proposal_followup_task WHERE proposal_id = ? AND status LIKE 'peer_review:%' AND closed_at IS NULL",
+    ).get(id) as { owner: string };
+    const r = await review(app, id, { reviewer_agent: assigned.owner, verdict: "concern" });
+    expect(r.status).toBe(201);
     // 같은 상태 재호출이 아니라 다음 상태 task는 새로 생기되, peer_review task는 팀 규모 기준 2개만 유지된다.
     const after = db.prepare("SELECT COUNT(*) AS c FROM task WHERE description LIKE ?").get(`%proposal:${id} status:peer_review%`) as { c: number };
     expect(before.c).toBe(1); // 새 모델: peer 1명
@@ -900,11 +926,11 @@ describe("proposals — 상태기계 + Guard", () => {
     expect(statusOf(db, id)).toBe("gd_report"); // review 1건 = 자동 전이
   });
 
-  test("Guard A 우회: emergency_override=true면 통과", async () => {
+  test("Guard A: emergency_override도 peer review 의무를 우회하지 못한다", async () => {
     const { app, id } = await fresh();
     await transition(app, id, "peer_review", "codex");
     const r = await transition(app, id, "gd_report", "bill", { emergency_override: true });
-    expect(r.status).toBe(200);
+    expect(r.status).toBe(409);
   });
 
   test("Guard C: legacy pm_review row는 PM review 1건 없으면 gd_report 금지", async () => {
@@ -972,7 +998,7 @@ describe("proposals — test fixture gate", () => {
       staleMinutes: 30,
       limit: 10,
     });
-    expect(out).toEqual({ advanced: [], reassigned: [], degraded: [] });
+    expect(out).toEqual({ advanced: [], reassigned: [], degraded: [], blocked: [] });
     expect(statusOf(db, id)).toBe("peer_review");
     const openTasks = db.prepare(
       "SELECT COUNT(*) AS c FROM proposal_followup_task WHERE proposal_id = ? AND closed_at IS NULL",
@@ -982,6 +1008,20 @@ describe("proposals — test fixture gate", () => {
 });
 
 describe("proposals — GD 심플 모델 (팀 크기별 라우팅)", () => {
+  test("4인 팀: 연속 제안의 peer review를 세 후보에게 least-loaded 순환 배정", async () => {
+    const { app, db } = setupTeam(["alice", "bob", "carol", "dave"]);
+    const owners: string[] = [];
+    for (let i = 0; i < 3; i += 1) {
+      const id = await createBy(app, "alice");
+      const row = db.prepare(
+        "SELECT owner FROM proposal_followup_task WHERE proposal_id = ? AND status LIKE 'peer_review:%'",
+      ).get(id) as { owner: string };
+      owners.push(row.owner);
+    }
+    expect(new Set(owners).size).toBe(3);
+    expect(owners).not.toContain("alice");
+  });
+
   test("1인 팀: draft → gd_report 직행 → 팀장(gd) accepted", async () => {
     const { app, db } = setupTeam(["alice"], { coordinator: "alice" });
     const id = await createBy(app, "alice");

--- a/src/server/routes/proposals.ts
+++ b/src/server/routes/proposals.ts
@@ -97,6 +97,16 @@ function existingAgent(db: Database, id: string): boolean {
   return Boolean(db.prepare("SELECT 1 FROM agent WHERE id = ?").get(id));
 }
 
+function isAssignedReviewer(db: Database, proposalId: string, stage: string, reviewer: string): boolean {
+  const statusPrefix = stage === "peer" ? "peer_review:" : stage === "pm" ? "pm_review:" : "";
+  if (!statusPrefix) return false;
+  return Boolean(db.prepare(
+    `SELECT 1 FROM proposal_followup_task
+      WHERE proposal_id = ? AND owner = ? AND status = ? AND closed_at IS NULL
+      LIMIT 1`,
+  ).get(proposalId, reviewer, `${statusPrefix}${reviewer}`));
+}
+
 function firstAvailableAgent(db: Database, candidates: string[], fallback: string): string {
   return candidates.find((id) => existingAgent(db, id)) ?? fallback;
 }
@@ -144,12 +154,46 @@ function coordinatorOwner(db: Database, agents: AgentRecord[], proposer: string)
   return otherReviewers(db, proposer, agents)[0] ?? proposer;
 }
 
-// peer_review 담당 = 나머지 팀원 중 랜덤 1명. 2+ 팀부터 팀장 보고 전 단일 review가 필수.
-function peerReviewOwners(db: Database, proposer: string, agents: AgentRecord[]): string[] {
+// peer_review 담당 = 제안자 제외 후보 중 열린/최근 배정이 가장 적은 1명.
+// 재배정 때는 이 proposal의 기존 담당자를 먼저 제외한다.
+function peerReviewOwners(db: Database, proposalId: string, proposer: string, agents: AgentRecord[]): string[] {
   const others = otherReviewers(db, proposer, agents);
   if (others.length < 1) return [];
-  const pick = others[Math.floor(Math.random() * others.length)];
-  return pick ? [pick] : [];
+  const prior = new Set(
+    (db.prepare(
+      `SELECT owner FROM proposal_followup_task
+        WHERE proposal_id = ? AND status LIKE 'peer_review:%'`,
+    ).all(proposalId) as { owner: string }[]).map((r) => r.owner),
+  );
+  const fresh = others.filter((id) => !prior.has(id));
+  const candidates = fresh.length > 0 ? fresh : others;
+  const load = db.prepare(
+    `SELECT
+       SUM(CASE WHEN pft.closed_at IS NULL THEN 1 ELSE 0 END) AS open_count,
+       SUM(CASE WHEN pft.created_at >= datetime('now', '-7 days') THEN 1 ELSE 0 END) AS recent_count,
+       MAX(pft.created_at) AS last_assigned_at
+      FROM proposal_followup_task pft
+      WHERE pft.owner = ? AND pft.status LIKE 'peer_review:%'`,
+  );
+  const ranked = candidates.map((id) => {
+    const row = load.get(id) as {
+      open_count: number | null;
+      recent_count: number | null;
+      last_assigned_at: string | null;
+    };
+    return {
+      id,
+      open: Number(row.open_count ?? 0),
+      recent: Number(row.recent_count ?? 0),
+      last: row.last_assigned_at ?? "",
+    };
+  }).sort((a, b) =>
+    a.open - b.open ||
+    a.recent - b.recent ||
+    a.last.localeCompare(b.last) ||
+    a.id.localeCompare(b.id),
+  );
+  return ranked[0] ? [ranked[0].id] : [];
 }
 
 // pm_review 담당 = coordinator(PM 역량) 우선, 없으면 랜덤 1명. peer 리뷰어와는 다른 사람.
@@ -358,7 +402,7 @@ function ensureProposalFollowup(db: Database, proposalId: string, status: string
     return { owner: "system", skipped: true };
   }
   if (status === "peer_review") {
-    const owners = peerReviewOwners(db, p.proposer_agent, agents);
+    const owners = peerReviewOwners(db, p.id, p.proposer_agent, agents);
     if (owners.length === 0) {
       // 방어: 팀 규모가 줄어 peer 후보가 없으면 coordinator 가 다음 단계를 판단(정상 경로에선 3+ 팀에서만 peer 진입).
       return createLinkedFollowup(
@@ -390,7 +434,9 @@ function ensureProposalFollowup(db: Database, proposalId: string, status: string
         `[Proposal peer review 요청]\n` +
           `대상: ${p.title}\nID: ${p.id}\n` +
           `역할: reviewer(${owner})\n` +
-          `해야 할 일: 팀장 보고 전에 실제 리스크와 개선점을 포함해 review를 남겨 주세요.`,
+          `해야 할 일: 팀장 보고 전에 아래 기준으로 실제 리스크와 개선점을 포함해 review를 남겨 주세요.\n` +
+          `1) 정말 팀에 필요한가?\n2) 팀 전체의 공통 이슈인가?\n3) 팀원 개인 수준의 learning인가?\n` +
+          `팀 공통 제안이 아니거나 개인 learning이면 reject(drop)하고 사유를 남겨 주세요.`,
       ));
     return { owner: followups.map((f) => f.owner).join(","), taskId: followups[0]?.taskId, messageId: followups[0]?.messageId };
   }
@@ -642,18 +688,23 @@ function notifyGdReportReachedSafely(db: Database, proposalId: string, agents: A
 export function sweepStaleProposals(
   db: Database, agents: AgentRecord[],
   opts: { staleMinutes?: number; limit?: number } = {},
-): { advanced: string[]; reassigned: string[]; degraded: string[] } {
+): { advanced: string[]; reassigned: string[]; degraded: string[]; blocked: string[] } {
   const staleMinutes = opts.staleMinutes ?? 30;
   const limit = opts.limit ?? 20; // thundering herd 방지: 한 tick 당 처리량 제한.
   const rows = db.prepare(
-    `SELECT id, title, source, status, proposer_agent, risk_level
+    `SELECT id, title, source, status, proposer_agent
        FROM proposal
       WHERE status IN ('draft','revise_requested','peer_review','pm_review')
         AND (julianday('now') - julianday(updated_at)) * 24 * 60 >= ?
       ORDER BY updated_at ASC
       LIMIT ?`,
-  ).all(staleMinutes, limit) as { id: string; title: string; source: string | null; status: string; proposer_agent: string; risk_level: string | null }[];
-  const out = { advanced: [] as string[], reassigned: [] as string[], degraded: [] as string[] };
+  ).all(staleMinutes, limit) as { id: string; title: string; source: string | null; status: string; proposer_agent: string }[];
+  const out = {
+    advanced: [] as string[],
+    reassigned: [] as string[],
+    degraded: [] as string[],
+    blocked: [] as string[],
+  };
   for (const row of rows) {
     if (isTestProposalFixture(row)) continue;
     // 제안 단위 트랜잭션 + try/catch(F1): 부분 실패 시 전이·카드·wake 전부 롤백 → 다음 tick 깨끗한 재시도.
@@ -671,31 +722,30 @@ export function sweepStaleProposals(
           return;
         }
         // peer_review / legacy pm_review 무응답
-        const to = "gd_report";
         const round = stageEntryCount(db, row.id, row.status);
         const reassignKey = `sweeper_reassign:${row.id}:${row.status}:${round}`;
         if (claimAutomationAction(db, reassignKey, row.id, "sweeper_reassign")) {
           // 1차: 담당 재배정(기존 카드 닫고 다른 후보 wake).
           closeProposalFollowups(db, row.id, row.status);
           ensureProposalFollowup(db, row.id, row.status, agents);
+          db.prepare("UPDATE proposal SET updated_at = datetime('now') WHERE id = ?").run(row.id);
           out.reassigned.push(row.id);
           return;
         }
-        // 2차: 여전히 무응답 → 리뷰 skip degraded 진행.
-        // 고위험(risk_level=high)은 무검토 자동 진행 금지(P1). reject/revise verdict 있으면 사람 판단 보존.
-        if (String(row.risk_level ?? "").toLowerCase() === "high") return;
-        const stageName = row.status === "peer_review" ? "peer" : "pm";
-        const blocking = db.prepare(
-          `SELECT 1 FROM proposal_review WHERE proposal_id = ? AND stage = ? AND verdict IN ('reject','revise') LIMIT 1`,
-        ).get(row.id, stageName);
-        if (blocking) return;
-        const r = tryAutoAdvance(db, row.id, row.status, to, agents, {
-          emergency_override: true,
-          reason: "sweeper: 무응답 자동 진행(review_missing)",
-        });
-        if (r.advanced) {
-          out.degraded.push(row.id);
-          if (to === "gd_report") gdReached = true;
+        // 2차: 여전히 무응답이어도 리뷰 게이트는 건너뛰지 않는다.
+        // 팀장 결정 화면에 무검토 제안을 올리는 대신 현재 단계에서 blocked로 남긴다.
+        const blockKey = `sweeper_blocked:${row.id}:${row.status}:${round}`;
+        if (claimAutomationAction(db, blockKey, row.id, "sweeper_blocked")) {
+          db.prepare(
+            `UPDATE task
+                SET description = description || char(10) || 'blocked: peer review 미확보',
+                    updated_at = datetime('now')
+              WHERE id IN (
+                SELECT task_id FROM proposal_followup_task
+                 WHERE proposal_id = ? AND status LIKE ? AND closed_at IS NULL
+              )`,
+          ).run(row.id, `${row.status}:%`);
+          out.blocked.push(row.id);
         }
       })();
     } catch (e) {
@@ -873,17 +923,22 @@ export function createProposalRoutes(deps: ProposalRouteDeps): Hono {
     if (!auth.ok || !auth.actor) return authError(c, auth);
     try {
       const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+      const proposalId = c.req.param("id");
+      const stage = String(body.stage ?? "");
       const suppliedReviewer = String(body.reviewer_agent ?? "").trim();
-      if (suppliedReviewer && suppliedReviewer !== auth.actor.actor) {
+      const assignedDashboardReviewer =
+        auth.actor.source === "loopback_dashboard" &&
+        suppliedReviewer &&
+        isAssignedReviewer(deps.db, proposalId, stage, suppliedReviewer);
+      if (suppliedReviewer && suppliedReviewer !== auth.actor.actor && !assignedDashboardReviewer) {
         return c.json({ error: "reviewer_actor_mismatch" }, 403);
       }
-      const proposalId = c.req.param("id");
+      const effectiveReviewer = assignedDashboardReviewer ? suppliedReviewer : auth.actor.actor;
       const agents = deps.agents?.() ?? ambientAgents();
       const runReview = deps.db.transaction(() => {
-        const stage = String(body.stage ?? "");
         const res = addReview(deps.db, {
           proposal_id: proposalId,
-          reviewer_agent: auth.actor!.actor,
+          reviewer_agent: effectiveReviewer,
           stage,
           verdict: body.verdict as string | undefined,
           is_adversarial: Boolean(body.is_adversarial),

--- a/src/server/routes/proposals.ts
+++ b/src/server/routes/proposals.ts
@@ -130,9 +130,22 @@ function otherReviewers(db: Database, proposer: string, agents: AgentRecord[]): 
     });
 }
 
-// 팀 크기(제안자 제외 리뷰 후보 수)로 draft 이후 첫 단계 결정.
-function firstReviewStage(otherCount: number): "peer_review" | "gd_report" {
-  if (otherCount <= 0) return "gd_report"; // 1인 팀: 리뷰 없이 팀장 보고 직행
+// 현재 상태와 무관한 실제 공식 팀원 수. blocked는 "지금 배정 불가"일 뿐 팀 탈퇴가 아니다.
+function otherTeamMembers(db: Database, proposer: string, agents: AgentRecord[]): string[] {
+  const nonInteractive = new Set(agentsWith(agents, "non_interactive").map((a) => a.id));
+  const registry = new Map(agents.map((a) => [a.id, a]));
+  const rows = db.prepare("SELECT id FROM agent WHERE id != ?").all(proposer) as { id: string }[];
+  return rows
+    .map((r) => r.id)
+    .filter((id) => {
+      const agent = registry.get(id);
+      return !nonInteractive.has(id) && isTeamOfficialMember(agent);
+    });
+}
+
+// 실제 1인 팀만 gd_report 직행. 다인 팀인데 현재 후보가 0명이면 peer_review에 blocked로 남긴다.
+function firstReviewStage(actualOtherCount: number): "peer_review" | "gd_report" {
+  if (actualOtherCount <= 0) return "gd_report";
   return "peer_review"; // 2+인 팀: 단일 review → gd_report
 }
 
@@ -219,7 +232,7 @@ function followupSpec(db: Database, p: ProposalRow, status: ProposalStatus, agen
   const marker = `proposal:${p.id} status:${status}`;
   if (status === "draft") {
     const owner = existingAgent(db, p.proposer_agent) ? p.proposer_agent : coordinatorOwner(db, agents, p.proposer_agent);
-    const stage = firstReviewStage(otherReviewers(db, p.proposer_agent, agents).length);
+    const stage = firstReviewStage(otherTeamMembers(db, p.proposer_agent, agents).length);
     return {
       owner,
       title: `[Proposal] Draft ready: ${p.title}`,
@@ -252,7 +265,7 @@ function followupSpec(db: Database, p: ProposalRow, status: ProposalStatus, agen
     };
   }
   const owner = existingAgent(db, p.proposer_agent) ? p.proposer_agent : coordinatorOwner(db, agents, p.proposer_agent);
-  const reviseStage = firstReviewStage(otherReviewers(db, p.proposer_agent, agents).length);
+  const reviseStage = firstReviewStage(otherTeamMembers(db, p.proposer_agent, agents).length);
   return {
     owner,
     title: `[Proposal] Revise requested: ${p.title}`,
@@ -404,19 +417,19 @@ function ensureProposalFollowup(db: Database, proposalId: string, status: string
   if (status === "peer_review") {
     const owners = peerReviewOwners(db, p.id, p.proposer_agent, agents);
     if (owners.length === 0) {
-      // 방어: 팀 규모가 줄어 peer 후보가 없으면 coordinator 가 다음 단계를 판단(정상 경로에선 3+ 팀에서만 peer 진입).
+      // 다인 팀인데 현재 리뷰 가능 후보가 없으면 무검토 gd_report로 보내지 않고 blocked로 유지한다.
       return createLinkedFollowup(
         db,
         p,
         "review_route_decision",
         coordinatorOwner(db, agents, p.proposer_agent),
-        `[Proposal] 다음 단계 판단 필요: ${p.title}`,
+        `[Proposal] Peer review blocked: ${p.title}`,
         `proposal:${p.id} status:review_route_decision\n` +
-          `목표: review 후보가 없어 다음 단계(gd_report)를 판단한다.\n` +
-          `완료 기준: /api/proposals/${p.id}/transition 으로 gd_report/revise_requested/rejected 중 하나 실행.`,
-        `[Proposal 다음 단계 판단 요청]\n` +
+          `blocked: 현재 review 가능 후보가 없어 peer_review에 유지한다.\n` +
+          `완료 기준: 리뷰 가능 팀원이 복귀하면 peer reviewer를 재배정한다. 무검토 gd_report 직행 금지.`,
+        `[Proposal peer review blocked]\n` +
           `대상: ${p.title}\nID: ${p.id}\n` +
-          `상태: peer 후보가 없습니다. 다음 단계를 판단해 주세요.`,
+          `상태: 현재 peer 후보가 없습니다. 리뷰 가능 팀원이 복귀하면 재배정해 주세요. 무검토 팀장 보고는 금지됩니다.`,
         "high",
       );
     }
@@ -482,7 +495,7 @@ function ensureProposalFollowup(db: Database, proposalId: string, status: string
     // 적대검토 F1/F3: owner를 comma-join 하지 않는다(owner="a,b"는 agent 조회 실패→500+롤백·카드 미아).
     // → createLinkedFollowup을 각각 1회씩 호출. proposer===coordinator면 dedup(1건만).
     const spec = followupSpec(db, p, status as ProposalStatus, agents);
-    const reviseStage = firstReviewStage(otherReviewers(db, p.proposer_agent, agents).length);
+    const reviseStage = firstReviewStage(otherTeamMembers(db, p.proposer_agent, agents).length);
     const proposerFollowup = createLinkedFollowup(db, p, "revise_requested", spec.owner, spec.title, spec.description, spec.body);
     const coordOwner = coordinatorOwner(db, agents, p.proposer_agent);
     if (coordOwner !== spec.owner) {
@@ -713,7 +726,7 @@ export function sweepStaleProposals(
     try {
       db.transaction(() => {
         if (row.status === "draft" || row.status === "revise_requested") {
-          const stage = firstReviewStage(otherReviewers(db, row.proposer_agent, agents).length);
+          const stage = firstReviewStage(otherTeamMembers(db, row.proposer_agent, agents).length);
           const r = tryAutoAdvance(db, row.id, row.status, stage, agents, { reason: "sweeper: 정체 제안 자동 제출" });
           if (r.advanced) {
             out.advanced.push(row.id);
@@ -841,7 +854,7 @@ export function createProposalRoutes(deps: ProposalRouteDeps): Hono {
         // (B, GD 2026-07-04): 생성 성공 = 곧 제출. 품질 하한선(근거+예상효과)이 이미 미완성을 막으므로
         // draft에 고이지 않고 팀 규모별 첫 리뷰 단계로 자동 진입(+담당자 배정/wake). 사람이 버튼 누를 필요 없음.
         const proposer = String(body.proposer_agent ?? "").trim();
-        const stage = firstReviewStage(otherReviewers(deps.db, proposer, agents).length);
+        const stage = firstReviewStage(otherTeamMembers(deps.db, proposer, agents).length);
         const auto = tryAutoAdvance(deps.db, proposalId, "draft", stage, agents);
         return { ok: true as const, id: proposalId, stage, advanced: auto.advanced, followup: auto.followup };
       });


### PR DESCRIPTION
## 핵심 3줄
1. Peer review 0건 proposal은 emergency override를 포함해 GD report로 올라갈 수 없습니다.
2. 4인 팀 reviewer는 열린·최근 배정이 적은 후보에게 순환되고, 재배정은 이전 담당자를 우선 제외합니다.
3. 실제 답변 뒤 늦은 wake 실패가 무응답으로 덮는 경합과 배정 reviewer의 리뷰 등록 경로를 함께 고쳤습니다.

## 무엇을 바꿨나
| 문제 | 고친 방법 |
|---|---|
| 리뷰 0건 자동 승격 | sweeper degraded 승격 제거, 재배정 후에도 없으면 peer_review에서 blocked 표시 |
| emergency override 우회 | DB Guard A가 override와 무관하게 peer review 1건을 요구 |
| 한 사람에게 몰림 | 열린 리뷰 수 → 최근 7일 배정 수 → 마지막 배정 시각 순 least-loaded 선택 |
| 같은 reviewer 재배정 | 해당 proposal의 과거 reviewer를 우선 제외 |
| 리뷰 등록 권한 실패 | loopback dashboard는 현재 배정된 reviewer 명의만 제한적으로 등록 허용 |
| 답변 후 무응답 오판 | recipient가 이미 답변/완료 상태면 늦은 wake 실패의 expired 덮어쓰기 차단 |
| 리뷰 품질 | 팀 필요성·팀 전체 공통 이슈·개인 learning 여부를 필수 질문으로 안내, 개인 learning은 reject(drop) |

## 검증
- 관련 회귀 테스트: 76 pass, 0 fail
- 전체 테스트: 2,125 pass, 6 skip, 0 fail
- 타입체크: `tsc --noEmit` 통과
- mutation: emergency override 가드를 원복하면 전용 회귀 테스트가 200/409 차이로 실패함을 확인
- `git diff --check` 통과

## 미검증
- 라이브 서버 재시작·배포 후 실제 Telegram/OpenClaw end-to-end는 수행하지 않았습니다.
- PR은 머지·배포하지 않았습니다.