### PR TITLE
fix(scheduler): 주간 루프가 시키는 방법 세 가지가 실제로는 실패했다

### DIFF
--- a/src/server/scheduler/core.test.ts
+++ b/src/server/scheduler/core.test.ts
@@ -81,14 +81,29 @@ describe("b3os scheduler core", () => {
       fallbackCapability: "coordinator",
       threadId: "weekly-shared-curation",
     });
-    expect(JSON.parse(first[0]!.payload_json).body).toContain("proposal 등록 세션이 아닙니다");
+    const curationBody = JSON.parse(first[0]!.payload_json).body as string;
+    expect(curationBody).toContain("proposal 등록 세션이 아닙니다");
+    // rules/SHARED.md 는 gitignore 대상이라 커밋할 수 없다. 예전 문구("중앙 … 에 올립니다")를
+    // 두 사람이 각각 "PR 로 올린다" 로 읽어 막혔다 → 방법을 문장에 박았는지 고정한다.
+    expect(curationBody).toContain("커밋도 PR 도 하지 마세요");
+
     expect(JSON.parse(first[1]!.payload_json)).toMatchObject({
       type: "capability_workloop",
       capability: "coordinator",
       fallbackCapability: "learning_loop_pm",
       threadId: "weekly-self-learning",
     });
