### PR TITLE
feat(scripts): 백업·복원 도구를 저장소에 넣는다 (+ 남의 기계에서 실패하는 것 3건)

### DIFF
--- a/scripts/restore-team.sh
+++ b/scripts/restore-team.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# restore-team.sh — snapshot-team.sh 로 뜬 스냅샷을 새 머신에 풀어 "우리 팀" 복원.
+#   전제: 이 repo(공개 코드)는 이미 clone/build 돼 있다. 스냅샷은 코드엔 없는 ★팀 고유 상태★만 복원한다.
+#   ①트리 gitignored(.env·agents.json·team.db·var·slack-tokens·rules상태) ②멤버 워크스페이스 ③~/.claude/channels ④~/.hermes/profiles auth ⑤launchd plist.
+#   ★안전★: 기존 파일은 덮기 전 .pre-restore-<STAMP> 로 백업. --dry-run 으로 미리 확인.
+# 사용: bash scripts/restore-team.sh <snapshot.tar.gz> [--dry-run]
+#   env override: B3OS_LIVE_DIR(복원 대상 repo, 기본 이 스크립트 repo)
+set -euo pipefail
+
+TARBALL="${1:-}"; DRY=0; [ "${2:-}" = "--dry-run" ] && DRY=1
+[ "${1:-}" = "--dry-run" ] && { DRY=1; TARBALL="${2:-}"; }
+LIVE_DIR="${B3OS_LIVE_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+STAMP="$(date '+%Y%m%d-%H%M%S')"
+say(){ printf "\033[32m%s\033[0m\n" "$1"; }
+warn(){ printf "\033[33m%s\033[0m\n" "$1"; }
+die(){ printf "\033[31m✗ %s\033[0m\n" "$1"; exit 1; }
+
+[ -n "$TARBALL" ] && [ -f "$TARBALL" ] || die "사용: bash scripts/restore-team.sh <snapshot.tar.gz> [--dry-run]"
+gzip -t "$TARBALL" 2>/dev/null || die "손상된 tarball: $TARBALL"
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+tar -xzf "$TARBALL" -C "$WORK"
+SNAP="$(find "$WORK" -maxdepth 1 -type d -name 'b3os-snapshot-*' | head -1)"
+[ -n "$SNAP" ] || die "스냅샷 구조 아님(b3os-snapshot-* 없음)"
+say "■ 복원 소스: $(basename "$TARBALL")  → 대상 repo: $LIVE_DIR"
+[ -f "$SNAP/MANIFEST.txt" ] && sed 's/^/    /' "$SNAP/MANIFEST.txt"
+[ "$DRY" = 1 ] && warn "■ DRY-RUN — 실제로 쓰지 않음. 아래는 복원 예정 항목:"
+
+# 덮기 전 백업 후 복사 (dry-run 이면 계획만 출력)
+place(){ # $1=src(스냅샷 내) $2=dst(실제)
+  [ -e "$1" ] || return 0
+  if [ "$DRY" = 1 ]; then echo "    복원: $2 $([ -e "$2" ] && echo '(기존→.pre-restore-'"$STAMP"' 백업)')"; return 0; fi
+  mkdir -p "$(dirname "$2")"
+  [ -e "$2" ] && mv "$2" "$2.pre-restore-$STAMP"
+  cp -R "$1" "$2"
+}
+
+# ① 트리 gitignored (repo 안으로)
+if [ -d "$SNAP/tree" ]; then
+  for p in .env agents.json team.db var slack-tokens; do place "$SNAP/tree/$p" "$LIVE_DIR/$p"; done
+  for r in STATE.md SHARED.md TEAM-OS.md; do place "$SNAP/tree/rules/$r" "$LIVE_DIR/rules/$r"; done
+  say "  ✓ 트리 gitignored"
+fi
+# ② 멤버 워크스페이스
+if [ -d "$SNAP/home/Development" ]; then
+  for d in "$SNAP/home/Development/"*/; do [ -d "$d" ] && place "$d" "$HOME/Development/$(basename "$d")"; done
+  say "  ✓ 멤버 워크스페이스"
+fi
+# ③ 페어링 ④ hermes auth
+place "$SNAP/home/.claude/channels" "$HOME/.claude/channels"
+place "$SNAP/home/.hermes/profiles" "$HOME/.hermes/profiles"
+say "  ✓ .claude/channels + .hermes/profiles"
+# ⑤ launchd plist (라벨의 user 부분은 새 머신 user 로 치환 필요 — 경고만)
+if [ -d "$SNAP/launchd" ] && [ "$DRY" = 0 ]; then
+  mkdir -p "$HOME/Library/LaunchAgents"
+  for pl in "$SNAP/launchd/"*.plist; do [ -e "$pl" ] && cp "$pl" "$HOME/Library/LaunchAgents/"; done
+  warn "  ⚠ launchd plist 복사됨 — 라벨/경로의 user·홈이 새 머신과 다르면 수정 후 load 필요"
+fi
+
+[ "$DRY" = 1 ] && { say "■ DRY-RUN 종료"; exit 0; }
+say "✓ 복원 완료. 다음: (1) launchd plist 경로/user 점검 → launchctl load  (2) bun run build  (3) /team 200 확인"

--- a/scripts/snapshot-cron.sh
+++ b/scripts/snapshot-cron.sh
@@ -1,16 +1,16 @@
-#!/opt/homebrew/bin/bash
+#!/usr/bin/env bash
 # snapshot-cron.sh — snapshot-team.sh 를 예약 실행용으로 감싼다.
 #   ① 로컬을 정본으로 뜬다  ② 되읽어 검증한다  ③ iCloud 로는 best-effort 복사하고 성패를 남긴다.
 #
 # 왜 로컬이 정본인가: 예약 실행에서 iCloud 쓰기가 실패하는 것이 실측됐다("Operation not permitted").
 #   목적지를 iCloud 하나로 두면 그 실패가 조용히 지나간다. 백업이 안 된 것을 모르는 상태가 제일 나쁘다.
