### PR TITLE
fix(proposals): 리뷰 0건 제안의 팀장 보고 승격 차단 + 막힌 뒤 조율자 인계

### DIFF
--- a/src/server/bus/expiryNotice.test.ts
+++ b/src/server/bus/expiryNotice.test.ts
@@ -17,6 +17,8 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { recipientAlreadyAnswered } from "./wakeDispatcher";
 
 const SRC = readFileSync(join(import.meta.dir, "wakeDispatcher.ts"), "utf8");
 
@@ -49,5 +51,20 @@ describe("★만료 통지 — 요청자가 영원히 기다리지 않게★", (
   it("★재시도는 여전히 안 한다★ (통지를 넣었다고 재시도를 되살리면 중복 팬아웃이 난다)", () => {
     expect(SRC).toMatch(/\["hermes_agent", "expire_no_retry"\]/);
     expect(SRC).toMatch(/\["openclaw", "expire_no_retry"\]/);
+  });
+
+  it("명시 답변으로 닫힌 recipient는 늦게 끝난 wake 실패가 무응답으로 덮지 않는다", () => {
+    const db = new Database(":memory:");
+    db.exec(
+      `CREATE TABLE message_recipient (
+        message_id TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        recipient_state TEXT NOT NULL
+      )`,
+    );
+    db.prepare("INSERT INTO message_recipient VALUES ('ask-1','devon','completed')").run();
+    expect(recipientAlreadyAnswered(db, "ask-1", "devon")).toBe(true);
+    db.prepare("UPDATE message_recipient SET recipient_state='open'").run();
+    expect(recipientAlreadyAnswered(db, "ask-1", "devon")).toBe(false);
   });
 });

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -1401,6 +1401,14 @@ function notifyRequesterOfExpiry(
   }
 }
 
