### PR TITLE
feat(codex cli): 승인 지문에 내용을 담는다 — 이름만 보면 바꿔치기를 못 잡는다 (#106 S4)

### DIFF
--- a/src/server/runtimes/codex/appServerPopup.opHash.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.opHash.test.ts
@@ -123,6 +123,28 @@ describe("갭2 닫힘 — 같은 파일이라도 내용이 다르면 지문이 �
     expect(approvalOperationHash(a)).toBe(approvalOperationHash(b));
   });
 
+  test("★빈 파일도 '아는 내용' 이다★ — 빈 파일 생성과 빈 파일 삭제는 다른 작업이다", () => {
+    // ★코덱스 리뷰 P1(재현 확인).★ 길이로 "내용을 얻었나" 를 재면 ★정상적인 빈 파일 작업이 '모름' 과 합쳐진다.★
+    // basis.files 에는 kind 가 없어서 그 둘을 갈라줄 다른 재료도 없었다 → 같은 지문이 됐다.
+    const addEmpty = oldGen({ "a.ts": { type: "add", content: "" } });
+    const delEmpty = oldGen({ "a.ts": { type: "delete", content: "" } });
+    expect(approvalOperationHash(addEmpty)).not.toBe(approvalOperationHash(delEmpty));
+  });
+
+  test("★'비어 있다' 와 '모른다' 는 다르다★ — 내용 필드가 아예 없는 것과 구분된다", () => {
+    const known = oldGen({ "a.ts": { type: "add", content: "" } });   // 빈 파일을 만든다(아는 것)
+    const unknown = oldGen({ "a.ts": { type: "add" } });               // 내용 필드가 없다(모르는 것)
+    expect(approvalOperationHash(known)).not.toBe(approvalOperationHash(unknown));
+  });
+
+  test("모르는 종류에서 필드 우선순위를 고정한다 — 먼저 선언된 쪽을 믿는다", () => {
+    // 비차단 지적(코덱스): type 없음 + unified_diff:"" + content:"X" 에서 ★빈 diff 가 X 를 가린다.★
+    // 그게 의도인지 사고인지 코드만 봐선 모르므로 ★계약으로 못박는다★ — 종류를 모를 때는 unified_diff 를 먼저 본다.
+    const a = oldGen({ "a.ts": { unified_diff: "", content: "X" } });
+    const b = oldGen({ "a.ts": { unified_diff: "", content: "Y" } });
+    expect(approvalOperationHash(a)).toBe(approvalOperationHash(b)); // content 는 안 본다
+  });
+
   test("★내용을 모르면 지문을 바꾸지 않는다★ — 구세대 golden 이 그대로여야 한다", () => {
     // 내용 없는 payload 에 빈 문자열을 해시하면 "내용을 안다" 는 거짓 신호가 되고 골든도 깨진다.
     expect(approvalOperationHash(oldGen({ "b.ts": {}, "a.ts": {} }))).toBe("c7fa63459c642993");

--- a/src/server/runtimes/codex/appServerPopup.opHash.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.opHash.test.ts
@@ -104,6 +104,25 @@ describe("갭2 닫힘 — 같은 파일이라도 내용이 다르면 지문이 �
     expect(approvalOperationHash(added)).not.toBe(approvalOperationHash(updated));
   });
 
+  test("★신세대도 종류가 지문에 들어간다★ — 같은 파일·같은 내용이라도 add 와 update 는 다르다", () => {
+    // ★뮤턴트가 살아남아 추가했다(M3).★ 앞 시험은 구세대만 봐서, 신세대 kind 를 상수로 바꿔도 초록이었다.
+    const req = (kind: string): ApprovalRequest => ({
+      method: "item/fileChange/requestApproval",
+      params: { itemId: "i1", turnId: "t1" },
+      observedItem: { itemId: "i1", turnId: "t1", threadId: "th", changes: [{ path: "a.ts", kind, movePath: null, diff: "x\n" }] },
+    });
+    expect(approvalOperationHash(req("add"))).not.toBe(approvalOperationHash(req("update")));
+  });
+
+  test("★종류와 필드가 어긋나면 내용을 안 읽는다★ — 엉뚱한 값을 지문에 넣지 않는다", () => {
+    // ★뮤턴트가 살아남아 추가했다(M4).★ 앞 시험은 kind 가 달라서 통과했고, ★필드 선택 자체는 재지 않았다.★
+    // update 인데 content 만 있는 payload 는 ★내용을 모르는 것★ 으로 본다(S3 에서 표시 쪽에 한 정정과 같다).
+    // 그러므로 content 가 A 든 B 든 지문이 같아야 한다 — 다르면 없는 내용을 읽고 있다는 뜻이다.
+    const a = oldGen({ "a.ts": { type: "update", content: "AAA" } });
+    const b = oldGen({ "a.ts": { type: "update", content: "BBB" } });
+    expect(approvalOperationHash(a)).toBe(approvalOperationHash(b));
+  });
+
   test("★내용을 모르면 지문을 바꾸지 않는다★ — 구세대 golden 이 그대로여야 한다", () => {
     // 내용 없는 payload 에 빈 문자열을 해시하면 "내용을 안다" 는 거짓 신호가 되고 골든도 깨진다.
     expect(approvalOperationHash(oldGen({ "b.ts": {}, "a.ts": {} }))).toBe("c7fa63459c642993");

--- a/src/server/runtimes/codex/appServerPopup.opHash.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.opHash.test.ts
@@ -56,16 +56,56 @@ describe("알려진 갭 (후속 작업에서 닫히면 이 테스트가 실패�
     expect(scopeKeyForOperation(safe)).toBe(scopeKeyForOperation(evil));
   });
 
-  test("갭2: 파일 이름이 같으면 ★내용이 달라도★ 지문이 같다", () => {
-    // basis의 files가 Object.keys()라 이름만 담는다 → 승인과 실행 사이 내용 변경을 구분하지 못한다.
-    const before: ApprovalRequest = {
+});
+
+/**
+ * ★갭2 는 닫혔다 (S4, 2026-07-31).★ 지문 basis 에 ★내용 해시★ 를 넣었다.
+ *
+ * ■ ★옛 테스트가 틀린 모양을 쓰고 있었다★ — 이걸 먼저 적는다
+ * 예전 갭2 테스트는 `fileChanges: { "a.ts": { diff: "..." } }` 로 갭을 보였다.
+ * 그런데 ★벤더 스키마에 `diff` 라는 필드는 없다★ (0.144.6 실측:
+ * AddFileChange{content} · DeleteFileChange{content} · UpdateFileChange{unified_diff, move_path}).
+ * 즉 ★실제로는 올 수 없는 입력으로 갭을 증명하고 있었다.★ 그래서 S4 를 구현한 뒤에도
+ * 그 테스트는 ★초록 그대로였다★ — "갭이 닫히면 빨강이 된다" 는 완료 신호가 작동하지 않았다.
+ * ★모양을 지어내면 시험은 통과하고 실물에서 틀린다★ — 오늘 반복해서 만난 형태다.
+ * → 실제 모양으로 다시 쓰고, 이제 ★갭이 닫혔다는 단언★ 으로 뒤집는다.
+ */
+describe("갭2 닫힘 — 같은 파일이라도 내용이 다르면 지문이 다르다 (S4)", () => {
+  const oldGen = (fileChanges: unknown): ApprovalRequest => ({
+    method: "applyPatchApproval",
+    params: { fileChanges, callId: "c1" },
+  });
+
+  test("★구세대: 내용만 달라도 지문이 갈린다★ — 승인과 실행 사이 바꿔치기를 상관키가 구분한다", () => {
+    const before = oldGen({ "a.ts": { type: "update", unified_diff: "export const x = 1;" } });
+    const after = oldGen({ "a.ts": { type: "update", unified_diff: "process.exit(1);" } });
+    expect(approvalOperationHash(before)).not.toBe(approvalOperationHash(after));
+  });
+
+  test("★신세대: 관측한 내용이 다르면 지문이 갈린다★ (payload 에는 내용이 없다 — 색인해 둔 것을 쓴다)", () => {
+    const req = (diff: string): ApprovalRequest => ({
       method: "item/fileChange/requestApproval",
-      params: { fileChanges: { "a.ts": { diff: "export const x = 1;" } } },
-    };
-    const after: ApprovalRequest = {
-      method: "item/fileChange/requestApproval",
-      params: { fileChanges: { "a.ts": { diff: "process.exit(1);" } } },
-    };
-    expect(approvalOperationHash(before)).toBe(approvalOperationHash(after));
+      params: { itemId: "i1", turnId: "t1" },
+      observedItem: { itemId: "i1", turnId: "t1", threadId: "th", changes: [{ path: "a.ts", kind: "update", movePath: null, diff }] },
+    });
+    expect(approvalOperationHash(req("@@ -1 +1 @@\n-a\n+b\n")))
+      .not.toBe(approvalOperationHash(req("@@ -1 +1 @@\n-a\n+DANGER\n")));
+  });
+
+  test("같은 내용이면 같은 지문이다 — 갈라지기만 하면 되는 게 아니다", () => {
+    const one = oldGen({ "a.ts": { type: "add", content: "hello\n" } });
+    const two = oldGen({ "a.ts": { type: "add", content: "hello\n" } });
+    expect(approvalOperationHash(one)).toBe(approvalOperationHash(two));
+  });
+
+  test("★종류가 다르면 다른 작업이다★ — 같은 내용을 add 하는 것과 update 하는 것은 같지 않다", () => {
+    const added = oldGen({ "a.ts": { type: "add", content: "x\n" } });
+    const updated = oldGen({ "a.ts": { type: "update", unified_diff: "x\n" } });
+    expect(approvalOperationHash(added)).not.toBe(approvalOperationHash(updated));
+  });
+
+  test("★내용을 모르면 지문을 바꾸지 않는다★ — 구세대 golden 이 그대로여야 한다", () => {
+    // 내용 없는 payload 에 빈 문자열을 해시하면 "내용을 안다" 는 거짓 신호가 되고 골든도 깨진다.
+    expect(approvalOperationHash(oldGen({ "b.ts": {}, "a.ts": {} }))).toBe("c7fa63459c642993");
   });
 });

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -105,11 +105,14 @@ export function approvalOperationHash(req: ApprovalRequest): string {
  */
 function approvalContentDigest(req: ApprovalRequest): string | null {
   const p = req.params as Record<string, any>;
-  const rows: Array<[string, string, string | null, string]> = [];
+  // ★body 는 string | null 이다 — ""(빈 내용을 안다) 와 null(내용을 모른다) 은 다른 상태다.★
+  //   앞선 판은 둘을 "" 하나로 합쳐서 ★빈 파일 생성과 빈 파일 삭제가 같은 지문★ 이었다(코덱스 리뷰 P1, 재현 확인).
+  //   basis.files 에는 kind 가 없으므로 그 둘을 갈라줄 다른 재료도 없었다.
+  const rows: Array<[string, string, string | null, string | null]> = [];
 
-  // 신세대 — 관측해 둔 변경(내용 포함)
+  // 신세대 — 관측해 둔 변경(내용 포함). 관측이 있으면 그 내용은 ★아는 것★ 이다(빈 문자열도 포함).
   for (const c of req.observedItem?.changes ?? []) {
-    rows.push([c.path, c.kind, c.movePath, c.diff]);
+    rows.push([c.path, c.kind, c.movePath, typeof c.diff === "string" ? c.diff : null]);
   }
   // 구세대 — payload 안에 내용이 있다
   const fc = p?.fileChanges;
@@ -120,18 +123,22 @@ function approvalContentDigest(req: ApprovalRequest): string | null {
       const mv = typeof ch.move_path === "string" && ch.move_path.trim() ? ch.move_path : null;
       // ★종류에 맞는 필드만 본다★ — 짝이 어긋난 payload 에서 엉뚱한 값을 지문에 넣지 않기 위해서다
       //   (S3 에서 표시 쪽에 같은 정정을 했다: 재료를 고르는 기준과 쓰는 기준이 달라 규모를 지어냈다).
+      //   ★필드가 없으면 null★ — "내용이 비어 있다" 가 아니라 "내용을 모른다" 다.
       const body =
         kind === "update"
-          ? typeof ch.unified_diff === "string" ? ch.unified_diff : ""
+          ? typeof ch.unified_diff === "string" ? ch.unified_diff : null
           : kind === "add" || kind === "delete"
-            ? typeof ch.content === "string" ? ch.content : ""
-            : typeof ch.unified_diff === "string" ? ch.unified_diff : typeof ch.content === "string" ? ch.content : "";
+            ? typeof ch.content === "string" ? ch.content : null
+            // 모르는 종류만 휴리스틱 — 있는 쪽을 쓴다. ★빈 문자열도 '있는 것' 으로 센다★
+            //   (unified_diff:"" 가 content:"X" 를 가리는 것은 의도된 우선순위다: 종류를 모를 때
+            //    먼저 선언된 필드를 믿는다. 시험으로 고정한다.)
+            : typeof ch.unified_diff === "string" ? ch.unified_diff : typeof ch.content === "string" ? ch.content : null;
       rows.push([path, kind, mv, body]);
     }
   }
-  // ★내용을 하나도 못 얻었으면 null★ — 이름만 아는 상태에서 빈 문자열을 해시하면
-  //   "내용을 안다" 는 거짓 신호가 되고, 구세대 골든 지문도 바뀐다.
-  if (!rows.some((r) => r[3].length > 0)) return null;
+  // ★하나라도 '아는' 내용이 있으면 지문화한다★ — 길이가 아니라 ★null 여부★ 로 판정한다.
+  //   길이로 재면 ★빈 파일 작업이 "모름" 과 합쳐진다★(P1). 아무것도 모르면 키를 안 붙여 구세대 골든을 지킨다.
+  if (!rows.some((r) => r[3] !== null)) return null;
   rows.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
   return createHash("sha256").update(JSON.stringify(rows)).digest("hex").slice(0, 16);
 }

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -80,7 +80,60 @@ export function approvalOperationHash(req: ApprovalRequest): string {
   if (itemId) basis.item_id = itemId;
   const grantRoot = grantRootOf(p);
   if (grantRoot) basis.grant_root = grantRoot;
+  // ★S4 — 내용까지 담는다.★ 여기까지의 basis 는 파일 ★이름★ 만 담아서, 같은 파일을 고치는 두 요청이
+  //   ★내용이 전혀 달라도 같은 지문★ 이었다(알려진 갭 #2 — 테스트로 못박아 뒀던 것).
+  //   상관키가 ★결정↔요청을 1:1로 맞추는 것★ 이 이 지문의 일인데, 이름만 보면
+  //   ★다른 작업의 승인이 이 슬롯에 배달되는 것★ 을 못 막는다.
+  //   ★있을 때만 넣는다★ — 무조건 키를 추가하면 null 로라도 직렬화에 끼어들어 ★구세대 지문 값이 바뀐다★
+  //   (진행 중 승인의 상관키가 어긋난다). S2 에서 item_id·grant_root 에 쓴 것과 같은 규칙이다.
+  const contentDigest = approvalContentDigest(req);
+  if (contentDigest) basis.content = contentDigest;
   return createHash("sha256").update(JSON.stringify(basis)).digest("hex").slice(0, 16);
+}
+
+/** 승인 요청이 실제로 바꾸려는 ★내용★ 의 지문. 내용을 모르면 null(그러면 basis 에 키가 안 붙는다).
+ *
+ *  ■ 어디서 내용을 얻나 — 세대마다 다르다(둘 다 실측)
+ *    구세대 `fileChanges` : `{type:"update", unified_diff}` · `{type:"add"|"delete", content}` (+`move_path`)
+ *    신세대               : payload 에 내용이 ★없다.★ 알림으로 먼저 온 것을 색인한 `observedItem` 에 있다.
+ *
+ *  ■ ★전문이 아니라 해시만 담는다★ — 지문은 "같은가 다른가" 만 답하면 되고,
+ *    전문을 basis 에 넣으면 큰 diff 마다 직렬화가 커진다.
+ *
+ *  ■ ★종류·이동 목적지도 함께 담는다★ — 같은 내용을 add 하는 것과 update 하는 것은 다른 작업이고,
+ *    옮기는 목적지가 다른 것도 다른 작업이다(S2·S3 에서 열쇠에 대해 배운 것과 같은 이유).
+ */
+function approvalContentDigest(req: ApprovalRequest): string | null {
+  const p = req.params as Record<string, any>;
+  const rows: Array<[string, string, string | null, string]> = [];
+
+  // 신세대 — 관측해 둔 변경(내용 포함)
+  for (const c of req.observedItem?.changes ?? []) {
+    rows.push([c.path, c.kind, c.movePath, c.diff]);
+  }
+  // 구세대 — payload 안에 내용이 있다
+  const fc = p?.fileChanges;
+  if (fc && typeof fc === "object" && !Array.isArray(fc)) {
+    for (const [path, raw] of Object.entries(fc)) {
+      const ch = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+      const kind = typeof ch.type === "string" && ch.type ? ch.type : "change";
+      const mv = typeof ch.move_path === "string" && ch.move_path.trim() ? ch.move_path : null;
+      // ★종류에 맞는 필드만 본다★ — 짝이 어긋난 payload 에서 엉뚱한 값을 지문에 넣지 않기 위해서다
+      //   (S3 에서 표시 쪽에 같은 정정을 했다: 재료를 고르는 기준과 쓰는 기준이 달라 규모를 지어냈다).
+      const body =
+        kind === "update"
+          ? typeof ch.unified_diff === "string" ? ch.unified_diff : ""
+          : kind === "add" || kind === "delete"
+            ? typeof ch.content === "string" ? ch.content : ""
+            : typeof ch.unified_diff === "string" ? ch.unified_diff : typeof ch.content === "string" ? ch.content : "";
+      rows.push([path, kind, mv, body]);
+    }
+  }
+  // ★내용을 하나도 못 얻었으면 null★ — 이름만 아는 상태에서 빈 문자열을 해시하면
+  //   "내용을 안다" 는 거짓 신호가 되고, 구세대 골든 지문도 바뀐다.
+  if (!rows.some((r) => r[3].length > 0)) return null;
+  rows.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  return createHash("sha256").update(JSON.stringify(rows)).digest("hex").slice(0, 16);
 }
 
 const POPUP_TTL_MS = Number(process.env.B3OS_CODEX_APPSERVER_POPUP_TTL_MS ?? 60 * 60 * 1000); // 1h (GD: 무응답→hold)


### PR DESCRIPTION
## 핵심 3줄

1. 승인 지문(`approvalOperationHash`)이 파일 **이름**만 담아, 같은 파일을 고치는 두 요청이 **내용이 달라도 같은 지문**이었다.
2. 이 지문의 일은 **결정↔요청을 1:1로 맞추는 것**이다. 이름만 보면 **다른 작업의 승인이 이 슬롯에 배달되는 것**을 못 막는다. 플래그는 꺼져 있어 라이브 영향은 없다.
3. basis 에 **내용 해시**를 추가 — 소스 `+62/−7`, 테스트 `+92/−13`.

## 무엇을 바꿨나

| 문제 | 고친 방법 |
|---|---|
| 이름만 담아 내용이 달라도 같은 지문 | basis 에 내용 해시 추가(전문 아님) + 종류·이동 목적지 포함 |
| 신세대는 payload 에 내용이 없다 | 알림으로 색인해 둔 `observedItem` 에서 읽는다 |
| 종류와 필드가 어긋난 payload | 종류에 맞는 필드만 본다(`update`=`unified_diff` · `add`/`delete`=`content`) |
| 빈 파일 작업이 '내용 모름' 과 같은 지문 | body 를 `string \| null` 로 분리 — `""`(안다)와 `null`(모른다)를 구분 |
| 내용을 모르는 요청까지 지문이 바뀌면 진행 중 승인의 상관키가 어긋난다 | 전부 `null` 이면 키를 안 붙인다 → 구세대 golden 유지 |

---

## 실측 근거

수정 전 — 세 경우가 한 지문이었다:

```
{type:"add",    content:""}   빈 파일 생성    → da4fa9100c0e7333
{type:"delete", content:""}   빈 파일 삭제    → da4fa9100c0e7333
{type:"add"}                  내용 필드 없음  → da4fa9100c0e7333
```

수정 후 — `88d865a2…` / `c98185181…` / `da4fa910…` 셋 다 갈린다.

내용이 다른 같은 파일도 갈린다(구세대·신세대 각각 확인). 구세대 golden `c7fa63459c642993` 은 그대로다.

## 검증

- 신규 10건 · 폐기 1건 → codex 241 pass 0 fail
- 전체 **2146 pass 0 fail** / 베이스라인(41ccb67 별도 워크트리) **2137** — 델타는 신규−폐기와 일치, 회귀 0
- `tsc` 0
- 뮤턴트 7종 전부 사망: 내용 지문 제거 · 내용 없어도 키 부착 · 신세대 kind 상수화 · 구세대 필드선택 종류무관 · 길이 판정 복원 · 미존재 필드를 빈 문자열로 · 모르는 종류 우선순위 뒤집기
- 플래그 `B3OS_CODEX_APPSERVER` OFF · 격리 워크트리에서만 작업

## 남은 것

갭1(240자 절단으로 **명령 경로** scope 충돌)은 그대로 — S5. 쓰기 경로는 S3 에서 닫혔다.
S5 는 공용 `lib/permissionGate` 에 손이 가므로 착수 전 팀 리드 승인이 필요하다. 선결 조건 실측: `permission_grant` **0행**(무효화될 grant 없음).

Reviewed-by: codex
Submitted-by: demis