### PR TITLE
fix(send.sh): --mention 이 조용히 죽던 것 — set -e 가 에러 분기 전에 스크립트를 끝냈다

### DIFF
--- a/scripts/send-mention.test.sh
+++ b/scripts/send-mention.test.sh
@@ -58,6 +58,23 @@ else
   bad "서버 소스를 못 찾음: $SRV"
 fi
 
+echo "── T7: ★풀리지 않는 멘션은 조용히 죽지 않고 에러를 낸다★ ──"
+# 라이브 회귀(2026-07-31): send.sh 는 `set -e` 다. resolve_mention 이 members 파일이 없어
+# `return 1` 하면 대입문의 명령치환이 실패로 끝나고 set -e 가 그 줄에서 스크립트를 죽였다.
+# 아래 에러 분기가 한 번도 실행되지 않아 stdout·stderr 0바이트 · 종료코드 1 · 메시지 미생성 —
+# 보내는 사람에게는 아무 표시가 없었다. 실제로 5건이 이렇게 사라졌다.
+grep -q 'resolve_mention "\$_m" || true' "$SRC" \
+  && ok "명령치환에 || true 가 있어 set -e 가 죽이지 않는다" \
+  || bad "★|| true 가 없다 — set -e 가 에러 분기 전에 스크립트를 죽인다★"
+
+# 껍데기로 재현: 같은 패턴이 정말 조용히 죽는지 확인한다(고정용).
+SILENT_OUT="$(bash -c 'set -e; f(){ return 1; }; x="$(f)"; echo REACHED' 2>&1 || true)"
+[ -z "$SILENT_OUT" ] && ok "set -e + 실패 치환은 아무 출력 없이 죽는다(전제 확인)" \
+  || bad "전제가 깨졌다: '$SILENT_OUT'"
+GUARDED_OUT="$(bash -c 'set -e; f(){ return 1; }; x="$(f || true)"; echo REACHED' 2>&1 || true)"
+[ "$GUARDED_OUT" = "REACHED" ] && ok "|| true 를 붙이면 다음 줄이 실행된다" \
+  || bad "|| true 인데 도달 못함: '$GUARDED_OUT'"
+
 echo
 [ "$FAIL" -eq 0 ] && echo "ALL PASS" || echo "FAIL"
 exit "$FAIL"