+export function recipientAlreadyAnswered(db: Database, messageId: string, agentId: string): boolean {
+  const current = db.prepare(
+    `SELECT recipient_state FROM message_recipient
+      WHERE message_id = ? AND agent_id = ?`,
+  ).get(messageId, agentId) as { recipient_state: string } | undefined;
+  return Boolean(current && current.recipient_state !== "open");
+}
+
 function recordDispatchOutcome(
   db: Database,
   row: PendingDispatchRow,
@@ -1421,6 +1429,13 @@ function recordDispatchOutcome(
     // the exception path was the last retry gap; the !result.ok path below already expires no-retry).
     // Same policy: expire (no retry), leave the bus message in the inbox for next-turn/manual collection.
     if (wakeFailurePolicy(targetAgent.runtime) === "expire_no_retry") {
+      if (recipientAlreadyAnswered(db, row.message_id, row.agent_id)) {
+        appendAudit(db, "bus_dispatcher", "late_wake_failure_ignored_after_reply", row.message_id, {
+          agent_id: row.agent_id,
+          detail: `exception:${errMsg}`.slice(0, 200),
+        });
+        return;
+      }
       db.prepare(
         `UPDATE message_recipient
          SET delivery_state = 'expired',
@@ -1507,6 +1522,13 @@ function recordDispatchOutcome(
     // OpenClaw gateway failures are ambiguous: the turn may already be queued or partially
     // visible to the native session. Retrying creates duplicate Codex turns, so expire and
     // leave the bus message in the inbox for manual/next-turn collection.
+    if (recipientAlreadyAnswered(db, row.message_id, row.agent_id)) {
+      appendAudit(db, "bus_dispatcher", "late_wake_failure_ignored_after_reply", row.message_id, {
+        agent_id: row.agent_id,
+        detail: lastError,
+      });
+      return;
+    }
     db.prepare(
       `UPDATE message_recipient
        SET delivery_state = 'expired',

--- a/src/server/db/proposal.ts
+++ b/src/server/db/proposal.ts
@@ -114,9 +114,16 @@ function eligiblePeerReviewerCapacity(db: Database, proposer: string): number {
   return rows.filter((r) => !skip.has(r.id)).length;
 }
 
-// GD 심플 모델: 팀장 보고 전 review는 필수. 단, 제안자 제외 리뷰 후보가 0명이면 gd_report 직행.
+// blocked 상태를 포함한 실제 공식 팀원 수. 실제 1인 팀인지 판정할 때만 사용한다.
+function actualPeerReviewerCapacity(db: Database, proposer: string): number {
+  const skip = reviewSkipIds();
+  const rows = db.prepare("SELECT id FROM agent WHERE id != ?").all(proposer) as { id: string }[];
+  return rows.filter((r) => !skip.has(r.id)).length;
+}
+
+// GD 심플 모델: 팀장 보고 전 review는 필수. 단, 실제 공식 팀원이 제안자 1명뿐이면 gd_report 직행.
 function requiredPeerReviewCount(db: Database, proposer: string): number {
-  return eligiblePeerReviewerCapacity(db, proposer) >= 1 ? 1 : 0;
+  return actualPeerReviewerCapacity(db, proposer) >= 1 ? 1 : 0;
 }
 
 // GD 모델: pm_review 는 2+ 팀(제안자 제외 후보 1명+)에서 1건 필요.
@@ -251,6 +258,9 @@ export function transitionProposal(
     // 사람: proposer 본인만(가로채기 방지). 자동화: SYSTEM_ACTOR 허용(생성=즉시 진입/sweeper 대리 제출).
     if (actor !== row.proposer_agent && actor !== SYSTEM_ACTOR) {
       return { ok: false, error: `draft → ${toStatus} 제출은 proposer_agent 또는 system만 가능(현재 actor=${actor}, proposer=${row.proposer_agent})` };
+    }
+    if (toStatus === "gd_report" && actualPeerReviewerCapacity(db, row.proposer_agent) > 0) {
+      return { ok: false, error: "draft → gd_report 직행은 실제 1인 팀에서만 가능" };
     }
   }
   // revise_requested→draft는 proposer-only이되, proposer 무응답/rate-limited 시 coordinator가

--- a/src/server/db/proposal.ts
+++ b/src/server/db/proposal.ts
@@ -228,7 +228,7 @@ export function updateProposal(
 
 /** 상태 전이 — 상태기계 밖 전이 금지 + 단계별 가드 + decision_log 자동 기록.
  *  Codex 교차검토 가드(2026-06-12):
- *   - peer→gd_report: 리뷰 1건 의무(팀장보고 전 review 생략 방지). emergency_override로만 예외(사유 기록).
+ *   - peer→gd_report: 리뷰 1건 의무(팀장보고 전 review 생략 방지). emergency_override도 우회 불가.
  *   - gd_report→accepted/rejected: team lead actor만(감사 무결성). PM은 pm-stage 리뷰로 recommend만. */
 export function transitionProposal(
   db: Database, id: string, actor: string, toStatus: string, reason: string,
@@ -262,7 +262,8 @@ export function transitionProposal(
   }
 
   // Guard A — review 의무: peer_review→gd_report는 실제 peer review 1건 이상 필요.
-  if (from === "peer_review" && toStatus === "gd_report" && !opts.emergency_override) {
+  // 팀장 결정 화면에는 검토를 마친 제안만 올라가야 하므로 emergency override도 이 가드를 우회하지 못한다.
+  if (from === "peer_review" && toStatus === "gd_report") {
     const requiredPeer = requiredPeerReviewCount(db, row.proposer_agent);
     const peerCount = eligiblePeerReviewCount(db, id, row.proposer_agent);
     if (peerCount < requiredPeer) {

--- a/src/server/routes/proposalAutomation.test.ts
+++ b/src/server/routes/proposalAutomation.test.ts
@@ -6,7 +6,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
 import { migrate } from "../db/migrate";
-import { createProposalRoutes, sweepStaleProposals } from "./proposals";
+import { coordinatorOwner, createProposalRoutes, otherReviewers, sweepStaleProposals } from "./proposals";
 import { advanceProposalIfCurrent, createProposal, SYSTEM_ACTOR } from "../db/proposal";
 import { ambientAgents } from "../lib/registry";
 import type { AgentRecord } from "../types";
@@ -326,5 +326,50 @@ describe("후보를 다 돌아도 리뷰가 없을 때", () => {
     expect(a?.owner).toBe("demis");
     expect(b?.owner).toBe("bill");
     expect(a?.description).toContain("다음 행동");
+  });
+
+  test("카드가 없어진 채로 넘기면 기록을 남긴다", async () => {
+    const { app, db } = setup();
+    const agents = agentsWithCoordinator("demis");
+    const { id } = (await (await create(app)).json()) as { id: string };
+
+    // 1차 재배정까지 진행시킨 뒤, 카드(task)만 지운다 — 장부(followup)는 열려 있다.
+    let reassigned = false;
+    for (let i = 0; i < 12 && !reassigned; i += 1) {
+      ageProposal(db, id, 40);
+      reassigned = sweepStaleProposals(db, agents).reassigned.includes(id);
+    }
+    expect(reassigned).toBe(true);
+    db.prepare(
+      `DELETE FROM task WHERE id IN (
+         SELECT task_id FROM proposal_followup_task WHERE proposal_id = ? AND closed_at IS NULL)`,
+    ).run(id);
+
+    let blocked = false;
+    for (let i = 0; i < 12 && !blocked; i += 1) {
+      ageProposal(db, id, 40);
+      blocked = sweepStaleProposals(db, agents).blocked.includes(id);
+    }
+    expect(blocked).toBe(true);
+
+    // 장부는 조율자로 바뀌는데 보드에는 아무것도 안 보인다. 남아야 설명이 된다.
+    const audit = db
+      .prepare("SELECT COUNT(*) AS n FROM audit_event WHERE action = ? AND target = ?")
+      .get("sweeper_blocked_card_missing", id) as { n: number };
+    expect(audit.n).toBe(1);
+  });
+
+  test("조율자도 제안자도 없으면, 방금 무응답한 그 사람에게 되돌리지 않는다", () => {
+    const { db } = setup();
+    // agents.json 과 team.db 가 어긋난 상태 — 등록부에는 있는데 DB 에는 없다.
+    const agents = agentsWithCoordinator("__none__"); // coordinator 없음 → coordinatorId 는 첫 에이전트로 폴백
+    db.prepare("DELETE FROM agent WHERE id IN ('bill','codex')").run(); // 그 첫 에이전트도, 제안자도 DB 에 없다
+
+    const tail = otherReviewers(db, "codex", agents);
+    expect(tail.length).toBeGreaterThan(1); // 제외해도 남는 후보가 있어야 이 검사가 뜻이 있다
+
+    // 꼬리가 그대로 첫 후보를 주면 방금 무응답한 그 사람이 다시 담당이 된다.
+    expect(coordinatorOwner(db, agents, "codex", tail[0])).not.toBe(tail[0]);
+    expect(coordinatorOwner(db, agents, "codex", tail[0])).toBe(tail[1]!);
   });
 });

--- a/src/server/routes/proposalAutomation.test.ts
+++ b/src/server/routes/proposalAutomation.test.ts
@@ -141,17 +141,28 @@ describe("자동화 — sweeper 정체 안전망", () => {
     expect(statusOf(db, id)).toBe("peer_review"); // 3+팀 → peer 자동 제출
   });
 
-  test("peer 무응답 → 1차 재배정 → 2차 리뷰 skip degraded 진행", async () => {
+  test("peer 무응답 → 1차 재배정 → 재대기 후에도 리뷰 없으면 blocked 유지", async () => {
     const { app, db } = setup();
     const { id } = (await (await create(app)).json()) as { id: string };
     expect(statusOf(db, id)).toBe("peer_review");
+    const firstOwner = (db.prepare(
+      "SELECT owner FROM proposal_followup_task WHERE proposal_id = ? AND status LIKE 'peer_review:%' ORDER BY created_at LIMIT 1",
+    ).get(id) as { owner: string }).owner;
     ageProposal(db, id, 40);
     const r1 = sweepStaleProposals(db, ambientAgents());
     expect(r1.reassigned).toContain(id);
     expect(statusOf(db, id)).toBe("peer_review"); // 재배정만, 아직 peer
-    const r2 = sweepStaleProposals(db, ambientAgents()); // 여전히 stale → degraded
-    expect(r2.degraded).toContain(id);
-    expect(statusOf(db, id)).toBe("gd_report"); // 리뷰 없이 자동 진행(degraded)
+    const reassignedOwner = (db.prepare(
+      "SELECT owner FROM proposal_followup_task WHERE proposal_id = ? AND status LIKE 'peer_review:%' AND closed_at IS NULL",
+    ).get(id) as { owner: string }).owner;
+    expect(reassignedOwner).not.toBe(firstOwner);
+    const immediate = sweepStaleProposals(db, ambientAgents());
+    expect(immediate.blocked).not.toContain(id); // 재배정 시 대기시계가 초기화된다
+    ageProposal(db, id, 40);
+    const r2 = sweepStaleProposals(db, ambientAgents());
+    expect(r2.degraded).toEqual([]);
+    expect(r2.blocked).toContain(id);
+    expect(statusOf(db, id)).toBe("peer_review"); // 리뷰 없이 gd_report 금지
   });
 
   test("정체 아닌(최근) 제안은 sweeper가 건드리지 않는다", async () => {
@@ -244,14 +255,16 @@ describe("자동화 — 교차검토 결함 회귀 방어", () => {
     expect(statusOf(db, id)).toBe("draft"); // 가로채기 실패
   });
 
-  test("P1: sweeper degraded는 risk_level=high 제안을 자동 진행하지 않는다", () => {
+  test("P1: sweeper는 risk와 무관하게 리뷰 없는 제안을 자동 진행하지 않는다", () => {
     const { db } = setup();
     const id = createProposal(db, { ...VALID_NEW, risk_level: "high" }).id!;
     advanceProposalIfCurrent(db, { proposalId: id, expectedFrom: "draft", to: "peer_review", actionKey: "k", kind: "t" });
     ageProposal(db, id, 40);
     sweepStaleProposals(db, ambientAgents()); // 1차 재배정
-    const r2 = sweepStaleProposals(db, ambientAgents()); // 2차: high-risk → skip
+    ageProposal(db, id, 40);
+    const r2 = sweepStaleProposals(db, ambientAgents());
     expect(r2.degraded).not.toContain(id);
+    expect(r2.blocked).toContain(id);
     expect(statusOf(db, id)).toBe("peer_review"); // 사람 리뷰 대기(무검토 승격 안 함)
   });
 });

--- a/src/server/routes/proposalAutomation.test.ts
+++ b/src/server/routes/proposalAutomation.test.ts
@@ -372,4 +372,59 @@ describe("후보를 다 돌아도 리뷰가 없을 때", () => {
     expect(coordinatorOwner(db, agents, "codex", tail[0])).not.toBe(tail[0]);
     expect(coordinatorOwner(db, agents, "codex", tail[0])).toBe(tail[1]!);
   });
+
+  test("넘길 사람이 없으면 카드에 명부가 어긋났다고 적는다", async () => {
+    const { app, db } = setup();
+    const agents = agentsWithCoordinator("__none__");
+    const { id } = (await (await create(app)).json()) as { id: string };
+
+    let reassigned = false;
+    for (let i = 0; i < 12 && !reassigned; i += 1) {
+      ageProposal(db, id, 40);
+      reassigned = sweepStaleProposals(db, agents).reassigned.includes(id);
+    }
+    expect(reassigned).toBe(true);
+
+    // 명부에는 있는데 DB 에는 없다 — 현재 담당 한 명만 남기고 제안자까지 지운다.
+    const owner = (db
+      .prepare(
+        `SELECT owner FROM proposal_followup_task
+          WHERE proposal_id = ? AND status LIKE 'peer_review:%' AND closed_at IS NULL
+          ORDER BY created_at DESC LIMIT 1`,
+      )
+      .get(id) as { owner: string }).owner;
+    db.prepare("DELETE FROM agent WHERE id != ?").run(owner);
+
+    let blocked = false;
+    for (let i = 0; i < 12 && !blocked; i += 1) {
+      ageProposal(db, id, 40);
+      blocked = sweepStaleProposals(db, agents).blocked.includes(id);
+    }
+    expect(blocked).toBe(true);
+
+    const card = db
+      .prepare(
+        `SELECT t.owner AS owner, t.description AS description FROM proposal_followup_task pft
+           JOIN task t ON t.id = pft.task_id
+          WHERE pft.proposal_id = ? AND pft.closed_at IS NULL`,
+      )
+      .get(id) as { owner: string; description: string };
+    expect(card.owner).toBe(owner); // 존재하지 않는 사람으로 바뀌지 않는다
+    expect(card.description).toContain("담당 없음");
+    expect(card.description).not.toContain("다음 행동");
+  });
+
+  test("남은 후보가 그 사람뿐이면, DB 에 없는 제안자를 담당으로 넣지 않는다", () => {
+    const { db } = setup();
+    const agents = agentsWithCoordinator("__none__");
+    db.prepare("DELETE FROM agent WHERE id IN ('bill','codex')").run();
+    // 후보를 한 명만 남긴다 — 그 한 명이 방금 무응답한 사람이다.
+    const only = otherReviewers(db, "codex", agents)[0]!;
+    db.prepare("DELETE FROM agent WHERE id NOT IN (?)").run(only);
+    expect(otherReviewers(db, "codex", agents)).toEqual([only]);
+
+    // 무응답이어도 실재하는 사람이, 존재하지 않는 사람보다 낫다.
+    expect(coordinatorOwner(db, agents, "codex", only)).toBe(only);
+    expect(coordinatorOwner(db, agents, "codex", only)).not.toBe("codex");
+  });
 });

--- a/src/server/routes/proposalAutomation.test.ts
+++ b/src/server/routes/proposalAutomation.test.ts
@@ -9,6 +9,7 @@ import { migrate } from "../db/migrate";
 import { createProposalRoutes, sweepStaleProposals } from "./proposals";
 import { advanceProposalIfCurrent, createProposal, SYSTEM_ACTOR } from "../db/proposal";
 import { ambientAgents } from "../lib/registry";
+import type { AgentRecord } from "../types";
 
 const OP_TOKEN = "proposal-auto-test-op-token";
 
@@ -266,5 +267,64 @@ describe("자동화 — 교차검토 결함 회귀 방어", () => {
     expect(r2.degraded).not.toContain(id);
     expect(r2.blocked).toContain(id);
     expect(statusOf(db, id)).toBe("peer_review"); // 사람 리뷰 대기(무검토 승격 안 함)
+  });
+});
+
+describe("후보를 다 돌아도 리뷰가 없을 때", () => {
+  // 막아두는 것과 멈춰두는 것은 다르다. blocked 로 남기면 팀장 보고로는 안 가지만,
+  // 카드 소유자가 무응답한 리뷰어 그대로면 다음 행동을 할 사람이 없다.
+  const ageProposal = (db: Database, id: string, minutes: number) =>
+    db.prepare("UPDATE proposal SET updated_at = datetime('now', ?) WHERE id = ?").run(`-${minutes} minutes`, id);
+
+  const agentsWithCoordinator = (coord: string): AgentRecord[] =>
+    ["bill", "codex", "steve", "demis", "devon"].map((id) => ({
+      id,
+      display_name: id,
+      role: "role",
+      runtime: "claude_channel",
+      status_provider: "claude_tmux",
+      tmux_session: null,
+      telegram_bot_username: null,
+      workspace_path: "/tmp",
+      persona_file: "P.md",
+      capabilities: id === coord ? ["coordinator"] : [],
+    })) as unknown as AgentRecord[];
+
+  // 조율자만 바꿔 같은 시나리오를 돌린다. 배정은 결정적이라, 재배정이 없으면
+  // 두 번 모두 같은 사람이 남는다 — 조율자를 따라가면 재배정이 실제로 일어난 것이다.
+  async function ownerAfterBlocked(coord: string) {
+    const { app, db } = setup();
+    const agents = agentsWithCoordinator(coord);
+    const { id } = (await (await create(app)).json()) as { id: string };
+    expect(statusOf(db, id)).toBe("peer_review");
+
+    let blocked = false;
+    for (let i = 0; i < 12 && !blocked; i += 1) {
+      ageProposal(db, id, 40);
+      blocked = sweepStaleProposals(db, agents).blocked.includes(id);
+    }
+    expect(blocked).toBe(true);
+
+    // 리뷰 0건인 채로 팀장 보고 단계로 가지 않는다
+    expect(statusOf(db, id)).toBe("peer_review");
+    expect(
+      (db.prepare("SELECT COUNT(*) AS n FROM proposal_review WHERE proposal_id = ?").get(id) as { n: number }).n,
+    ).toBe(0);
+
+    return db
+      .prepare(
+        `SELECT t.owner AS owner, t.description AS description
+           FROM proposal_followup_task pft JOIN task t ON t.id = pft.task_id
+          WHERE pft.proposal_id = ? AND pft.closed_at IS NULL`,
+      )
+      .get(id) as { owner: string; description: string } | undefined;
+  }
+
+  test("카드가 coordinator 에게 넘어가고 다음 행동이 적힌다", async () => {
+    const a = await ownerAfterBlocked("demis");
+    const b = await ownerAfterBlocked("bill");
+    expect(a?.owner).toBe("demis");
+    expect(b?.owner).toBe("bill");
+    expect(a?.description).toContain("다음 행동");
   });
 });

--- a/src/server/routes/proposals.test.ts
+++ b/src/server/routes/proposals.test.ts
@@ -1031,6 +1031,21 @@ describe("proposals — GD 심플 모델 (팀 크기별 라우팅)", () => {
     expect(statusOf(db, id)).toBe("accepted");
   });
 
+  test("다인 팀의 다른 팀원이 모두 blocked면 무검토 gd_report 대신 peer_review blocked 유지", async () => {
+    const { app, db } = setupTeam(["alice", "bob", "carol"], { coordinator: "bob" });
+    db.prepare("INSERT INTO agent_status (agent_id, state) VALUES (?, 'blocked')").run("bob");
+    db.prepare("INSERT INTO agent_status (agent_id, state) VALUES (?, 'blocked')").run("carol");
+
+    const id = await createBy(app, "alice");
+    expect(statusOf(db, id)).toBe("peer_review");
+    expect((await transition(app, id, "gd_report", "alice")).status).toBe(409);
+    const task = db.prepare(
+      "SELECT description FROM task WHERE id IN (SELECT task_id FROM proposal_followup_task WHERE proposal_id = ?)",
+    ).get(id) as { description: string };
+    expect(task.description).toContain("blocked:");
+    expect(task.description).toContain("무검토 gd_report 직행 금지");
+  });
+
   test("LEAD_ACTOR_ID 설정은 리뷰 후보 계산에 관여하지 않는다", async () => {
     process.env.LEAD_ACTOR_ID = "lead";
     const { app, db } = setupTeam(["lead", "alice", "bob"], { coordinator: "bob" });

--- a/src/server/routes/proposals.test.ts
+++ b/src/server/routes/proposals.test.ts
@@ -190,6 +190,29 @@ describe("proposals — 상태기계 + Guard", () => {
     expect(r.status).toBe(409);
   });
 
+  test("authz: loopback dashboard는 현재 배정된 reviewer 명의의 리뷰만 등록할 수 있다", async () => {
+    const current = await fresh();
+    const assigned = current.db.prepare(
+      "SELECT owner FROM proposal_followup_task WHERE proposal_id = ? AND status LIKE 'peer_review:%' AND closed_at IS NULL",
+    ).get(current.id) as { owner: string };
+    const ok = await current.app.request(`/proposals/${current.id}/reviews`, json({
+      reviewer_agent: assigned.owner,
+      stage: "peer",
+      verdict: "concern",
+      comments: "팀 공통 이슈 여부 검토",
+    }));
+    expect(ok.status).toBe(201);
+
+    const next = await fresh();
+    const unassigned = ["steve", "demis", "devon"].find((id) => id !== next.followup?.owner)!;
+    const denied = await next.app.request(`/proposals/${next.id}/reviews`, json({
+      reviewer_agent: unassigned,
+      stage: "peer",
+      verdict: "approve",
+    }));
+    expect(denied.status).toBe(403);
+  });
+
   test("PATCH /proposals/:id updates draft text fields through standard API", async () => {
     const { app, db } = setup();
     const id = createProposalRow(db, {
@@ -365,7 +388,7 @@ describe("proposals — 상태기계 + Guard", () => {
     expect(openTasks.c).toBe(0);
   });
 
-  test("peer review는 제안자를 제외하고 나머지 팀원 중 랜덤 1명에게 보낸다", async () => {
+  test("peer review는 제안자를 제외하고 현재 부담이 가장 적은 1명에게 보낸다", async () => {
     const { app, db } = setup();
     seedAgent(db, "lui");
     seedAgent(db, "hermes");
@@ -376,11 +399,11 @@ describe("proposals — 상태기계 + Guard", () => {
       author_agent: "lui",
     })).json()) as { id: string };
 
-    // 생성=peer 진입 시점에 peer 1명(랜덤) 배정.
+    // 생성=peer 진입 시점에 peer 1명 배정.
     const peerTasks = db.prepare(
       "SELECT owner, status FROM proposal_followup_task WHERE proposal_id = ? AND status LIKE 'peer_review:%' ORDER BY owner",
     ).all(id) as { owner: string; status: string }[];
-    expect(peerTasks).toHaveLength(1); // 새 모델: peer 1명(랜덤)
+    expect(peerTasks).toHaveLength(1);
     expect(peerTasks[0]!.owner).not.toBe("lui"); // 제안자 제외
     expect(peerTasks[0]!.owner).toBeTruthy();
   });
@@ -584,8 +607,11 @@ describe("proposals — 상태기계 + Guard", () => {
     const { app, db, id } = await fresh();
     await transition(app, id, "peer_review", "codex");
     const before = db.prepare("SELECT COUNT(*) AS c FROM task WHERE description LIKE ?").get(`%proposal:${id} status:peer_review%`) as { c: number };
-    const r = await transition(app, id, "gd_report", "bill", { emergency_override: true });
-    expect(r.status).toBe(200);
+    const assigned = db.prepare(
+      "SELECT owner FROM proposal_followup_task WHERE proposal_id = ? AND status LIKE 'peer_review:%' AND closed_at IS NULL",
+    ).get(id) as { owner: string };
+    const r = await review(app, id, { reviewer_agent: assigned.owner, verdict: "concern" });
+    expect(r.status).toBe(201);
     // 같은 상태 재호출이 아니라 다음 상태 task는 새로 생기되, peer_review task는 팀 규모 기준 2개만 유지된다.
     const after = db.prepare("SELECT COUNT(*) AS c FROM task WHERE description LIKE ?").get(`%proposal:${id} status:peer_review%`) as { c: number };
     expect(before.c).toBe(1); // 새 모델: peer 1명
@@ -900,11 +926,11 @@ describe("proposals — 상태기계 + Guard", () => {
     expect(statusOf(db, id)).toBe("gd_report"); // review 1건 = 자동 전이
   });
 
-  test("Guard A 우회: emergency_override=true면 통과", async () => {
+  test("Guard A: emergency_override도 peer review 의무를 우회하지 못한다", async () => {
     const { app, id } = await fresh();
     await transition(app, id, "peer_review", "codex");
     const r = await transition(app, id, "gd_report", "bill", { emergency_override: true });
-    expect(r.status).toBe(200);
+    expect(r.status).toBe(409);
   });
 
   test("Guard C: legacy pm_review row는 PM review 1건 없으면 gd_report 금지", async () => {
@@ -972,7 +998,7 @@ describe("proposals — test fixture gate", () => {
       staleMinutes: 30,
       limit: 10,
     });
-    expect(out).toEqual({ advanced: [], reassigned: [], degraded: [] });
+    expect(out).toEqual({ advanced: [], reassigned: [], degraded: [], blocked: [] });
     expect(statusOf(db, id)).toBe("peer_review");
     const openTasks = db.prepare(
       "SELECT COUNT(*) AS c FROM proposal_followup_task WHERE proposal_id = ? AND closed_at IS NULL",
@@ -982,6 +1008,20 @@ describe("proposals — test fixture gate", () => {
 });
 
 describe("proposals — GD 심플 모델 (팀 크기별 라우팅)", () => {
+  test("4인 팀: 연속 제안의 peer review를 세 후보에게 least-loaded 순환 배정", async () => {
+    const { app, db } = setupTeam(["alice", "bob", "carol", "dave"]);
+    const owners: string[] = [];
+    for (let i = 0; i < 3; i += 1) {
+      const id = await createBy(app, "alice");
+      const row = db.prepare(
+        "SELECT owner FROM proposal_followup_task WHERE proposal_id = ? AND status LIKE 'peer_review:%'",
+      ).get(id) as { owner: string };
+      owners.push(row.owner);
+    }
+    expect(new Set(owners).size).toBe(3);
+    expect(owners).not.toContain("alice");
+  });
+
   test("1인 팀: draft → gd_report 직행 → 팀장(gd) accepted", async () => {
     const { app, db } = setupTeam(["alice"], { coordinator: "alice" });
     const id = await createBy(app, "alice");

--- a/src/server/routes/proposals.ts
+++ b/src/server/routes/proposals.ts
@@ -97,6 +97,16 @@ function existingAgent(db: Database, id: string): boolean {
   return Boolean(db.prepare("SELECT 1 FROM agent WHERE id = ?").get(id));
 }
 
+function isAssignedReviewer(db: Database, proposalId: string, stage: string, reviewer: string): boolean {
+  const statusPrefix = stage === "peer" ? "peer_review:" : stage === "pm" ? "pm_review:" : "";
+  if (!statusPrefix) return false;
+  return Boolean(db.prepare(
+    `SELECT 1 FROM proposal_followup_task
+      WHERE proposal_id = ? AND owner = ? AND status = ? AND closed_at IS NULL
+      LIMIT 1`,
+  ).get(proposalId, reviewer, `${statusPrefix}${reviewer}`));
+}
+
 function firstAvailableAgent(db: Database, candidates: string[], fallback: string): string {
   return candidates.find((id) => existingAgent(db, id)) ?? fallback;
 }
@@ -144,12 +154,46 @@ function coordinatorOwner(db: Database, agents: AgentRecord[], proposer: string)
   return otherReviewers(db, proposer, agents)[0] ?? proposer;
 }
 
-// peer_review 담당 = 나머지 팀원 중 랜덤 1명. 2+ 팀부터 팀장 보고 전 단일 review가 필수.
-function peerReviewOwners(db: Database, proposer: string, agents: AgentRecord[]): string[] {
+// peer_review 담당 = 제안자 제외 후보 중 열린/최근 배정이 가장 적은 1명.
+// 재배정 때는 이 proposal의 기존 담당자를 먼저 제외한다.
+function peerReviewOwners(db: Database, proposalId: string, proposer: string, agents: AgentRecord[]): string[] {
   const others = otherReviewers(db, proposer, agents);
   if (others.length < 1) return [];
-  const pick = others[Math.floor(Math.random() * others.length)];
-  return pick ? [pick] : [];
+  const prior = new Set(
+    (db.prepare(
+      `SELECT owner FROM proposal_followup_task
+        WHERE proposal_id = ? AND status LIKE 'peer_review:%'`,
+    ).all(proposalId) as { owner: string }[]).map((r) => r.owner),
+  );
+  const fresh = others.filter((id) => !prior.has(id));
+  const candidates = fresh.length > 0 ? fresh : others;
+  const load = db.prepare(
+    `SELECT
+       SUM(CASE WHEN pft.closed_at IS NULL THEN 1 ELSE 0 END) AS open_count,
+       SUM(CASE WHEN pft.created_at >= datetime('now', '-7 days') THEN 1 ELSE 0 END) AS recent_count,
+       MAX(pft.created_at) AS last_assigned_at
+      FROM proposal_followup_task pft
+      WHERE pft.owner = ? AND pft.status LIKE 'peer_review:%'`,
+  );
+  const ranked = candidates.map((id) => {
+    const row = load.get(id) as {
+      open_count: number | null;
+      recent_count: number | null;
+      last_assigned_at: string | null;
+    };
+    return {
+      id,
+      open: Number(row.open_count ?? 0),
+      recent: Number(row.recent_count ?? 0),
+      last: row.last_assigned_at ?? "",
+    };
+  }).sort((a, b) =>
+    a.open - b.open ||
+    a.recent - b.recent ||
+    a.last.localeCompare(b.last) ||
+    a.id.localeCompare(b.id),
+  );
+  return ranked[0] ? [ranked[0].id] : [];
 }
 
 // pm_review 담당 = coordinator(PM 역량) 우선, 없으면 랜덤 1명. peer 리뷰어와는 다른 사람.
@@ -358,7 +402,7 @@ function ensureProposalFollowup(db: Database, proposalId: string, status: string
     return { owner: "system", skipped: true };
   }
   if (status === "peer_review") {
-    const owners = peerReviewOwners(db, p.proposer_agent, agents);
+    const owners = peerReviewOwners(db, p.id, p.proposer_agent, agents);
     if (owners.length === 0) {
       // 방어: 팀 규모가 줄어 peer 후보가 없으면 coordinator 가 다음 단계를 판단(정상 경로에선 3+ 팀에서만 peer 진입).
       return createLinkedFollowup(
@@ -390,7 +434,9 @@ function ensureProposalFollowup(db: Database, proposalId: string, status: string
         `[Proposal peer review 요청]\n` +
           `대상: ${p.title}\nID: ${p.id}\n` +
           `역할: reviewer(${owner})\n` +
-          `해야 할 일: 팀장 보고 전에 실제 리스크와 개선점을 포함해 review를 남겨 주세요.`,
+          `해야 할 일: 팀장 보고 전에 아래 기준으로 실제 리스크와 개선점을 포함해 review를 남겨 주세요.\n` +
+          `1) 정말 팀에 필요한가?\n2) 팀 전체의 공통 이슈인가?\n3) 팀원 개인 수준의 learning인가?\n` +
+          `팀 공통 제안이 아니거나 개인 learning이면 reject(drop)하고 사유를 남겨 주세요.`,
       ));
     return { owner: followups.map((f) => f.owner).join(","), taskId: followups[0]?.taskId, messageId: followups[0]?.messageId };
   }
@@ -642,18 +688,23 @@ function notifyGdReportReachedSafely(db: Database, proposalId: string, agents: A
 export function sweepStaleProposals(
   db: Database, agents: AgentRecord[],
   opts: { staleMinutes?: number; limit?: number } = {},
-): { advanced: string[]; reassigned: string[]; degraded: string[] } {
+): { advanced: string[]; reassigned: string[]; degraded: string[]; blocked: string[] } {
   const staleMinutes = opts.staleMinutes ?? 30;
   const limit = opts.limit ?? 20; // thundering herd 방지: 한 tick 당 처리량 제한.
   const rows = db.prepare(
-    `SELECT id, title, source, status, proposer_agent, risk_level
+    `SELECT id, title, source, status, proposer_agent
        FROM proposal
       WHERE status IN ('draft','revise_requested','peer_review','pm_review')
         AND (julianday('now') - julianday(updated_at)) * 24 * 60 >= ?
       ORDER BY updated_at ASC
       LIMIT ?`,
-  ).all(staleMinutes, limit) as { id: string; title: string; source: string | null; status: string; proposer_agent: string; risk_level: string | null }[];
-  const out = { advanced: [] as string[], reassigned: [] as string[], degraded: [] as string[] };
+  ).all(staleMinutes, limit) as { id: string; title: string; source: string | null; status: string; proposer_agent: string }[];
+  const out = {
+    advanced: [] as string[],
+    reassigned: [] as string[],
+    degraded: [] as string[],
+    blocked: [] as string[],
+  };
   for (const row of rows) {
     if (isTestProposalFixture(row)) continue;
     // 제안 단위 트랜잭션 + try/catch(F1): 부분 실패 시 전이·카드·wake 전부 롤백 → 다음 tick 깨끗한 재시도.
@@ -671,31 +722,30 @@ export function sweepStaleProposals(
           return;
         }
         // peer_review / legacy pm_review 무응답
-        const to = "gd_report";
         const round = stageEntryCount(db, row.id, row.status);
         const reassignKey = `sweeper_reassign:${row.id}:${row.status}:${round}`;
         if (claimAutomationAction(db, reassignKey, row.id, "sweeper_reassign")) {
           // 1차: 담당 재배정(기존 카드 닫고 다른 후보 wake).
           closeProposalFollowups(db, row.id, row.status);
           ensureProposalFollowup(db, row.id, row.status, agents);
+          db.prepare("UPDATE proposal SET updated_at = datetime('now') WHERE id = ?").run(row.id);
           out.reassigned.push(row.id);
           return;
         }
-        // 2차: 여전히 무응답 → 리뷰 skip degraded 진행.
-        // 고위험(risk_level=high)은 무검토 자동 진행 금지(P1). reject/revise verdict 있으면 사람 판단 보존.
-        if (String(row.risk_level ?? "").toLowerCase() === "high") return;
-        const stageName = row.status === "peer_review" ? "peer" : "pm";
-        const blocking = db.prepare(
-          `SELECT 1 FROM proposal_review WHERE proposal_id = ? AND stage = ? AND verdict IN ('reject','revise') LIMIT 1`,
-        ).get(row.id, stageName);
-        if (blocking) return;
-        const r = tryAutoAdvance(db, row.id, row.status, to, agents, {
-          emergency_override: true,
-          reason: "sweeper: 무응답 자동 진행(review_missing)",
-        });
-        if (r.advanced) {
-          out.degraded.push(row.id);
-          if (to === "gd_report") gdReached = true;
+        // 2차: 여전히 무응답이어도 리뷰 게이트는 건너뛰지 않는다.
+        // 팀장 결정 화면에 무검토 제안을 올리는 대신 현재 단계에서 blocked로 남긴다.
+        const blockKey = `sweeper_blocked:${row.id}:${row.status}:${round}`;
+        if (claimAutomationAction(db, blockKey, row.id, "sweeper_blocked")) {
+          db.prepare(
+            `UPDATE task
+                SET description = description || char(10) || 'blocked: peer review 미확보',
+                    updated_at = datetime('now')
+              WHERE id IN (
+                SELECT task_id FROM proposal_followup_task
+                 WHERE proposal_id = ? AND status LIKE ? AND closed_at IS NULL
+              )`,
+          ).run(row.id, `${row.status}:%`);
+          out.blocked.push(row.id);
         }
       })();
     } catch (e) {
@@ -873,17 +923,22 @@ export function createProposalRoutes(deps: ProposalRouteDeps): Hono {
     if (!auth.ok || !auth.actor) return authError(c, auth);
     try {
       const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+      const proposalId = c.req.param("id");
+      const stage = String(body.stage ?? "");
       const suppliedReviewer = String(body.reviewer_agent ?? "").trim();
-      if (suppliedReviewer && suppliedReviewer !== auth.actor.actor) {
+      const assignedDashboardReviewer =
+        auth.actor.source === "loopback_dashboard" &&
+        suppliedReviewer &&
+        isAssignedReviewer(deps.db, proposalId, stage, suppliedReviewer);
+      if (suppliedReviewer && suppliedReviewer !== auth.actor.actor && !assignedDashboardReviewer) {
         return c.json({ error: "reviewer_actor_mismatch" }, 403);
       }
-      const proposalId = c.req.param("id");
+      const effectiveReviewer = assignedDashboardReviewer ? suppliedReviewer : auth.actor.actor;
       const agents = deps.agents?.() ?? ambientAgents();
       const runReview = deps.db.transaction(() => {
-        const stage = String(body.stage ?? "");
         const res = addReview(deps.db, {
           proposal_id: proposalId,
-          reviewer_agent: auth.actor!.actor,
+          reviewer_agent: effectiveReviewer,
           stage,
           verdict: body.verdict as string | undefined,
           is_adversarial: Boolean(body.is_adversarial),

--- a/src/server/routes/proposals.ts
+++ b/src/server/routes/proposals.ts
@@ -112,7 +112,7 @@ function firstAvailableAgent(db: Database, candidates: string[], fallback: strin
 }
 
 // interactive 팀원(비대화 non_interactive · team_official_member:false · 제안자 · blocked 제외) 중 리뷰 후보 id 목록.
-function otherReviewers(db: Database, proposer: string, agents: AgentRecord[]): string[] {
+export function otherReviewers(db: Database, proposer: string, agents: AgentRecord[]): string[] {
   const nonInteractive = new Set(agentsWith(agents, "non_interactive").map((a) => a.id));
   const registry = new Map(agents.map((a) => [a.id, a]));
   const rows = db.prepare(
@@ -164,11 +164,15 @@ const REVIEW_CRITERIA =
   `1) 정말 팀에 필요한가?\n2) 팀 전체의 공통 이슈인가?\n3) 팀원 개인 수준의 learning인가?`;
 
 // 팀장 보고/조율 owner = coordinator(PM 역량) 우선 → 제안자 → 첫 후보 순 폴백(하드코딩 id 없음).
-function coordinatorOwner(db: Database, agents: AgentRecord[], proposer: string): string {
+// exclude 는 ★꼬리 폴백에만★ 건다. 앞의 두 층은 역할로 정해진 자리라 그대로 둔다 —
+// 조율자가 리뷰에 무응답이었더라도 "누구에게 맡길지·접을지" 를 정하는 역할은 여전히 그 사람이다.
+// 꼬리는 다르다. otherReviewers 는 방금 무응답한 리뷰어를 걸러내지 않아서,
+// 조율자도 제안자도 없으면 카드가 그 사람에게 되돌아간다 — 이 재배정이 없앤 상태 그대로다.
+export function coordinatorOwner(db: Database, agents: AgentRecord[], proposer: string, exclude?: string): string {
   const coord = coordinatorId(agents);
   if (coord && existingAgent(db, coord)) return coord;
   if (existingAgent(db, proposer)) return proposer;
-  return otherReviewers(db, proposer, agents)[0] ?? proposer;
+  return otherReviewers(db, proposer, agents).find((id) => id !== exclude) ?? proposer;
 }
 
 // peer_review 담당 = 제안자 제외 후보 중 열린/최근 배정이 가장 적은 1명.
@@ -757,8 +761,13 @@ export function sweepStaleProposals(
         // 막아두는 것과 멈춰두는 것은 다르다 — 막은 뒤에는 누군가 다음 행동을 해야 한다.
         const blockKey = `sweeper_blocked:${row.id}:${row.status}:${round}`;
         if (claimAutomationAction(db, blockKey, row.id, "sweeper_blocked")) {
-          const rescuer = coordinatorOwner(db, agents, row.proposer_agent);
-          db.prepare(
+          const stalled = (db.prepare(
+            `SELECT owner FROM proposal_followup_task
+              WHERE proposal_id = ? AND status LIKE ? AND closed_at IS NULL
+              ORDER BY created_at DESC LIMIT 1`,
+          ).get(row.id, `${row.status}:%`) as { owner: string } | undefined)?.owner;
+          const rescuer = coordinatorOwner(db, agents, row.proposer_agent, stalled);
+          const cardUpdate = db.prepare(
             `UPDATE task
                 SET owner = ?,
                     description = description || char(10)
@@ -770,12 +779,20 @@ export function sweepStaleProposals(
                 SELECT task_id FROM proposal_followup_task
                  WHERE proposal_id = ? AND status LIKE ? AND closed_at IS NULL
               )`,
-          ).run(rescuer, row.id, `${row.status}:%`);
-          db.prepare(
+          );
+          const cardChanges = cardUpdate.run(rescuer, row.id, `${row.status}:%`).changes ?? 0;
+          const ledgerChanges = db.prepare(
             `UPDATE proposal_followup_task
                 SET owner = ?
               WHERE proposal_id = ? AND status LIKE ? AND closed_at IS NULL`,
-          ).run(rescuer, row.id, `${row.status}:%`);
+          ).run(rescuer, row.id, `${row.status}:%`).changes ?? 0;
+          // 장부(followup)는 걸리는데 카드(task)가 안 걸리는 입력이 있다 — task 행이 지워진 고아 followup.
+          // 그 경우 "조율자에게 넘겼다" 는 기록만 남고 보드에는 아무것도 안 보인다. 남겨야 설명이 된다.
+          if (cardChanges !== ledgerChanges) {
+            auditGdReportNotice(db, "sweeper_blocked_card_missing", row.id, {
+              status: row.status, rescuer, card_changes: cardChanges, ledger_changes: ledgerChanges,
+            });
+          }
           out.blocked.push(row.id);
         }
       })();

--- a/src/server/routes/proposals.ts
+++ b/src/server/routes/proposals.ts
@@ -130,9 +130,22 @@ function otherReviewers(db: Database, proposer: string, agents: AgentRecord[]): 
     });
 }
 
-// 팀 크기(제안자 제외 리뷰 후보 수)로 draft 이후 첫 단계 결정.
-function firstReviewStage(otherCount: number): "peer_review" | "gd_report" {
-  if (otherCount <= 0) return "gd_report"; // 1인 팀: 리뷰 없이 팀장 보고 직행
+// 현재 상태와 무관한 실제 공식 팀원 수. blocked는 "지금 배정 불가"일 뿐 팀 탈퇴가 아니다.
+function otherTeamMembers(db: Database, proposer: string, agents: AgentRecord[]): string[] {
+  const nonInteractive = new Set(agentsWith(agents, "non_interactive").map((a) => a.id));
+  const registry = new Map(agents.map((a) => [a.id, a]));
+  const rows = db.prepare("SELECT id FROM agent WHERE id != ?").all(proposer) as { id: string }[];
+  return rows
+    .map((r) => r.id)
+    .filter((id) => {
+      const agent = registry.get(id);
+      return !nonInteractive.has(id) && isTeamOfficialMember(agent);
+    });
+}
+
+// 실제 1인 팀만 gd_report 직행. 다인 팀인데 현재 후보가 0명이면 peer_review에 blocked로 남긴다.
+function firstReviewStage(actualOtherCount: number): "peer_review" | "gd_report" {
+  if (actualOtherCount <= 0) return "gd_report";
   return "peer_review"; // 2+인 팀: 단일 review → gd_report
 }
 
@@ -219,7 +232,7 @@ function followupSpec(db: Database, p: ProposalRow, status: ProposalStatus, agen
   const marker = `proposal:${p.id} status:${status}`;
   if (status === "draft") {
     const owner = existingAgent(db, p.proposer_agent) ? p.proposer_agent : coordinatorOwner(db, agents, p.proposer_agent);
-    const stage = firstReviewStage(otherReviewers(db, p.proposer_agent, agents).length);
+    const stage = firstReviewStage(otherTeamMembers(db, p.proposer_agent, agents).length);
     return {
       owner,
       title: `[Proposal] Draft ready: ${p.title}`,
@@ -252,7 +265,7 @@ function followupSpec(db: Database, p: ProposalRow, status: ProposalStatus, agen
     };
   }
   const owner = existingAgent(db, p.proposer_agent) ? p.proposer_agent : coordinatorOwner(db, agents, p.proposer_agent);
-  const reviseStage = firstReviewStage(otherReviewers(db, p.proposer_agent, agents).length);
+  const reviseStage = firstReviewStage(otherTeamMembers(db, p.proposer_agent, agents).length);
   return {
     owner,
     title: `[Proposal] Revise requested: ${p.title}`,
@@ -404,19 +417,19 @@ function ensureProposalFollowup(db: Database, proposalId: string, status: string
   if (status === "peer_review") {
     const owners = peerReviewOwners(db, p.id, p.proposer_agent, agents);
     if (owners.length === 0) {
-      // 방어: 팀 규모가 줄어 peer 후보가 없으면 coordinator 가 다음 단계를 판단(정상 경로에선 3+ 팀에서만 peer 진입).
+      // 다인 팀인데 현재 리뷰 가능 후보가 없으면 무검토 gd_report로 보내지 않고 blocked로 유지한다.
       return createLinkedFollowup(
         db,
         p,
         "review_route_decision",
         coordinatorOwner(db, agents, p.proposer_agent),
-        `[Proposal] 다음 단계 판단 필요: ${p.title}`,
+        `[Proposal] Peer review blocked: ${p.title}`,
         `proposal:${p.id} status:review_route_decision\n` +
-          `목표: review 후보가 없어 다음 단계(gd_report)를 판단한다.\n` +
-          `완료 기준: /api/proposals/${p.id}/transition 으로 gd_report/revise_requested/rejected 중 하나 실행.`,
-        `[Proposal 다음 단계 판단 요청]\n` +
+          `blocked: 현재 review 가능 후보가 없어 peer_review에 유지한다.\n` +
+          `완료 기준: 리뷰 가능 팀원이 복귀하면 peer reviewer를 재배정한다. 무검토 gd_report 직행 금지.`,
+        `[Proposal peer review blocked]\n` +
           `대상: ${p.title}\nID: ${p.id}\n` +
-          `상태: peer 후보가 없습니다. 다음 단계를 판단해 주세요.`,
+          `상태: 현재 peer 후보가 없습니다. 리뷰 가능 팀원이 복귀하면 재배정해 주세요. 무검토 팀장 보고는 금지됩니다.`,
         "high",
       );
     }
@@ -482,7 +495,7 @@ function ensureProposalFollowup(db: Database, proposalId: string, status: string
     // 적대검토 F1/F3: owner를 comma-join 하지 않는다(owner="a,b"는 agent 조회 실패→500+롤백·카드 미아).
     // → createLinkedFollowup을 각각 1회씩 호출. proposer===coordinator면 dedup(1건만).
     const spec = followupSpec(db, p, status as ProposalStatus, agents);
-    const reviseStage = firstReviewStage(otherReviewers(db, p.proposer_agent, agents).length);
+    const reviseStage = firstReviewStage(otherTeamMembers(db, p.proposer_agent, agents).length);
     const proposerFollowup = createLinkedFollowup(db, p, "revise_requested", spec.owner, spec.title, spec.description, spec.body);
     const coordOwner = coordinatorOwner(db, agents, p.proposer_agent);
     if (coordOwner !== spec.owner) {
@@ -713,7 +726,7 @@ export function sweepStaleProposals(
     try {
       db.transaction(() => {
         if (row.status === "draft" || row.status === "revise_requested") {
-          const stage = firstReviewStage(otherReviewers(db, row.proposer_agent, agents).length);
+          const stage = firstReviewStage(otherTeamMembers(db, row.proposer_agent, agents).length);
           const r = tryAutoAdvance(db, row.id, row.status, stage, agents, { reason: "sweeper: 정체 제안 자동 제출" });
           if (r.advanced) {
             out.advanced.push(row.id);
@@ -841,7 +854,7 @@ export function createProposalRoutes(deps: ProposalRouteDeps): Hono {
         // (B, GD 2026-07-04): 생성 성공 = 곧 제출. 품질 하한선(근거+예상효과)이 이미 미완성을 막으므로
         // draft에 고이지 않고 팀 규모별 첫 리뷰 단계로 자동 진입(+담당자 배정/wake). 사람이 버튼 누를 필요 없음.
         const proposer = String(body.proposer_agent ?? "").trim();
-        const stage = firstReviewStage(otherReviewers(deps.db, proposer, agents).length);
+        const stage = firstReviewStage(otherTeamMembers(deps.db, proposer, agents).length);
         const auto = tryAutoAdvance(deps.db, proposalId, "draft", stage, agents);
         return { ok: true as const, id: proposalId, stage, advanced: auto.advanced, followup: auto.followup };
       });

--- a/src/server/routes/proposals.ts
+++ b/src/server/routes/proposals.ts
@@ -93,7 +93,7 @@ function noticeSummaryText(summary: string): string {
   return oneLine.length <= 160 ? oneLine : `${oneLine.slice(0, 157)}...`;
 }
 
-function existingAgent(db: Database, id: string): boolean {
+export function existingAgent(db: Database, id: string): boolean {
   return Boolean(db.prepare("SELECT 1 FROM agent WHERE id = ?").get(id));
 }
 
@@ -172,7 +172,9 @@ export function coordinatorOwner(db: Database, agents: AgentRecord[], proposer: 
   const coord = coordinatorId(agents);
   if (coord && existingAgent(db, coord)) return coord;
   if (existingAgent(db, proposer)) return proposer;
-  return otherReviewers(db, proposer, agents).find((id) => id !== exclude) ?? proposer;
+  // 남은 후보가 없으면 exclude 를 그대로 돌려준다. 여기까지 왔다는 건 제안자가 DB 에 없다는 뜻이라,
+  // 제안자를 넣으면 ★존재하지 않는 사람★ 이 담당이 된다 — 무응답이어도 실재하는 사람이 낫다.
+  return otherReviewers(db, proposer, agents).find((id) => id !== exclude) ?? exclude ?? proposer;
 }
 
 // peer_review 담당 = 제안자 제외 후보 중 열린/최근 배정이 가장 적은 1명.
@@ -772,15 +774,19 @@ export function sweepStaleProposals(
                 SET owner = ?,
                     description = description || char(10)
                       || 'blocked: peer review 미확보 — 후보를 모두 돌았으나 리뷰 0건.' || char(10)
-                      || '다음 행동: 리뷰할 팀원을 직접 지정하거나, 제안을 접을지 판단한다.' || char(10)
-                      || '판단 기준: 팀 전체의 이슈가 아니거나 개인 수준의 learning 이면 드랍한다.',
+                      || ?,
                     updated_at = datetime('now')
               WHERE id IN (
                 SELECT task_id FROM proposal_followup_task
                  WHERE proposal_id = ? AND status LIKE ? AND closed_at IS NULL
               )`,
           );
-          const cardChanges = cardUpdate.run(rescuer, row.id, `${row.status}:%`).changes ?? 0;
+          // 조율자도 제안자도 DB 에 없어 담당이 그대로면(명부와 DB 어긋남), 다음 행동이 아니라
+          // 그 사실을 적어야 사람이 고칠 수 있다. 조율자가 마침 그 담당인 정상 경우와 구분된다.
+          const nextAction = rescuer === stalled && !existingAgent(db, row.proposer_agent)
+            ? "담당 없음 — 팀 명부와 DB 가 어긋나 있다. 명부를 맞춘 뒤 리뷰어를 지정한다."
+            : `다음 행동: 리뷰할 팀원을 직접 지정하거나, 제안을 접을지 판단한다.\n판단 기준: 팀 전체의 이슈가 아니거나 개인 수준의 learning 이면 드랍한다.`;
+          const cardChanges = cardUpdate.run(rescuer, nextAction, row.id, `${row.status}:%`).changes ?? 0;
           const ledgerChanges = db.prepare(
             `UPDATE proposal_followup_task
                 SET owner = ?

--- a/src/server/routes/proposals.ts
+++ b/src/server/routes/proposals.ts
@@ -159,6 +159,10 @@ function isTestProposalFixture(p: { title?: string | null; source?: string | nul
   return isTestProposalTitle(p.title) || isTestProposalSource(p.source);
 }
 
+// 통과 판정 기준. 리뷰 요청과 조율자 카드가 같은 문구를 쓴다 — 기준이 없으면 통과가 기본값이 된다.
+const REVIEW_CRITERIA =
+  `1) 정말 팀에 필요한가?\n2) 팀 전체의 공통 이슈인가?\n3) 팀원 개인 수준의 learning인가?`;
+
 // 팀장 보고/조율 owner = coordinator(PM 역량) 우선 → 제안자 → 첫 후보 순 폴백(하드코딩 id 없음).
 function coordinatorOwner(db: Database, agents: AgentRecord[], proposer: string): string {
   const coord = coordinatorId(agents);
@@ -448,7 +452,7 @@ function ensureProposalFollowup(db: Database, proposalId: string, status: string
           `대상: ${p.title}\nID: ${p.id}\n` +
           `역할: reviewer(${owner})\n` +
           `해야 할 일: 팀장 보고 전에 아래 기준으로 실제 리스크와 개선점을 포함해 review를 남겨 주세요.\n` +
-          `1) 정말 팀에 필요한가?\n2) 팀 전체의 공통 이슈인가?\n3) 팀원 개인 수준의 learning인가?\n` +
+          `${REVIEW_CRITERIA}\n` +
           `팀 공통 제안이 아니거나 개인 learning이면 reject(drop)하고 사유를 남겨 주세요.`,
       ));
     return { owner: followups.map((f) => f.owner).join(","), taskId: followups[0]?.taskId, messageId: followups[0]?.messageId };
@@ -747,17 +751,31 @@ export function sweepStaleProposals(
         }
         // 2차: 여전히 무응답이어도 리뷰 게이트는 건너뛰지 않는다.
         // 팀장 결정 화면에 무검토 제안을 올리는 대신 현재 단계에서 blocked로 남긴다.
+        //
+        // 그리고 카드를 coordinator 에게 넘긴다. blocked 표시만 하고 소유자를 그대로 두면
+        // 그 소유자는 이미 두 번 무응답한 사람이고, 아무도 이 제안을 풀어줄 책임을 지지 않는다.
+        // 막아두는 것과 멈춰두는 것은 다르다 — 막은 뒤에는 누군가 다음 행동을 해야 한다.
         const blockKey = `sweeper_blocked:${row.id}:${row.status}:${round}`;
         if (claimAutomationAction(db, blockKey, row.id, "sweeper_blocked")) {
+          const rescuer = coordinatorOwner(db, agents, row.proposer_agent);
           db.prepare(
             `UPDATE task
-                SET description = description || char(10) || 'blocked: peer review 미확보',
+                SET owner = ?,
+                    description = description || char(10)
+                      || 'blocked: peer review 미확보 — 후보를 모두 돌았으나 리뷰 0건.' || char(10)
+                      || '다음 행동: 리뷰할 팀원을 직접 지정하거나, 제안을 접을지 판단한다.' || char(10)
+                      || '판단 기준: 팀 전체의 이슈가 아니거나 개인 수준의 learning 이면 드랍한다.',
                     updated_at = datetime('now')
               WHERE id IN (
                 SELECT task_id FROM proposal_followup_task
                  WHERE proposal_id = ? AND status LIKE ? AND closed_at IS NULL
               )`,
-          ).run(row.id, `${row.status}:%`);
+          ).run(rescuer, row.id, `${row.status}:%`);
+          db.prepare(
+            `UPDATE proposal_followup_task
+                SET owner = ?
+              WHERE proposal_id = ? AND status LIKE ? AND closed_at IS NULL`,
+          ).run(rescuer, row.id, `${row.status}:%`);
           out.blocked.push(row.id);
         }
       })();


### PR DESCRIPTION
리뷰 0건인 제안이 팀장 보고 단계로 올라가던 경로를 막고, 막힌 뒤 다음 행동의 주체를 정한다.
#183(codex) 을 기준으로 하고 #184(lisa) 의 조율자 출구를 얹었다.

## 문제

1. peer 리뷰어가 무응답이면 후보를 재배정하다가, 후보가 비면 리뷰 0건인 채로 `gd_report` 로 넘어갔다.
2. 리뷰 요청이 무작위로 배정돼 같은 사람에게 몰렸다.
3. 후보를 모두 돌아 `blocked` 로 유지될 때, 후속 카드의 owner 가 방금 무응답한 리뷰어 그대로였다.

## 왜 그렇게 되나

- 후보 수만 보고 단계를 정하면, 후보가 `blocked` 라 잠깐 빈 상태와 1인 팀이 같은 값으로 읽힌다.
- 배정에 `Math.random` 을 쓰면 부하가 고르게 퍼지지 않는다.
- `blocked` 는 상태만 바꾸고 카드 owner 는 그대로 둔다. 카드가 남아도 행동할 사람이 없다.

## 고친 것

- 판정과 DB 가드 두 층에서 리뷰 0건의 `gd_report` 승격을 막는다.
- `blocked` 인 리뷰어가 있으면 "1인 팀" 으로 판정하지 않고 다음 tick 에 다시 본다.
- 배정을 `proposalId` 기반으로 바꾼다. 재배정 시 대기 시계를 초기화한다.
- `blocked` 시 카드 owner 를 coordinator 로 재배정하고, 다음 행동과 드랍 판단 기준을 카드에 적는다.
- 통과 판정 기준을 상수로 묶어 리뷰 요청 본문과 카드가 같은 문구를 쓴다.

## 검증

- `bun test src/server src/web` — 2075 pass / 0 fail. `tsc --noEmit` 0.
- 회귀 테스트는 조율자만 바꿔 같은 시나리오를 두 번 돌린다. 배정이 결정적이라 재배정이 없으면 두 번 모두 같은 사람이 남는다.
- 변이 3종 — 재배정 제거 · 조율자 대신 제안자 · 문구 제거 — 모두 테스트가 잡는다.

## 알아둘 것

`untried` 검사가 claim 보다 앞이라는 조건 순서는 테스트로 고정되어 있지 않다.
현재는 `review_missing` 카드가 tried 집합에 잡혀 키가 달라지므로 두 순서의 동작이 같다.

Co-authored-by: lisa <lisa@b3rys.local>