-# 왜 bash 경로를 박는가: snapshot-team.sh 는 mapfile·declare -A 를 쓴다(bash 4+).
-#   launchd 는 최소 PATH 라 `env bash` 가 /bin/bash 3.2 로 잡히고, 그러면 로테이션이 깨진다.
+#   둘 다 bash 3.2 에서 돈다 — launchd 의 최소 PATH 에서 `env bash` 가 /bin/bash 로 잡히기 때문이다.
 set -euo pipefail
 
-# launchd 는 최소 PATH(/usr/bin:/bin:/usr/sbin:/sbin)로 돈다. snapshot-team.sh 는 멤버 워크스페이스 목록을
-# node 로 읽고 실패를 삼킨다 — PATH 에 node 가 없으면 ★목록이 비고 워크스페이스가 통째로 빠진 채 성공한다.★
-export PATH="/opt/homebrew/bin:$PATH"
+# launchd 는 최소 PATH(/usr/bin:/bin:/usr/sbin:/sbin)로 돈다. 쓰는 도구(python3·sqlite3·tar·rsync)는
+# 전부 /usr/bin 에 있지만, 홈브루로 덮어 쓴 기계도 있으므로 있으면 앞에 둔다(없으면 무해).
+for d in /opt/homebrew/bin /usr/local/bin; do [ -d "$d" ] && PATH="$d:$PATH"; done
+export PATH
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 LOCAL="${B3OS_SNAPSHOT_LOCAL:-$HOME/.b3os-backups}"
@@ -43,11 +43,17 @@ INTEG="$(sqlite3 "$TMP/$DB" 'PRAGMA integrity_check;' 2>&1 | head -1)"
 #   .env — 없으면 복원해도 서버가 안 뜬다(토큰·바인드·신뢰 주소가 여기 있다)
 #   rules/SHARED.md — 추적도 이력도 없는 단일 사본
 #   .claude/projects — 팀원 장기기억. 코드로 다시 만들 수 없다
+#   .codex — 인증. 이름이 바뀌어도 줄어든 것을 알아채게 ★건수 하한★ 으로 본다
 for part in tree/team.db tree/agents.json tree/.env tree/rules/SHARED.md \
             home/.claude/channels home/.claude/projects; do
   n="$(tar -tzf "$NEW" | grep -c "/$part" || true)"
   [ "$n" -gt 0 ] || { log "✗ 검증 실패 — 묶음에 $part 가 0건이다"; exit 1; }
 done
+# 인증 파일은 "있나" 가 아니라 "몇 개인가" 로 본다. 최소 auth 와 설정 두 개는 있어야 한다.
+if [ -d "$HOME/.codex" ]; then
+  n="$(tar -tzf "$NEW" | grep -c 'home/\.codex/[^/]\+$' || true)"
+  [ "$n" -ge 2 ] || { log "✗ 검증 실패 — .codex 인증 파일이 ${n}개다(2개 미만). 이름 규칙이 바뀌었는지 보라"; exit 1; }
+fi
 
 # 멤버 워크스페이스는 "있나" 로 세면 안 된다 — 빈 디렉토리도 1건으로 잡혀 통과한다.
 # ★몇 명 것이 들어갔나★ 를 세서 등록부의 기대값과 맞춘다.
@@ -55,9 +61,17 @@ LIVE_DIR="${B3OS_LIVE_DIR:-$(cd "$HERE/.." && pwd)}"
 EXPECT="$(python3 -c 'import json,os,sys
 a=json.load(open(sys.argv[1]))
 print(sum(1 for x in a if os.path.isdir(x.get("workspace_path") or os.path.expanduser("~/Development/"+x["id"]))))' "$LIVE_DIR/agents.json" 2>/dev/null || echo 0)"
-GOT="$(tar -tzf "$NEW" | grep -oE 'home/Development/[^/]+/' | sort -u | wc -l | tr -d ' ')"
-[ "$EXPECT" -gt 0 ] || { log "✗ 검증 실패 — 기대 워크스페이스 수를 못 구했다(agents.json 확인)"; exit 1; }
-[ "$GOT" -ge "$EXPECT" ] || { log "✗ 검증 실패 — 워크스페이스 $GOT/$EXPECT 만 들어갔다"; exit 1; }
+# ★|| true 를 떼지 마라★ — grep 이 0건이면 pipefail 로 파이프가 실패하고, set -e 가 ★이 대입문에서★
+# 스크립트를 끝낸다. 아래 판정은 실행되지 않고 아무 표시도 남지 않는다(워크스페이스 0인 새 설치가 그 경우다).
+GOT="$(tar -tzf "$NEW" | grep -oE 'home/Development/[^/]+/' | sort -u | wc -l | tr -d ' ' || true)"
+GOT="${GOT:-0}"
+# ★기대 0 은 실패가 아니다★ — 워크스페이스가 아직 없는 새 설치본이다. snapshot-team.sh 도 같은 판정으로 넘어간다.
+#   두 곳이 반대로 말하면, 백업 도구를 처음 받는 팀이 첫날부터 빨간 로그를 본다.
+if [ "$EXPECT" -eq 0 ]; then
+  log "워크스페이스 기대 0 — 아직 만들어진 것이 없다(새 설치). 이 검사는 건너뛴다"
+else
+  [ "$GOT" -ge "$EXPECT" ] || { log "✗ 검증 실패 — 워크스페이스 $GOT/$EXPECT 만 들어갔다"; exit 1; }
+fi
 log "검증 ok — agent=$(sqlite3 "$TMP/$DB" 'SELECT COUNT(*) FROM agent;') message=$(sqlite3 "$TMP/$DB" 'SELECT COUNT(*) FROM message;') 워크스페이스=$(tar -tzf "$NEW" | grep -c '/home/Development' || true)건"
 
 # ③ iCloud 는 best-effort. 실패해도 로컬 정본은 이미 있다 — 다만 조용히 지나가지 않게 남긴다.

