### PR TITLE
fix(snapshot-cron): 산출물을 못 찾았다는 안내가 실행될 수 없었다

### DIFF
--- a/scripts/snapshot-cron.sh
+++ b/scripts/snapshot-cron.sh
@@ -27,8 +27,9 @@ log "=== 시작 ==="
 B3OS_SNAPSHOT_DEST="$LOCAL" "$BASH" "$HERE/snapshot-team.sh" >>"$LOG" 2>&1 \
   || { log "✗ 스냅샷 실패 — 여기서 멈춘다"; exit 1; }
 
-# ls 는 무늬에 맞는 것이 없으면 실패한다. 그러면 set -e 가 여기서 끝내고
-# ★바로 아래 안내가 실행되지 않는다.★ 안내를 살리려면 이 줄이 실패하지 않아야 한다.
+# ls 는 무늬에 맞는 것이 없으면 실패한다. 파이프의 종료코드는 마지막 명령(head)이라 0 인데,
+# ★pipefail★ 이 그 실패를 밖으로 내보내고 set -e 가 대입문에서 끝낸다(8행에 pipefail 이 있다).
+# 그러면 ★바로 아래 안내가 실행되지 않는다.★ 안내를 살리려면 이 줄이 실패하지 않아야 한다.
 NEW="$(ls -1t "$LOCAL"/b3os-snapshot-*.tar.gz 2>/dev/null | head -1 || true)"
 [ -n "$NEW" ] || { log "✗ 산출물을 찾지 못했다"; exit 1; }
 log "떴다: $(basename "$NEW") ($(du -h "$NEW" | cut -f1))"
@@ -38,7 +39,9 @@ TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 DB="$(tar -tzf "$NEW" | grep -m1 'tree/team\.db$' || true)"
 [ -n "$DB" ] || { log "✗ 검증 실패 — 묶음 안에 team.db 가 없다"; exit 1; }
 tar -xzf "$NEW" -C "$TMP" "$DB"
-INTEG="$(sqlite3 "$TMP/$DB" 'PRAGMA integrity_check;' 2>&1 | head -1)"
+# 손상된 db 면 sqlite3 가 실패한다(rc 26). pipefail 이 그 실패를 파이프 밖으로 내보내고
+# set -e 가 대입문에서 끝낸다 — ★손상을 알리라고 둔 검사가, 손상됐을 때만 침묵한다.★
+INTEG="$(sqlite3 "$TMP/$DB" 'PRAGMA integrity_check;' 2>&1 | head -1 || true)"
 [ "$INTEG" = "ok" ] || { log "✗ 검증 실패 — integrity_check=$INTEG"; exit 1; }
 # team.db 만 보면 부족하다. 도구가 PATH 에 없어 한 구획이 통째로 빠져도 그건 멀쩡하다.
 # 그리고 수집 쪽 rsync 는 실패를 삼키므로(|| true) ★이 목록이 유일한 방어다.★

--- a/scripts/snapshot-cron.sh
+++ b/scripts/snapshot-cron.sh
@@ -27,7 +27,9 @@ log "=== 시작 ==="
 B3OS_SNAPSHOT_DEST="$LOCAL" "$BASH" "$HERE/snapshot-team.sh" >>"$LOG" 2>&1 \
   || { log "✗ 스냅샷 실패 — 여기서 멈춘다"; exit 1; }
 
-NEW="$(ls -1t "$LOCAL"/b3os-snapshot-*.tar.gz 2>/dev/null | head -1)"
+# ls 는 무늬에 맞는 것이 없으면 실패한다. 그러면 set -e 가 여기서 끝내고
+# ★바로 아래 안내가 실행되지 않는다.★ 안내를 살리려면 이 줄이 실패하지 않아야 한다.
+NEW="$(ls -1t "$LOCAL"/b3os-snapshot-*.tar.gz 2>/dev/null | head -1 || true)"
 [ -n "$NEW" ] || { log "✗ 산출물을 찾지 못했다"; exit 1; }
 log "떴다: $(basename "$NEW") ($(du -h "$NEW" | cut -f1))"
 


### PR DESCRIPTION
## 문제

`snapshot-cron.sh` 는 산출물을 못 찾으면 안내하고 멈추게 되어 있다.
그 안내는 실행되지 않는다.

```
NEW="$(ls -1t "$LOCAL"/b3os-snapshot-*.tar.gz 2>/dev/null | head -1)"
[ -n "$NEW" ] || { log "✗ 산출물을 찾지 못했다"; exit 1; }   # ← 도달하지 못한다
```

`ls` 는 무늬에 맞는 것이 없으면 실패한다. `set -e` 가 대입문에서 스크립트를 끝낸다.
출력 없는 종료코드 1 만 남는다.

## 고친 것

대입문이 실패하지 않게 한다. 판정은 아래 줄이 한다.

## 실측 — 없음을 실패로 알리는 명령은 grep 만이 아니다

`set -euo pipefail` 에서 대입문의 명령치환을 재봤다.

| 명령 | 결과 | 방아쇠 |
|---|---|---|
| `grep` 0건 | 스크립트 종료 | 없음 |
| `ls <없는 파일>` | 스크립트 종료 | 없음 |
| `find` 0건 | 계속 진행 | — |
| `diff` · `cmp` | 스크립트 종료 | 다름 |

`find` 를 같은 부류로 보면 오탐이 난다.

점검:

```
grep -nE '^[[:space:]]*[A-Za-z_]+="?\$\(.*(grep|ls |diff|cmp)' *.sh | grep -v '|| true'
```