--- a/skills/b3os-team-inbox/scripts/send.sh
+++ b/skills/b3os-team-inbox/scripts/send.sh
@@ -169,10 +169,22 @@ resolve_mention() {  # resolve_mention <원시ID|이름> -> ID 또는 빈 문자
 #     (채널마다 다른 것은 그 채널로 나갈 때 붙인다. 저장 본문은 채널 중립으로 둔다).
 MENTION_IDS=""
 for _m in $MENTIONS; do
-  _id="$(resolve_mention "$_m")"
+  # ★`|| true` 를 떼지 말 것★ (2026-07-31 실측). 이 스크립트는 `set -e` 다.
+  #   resolve_mention 은 members 파일이 없으면 `return 1` 한다. 그러면 대입문의 명령치환이
+  #   0 이 아닌 값으로 끝나고 `set -e` 가 ★바로 이 줄에서 스크립트를 죽인다★ — 아래 에러
+  #   분기가 ★한 번도 실행되지 않는다.★ 결과는 stdout 0바이트 · stderr 0바이트 · 종료코드 1.
+  #   보내는 사람 눈에는 아무 일도 안 일어난 것처럼 보이고, 메시지는 생성되지 않는다.
+  #   라이브에서 이렇게 5건이 조용히 사라졌다(맥스튜디오 보고 2건 · 카드 정리 1건 포함).
+  _id="$(resolve_mention "$_m" || true)"
   if [ -z "$_id" ]; then
-    echo "ERROR: --mention '$_m' 을 member ID 로 풀 수 없습니다." >&2
-    echo "  원시 ID(U…)를 직접 주거나, $MEMBERS_FILE 에 '이름=U01234567' 을 추가하세요." >&2
+    echo "ERROR: --mention '$_m' 을 member ID 로 풀 수 없습니다 — ★메시지를 보내지 않았습니다.★" >&2
+    if [ -f "$MEMBERS_FILE" ]; then
+      echo "  '$MEMBERS_FILE' 에 '$_m=U01234567' 줄이 없습니다. 추가하거나 원시 ID(U…)를 직접 주세요." >&2
+    else
+      echo "  members 파일이 없습니다: $MEMBERS_FILE" >&2
+      echo "  파일을 만들어 '이름=U01234567' 을 넣거나, 원시 ID(U…)를 직접 주세요." >&2
+    fi
+    echo "  멘션 없이 보내려면 --mention 을 빼세요(알림은 안 갑니다)." >&2
     exit 1
   fi
   MENTION_IDS="$MENTION_IDS $_id"


### PR DESCRIPTION
## 핵심 3줄
1. `send.sh --mention` 이 **아무 출력 없이** 죽는다 — stdout 0바이트, stderr 0바이트, 종료코드 1, 메시지 미생성
2. 원인은 `set -e` 다. 멘션 해석이 실패하면 **대입문 그 줄에서** 스크립트가 끝나서, 바로 아래 있는 친절한 에러 메시지가 **한 번도 실행되지 않는다**
3. 명령치환에 `|| true` 를 붙여 기존 에러 분기가 실제로 돌게 했다. 라이브에서 이 경로로 **5건이 조용히 사라졌다**

## 무엇을 바꿨나
| 문제 | 고친 방법 |
|---|---|
| 멘션 해석 실패 시 침묵 종료 | `_id="$(resolve_mention "$_m" \|\| true)"` — `set -e` 우회, 에러 분기 도달 |
| 에러 메시지가 원인을 구분 못 함 | 사전 파일 없음 / 이름 없음을 나눠서 안내 + "메시지를 보내지 않았습니다" 명시 |
| 회귀 방지 없음 | `scripts/send-mention.test.sh` 에 T7 추가 |

## 왜 이렇게 되나
```sh
set -e                                    # 23행
resolve_mention() { ... [ -f "$MEMBERS_FILE" ] || return 1 ... }

_id="$(resolve_mention "$_m")"            # ← 치환이 1 로 끝나면 set -e 가 여기서 종료
if [ -z "$_id" ]; then                    # ← 이 아래는 실행되지 않는다
  echo "ERROR: --mention ... 풀 수 없습니다" >&2
  exit 1
fi
```
에러 메시지 자체는 잘 쓰여 있었다. **도달할 수 없었을 뿐이다.**

## 실측 (before / after, 같은 인자 · 같은 DB)
```
수정 전  종료코드=1  stdout=0B  stderr=0B      ← 완전 침묵
수정 후  종료코드=1  stdout=0B  stderr=458B
         ERROR: --mention 'bill' 을 member ID 로 풀 수 없습니다 — ★메시지를 보내지 않았습니다.★
           members 파일이 없습니다: <경로>
           파일을 만들어 '이름=U01234567' 을 넣거나, 원시 ID(U…)를 직접 주세요.
           멘션 없이 보내려면 --mention 을 빼세요(알림은 안 갑니다).
```
두 경우 모두 메시지는 생성되지 않는다(스레드 조회 `not_found`) — 동작은 그대로고, **보이기만 달라진다.**

## 영향
`--mention` 을 붙여 보낸 메시지 5건이 생성되지 않았다. 보내는 쪽에 오류 표시가 없어 전달 여부를 확인할 수 없다.

## 검증
| 항목 | 결과 |
|---|---|
| `scripts/send-mention.test.sh` (수정본) | ALL PASS |
| 같은 테스트를 **수정 전 스크립트**에 실행 | T7 이 정확히 실패 — 회귀를 잡는다 |
| `scripts/send-tools-honesty.test.sh` | ALL PASS |
| 실제 실행 before/after | 위 표 |

T7 은 소스 grep 뿐 아니라 `set -e` 동작 자체도 껍데기로 재현해 전제를 고정한다(전제가 바뀌면 테스트가 먼저 깨진다).

## 범위 밖으로 둔 것
`slack-tokens/members.env` 는 gitignore 대상이라 이 PR 에 없다. 각 설치가 자기 사전을 만들어야 한다. 이 PR 은 **없을 때 그 사실이 보이게** 하는 것까지다.

## 롤백
이 커밋 revert. 되돌리면 멘션 실패가 다시 침묵한다.

Submitted-by: Lisa ✦

