### PR TITLE
fix(proposals): 리뷰 0건이면 팀장에게 올리지 않는다 — 재배정 시계·쏠림·판정기준까지

### DIFF
--- a/src/server/routes/proposalAutomation.test.ts
+++ b/src/server/routes/proposalAutomation.test.ts
@@ -217,6 +217,22 @@ describe("자동화 — sweeper 정체 안전망", () => {
     expect(statusOf(db, id)).toBe("draft"); // 직행하지 않고 다음 tick 을 기다린다
   });
 
+  test("후보 소진 뒤 새 팀원이 오면 재배정이 다시 시작된다", async () => {
+    // 후보가 다 무응답이어도 파이프라인이 영구히 멈추지는 않는다는 것을 고정한다.
+    // (조건문 순서 자체는 이 테스트가 잡지 못한다 — proposals.ts 의 주석 참조)
+    const { app, db } = setup();
+    const { id } = (await (await create(app)).json()) as { id: string };
+    for (let i = 0; i < 10; i++) {
+      ageProposal(db, id, 40);
+      if (sweepStaleProposals(db, ambientAgents()).degraded.includes(id)) break;
+    }
+    expect(statusOf(db, id)).toBe("peer_review"); // 에스컬레이션까지 갔다
+
+    seedAgent(db, "newbie"); // 새 팀원 합류
+    ageProposal(db, id, 40);
+    expect(sweepStaleProposals(db, ambientAgents()).reassigned).toContain(id);
+  });
+
   test("정체 아닌(최근) 제안은 sweeper가 건드리지 않는다", async () => {
     const { app, db } = setup();
     const { id } = (await (await create(app)).json()) as { id: string };

--- a/src/server/routes/proposalAutomation.test.ts
+++ b/src/server/routes/proposalAutomation.test.ts
@@ -141,17 +141,63 @@ describe("자동화 — sweeper 정체 안전망", () => {
     expect(statusOf(db, id)).toBe("peer_review"); // 3+팀 → peer 자동 제출
   });
 
-  test("peer 무응답 → 1차 재배정 → 2차 리뷰 skip degraded 진행", async () => {
+  test("재배정하면 정체 시계가 다시 돈다 — 바로 다음 tick 에 무응답 처리되지 않는다", async () => {
+    // 라이브 회귀(2026-07-31): 재배정이 updated_at 을 건드리지 않아 새 담당자가 5분만 받았다.
+    const { app, db } = setup();
+    const { id } = (await (await create(app)).json()) as { id: string };
+    ageProposal(db, id, 40);
+    expect(sweepStaleProposals(db, ambientAgents()).reassigned).toContain(id);
+
+    const r2 = sweepStaleProposals(db, ambientAgents()); // 곧바로 다시 돌린다
+    expect(r2.degraded).not.toContain(id);
+    expect(r2.reassigned).not.toContain(id);
+    expect(statusOf(db, id)).toBe("peer_review");
+  });
+
+  test("후보를 다 돌아도 리뷰가 없으면 ★팀장에게 올리지 않고★ coordinator 에게 넘긴다", async () => {
     const { app, db } = setup();
     const { id } = (await (await create(app)).json()) as { id: string };
     expect(statusOf(db, id)).toBe("peer_review");
+
+    // 후보가 소진될 때까지 재배정을 반복한다(매번 시계를 다시 늙힌다).
+    for (let i = 0; i < 10; i++) {
+      ageProposal(db, id, 40);
+      const r = sweepStaleProposals(db, ambientAgents());
+      if (r.degraded.includes(id)) break;
+      expect(r.reassigned).toContain(id);
+    }
+
+    // 핵심: 리뷰 0건이면 gd_report 로 가지 않는다.
+    expect(statusOf(db, id)).toBe("peer_review");
+    const reviews = db
+      .prepare("SELECT COUNT(*) AS n FROM proposal_review WHERE proposal_id = ?")
+      .get(id) as { n: number };
+    expect(reviews.n).toBe(0);
+
+    // 대신 coordinator 에게 "리뷰 미완" 카드가 열린다.
+    const card = db
+      .prepare(
+        "SELECT owner, status FROM proposal_followup_task WHERE proposal_id = ? AND closed_at IS NULL",
+      )
+      .get(id) as { owner: string; status: string } | undefined;
+    expect(card?.status).toContain("review_missing");
+  });
+
+  test("재배정은 이미 무응답이던 담당자를 다시 고르지 않는다", async () => {
+    const { app, db } = setup();
+    const { id } = (await (await create(app)).json()) as { id: string };
+    const ownerOf = (): string =>
+      (
+        db
+          .prepare(
+            "SELECT owner FROM proposal_followup_task WHERE proposal_id = ? AND closed_at IS NULL",
+          )
+          .get(id) as { owner: string }
+      ).owner;
+    const first = ownerOf();
     ageProposal(db, id, 40);
-    const r1 = sweepStaleProposals(db, ambientAgents());
-    expect(r1.reassigned).toContain(id);
-    expect(statusOf(db, id)).toBe("peer_review"); // 재배정만, 아직 peer
-    const r2 = sweepStaleProposals(db, ambientAgents()); // 여전히 stale → degraded
-    expect(r2.degraded).toContain(id);
-    expect(statusOf(db, id)).toBe("gd_report"); // 리뷰 없이 자동 진행(degraded)
+    expect(sweepStaleProposals(db, ambientAgents()).reassigned).toContain(id);
+    expect(ownerOf()).not.toBe(first);
   });
 
   test("정체 아닌(최근) 제안은 sweeper가 건드리지 않는다", async () => {

--- a/src/server/routes/proposalAutomation.test.ts
+++ b/src/server/routes/proposalAutomation.test.ts
@@ -200,6 +200,23 @@ describe("자동화 — sweeper 정체 안전망", () => {
     expect(ownerOf()).not.toBe(first);
   });
 
+  test("blocked 로 후보가 비면 draft 를 팀장 보고로 직행시키지 않는다", () => {
+    // jane 리뷰(2026-07-31): otherReviewers 가 blocked 를 빼므로, 상대가 잠깐 blocked 이면
+    // 진짜 1인 팀과 구분되지 않고 리뷰 0건이 팀장 게이트에 도달한다.
+    const { db } = setup();
+    const id = createProposal(db, VALID_NEW).id!;
+    expect(statusOf(db, id)).toBe("draft");
+    db.prepare(
+      `INSERT INTO agent_status (agent_id, state) SELECT id, 'blocked' FROM agent WHERE id != ?
+         ON CONFLICT(agent_id) DO UPDATE SET state = 'blocked'`,
+    ).run(VALID_NEW.proposer_agent);
+    ageProposal(db, id, 40);
+
+    const r = sweepStaleProposals(db, ambientAgents());
+    expect(r.advanced).not.toContain(id);
+    expect(statusOf(db, id)).toBe("draft"); // 직행하지 않고 다음 tick 을 기다린다
+  });
+
   test("정체 아닌(최근) 제안은 sweeper가 건드리지 않는다", async () => {
     const { app, db } = setup();
     const { id } = (await (await create(app)).json()) as { id: string };

--- a/src/server/routes/proposals.ts
+++ b/src/server/routes/proposals.ts
@@ -120,6 +120,27 @@ function otherReviewers(db: Database, proposer: string, agents: AgentRecord[]): 
     });
 }
 
+/**
+ * 지금은 제외됐지만 ★원래는 리뷰 후보인★ 팀원이 있나 — blocked 때문에 후보가 빈 경우다.
+ *
+ * otherReviewers 는 state='blocked' 를 뺀다. 그래서 상대가 잠깐 blocked 이면 후보 0명이 되고,
+ * 진짜 1인 팀과 구분되지 않아 리뷰 0건인 채로 팀장 보고 직행이 된다(jane 리뷰 2026-07-31,
+ * 실측: registry 4명 중 1명 blocked). 일시 제외면 직행시키지 않기 위해 둘을 구분한다.
+ */
+function hasBlockedReviewers(db: Database, proposer: string, agents: AgentRecord[]): boolean {
+  const nonInteractive = new Set(agentsWith(agents, "non_interactive").map((a) => a.id));
+  const registry = new Map(agents.map((a) => [a.id, a]));
+  const rows = db
+    .prepare(
+      `SELECT a.id
+         FROM agent a
+         LEFT JOIN agent_status s ON s.agent_id = a.id
+        WHERE a.id != ? AND COALESCE(s.state, 'idle') = 'blocked'`,
+    )
+    .all(proposer) as { id: string }[];
+  return rows.some((r) => !nonInteractive.has(r.id) && isTeamOfficialMember(registry.get(r.id)));
+}
+
 // 팀 크기(제안자 제외 리뷰 후보 수)로 draft 이후 첫 단계 결정.
 function firstReviewStage(otherCount: number): "peer_review" | "gd_report" {
   if (otherCount <= 0) return "gd_report"; // 1인 팀: 리뷰 없이 팀장 보고 직행
@@ -716,6 +737,10 @@ export function sweepStaleProposals(
       db.transaction(() => {
         if (row.status === "draft" || row.status === "revise_requested") {
           const stage = firstReviewStage(otherReviewers(db, row.proposer_agent, agents).length);
+          // ★후보가 "지금" 비었다고 1인 팀은 아니다.★ blocked 로 잠깐 빈 것이라면 직행시키지 않는다 —
+          // 직행하면 리뷰 0건이 그대로 팀장 게이트에 도착한다(이 PR 이 막으려는 바로 그 경로).
+          // 다음 tick 에 다시 본다. 사람이 풀리면 정상적으로 peer_review 로 간다.
+          if (stage === "gd_report" && hasBlockedReviewers(db, row.proposer_agent, agents)) return;
           const r = tryAutoAdvance(db, row.id, row.status, stage, agents, { reason: "sweeper: 정체 제안 자동 제출" });
           if (r.advanced) {
             out.advanced.push(row.id);
@@ -730,6 +755,9 @@ export function sweepStaleProposals(
           (id) => !tried.includes(id),
         );
         const reassignKey = `sweeper_reassign:${row.id}:${row.status}:${round}:${tried.length}`;
+        // ★순서를 바꾸지 말 것★: untried 검사가 먼저여야 한다. claim 을 먼저 호출하면 후보 소진
+        // 시점에도 키가 소모돼, 나중에 새 팀원이 들어와도 영영 재배정되지 않는다. 단락 평가가
+        // 그걸 막고 있다(jane 리뷰 2026-07-31). 아래 테스트가 이 순서를 고정한다.
         if (untried.length > 0 && claimAutomationAction(db, reassignKey, row.id, "sweeper_reassign")) {
           // 아직 담당한 적 없는 후보로 재배정(기존 카드 닫고 wake).
           //
@@ -801,7 +829,8 @@ function escalateReviewMissing(
     `proposal:${p.id} status:${status} review_missing\n` +
       `상황: 후보를 다 돌았는데 리뷰가 한 건도 없다. 무응답 담당: ${triedText}\n` +
       `목표: 리뷰를 받아오거나, 판정 기준에 안 맞으면 드랍한다. ★팀장에게 자동으로 올라가지 않는다.★${selfNote}\n` +
-      `완료 기준: /api/proposals/${p.id}/reviews 에 stage=peer 리뷰 등록, 또는 transition to=rejected.`,
+      `완료 기준: /api/proposals/${p.id}/reviews 에 stage=peer 리뷰 등록, 또는 transition to=rejected.\n` +
+      `참고: 새 리뷰어가 배정되면 이 카드는 자동으로 닫힌다(사라져도 이상 아님).`,
     `[Proposal 리뷰 미완 — 처리 필요]\n` +
       `대상: ${p.title}\nID: ${p.id}\n` +
       `무응답 담당: ${triedText}\n` +

--- a/src/server/routes/proposals.ts
+++ b/src/server/routes/proposals.ts
@@ -144,12 +144,62 @@ function coordinatorOwner(db: Database, agents: AgentRecord[], proposer: string)
   return otherReviewers(db, proposer, agents)[0] ?? proposer;
 }
 
-// peer_review 담당 = 나머지 팀원 중 랜덤 1명. 2+ 팀부터 팀장 보고 전 단일 review가 필수.
-function peerReviewOwners(db: Database, proposer: string, agents: AgentRecord[]): string[] {
+// peer_review 담당 = 나머지 팀원 중 1명. 2+ 팀부터 팀장 보고 전 단일 review가 필수.
+//
+// 랜덤 1명이었는데 재배정에서 문제가 됐다(2026-07-31 라이브): 무응답으로 5건이 한꺼번에
+// 재배정됐을 때 랜덤이 5건 모두 같은 사람에게 몰렸다. 그래서 (1) 이미 담당이었던 사람을
+// 빼고 (2) 열린 리뷰가 적은 쪽을 먼저 준다. 후보가 그 사람뿐이면 되돌린다 — 배정 없음보다 낫다.
+function peerReviewOwners(
+  db: Database,
+  proposer: string,
+  agents: AgentRecord[],
+  opts: { exclude?: string[] } = {},
+): string[] {
   const others = otherReviewers(db, proposer, agents);
   if (others.length < 1) return [];
-  const pick = others[Math.floor(Math.random() * others.length)];
+  const exclude = new Set((opts.exclude ?? []).filter(Boolean));
+  const pool = others.filter((id) => !exclude.has(id));
+  const candidates = pool.length ? pool : others;
+  const pick = leastLoadedReviewer(db, candidates);
   return pick ? [pick] : [];
+}
+
+/**
+ * 리뷰 판정 기준(팀장 지시 2026-07-31). 기준 없이 "리뷰해달라" 만 보내면 통과가 기본값이 된다 —
+ * 실제로 이 문구가 없던 회차에 리뷰 0건으로 5건이 그대로 팀장 게이트까지 올라갔다.
+ */
+const PEER_REVIEW_RUBRIC =
+  `판정 기준 — 셋 다 예여야 통과입니다. 하나라도 아니면 드랍(reject)하세요.\n` +
+  `  1. 정말 팀에 필요한 것인가\n` +
+  `  2. 팀 전체의 이슈인가\n` +
+  `  3. 팀원 개인 레벨의 러닝이 아닌가\n` +
+  `애매하면 드랍이 기본입니다. 리뷰 내용은 DB(proposal_review)에 남습니다.`;
+
+/** 이 단계에서 이미 담당이었던 사람들 — 재배정에서 제외한다. */
+function previousReviewOwners(db: Database, proposalId: string, status: string): string[] {
+  return (
+    db
+      .prepare(
+        `SELECT DISTINCT owner AS id FROM proposal_followup_task
+          WHERE proposal_id = ? AND status LIKE ?`,
+      )
+      .all(proposalId, `${status}%`) as { id: string }[]
+  ).map((r) => r.id);
+}
+
+/** 열린 리뷰 카드가 가장 적은 후보. 동수면 후보 순서를 따른다(결정적 — 테스트가 재현 가능하다). */
+function leastLoadedReviewer(db: Database, candidates: string[]): string | undefined {
+  if (candidates.length <= 1) return candidates[0];
+  const rows = db
+    .prepare(
+      `SELECT owner AS id, COUNT(*) AS n
+         FROM proposal_followup_task
+        WHERE closed_at IS NULL
+        GROUP BY owner`,
+    )
+    .all() as { id: string; n: number }[];
+  const load = new Map(rows.map((r) => [r.id, r.n]));
+  return candidates.reduce((best, id) => ((load.get(id) ?? 0) < (load.get(best) ?? 0) ? id : best));
 }
 
 // pm_review 담당 = coordinator(PM 역량) 우선, 없으면 랜덤 1명. peer 리뷰어와는 다른 사람.
@@ -358,7 +408,9 @@ function ensureProposalFollowup(db: Database, proposalId: string, status: string
     return { owner: "system", skipped: true };
   }
   if (status === "peer_review") {
-    const owners = peerReviewOwners(db, p.proposer_agent, agents);
+    const owners = peerReviewOwners(db, p.proposer_agent, agents, {
+      exclude: previousReviewOwners(db, p.id, status),
+    });
     if (owners.length === 0) {
       // 방어: 팀 규모가 줄어 peer 후보가 없으면 coordinator 가 다음 단계를 판단(정상 경로에선 3+ 팀에서만 peer 진입).
       return createLinkedFollowup(
@@ -390,7 +442,8 @@ function ensureProposalFollowup(db: Database, proposalId: string, status: string
         `[Proposal peer review 요청]\n` +
           `대상: ${p.title}\nID: ${p.id}\n` +
           `역할: reviewer(${owner})\n` +
-          `해야 할 일: 팀장 보고 전에 실제 리스크와 개선점을 포함해 review를 남겨 주세요.`,
+          `해야 할 일: 팀장 보고 전에 실제 리스크와 개선점을 포함해 review를 남겨 주세요.\n` +
+          PEER_REVIEW_RUBRIC,
       ));
     return { owner: followups.map((f) => f.owner).join(","), taskId: followups[0]?.taskId, messageId: followups[0]?.messageId };
   }
@@ -671,31 +724,35 @@ export function sweepStaleProposals(
           return;
         }
         // peer_review / legacy pm_review 무응답
-        const to = "gd_report";
         const round = stageEntryCount(db, row.id, row.status);
-        const reassignKey = `sweeper_reassign:${row.id}:${row.status}:${round}`;
-        if (claimAutomationAction(db, reassignKey, row.id, "sweeper_reassign")) {
-          // 1차: 담당 재배정(기존 카드 닫고 다른 후보 wake).
+        const tried = previousReviewOwners(db, row.id, row.status);
+        const untried = otherReviewers(db, row.proposer_agent, agents).filter(
+          (id) => !tried.includes(id),
+        );
+        const reassignKey = `sweeper_reassign:${row.id}:${row.status}:${round}:${tried.length}`;
+        if (untried.length > 0 && claimAutomationAction(db, reassignKey, row.id, "sweeper_reassign")) {
+          // 아직 담당한 적 없는 후보로 재배정(기존 카드 닫고 wake).
+          //
+          // ★재배정하면 정체 시계를 다시 돌린다(2026-07-31).★ 예전에는 updated_at 을 건드리지
+          // 않아서 재배정 직후에도 이미 30분 초과 상태였다 → 바로 다음 tick(5분 뒤) 무응답 판정.
+          // 라이브에서 05:36 재배정 → 05:41 무응답으로 5건이 한꺼번에 나갔다. 새 담당자가
+          // 실제로 staleMinutes 만큼 받도록 여기서 시계를 리셋한다.
           closeProposalFollowups(db, row.id, row.status);
           ensureProposalFollowup(db, row.id, row.status, agents);
+          db.prepare(`UPDATE proposal SET updated_at = datetime('now') WHERE id = ?`).run(row.id);
           out.reassigned.push(row.id);
           return;
         }
-        // 2차: 여전히 무응답 → 리뷰 skip degraded 진행.
-        // 고위험(risk_level=high)은 무검토 자동 진행 금지(P1). reject/revise verdict 있으면 사람 판단 보존.
-        if (String(row.risk_level ?? "").toLowerCase() === "high") return;
-        const stageName = row.status === "peer_review" ? "peer" : "pm";
-        const blocking = db.prepare(
-          `SELECT 1 FROM proposal_review WHERE proposal_id = ? AND stage = ? AND verdict IN ('reject','revise') LIMIT 1`,
-        ).get(row.id, stageName);
-        if (blocking) return;
-        const r = tryAutoAdvance(db, row.id, row.status, to, agents, {
-          emergency_override: true,
-          reason: "sweeper: 무응답 자동 진행(review_missing)",
-        });
-        if (r.advanced) {
+        // 후보를 다 돌았는데도 리뷰가 없다 → ★팀장에게 올리지 않는다.★
+        //
+        // 예전에는 여기서 리뷰를 건너뛰고 gd_report 로 승격했다("정체 방지", GD 2026-07-04).
+        // 그 결과 리뷰 0건인 제안이 팀장 결정 게이트에 도착했다 — 게이트가 있는데 걸러지지 않는
+        // 상태다. 팀장 지시(2026-07-31)로 승격 대신 coordinator(팀리드)에게 넘긴다: 파이프라인은
+        // 멈추지만 멈춘 사실이 사람에게 보이고, 팀장 앞에는 리뷰를 거친 것만 남는다.
+        const escalateKey = `sweeper_review_missing:${row.id}:${row.status}:${round}`;
+        if (claimAutomationAction(db, escalateKey, row.id, "sweeper_review_missing")) {
+          escalateReviewMissing(db, row.id, row.status, agents, tried);
           out.degraded.push(row.id);
-          if (to === "gd_report") gdReached = true;
         }
       })();
     } catch (e) {
@@ -705,6 +762,61 @@ export function sweepStaleProposals(
     if (gdReached) notifyGdReportReachedSafely(db, row.id, agents, "sweeper");
   }
   return out;
+}
+
+/**
+ * 후보를 다 돌았는데도 리뷰가 없을 때 — 승격시키지 않고 coordinator(팀리드)에게 넘긴다.
+ *
+ * 제안은 peer_review 에 그대로 남는다. 사람이 리뷰를 붙이거나 드랍하기 전에는 팀장 게이트로
+ * 가지 않는다. 상태를 바꾸지 않는 이유는 "리뷰 대기" 가 사실 그대로이기 때문이다 — 다른
+ * 상태로 옮기면 어디까지 갔는지가 흐려진다.
+ *
+ * coordinator 가 제안자 본인이어도 넘긴다. 본인이 리뷰를 등록하는 건 addReview 가 막으므로
+ * (peer reviewer != 제안자), 할 수 있는 일은 "다른 사람에게 붙이거나 드랍" 뿐이다.
+ */
+function escalateReviewMissing(
+  db: Database,
+  proposalId: string,
+  status: string,
+  agents: AgentRecord[],
+  tried: string[],
+): void {
+  const p = db
+    .prepare("SELECT id, title, proposer_agent, source FROM proposal WHERE id = ?")
+    .get(proposalId) as ProposalRow | undefined;
+  if (!p) return;
+  const owner = coordinatorOwner(db, agents, p.proposer_agent);
+  const triedText = tried.length ? tried.join(", ") : "없음";
+  const selfNote =
+    owner === p.proposer_agent
+      ? `\n주의: 이 제안의 제안자가 당신이다. 본인 리뷰는 등록되지 않으니 다른 팀원에게 붙여야 한다.`
+      : "";
+  closeProposalFollowups(db, proposalId, status);
+  createLinkedFollowup(
+    db,
+    p,
+    `${status}:review_missing`,
+    owner,
+    `[Proposal] 리뷰가 안 됐다: ${p.title}`,
+    `proposal:${p.id} status:${status} review_missing\n` +
+      `상황: 후보를 다 돌았는데 리뷰가 한 건도 없다. 무응답 담당: ${triedText}\n` +
+      `목표: 리뷰를 받아오거나, 판정 기준에 안 맞으면 드랍한다. ★팀장에게 자동으로 올라가지 않는다.★${selfNote}\n` +
+      `완료 기준: /api/proposals/${p.id}/reviews 에 stage=peer 리뷰 등록, 또는 transition to=rejected.`,
+    `[Proposal 리뷰 미완 — 처리 필요]\n` +
+      `대상: ${p.title}\nID: ${p.id}\n` +
+      `무응답 담당: ${triedText}\n` +
+      `이 제안은 리뷰 0건입니다. 팀장 보고로 넘어가지 않고 여기서 멈춰 있습니다.\n` +
+      `리뷰를 받아오거나 드랍해 주세요.${selfNote}\n` +
+      PEER_REVIEW_RUBRIC,
+    "high",
+  );
+  auditGdReportNotice(db, "proposal_review_missing_escalated", proposalId, {
+    title: p.title,
+    status,
+    tried,
+    owner,
+    reason: "리뷰 0건 — 팀장 승격 대신 coordinator 에스컬레이션(GD 2026-07-31)",
+  });
 }
 
 export function createProposalRoutes(deps: ProposalRouteDeps): Hono {

--- a/src/server/routes/proposals.ts
+++ b/src/server/routes/proposals.ts
@@ -755,9 +755,15 @@ export function sweepStaleProposals(
           (id) => !tried.includes(id),
         );
         const reassignKey = `sweeper_reassign:${row.id}:${row.status}:${round}:${tried.length}`;
-        // ★순서를 바꾸지 말 것★: untried 검사가 먼저여야 한다. claim 을 먼저 호출하면 후보 소진
-        // 시점에도 키가 소모돼, 나중에 새 팀원이 들어와도 영영 재배정되지 않는다. 단락 평가가
-        // 그걸 막고 있다(jane 리뷰 2026-07-31). 아래 테스트가 이 순서를 고정한다.
+        // untried 검사를 claim 보다 앞에 둔다: 후보 소진 시점에 키를 소모하지 않기 위해서다
+        // (jane 리뷰 2026-07-31).
+        //
+        // ★단, 이 순서는 테스트로 고정되어 있지 않다.★ 순서를 뒤집는 변이를 걸어도 테스트가
+        // 통과한다 — 실측으로 확인했다. 이유는 escalateReviewMissing 이 남기는 review_missing
+        // 카드가 previousReviewOwners(LIKE 'peer_review%')에 잡혀 tried.length 를 1 늘리고,
+        // 그래서 키가 달라지기 때문이다. 즉 오늘은 두 순서의 동작이 같다.
+        // 그 우연에 기대지 않으려고 순서를 이렇게 둔다. review_missing 카드의 status 접두사나
+        // previousReviewOwners 의 매칭을 바꾸면 이 우연이 사라지므로, 그때 순서가 실제로 중요해진다.
         if (untried.length > 0 && claimAutomationAction(db, reassignKey, row.id, "sweeper_reassign")) {
           // 아직 담당한 적 없는 후보로 재배정(기존 카드 닫고 wake).
           //


### PR DESCRIPTION
## 핵심 3줄
1. 리뷰 0건인 제안이 팀장 결정 게이트에 도착했다 — 게이트가 있는데 걸러지지 않는 상태였다
2. 원인은 셋이다: 재배정이 정체 시계를 리셋하지 않아 새 담당자가 **5분**만 받았고, 재배정이 **이미 무응답이던 사람**을 다시 골랐고, 무응답이면 리뷰를 **건너뛰고 승격**했다
3. 승격 대신 coordinator(팀리드)에게 넘긴다. 파이프라인은 멈추지만 멈춘 사실이 사람에게 보이고, 팀장 앞에는 리뷰를 거친 것만 남는다

## 무엇을 바꿨나
| 문제 | 고친 방법 |
|---|---|
| 리뷰 0건이어도 `gd_report` 로 승격 | 승격 제거. 후보 소진 시 coordinator 에게 "리뷰 미완" 카드 + wake |
| 재배정 후 실질 5분 | 재배정 시 `updated_at` 리셋 → 새 담당자도 `staleMinutes` 만큼 받는다 |
| 재배정이 한 사람에게 쏠림 | 이미 담당이었던 사람 제외 + 열린 리뷰가 적은 후보 우선 (랜덤 → 결정적) |
| 리뷰 기준 없음 | 요청 본문에 판정 기준 3개 + "애매하면 드랍" 명시 |

## 라이브에서 무슨 일이 있었나 (2026-07-31, gdstudio)
```
05:03~05:04  리뷰 요청 5건 발송 (herm 3, clo 2)  전부 delivered
05:36:06     1차 재배정 → 5건 전부 herm 한 사람에게
05:41:06     "무응답" 판정 → gd_report 승격.  리뷰 0건
```
재배정과 무응답 판정 사이가 **5분**이다. 무응답 기준은 30분인데, 재배정이 `updated_at` 을 건드리지 않아 재배정 직후에도 이미 33분 초과 상태로 남았다. 그래서 다음 tick(5분 주기)에 바로 판정이 났다. 2단계 안전망이 실질 1단계로 붕괴한다.

근거: `proposal_decision_log`, `proposal_automation_action`, `message_recipient` 실측.

## 설계 판단
승격 경로는 "담당자 무응답으로 파이프라인이 멈추지 않게" 의도적으로 넣은 것이다(GD 2026-07-04). 이번 변경은 그 판단을 뒤집는다 — **무응답이면 실제로 멈춘다.** 대신 멈춘 사실이 coordinator 에게 카드+wake 로 보인다. 팀장 승인 받고 진행했다(2026-07-31).

제안 상태는 `peer_review` 그대로 둔다. "리뷰 대기" 가 사실 그대로이고, 다른 상태로 옮기면 어디까지 갔는지가 흐려진다.

coordinator 가 제안자 본인이어도 넘긴다. 본인 리뷰는 `addReview` 가 이미 막으므로(peer reviewer != 제안자) 할 수 있는 일은 "다른 사람에게 붙이거나 드랍" 뿐이고, 카드에 그 문구를 넣었다.

## 검증
| 항목 | 결과 |
|---|---|
| 전체 | 2120 pass / 4 fail |
| 4 fail | **기준선(origin/main) 동일** — EXAONE 로컬 모델 필요 테스트. 이 변경과 무관 |
| 신규 테스트 | 3건 — 시계 리셋 · 리뷰 0건 승격 금지 · 직전 담당자 제외 |
| 변이 1 | 시계 리셋 제거 → **치환 적용 확인 후** 실행 → 해당 1건 실패. 사본에서 원복 후 통과 |
| 변이 2 | 에스컬레이션 → 리뷰 없이 승격 되돌림 → 해당 1건 실패. 원복 후 19 pass |
| typecheck | 오류 0 |

기존 테스트 `peer 무응답 → 1차 재배정 → 2차 리뷰 skip degraded 진행` 은 옛 계약을 고정하던 것이라 새 계약으로 교체했다.

## 미검증
라이브 재기동 후 실제 동작. 이 저장소를 돌리는 맥스튜디오는 현재 옛 커밋으로 떠 있다(별건).
`prettier --check` 경고가 `proposals.ts` 에 뜨는데 **origin/main 에서도 동일하게 뜬다.** 전체 재포맷은 무관한 diff 를 크게 만들어 하지 않았다.

## 롤백
이 커밋 revert. 되돌리면 무응답 시 리뷰 없이 팀장 게이트로 승격하는 옛 동작으로 돌아간다.

Submitted-by: Lisa ✦