--- a/scripts/snapshot-cron.sh
+++ b/scripts/snapshot-cron.sh
@@ -39,14 +39,19 @@ tar -xzf "$NEW" -C "$TMP" "$DB"
 INTEG="$(sqlite3 "$TMP/$DB" 'PRAGMA integrity_check;' 2>&1 | head -1)"
 [ "$INTEG" = "ok" ] || { log "✗ 검증 실패 — integrity_check=$INTEG"; exit 1; }
 # team.db 만 보면 부족하다. 도구가 PATH 에 없어 한 구획이 통째로 빠져도 그건 멀쩡하다.
-for part in tree/team.db tree/agents.json home/.claude/channels; do
+# 그리고 수집 쪽 rsync 는 실패를 삼키므로(|| true) ★이 목록이 유일한 방어다.★
+#   .env — 없으면 복원해도 서버가 안 뜬다(토큰·바인드·신뢰 주소가 여기 있다)
+#   rules/SHARED.md — 추적도 이력도 없는 단일 사본
+#   .claude/projects — 팀원 장기기억. 코드로 다시 만들 수 없다
+for part in tree/team.db tree/agents.json tree/.env tree/rules/SHARED.md \
+            home/.claude/channels home/.claude/projects; do
   n="$(tar -tzf "$NEW" | grep -c "/$part" || true)"
   [ "$n" -gt 0 ] || { log "✗ 검증 실패 — 묶음에 $part 가 0건이다"; exit 1; }
 done
 
 # 멤버 워크스페이스는 "있나" 로 세면 안 된다 — 빈 디렉토리도 1건으로 잡혀 통과한다.
 # ★몇 명 것이 들어갔나★ 를 세서 등록부의 기대값과 맞춘다.
-LIVE_DIR="$(cd "$HERE/.." && pwd)"
+LIVE_DIR="${B3OS_LIVE_DIR:-$(cd "$HERE/.." && pwd)}"
 EXPECT="$(python3 -c 'import json,os,sys
 a=json.load(open(sys.argv[1]))
 print(sum(1 for x in a if os.path.isdir(x.get("workspace_path") or os.path.expanduser("~/Development/"+x["id"]))))' "$LIVE_DIR/agents.json" 2>/dev/null || echo 0)"