-    expect(JSON.parse(first[1]!.payload_json).body).toContain("POST /api/proposals");
+    const learningBody = JSON.parse(first[1]!.payload_json).body as string;
+    // 라우터는 /team 아래에 붙는다. "POST /api/proposals" 로 시키면 404 가 난다.
+    expect(learningBody).toContain("POST /team/api/proposals");
+    expect(learningBody).not.toMatch(/등록 방법: POST \/api\/proposals/);
+
+    // 두 루프 다 보고 경로가 런타임별로 갈린다는 것을 말해야 한다. 예전처럼
+    // "send.sh --direct-to-gd" 만 적으면 발신자가 system 이라 서버가 거부한다.
+    for (const body of [curationBody, learningBody]) {
+      expect(body).toContain("보고 경로는 런타임마다 다릅니다");
+      expect(body).not.toMatch(/정리 보고: send\.sh --direct-to-gd\./);
+    }
   });
 
   test("weekly learning reconciles config drift on existing jobs", () => {

--- a/src/server/scheduler/core.ts
+++ b/src/server/scheduler/core.ts
@@ -65,21 +65,44 @@ export const WEEKLY_SHARED_CURATION_JOB_ID = "sched_weekly_shared_curation";
 export const WEEKLY_SELF_LEARNING_JOB_ID = "sched_weekly_self_learning_session";
 export const WEEKLY_SHARED_CURATION_CRON = "0 4 * * 5";
 export const WEEKLY_SELF_LEARNING_CRON = "0 5 * * 5";
+// 보고 경로 — 두 루프가 같은 문구를 쓴다.
+//
+// 예전에는 "send.sh --direct-to-gd" 한 줄이었는데 ★그대로 하면 실패한다★(2026-07-31 실측).
+// --direct-to-gd 는 --to <요청자> 를 함께 요구하는데, 이 알림의 발신자는 `system` 이고
+// 서버는 system 을 수신자로 받지 않는다(`not_a_recipient`). 즉 시킨 대로 하면 400 이 난다.
+// 게다가 claude 계열 런타임은 팀장 1:1 이 텔레그램이라 send.sh 자체가 그 자리에 맞지 않는다.
+const WORKLOOP_REPORT_LINE = [
+  "★완료 후 GD 에게 직접 보고하세요.★ 보고 경로는 런타임마다 다릅니다 —",
+  "  claude 계열은 자기 텔레그램 1:1 reply 도구, 그 외는 send.sh --to <요청자> --direct-to-gd.",
+  "  (이 알림은 발신자가 system 이라 send.sh --to system 은 서버가 거부합니다.",
+  "   1:1 로 보고했으면 마감 알림은 무시하세요 — 서버는 1:1 DM 을 보지 못합니다.)",
+].join("\n");
+
 export const WEEKLY_SHARED_CURATION_BODY = [
   "[workloop: SHARED.md 미팅 · 금 04:00 KST]",
   "b3os-task-loop의 scheduled workloop 계약으로 이번 세션을 오픈→수집·정리→보고→닫기까지 한 턴에 수행하세요.",
-  "목적: 지난 1주 팀원들이 실제 작업에서 겪은 것 중 '팀 지식'으로 남길 만한 것을 중앙 rules/SHARED.md 에 올립니다(수집·정리). 팀원 주중 메모/교훈 취합해 수록 + 완료·확정 항목 정돈·중복 정리.",
+  "목적: 지난 1주 팀원들이 실제 작업에서 겪은 것 중 '팀 지식'으로 남길 만한 것을 rules/SHARED.md 에 기록합니다(수집·정리). 팀원 주중 메모/교훈 취합해 수록 + 완료·확정 항목 정돈·중복 정리.",
+  // "중앙 … 에 올립니다" 였는데 수집 담당과 팀원이 각각 그걸 "PR 로 올린다" 로 읽었다(2026-07-31).
+  // rules/SHARED.md 는 .gitignore 대상이라 애초에 커밋되지 않는다 → 방법을 문장에 박는다.
+  "★기록 방법: rules/SHARED.md 를 직접 편집합니다. 커밋도 PR 도 하지 마세요★ — 이 파일은 .gitignore 대상(팀 전용 로컬 파일)이라 공개 저장소에 올라가지 않습니다. 공개 템플릿은 rules/SHARED.template.md 입니다.",
   "이 세션은 proposal 등록 세션이 아닙니다. 억지로 만들지 마세요 — 없거나 팀 레벨 교훈이 아니면 스킵, SHARED 에 꾸며 넣지 마세요.",
   "정책·보안·라우팅·외부전송 규칙은 자동 변경 금지.",
-  "★완료 후 GD에게 직접 정리 보고: send.sh --direct-to-gd. 내용 = SHARED.md 에 올린 항목 건수·주요 내용. 없으면 '이번 주 없음' 한 줄.",
+  WORKLOOP_REPORT_LINE,
+  "내용 = SHARED.md 에 올린 항목 건수·주요 내용. 없으면 '이번 주 없음' 한 줄.",
 ].join("\n");
 export const WEEKLY_SELF_LEARNING_BODY = [
   "[workloop: self-learning 세션 · 금 05:00 KST]",
   "b3os-task-loop의 scheduled workloop 계약으로 이번 세션을 오픈→검토→proposal 등록→보고→닫기까지 한 턴에 수행하세요.",
   "목적: SHARED.md(04:00에 정리된 것 포함)와 지난 1주 팀 활동을 검토해, 팀에 필요한 (a)팀 룰 변경 (b)새로운 과제 (c)고쳐야 할 이슈를 뽑아 ★proposal 시스템에 등록★하세요.",
-  "등록 방법: POST /api/proposals — 각 proposal 에 근거(왜)+예상효과 필수. 등록하면 GD 리뷰 게이트로 올라갑니다(자동 적용 아님).",
+  // 라우터가 /api 아래 마운트되고 그 전체가 /team 아래 붙는다 → 실제 경로는 /team/api/proposals.
+  // "POST /api/proposals" 로 적혀 있어서 시킨 대로 하면 404 가 난다(2026-07-31 실측).
+  "★등록 방법: POST /team/api/proposals★ (/api/proposals 는 404 입니다). 각 proposal 에 근거(왜)+예상효과 필수. 등록하면 리뷰 게이트로 올라갑니다(자동 적용 아님).",
+  "★올리기 전에 이 세 가지를 스스로 통과시키세요. 하나라도 아니면 등록하지 마세요:★",
+  "  1. 정말 팀에 필요한 것인가   2. 팀 전체의 이슈인가   3. 팀원 개인 레벨의 러닝이 아닌가",
+  "  규칙으로 써봤을 때 \"잘 확인해라\" 류가 되면 등록하지 마세요 — 그런 규칙은 지켜지지 않습니다. 도구·절차를 고치는 쪽이 실효가 있습니다.",
   "억지로 만들지 마세요 — 진짜 팀에 필요한 것만. 없으면 등록하지 말고 '이번 주 없음'. 정책·보안·라우팅·외부전송 규칙 변경도 proposal 로만(자동 적용 금지).",
-  "★완료 후 GD에게 직접 정리 보고: send.sh --direct-to-gd. 내용 = 등록한 proposal 목록(각 제목·유형[룰/과제/이슈]·근거 한 줄·proposal ID). 없으면 '이번 주 없음' 한 줄.",
+  WORKLOOP_REPORT_LINE,
+  "내용 = 등록한 proposal 목록(각 제목·유형[룰/과제/이슈]·근거 한 줄·proposal ID). 없으면 '이번 주 없음' 한 줄.",
 ].join("\n");
 
 export const DAILY_TASK_REVIEW_PING_JOB_ID = "sched_task_review_ping";


### PR DESCRIPTION
## 핵심 3줄
1. 주간 루프 2개가 시키는 방법 **세 가지가 전부 실패**한다 — 없는 주소, 서버가 거부하는 명령, 불가능한 방법
2. 이 문구는 `scheduler/core.ts` 상수라 **모든 설치본이 같은 지시를 받는다**
3. `ensureCronJob` 이 기존 job 도 재조정하므로, 머지되면 **이미 돌고 있는 팀들도 다음 기동에 고쳐진다**

## 무엇이 틀렸나 (실측)
| 루프가 시킨 것 | 실제 |
|---|---|
| `POST /api/proposals` | **404**. 라우터가 `/team` 아래에 붙어 실제는 `/team/api/proposals` |
| `send.sh --direct-to-gd` 로 보고 | **400 `not_a_recipient`**. 이 플래그는 `--to <요청자>` 를 함께 요구하는데 알림 발신자가 `system` 이고 서버는 `system` 을 수신자로 받지 않는다 |
| SHARED.md 에 "올립니다" | `rules/SHARED.md` 는 `.gitignore` 대상이라 **커밋할 수 없다.** 수집 담당과 팀원이 **각각 독립적으로** 이 문구를 "PR 로 올린다" 로 읽고 막혔다 |

세 번째는 문구가 틀렸다기보다 **방법이 안 적혀 있어 두 사람이 같은 오해**를 했다. 그래서 방법을 문장에 박았다.

## 무엇을 바꿨나
- **등록 주소**를 `/team/api/proposals` 로. 옛 주소가 404 라는 것도 괄호로 남겼다
- **보고 경로**를 런타임별로 갈라 적었다 — claude 계열은 텔레그램 1:1 reply, 그 외는 `send.sh --to <요청자> --direct-to-gd`. 마감 알림이 1:1 보고를 못 본다는 것도 한 줄
- **SHARED.md 기록 방법**을 "직접 편집, 커밋·PR 하지 마세요" 로 명시 + 이유(gitignore)와 공개 템플릿 위치
- self-learning 루프에 **등록 전 3기준**을 넣었다(팀에 필요한가 / 팀 전체 이슈인가 / 개인 러닝 아닌가). 규칙으로 써서 "잘 확인해라" 가 되면 등록하지 말라는 문장도 — 그런 규칙은 지켜지지 않고, 도구·절차를 고치는 쪽이 실효가 있다

동작 코드는 건드리지 않았다. **문자열과 테스트만** 바뀐다.

## 검증
| 항목 | 결과 |
|---|---|
| 전체 | 2127 pass / 4 fail |
| 4 fail | **기준선(origin/main) 동일** — EXAONE 로컬 모델 필요. 이 변경과 무관 |
| 변이 | 등록 주소를 옛 값으로 되돌림 → **치환 적용 확인 후** 실행 → 해당 1건 실패. 사본에서 원복 후 87 pass |
| typecheck | 오류 0 |

기존 테스트가 `toContain("POST /api/proposals")` 로 **틀린 값을 고정**하고 있었다. 올바른 값으로 바꾸고, 옛 값이 다시 들어오지 못하도록 `not.toMatch` 를 함께 넣었다. 보고 문구와 SHARED 기록 방법도 같은 방식으로 고정했다.

## 참고 — 이미 돌고 있는 팀
`ensureCronJob` 은 payload 가 다르면 기존 row 를 UPDATE 한다. 즉 이 PR 이 머지되고 서버가 다시 뜨면 **기존 팀의 job 본문도 자동으로 갱신된다.** 손으로 DB 를 고쳐둔 설치본이 있다면 그것도 이 값으로 수렴한다.

## 롤백
이 커밋 revert. 되돌리면 루프가 다시 404 나는 주소와 거부되는 명령을 시킨다.

Submitted-by: Lisa ✦