--- a/scripts/snapshot-cron.sh
+++ b/scripts/snapshot-cron.sh
@@ -1,0 +1,66 @@
+#!/opt/homebrew/bin/bash
+# snapshot-cron.sh — snapshot-team.sh 를 예약 실행용으로 감싼다.
+#   ① 로컬을 정본으로 뜬다  ② 되읽어 검증한다  ③ iCloud 로는 best-effort 복사하고 성패를 남긴다.
+#
+# 왜 로컬이 정본인가: 예약 실행에서 iCloud 쓰기가 실패하는 것이 실측됐다("Operation not permitted").
+#   목적지를 iCloud 하나로 두면 그 실패가 조용히 지나간다. 백업이 안 된 것을 모르는 상태가 제일 나쁘다.
+# 왜 bash 경로를 박는가: snapshot-team.sh 는 mapfile·declare -A 를 쓴다(bash 4+).
+#   launchd 는 최소 PATH 라 `env bash` 가 /bin/bash 3.2 로 잡히고, 그러면 로테이션이 깨진다.
+set -euo pipefail
+
+# launchd 는 최소 PATH(/usr/bin:/bin:/usr/sbin:/sbin)로 돈다. snapshot-team.sh 는 멤버 워크스페이스 목록을
+# node 로 읽고 실패를 삼킨다 — PATH 에 node 가 없으면 ★목록이 비고 워크스페이스가 통째로 빠진 채 성공한다.★
+export PATH="/opt/homebrew/bin:$PATH"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LOCAL="${B3OS_SNAPSHOT_LOCAL:-$HOME/.b3os-backups}"
+CLOUD="${B3OS_SNAPSHOT_CLOUD:-$HOME/Library/Mobile Documents/com~apple~CloudDocs/Documents/b3os-live}"
+LOG="${B3OS_SNAPSHOT_LOG:-$LOCAL/snapshot.log}"
+mkdir -p "$LOCAL"
+log(){ printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" | tee -a "$LOG"; }
+
+log "=== 시작 ==="
+
+# ① 로컬 정본
+# ★`bash` 라고 쓰면 안 된다★ — launchd 의 최소 PATH 에서는 /bin/bash 3.2 로 잡힌다.
+# 지금 이 스크립트를 돌리는 그 인터프리터($BASH)를 그대로 넘긴다.
+B3OS_SNAPSHOT_DEST="$LOCAL" "$BASH" "$HERE/snapshot-team.sh" >>"$LOG" 2>&1 \
+  || { log "✗ 스냅샷 실패 — 여기서 멈춘다"; exit 1; }
+
+NEW="$(ls -1t "$LOCAL"/b3os-snapshot-*.tar.gz 2>/dev/null | head -1)"
+[ -n "$NEW" ] || { log "✗ 산출물을 찾지 못했다"; exit 1; }
+log "떴다: $(basename "$NEW") ($(du -h "$NEW" | cut -f1))"
+
+# ② 되읽어 검증 — 뜨고 끝내면 깨진 파일도 성공으로 보인다.
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+DB="$(tar -tzf "$NEW" | grep -m1 'tree/team\.db$' || true)"
+[ -n "$DB" ] || { log "✗ 검증 실패 — 묶음 안에 team.db 가 없다"; exit 1; }
+tar -xzf "$NEW" -C "$TMP" "$DB"
+INTEG="$(sqlite3 "$TMP/$DB" 'PRAGMA integrity_check;' 2>&1 | head -1)"
+[ "$INTEG" = "ok" ] || { log "✗ 검증 실패 — integrity_check=$INTEG"; exit 1; }
+# team.db 만 보면 부족하다. 도구가 PATH 에 없어 한 구획이 통째로 빠져도 그건 멀쩡하다.
+for part in tree/team.db tree/agents.json home/.claude/channels; do
+  n="$(tar -tzf "$NEW" | grep -c "/$part" || true)"
+  [ "$n" -gt 0 ] || { log "✗ 검증 실패 — 묶음에 $part 가 0건이다"; exit 1; }
+done
+
+# 멤버 워크스페이스는 "있나" 로 세면 안 된다 — 빈 디렉토리도 1건으로 잡혀 통과한다.
+# ★몇 명 것이 들어갔나★ 를 세서 등록부의 기대값과 맞춘다.
+LIVE_DIR="$(cd "$HERE/.." && pwd)"
+EXPECT="$(python3 -c 'import json,os,sys
+a=json.load(open(sys.argv[1]))
+print(sum(1 for x in a if os.path.isdir(x.get("workspace_path") or os.path.expanduser("~/Development/"+x["id"]))))' "$LIVE_DIR/agents.json" 2>/dev/null || echo 0)"
+GOT="$(tar -tzf "$NEW" | grep -oE 'home/Development/[^/]+/' | sort -u | wc -l | tr -d ' ')"
+[ "$EXPECT" -gt 0 ] || { log "✗ 검증 실패 — 기대 워크스페이스 수를 못 구했다(agents.json 확인)"; exit 1; }
+[ "$GOT" -ge "$EXPECT" ] || { log "✗ 검증 실패 — 워크스페이스 $GOT/$EXPECT 만 들어갔다"; exit 1; }
+log "검증 ok — agent=$(sqlite3 "$TMP/$DB" 'SELECT COUNT(*) FROM agent;') message=$(sqlite3 "$TMP/$DB" 'SELECT COUNT(*) FROM message;') 워크스페이스=$(tar -tzf "$NEW" | grep -c '/home/Development' || true)건"
+
+# ③ iCloud 는 best-effort. 실패해도 로컬 정본은 이미 있다 — 다만 조용히 지나가지 않게 남긴다.
+#    목적지 폴더 목록 조회는 응답이 없을 수 있어 하지 않는다. 파일 하나만 직접 쓴다.
+if mkdir -p "$CLOUD" 2>/dev/null && cp "$NEW" "$CLOUD/$(basename "$NEW")" 2>>"$LOG"; then
+  log "기기밖=ok ($(basename "$NEW"))"
+else
+  log "기기밖=실패 — 로컬에는 있다. iCloud 쓰기를 확인하라"
+fi
+
+log "=== 끝 ==="

--- a/scripts/snapshot-team.sh
+++ b/scripts/snapshot-team.sh
@@ -15,24 +15,34 @@ say(){ printf "\033[32m%s\033[0m\n" "$1"; }
 warn(){ printf "\033[33m%s\033[0m\n" "$1"; }
 mkdir -p "$DEST" "$STAGE"/{tree,home/Development,home/.claude,home/.hermes,launchd}
 
-# ★재생성 가능 대용량 제외 목록★
-EX=(--exclude='.git' --exclude='node_modules' --exclude='backups' --exclude='migration-backups-*'
+# ★제외 목록은 구획마다 다르다★
+#   하나로 합쳐 쓰면 이름이 같은 것까지 같이 걸린다. hermes 프로필의 재생성 가능한 reports·decks 를
+#   지우려던 패턴이 ★멤버 워크스페이스의 reports·decks(작업물)까지★ 걸어 백업에서 빼고 있었다.
+#   백업 도구가 조용히 작업물을 버리는 형태라, 구획별로 나눈다.
+
+# 어디서나 안전한 것 — 재생성물·임시물
+EX_COMMON=(--exclude='.git' --exclude='node_modules' --exclude='backups' --exclude='migration-backups-*'
     --exclude='*.pre-*' --exclude='*.bak' --exclude='*.bak-*' --exclude='*.log' --exclude='.DS_Store'
-    --exclude='state.db' --exclude='state.db-*' --exclude='state-snapshots' --exclude='audio_cache'
-    --exclude='lsp' --exclude='.cache' --exclude='dist' --exclude='decks' --exclude='team.db.pre-*'
-    # hermes 프로필의 대용량 런타임(재생성 가능): 대화state·홈·캐시·bin·모델·세션·미디어·스킬(repo서 옴)
-    --exclude='home' --exclude='models' --exclude='sessions' --exclude='media' --exclude='tmp'
-    --exclude='*.wal' --exclude='*.sqlite-*' --exclude='reports' --exclude='images'
-    --exclude='bin' --exclude='cache' --exclude='skills'
-    # var 대용량 재생성물(모델·검색eval·벡터인덱스) + 멤버 전송/임시(재생성)
-    --exclude='models' --exclude='team-search-eval' --exclude='*.lancedb'
-    --exclude='scratchpad' --exclude='outbox')
+    --exclude='dist' --exclude='.cache' --exclude='scratchpad' --exclude='outbox'
+    --exclude='team.db.pre-*' --exclude='*.wal' --exclude='*.sqlite-*')
+
+# 트리(var) 대용량 재생성물 — 모델·검색eval·벡터인덱스
+EX_TREE=("${EX_COMMON[@]}" --exclude='models' --exclude='team-search-eval' --exclude='*.lancedb')
+
+# 멤버 워크스페이스 — ★작업물을 지우지 않는다.★ 공통 제외만 건다.
+EX_MEMBER=("${EX_COMMON[@]}")
+
+# hermes 프로필 — 대화state·홈·캐시·bin·모델·세션·미디어·스킬(repo서 옴)은 재생성 가능
+EX_HERMES=("${EX_COMMON[@]}" --exclude='state.db' --exclude='state.db-*' --exclude='state-snapshots'
+    --exclude='audio_cache' --exclude='lsp' --exclude='home' --exclude='models' --exclude='sessions'
+    --exclude='media' --exclude='tmp' --exclude='reports' --exclude='images' --exclude='decks'
+    --exclude='bin' --exclude='cache' --exclude='skills')
 
 say "■ 팀 핵심 상태 수집 ($STAMP)"
 # ① 트리 gitignored (team.db 는 핵심이라 통째)
 cd "$LIVE_DIR"
 for p in .env agents.json team.db var slack-tokens scripts rules/STATE.md rules/SHARED.md rules/TEAM-OS.md; do
-  [ -e "$p" ] && { mkdir -p "$STAGE/tree/$(dirname "$p")"; rsync -a "${EX[@]}" "$p" "$STAGE/tree/$(dirname "$p")/" 2>/dev/null || true; }
+  [ -e "$p" ] && { mkdir -p "$STAGE/tree/$(dirname "$p")"; rsync -a "${EX_TREE[@]}" "$p" "$STAGE/tree/$(dirname "$p")/" 2>/dev/null || true; }
 done
 say "  ✓ 트리 (team.db $(du -h team.db 2>/dev/null|cut -f1))"
 
@@ -44,21 +54,50 @@ MEMBERS="$(python3 -c 'import json,os,sys
 a=json.load(open(sys.argv[1]))
 print("\n".join(x.get("workspace_path") or os.path.join(os.path.expanduser("~/Development"), x["id"]) for x in a))' "$LIVE_DIR/agents.json")" \
   || { printf '\033[31m✗ agents.json 에서 멤버 워크스페이스를 읽지 못했다 — 스냅샷을 중단한다\033[0m\n' >&2; exit 1; }
-COPIED=0
+EXPECTED=0; COPIED=0
 while IFS= read -r ws; do
+  [ -n "$ws" ] && EXPECTED=$((EXPECTED+1))
   [ -n "$ws" ] && [ -d "$ws" ] || continue
-  rsync -a "${EX[@]}" "$ws" "$STAGE/home/Development/" 2>/dev/null || true
+  rsync -a "${EX_MEMBER[@]}" "$ws" "$STAGE/home/Development/" 2>/dev/null || true
   COPIED=$((COPIED+1))
 done <<EOF
 $MEMBERS
 EOF
-[ "$COPIED" -gt 0 ] || { printf '\033[31m✗ 멤버 워크스페이스가 0건이다 — 백업이 반쪽이므로 중단한다\033[0m\n' >&2; exit 1; }
-say "  ✓ 멤버 워크스페이스 $COPIED개 (대용량 제외)"
+# ★기대 0 과 유실 0 은 다르다.★ 새로 설치해 워크스페이스가 아직 없는 팀은 기대도 0 이라 그냥 넘어간다.
+# 기대가 있는데 하나도 못 담았으면 경로가 어긋난 것이다 — 그때 멈춘다(묶기 전이라 반쪽 산출물이 안 남는다).
+if [ "$EXPECTED" -gt 0 ] && [ "$COPIED" -eq 0 ]; then
+  printf '\033[31m✗ 멤버 워크스페이스 %s곳을 찾았는데 하나도 담지 못했다 — 중단한다\033[0m\n' "$EXPECTED" >&2
+  printf '   확인: agents.json 의 workspace_path (없으면 ~/Development/<id> 로 본다)\n' >&2
+  exit 1
+fi
+say "  ✓ 멤버 워크스페이스 $COPIED/$EXPECTED (작업물 포함)"
 
 # ③ 페어링 ④ hermes auth (대용량 state 제외)
-[ -d "$HOME/.claude/channels" ] && rsync -a "${EX[@]}" "$HOME/.claude/channels" "$STAGE/home/.claude/" 2>/dev/null||true
-[ -d "$HOME/.hermes/profiles" ] && rsync -a "${EX[@]}" "$HOME/.hermes/profiles" "$STAGE/home/.hermes/" 2>/dev/null||true
+[ -d "$HOME/.claude/channels" ] && rsync -a "${EX_COMMON[@]}" "$HOME/.claude/channels" "$STAGE/home/.claude/" 2>/dev/null||true
+[ -d "$HOME/.hermes/profiles" ] && rsync -a "${EX_HERMES[@]}" "$HOME/.hermes/profiles" "$STAGE/home/.hermes/" 2>/dev/null||true
 say "  ✓ .claude/channels + .hermes/profiles(auth만)"
+# ★클로드 팀원의 장기기억★ — 코드로 다시 만들 수 없는 유일본이다. 이게 빠지면 팀원이 배운 것이 사라진다.
+#   projects 전체는 대화 기록까지 있어 크다 → memory 디렉토리만 담는다.
+MEM=0
+for d in "$HOME"/.claude/projects/*/memory; do
+  [ -d "$d" ] || continue
+  t="$STAGE/home/.claude/projects/$(basename "$(dirname "$d")")"
+  mkdir -p "$t"; rsync -a "${EX_COMMON[@]}" "$d" "$t/" 2>/dev/null || true
+  MEM=$((MEM+1))
+done
+say "  ✓ 팀원 장기기억 ${MEM}개 디렉토리"
+# openclaw · codex 런타임 인증 — 없으면 그 런타임 팀원이 인증을 못 한다.
+#   두 홈 모두 대용량 캐시가 있으므로 ★설정·인증 파일만★ 담는다.
+[ -f "$HOME/.openclaw/openclaw.json" ] && { mkdir -p "$STAGE/home/.openclaw"; cp "$HOME/.openclaw/openclaw.json" "$STAGE/home/.openclaw/"; }
+# ★파일을 이름으로 집는다.★ rsync 의 --include 는 --exclude='*' 가 뒤에 없으면 아무것도 안 걸러서,
+#   플러그인·세션·캐시까지 통째로 딸려온다(여기서 760MB 중 대부분이 재생성 가능한 것들이다).
+if [ -d "$HOME/.codex" ]; then
+  mkdir -p "$STAGE/home/.codex"
+  for f in auth.json config.toml version.json; do
+    [ -f "$HOME/.codex/$f" ] && cp "$HOME/.codex/$f" "$STAGE/home/.codex/"
+  done
+fi
+say "  ✓ openclaw·codex 인증 설정"
 # ⑤ launchd
 cp "$HOME/Library/LaunchAgents/com.$(id -un)."*.plist "$STAGE/launchd/" 2>/dev/null||true
 say "  ✓ launchd ($(ls "$STAGE/launchd/" 2>/dev/null|wc -l|tr -d ' ')개)"
@@ -72,7 +111,7 @@ tar -czf "$OUT" -C "$(dirname "$STAGE")" "b3os-snapshot-$STAMP"
 rm -rf "$(dirname "$STAGE")"
 say "  ✓ $(du -h "$OUT"|cut -f1)"
 
-# GFS 로테이션 (7일/4주/3개월)
+# GFS 로테이션 — 최근 7개 · 주 4개 · 월 3개 (하루 한 번 돌면 '7일' 과 같다)
 # ★bash 3.2 에서도 돌아야 한다★ — macOS 기본 셸이 3.2 이고, launchd 는 최소 PATH 라
 #   `env bash` 가 그쪽으로 잡힌다. mapfile·declare -A(bash 4)를 쓰면 그 자리에서 깨진다.
 cd "$DEST"
@@ -83,7 +122,7 @@ i=0; for f in $ALL; do [ $i -lt 7 ] && keep "$f"; i=$((i+1)); done
 seen=""; n=0
 for f in $ALL; do
   d="$(echo "$f" | grep -oE '[0-9]{8}' | head -1)"; [ -z "$d" ] && continue
-  k="w$(date -j -f '%Y%m%d' "$d" '+%Y-W%V' 2>/dev/null || echo "$d")"
+  k="w$(date -j -f '%Y%m%d' "$d" '+%G-W%V' 2>/dev/null || echo "$d")"
   case " $seen " in *" $k "*) ;; *) seen="$seen $k"; keep "$f"; n=$((n+1)); [ $n -ge 4 ] && break ;; esac
 done
 seen=""; n=0

--- a/scripts/snapshot-team.sh
+++ b/scripts/snapshot-team.sh
@@ -63,12 +63,12 @@ while IFS= read -r ws; do
 done <<EOF
 $MEMBERS
 EOF
-# ★기대 0 과 유실 0 은 다르다.★ 새로 설치해 워크스페이스가 아직 없는 팀은 기대도 0 이라 그냥 넘어간다.
-# 기대가 있는데 하나도 못 담았으면 경로가 어긋난 것이다 — 그때 멈춘다(묶기 전이라 반쪽 산출물이 안 남는다).
-if [ "$EXPECTED" -gt 0 ] && [ "$COPIED" -eq 0 ]; then
-  printf '\033[31m✗ 멤버 워크스페이스 %s곳을 찾았는데 하나도 담지 못했다 — 중단한다\033[0m\n' "$EXPECTED" >&2
-  printf '   확인: agents.json 의 workspace_path (없으면 ~/Development/<id> 로 본다)\n' >&2
-  exit 1
+# 등록부에 있는데 디스크에 없는 것은 ★아직 안 만들어진 것★ 이지 유실이 아니다(새 설치가 그렇다).
+# 담을 게 없는 상태로 중단하면 백업 도구를 처음 받는 팀이 첫날부터 못 쓴다 → 여기서는 알리기만 한다.
+# ★유실 판정은 래퍼가 한다★ — 실제로 있는 디렉토리 수와 묶음 안의 수를 비교한다. 판정은 한 곳에만 둔다.
+if [ "$COPIED" -lt "$EXPECTED" ]; then
+  warn "  ⚠ 멤버 워크스페이스 $COPIED/$EXPECTED — 등록부에 있으나 디스크에 없는 것이 있다"
+  warn "     확인: agents.json 의 workspace_path (없으면 ~/Development/<id> 로 본다)"
 fi
 say "  ✓ 멤버 워크스페이스 $COPIED/$EXPECTED (작업물 포함)"
 
@@ -91,10 +91,12 @@ say "  ✓ 팀원 장기기억 ${MEM}개 디렉토리"
 [ -f "$HOME/.openclaw/openclaw.json" ] && { mkdir -p "$STAGE/home/.openclaw"; cp "$HOME/.openclaw/openclaw.json" "$STAGE/home/.openclaw/"; }
 # ★파일을 이름으로 집는다.★ rsync 의 --include 는 --exclude='*' 가 뒤에 없으면 아무것도 안 걸러서,
 #   플러그인·세션·캐시까지 통째로 딸려온다(여기서 760MB 중 대부분이 재생성 가능한 것들이다).
+#   이름을 하나씩 박으면 이름이 바뀔 때 조용히 빠진다(이 디렉토리는 이미 auth.json.<런타임>-backup-<날짜>
+#   같은 이름이 늘어난 적이 있다). ★최상위 파일만★ 을 무늬로 집는다 — 하위 디렉토리는 안 따라온다.
 if [ -d "$HOME/.codex" ]; then
   mkdir -p "$STAGE/home/.codex"
-  for f in auth.json config.toml version.json; do
-    [ -f "$HOME/.codex/$f" ] && cp "$HOME/.codex/$f" "$STAGE/home/.codex/"
+  for f in "$HOME"/.codex/auth* "$HOME"/.codex/*.toml "$HOME"/.codex/*.json; do
+    [ -f "$f" ] && cp "$f" "$STAGE/home/.codex/"
   done
 fi
 say "  ✓ openclaw·codex 인증 설정"
@@ -121,13 +123,13 @@ keep(){ case " $KEEP " in *" $1 "*) ;; *) KEEP="$KEEP $1" ;; esac; }
 i=0; for f in $ALL; do [ $i -lt 7 ] && keep "$f"; i=$((i+1)); done
 seen=""; n=0
 for f in $ALL; do
-  d="$(echo "$f" | grep -oE '[0-9]{8}' | head -1)"; [ -z "$d" ] && continue
+  d="$(echo "$f" | grep -oE '[0-9]{8}' | head -1 || true)"; [ -z "$d" ] && continue
   k="w$(date -j -f '%Y%m%d' "$d" '+%G-W%V' 2>/dev/null || echo "$d")"
   case " $seen " in *" $k "*) ;; *) seen="$seen $k"; keep "$f"; n=$((n+1)); [ $n -ge 4 ] && break ;; esac
 done
 seen=""; n=0
 for f in $ALL; do
-  d="$(echo "$f" | grep -oE '[0-9]{8}' | head -1)"; [ -z "$d" ] && continue
+  d="$(echo "$f" | grep -oE '[0-9]{8}' | head -1 || true)"; [ -z "$d" ] && continue
   k="m$(echo "$d" | cut -c1-6)"
   case " $seen " in *" $k "*) ;; *) seen="$seen $k"; keep "$f"; n=$((n+1)); [ $n -ge 3 ] && break ;; esac
 done

--- a/scripts/snapshot-team.sh
+++ b/scripts/snapshot-team.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# snapshot-team.sh — "우리 팀"을 다른 머신서 그대로 돌리기 위한 ★핵심 상태★ 스냅샷.
+#   공개 repo(코드)엔 없는 팀 고유 상태만 묶는다: ①트리 gitignored(.env·agents.json·team.db·var·slack-tokens·rules상태)
+#   ②멤버 워크스페이스 persona/MEMORY ③~/.claude/channels(페어링) ④~/.hermes/profiles 의 auth(대용량 state/캐시 제외) ⑤launchd.
+#   ★재생성 가능한 대용량(hermes state.db·snapshots·audio_cache·backups·node_modules)은 제외★ → 스냅샷 슬림.
+#   → gzip tarball → iCloud Documents/b3os-live/ (암호화 없음) + GFS 로테이션(7일/4주/3개월).
+# 사용: bash scripts/snapshot-team.sh   (env: B3OS_LIVE_DIR · B3OS_SNAPSHOT_DEST)
+set -euo pipefail
+
+LIVE_DIR="${B3OS_LIVE_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+DEST="${B3OS_SNAPSHOT_DEST:-$HOME/Library/Mobile Documents/com~apple~CloudDocs/Documents/b3os-live}"
+STAMP="$(date '+%Y%m%d-%H%M%S')"
+STAGE="$(mktemp -d)/b3os-snapshot-$STAMP"
+say(){ printf "\033[32m%s\033[0m\n" "$1"; }
+warn(){ printf "\033[33m%s\033[0m\n" "$1"; }
+mkdir -p "$DEST" "$STAGE"/{tree,home/Development,home/.claude,home/.hermes,launchd}
+
+# ★재생성 가능 대용량 제외 목록★
+EX=(--exclude='.git' --exclude='node_modules' --exclude='backups' --exclude='migration-backups-*'
+    --exclude='*.pre-*' --exclude='*.bak' --exclude='*.bak-*' --exclude='*.log' --exclude='.DS_Store'
+    --exclude='state.db' --exclude='state.db-*' --exclude='state-snapshots' --exclude='audio_cache'
+    --exclude='lsp' --exclude='.cache' --exclude='dist' --exclude='decks' --exclude='team.db.pre-*'
+    # hermes 프로필의 대용량 런타임(재생성 가능): 대화state·홈·캐시·bin·모델·세션·미디어·스킬(repo서 옴)
+    --exclude='home' --exclude='models' --exclude='sessions' --exclude='media' --exclude='tmp'
+    --exclude='*.wal' --exclude='*.sqlite-*' --exclude='reports' --exclude='images'
+    --exclude='bin' --exclude='cache' --exclude='skills'
+    # var 대용량 재생성물(모델·검색eval·벡터인덱스) + 멤버 전송/임시(재생성)
+    --exclude='models' --exclude='team-search-eval' --exclude='*.lancedb'
+    --exclude='scratchpad' --exclude='outbox')
+
+say "■ 팀 핵심 상태 수집 ($STAMP)"
+# ① 트리 gitignored (team.db 는 핵심이라 통째)
+cd "$LIVE_DIR"
+for p in .env agents.json team.db var slack-tokens scripts rules/STATE.md rules/SHARED.md rules/TEAM-OS.md; do
+  [ -e "$p" ] && { mkdir -p "$STAGE/tree/$(dirname "$p")"; rsync -a "${EX[@]}" "$p" "$STAGE/tree/$(dirname "$p")/" 2>/dev/null || true; }
+done
+say "  ✓ 트리 (team.db $(du -h team.db 2>/dev/null|cut -f1))"
+
+# ② 멤버 워크스페이스 (persona·MEMORY, 대용량 제외)
+# ★python3 로 읽는다★ — 예전에는 node 였는데 launchd 의 최소 PATH 에는 node 가 없다.
+#   그때 실패를 삼키고 있어서 ★워크스페이스가 통째로 빠진 채 스냅샷이 성공으로 끝났다.★
+#   python3 는 macOS 에 기본으로 있다. 그리고 실패하면 여기서 멈춘다 — 조용히 넘기지 않는다.
+MEMBERS="$(python3 -c 'import json,os,sys
+a=json.load(open(sys.argv[1]))
+print("\n".join(x.get("workspace_path") or os.path.join(os.path.expanduser("~/Development"), x["id"]) for x in a))' "$LIVE_DIR/agents.json")" \
+  || { printf '\033[31m✗ agents.json 에서 멤버 워크스페이스를 읽지 못했다 — 스냅샷을 중단한다\033[0m\n' >&2; exit 1; }
+COPIED=0
+while IFS= read -r ws; do
+  [ -n "$ws" ] && [ -d "$ws" ] || continue
+  rsync -a "${EX[@]}" "$ws" "$STAGE/home/Development/" 2>/dev/null || true
+  COPIED=$((COPIED+1))
+done <<EOF
+$MEMBERS
+EOF
+[ "$COPIED" -gt 0 ] || { printf '\033[31m✗ 멤버 워크스페이스가 0건이다 — 백업이 반쪽이므로 중단한다\033[0m\n' >&2; exit 1; }
+say "  ✓ 멤버 워크스페이스 $COPIED개 (대용량 제외)"
+
+# ③ 페어링 ④ hermes auth (대용량 state 제외)
+[ -d "$HOME/.claude/channels" ] && rsync -a "${EX[@]}" "$HOME/.claude/channels" "$STAGE/home/.claude/" 2>/dev/null||true
+[ -d "$HOME/.hermes/profiles" ] && rsync -a "${EX[@]}" "$HOME/.hermes/profiles" "$STAGE/home/.hermes/" 2>/dev/null||true
+say "  ✓ .claude/channels + .hermes/profiles(auth만)"
+# ⑤ launchd
+cp "$HOME/Library/LaunchAgents/com.$(id -un)."*.plist "$STAGE/launchd/" 2>/dev/null||true
+say "  ✓ launchd ($(ls "$STAGE/launchd/" 2>/dev/null|wc -l|tr -d ' ')개)"
+
+{ echo "b3os team snapshot $STAMP"; echo "source: $LIVE_DIR (public $(git -C "$LIVE_DIR" rev-parse --short HEAD 2>/dev/null))";
+  echo "restore: scripts/restore-team.sh <tarball>"; echo "제외: hermes state/캐시·backups·node_modules(재생성 가능)"; } > "$STAGE/MANIFEST.txt"
+
+OUT="$DEST/b3os-snapshot-$STAMP.tar.gz"
+say "■ 압축 → $(basename "$OUT")"
+tar -czf "$OUT" -C "$(dirname "$STAGE")" "b3os-snapshot-$STAMP"
+rm -rf "$(dirname "$STAGE")"
+say "  ✓ $(du -h "$OUT"|cut -f1)"
+
+# GFS 로테이션 (7일/4주/3개월)
+# ★bash 3.2 에서도 돌아야 한다★ — macOS 기본 셸이 3.2 이고, launchd 는 최소 PATH 라
+#   `env bash` 가 그쪽으로 잡힌다. mapfile·declare -A(bash 4)를 쓰면 그 자리에서 깨진다.
+cd "$DEST"
+ALL="$(ls -1 b3os-snapshot-*.tar.gz 2>/dev/null | sort -r || true)"
+KEEP=""
+keep(){ case " $KEEP " in *" $1 "*) ;; *) KEEP="$KEEP $1" ;; esac; }
+i=0; for f in $ALL; do [ $i -lt 7 ] && keep "$f"; i=$((i+1)); done
+seen=""; n=0
+for f in $ALL; do
+  d="$(echo "$f" | grep -oE '[0-9]{8}' | head -1)"; [ -z "$d" ] && continue
+  k="w$(date -j -f '%Y%m%d' "$d" '+%Y-W%V' 2>/dev/null || echo "$d")"
+  case " $seen " in *" $k "*) ;; *) seen="$seen $k"; keep "$f"; n=$((n+1)); [ $n -ge 4 ] && break ;; esac
+done
+seen=""; n=0
+for f in $ALL; do
+  d="$(echo "$f" | grep -oE '[0-9]{8}' | head -1)"; [ -z "$d" ] && continue
+  k="m$(echo "$d" | cut -c1-6)"
+  case " $seen " in *" $k "*) ;; *) seen="$seen $k"; keep "$f"; n=$((n+1)); [ $n -ge 3 ] && break ;; esac
+done
+for f in $ALL; do
+  case " $KEEP " in *" $f "*) ;; *) rm -f "$f"; warn "  삭제(로테이션): $f" ;; esac
+done
+say "✓ 완료 — 보관 $(ls -1 b3os-snapshot-*.tar.gz 2>/dev/null|wc -l|tr -d ' ')개 · 총 $(du -sh "$DEST" 2>/dev/null|cut -f1)"


### PR DESCRIPTION
설치본에 백업 도구가 오지 않는다. 백업이 없다는 사실도 드러나지 않는다.

## 문제

`.gitignore` 의 `/scripts/*` 가 `scripts/` 를 통째로 무시하고, 18개 파일만 강제로 추가돼 있었다.
백업·복원 스크립트 3개는 그 밖에 있어 저장소에 존재하지 않는다.
공개본으로 설치한 팀은 스냅샷 도구도 복원 도구도 받지 못한다.

## 고친 것

`snapshot-team.sh` · `restore-team.sh` 를 추가하고, 예약 실행용 래퍼 `snapshot-cron.sh` 를 새로 넣는다.
그대로 내보내면 남의 기계에서 실패하는 것 세 가지를 같이 고친다.

**① 로테이션이 bash 4 문법을 쓴다**
`mapfile` 과 `declare -A` 를 쓴다. macOS 기본 셸은 3.2 다.
launchd 는 최소 PATH 로 도는데 거기서 `env bash` 는 `/bin/bash` 3.2 로 잡힌다.
같은 판정을 bash 3.2 문법으로 다시 썼다.

**② 멤버 워크스페이스 목록을 node 로 읽고 실패를 삼킨다**
launchd 의 최소 PATH 에는 node 가 없다. 목록이 비면 워크스페이스가 통째로 빠지고, 스냅샷은 성공으로 끝난다.
`python3` 로 읽고, 읽지 못하거나 결과가 0건이면 중단한다.

**③ 목적지가 클라우드 하나면 쓰기 실패가 조용히 지나간다**
래퍼가 로컬에 먼저 쓰고, 되읽어 `integrity_check` 와 구획별 건수를 확인한 뒤 클라우드로 복사한다.
클라우드 복사는 실패해도 진행하되 결과를 기록한다.

## 검증

- bash 3.2 로 실제 실행 — 워크스페이스 12명 전부 포함, 273MB.
- 로테이션은 파일 18개로 옛 판(bash 4)과 새 판(bash 3.2)을 각각 돌려 남는 목록이 같은 것을 확인했다(11개 동일).
- 래퍼는 launchd 로 발사해 확인했다. 워크스페이스가 빠진 묶음은 0/12 로 차단되고, 정상은 12/12 로 통과한다.

## 남는 것

`deploy-live.sh` 는 넣지 않는다. 배포 방식은 팀마다 다르다.
