### PR TITLE
fix(proposals): 승인·반려 모달 포커스 보존

### DIFF
--- a/src/web/components/ProposalsView.ts
+++ b/src/web/components/ProposalsView.ts
@@ -74,6 +74,7 @@ type ProposalModalState =
       title: string;
       to: "accepted" | "rejected";
       label: string;
+      comment: string;
     }
   | {
       kind: "archive";
@@ -507,6 +508,8 @@ export function renderProposalsView(root: HTMLElement): void {
   }
 
   async function refreshCurrent() {
+    // 결정/보관 입력 중에는 5초 폴링이 모달 DOM을 교체해 포커스를 빼앗지 않게 멈춘다.
+    if (actionModal) return;
     if (pollInFlight) return;
     pollInFlight = true;
     try {
@@ -671,11 +674,18 @@ export function renderProposalsView(root: HTMLElement): void {
         const to = b.dataset.gdDecision;
         if (to !== "accepted" && to !== "rejected") return;
         const label = to === "accepted" ? pick("승인", "Approve") : to === "rejected" ? pick("반려", "Reject") : pick("수정요청", "Revise");
-        actionModal = { kind: "gd-decision", proposalId: detail.proposal.id, title: detail.proposal.title, to, label };
+        actionModal = { kind: "gd-decision", proposalId: detail.proposal.id, title: detail.proposal.title, to, label, comment: "" };
         actionError = null;
         render();
         focusActionModal();
       }));
+    const actionComment = root.querySelector<HTMLTextAreaElement>("[data-proposal-action-comment]");
+    if (actionComment && actionModal?.kind === "gd-decision") actionComment.value = actionModal.comment;
+    actionComment?.addEventListener("input", (e) => {
+      if (actionModal?.kind === "gd-decision") {
+        actionModal.comment = (e.currentTarget as HTMLTextAreaElement).value;
+      }
+    });
     root.querySelectorAll<HTMLButtonElement>("[data-archive-proposal]").forEach((b) =>
       b.addEventListener("click", () => {
         if (!detail) return;
@@ -715,6 +725,7 @@ export function renderProposalsView(root: HTMLElement): void {
           if (actionModal) focusActionModal();
         });
     });
+    if (actionModal) focusActionModal();
     const resizeHandle = root.querySelector<HTMLElement>("[data-proposals-resize-detail]");
     resizeHandle?.addEventListener("mousedown", (e) => {
       e.preventDefault();

--- a/src/web/components/inboxAudit.dom.test.ts
+++ b/src/web/components/inboxAudit.dom.test.ts
@@ -415,12 +415,20 @@ describe("ProposalsView — read-only list/detail", () => {
     }
   });
 
-  test("opens an in-page modal for GD decisions and sends the typed comment", async () => {
+  test("keeps focus and draft in the shared approve/reject modal, then sends the typed comment", async () => {
     const origFetch = globalThis.fetch;
+    const origSetInterval = globalThis.setInterval;
     let transitionPayload: Record<string, unknown> | null = null;
+    let listFetchCount = 0;
+    let pollTick: (() => void) | null = null;
+    globalThis.setInterval = ((handler: TimerHandler) => {
+      if (typeof handler === "function") pollTick = handler;
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    }) as typeof setInterval;
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.endsWith("/api/proposals")) {
+        listFetchCount += 1;
         return new Response(
           JSON.stringify({
             proposals: [
@@ -482,8 +490,15 @@ describe("ProposalsView — read-only list/detail", () => {
     try {
       const { renderProposalsView } = await import("./ProposalsView");
       const root = document.createElement("div");
+      document.body.appendChild(root);
       renderProposalsView(root);
       await new Promise((r) => setTimeout(r, 40));
+
+      const reject = root.querySelector<HTMLButtonElement>("[data-gd-decision='rejected']");
+      expect(reject).toBeTruthy();
+      reject?.click();
+      expect(root.querySelector("[data-proposal-action-modal]")?.textContent).toContain("반려 사유/코멘트");
+      root.querySelector<HTMLButtonElement>("[data-proposal-action-cancel]")?.click();
 
       const approve = root.querySelector<HTMLButtonElement>("[data-gd-decision='accepted']");
       expect(approve).toBeTruthy();
@@ -491,9 +506,27 @@ describe("ProposalsView — read-only list/detail", () => {
 
       const modal = root.querySelector("[data-proposal-action-modal]");
       expect(modal?.textContent).toContain("승인 사유/코멘트");
-      const textarea = root.querySelector<HTMLTextAreaElement>("[data-proposal-action-comment]");
+      let textarea = root.querySelector<HTMLTextAreaElement>("[data-proposal-action-comment]");
       expect(textarea).toBeTruthy();
-      textarea!.value = "승인합니다. 실행하세요.";
+      expect(document.activeElement).toBe(textarea);
+      textarea!.value = "\n승인합니다. 실행하세요.";
+      textarea!.dispatchEvent(new window.Event("input", { bubbles: true }));
+
+      // 5초 자동 폴링 콜백은 열린 모달의 fetch와 DOM을 건드리지 않는다.
+      const listFetchCountBeforePoll = listFetchCount;
+      const textareaBeforePoll = textarea;
+      pollTick?.();
+      await new Promise((r) => setTimeout(r, 0));
+      expect(listFetchCount).toBe(listFetchCountBeforePoll);
+      expect(root.querySelector("[data-proposal-action-comment]")).toBe(textareaBeforePoll);
+
+      // 수동 새로고침 같은 예외적 재렌더에도 입력과 포커스가 복구된다.
+      root.querySelector<HTMLButtonElement>("[data-refresh-proposals]")?.click();
+      await new Promise((r) => setTimeout(r, 40));
+      textarea = root.querySelector<HTMLTextAreaElement>("[data-proposal-action-comment]");
+      expect(textarea?.value).toBe("\n승인합니다. 실행하세요.");
+      expect(document.activeElement).toBe(textarea);
+
       root.querySelector<HTMLFormElement>("[data-proposal-action-form]")?.dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
       await new Promise((r) => setTimeout(r, 40));
 
@@ -505,6 +538,8 @@ describe("ProposalsView — read-only list/detail", () => {
       });
     } finally {
       globalThis.fetch = origFetch;
+      globalThis.setInterval = origSetInterval;
+      document.body.innerHTML = "";
     }
   });
 

--- a/src/web/components/inboxAudit.dom.test.ts
+++ b/src/web/components/inboxAudit.dom.test.ts
@@ -422,9 +422,9 @@ describe("ProposalsView — read-only list/detail", () => {
     let listFetchCount = 0;
     let pollTick: (() => void) | null = null;
     globalThis.setInterval = ((handler: TimerHandler) => {
-      if (typeof handler === "function") pollTick = handler;
-      return 1 as unknown as ReturnType<typeof setInterval>;
-    }) as typeof setInterval;
+      if (typeof handler === "function") pollTick = handler as () => void;
+      return 1;
+    }) as unknown as typeof setInterval;
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.endsWith("/api/proposals")) {
@@ -515,7 +515,8 @@ describe("ProposalsView — read-only list/detail", () => {
       // 5초 자동 폴링 콜백은 열린 모달의 fetch와 DOM을 건드리지 않는다.
       const listFetchCountBeforePoll = listFetchCount;
       const textareaBeforePoll = textarea;
-      pollTick?.();
+      expect(pollTick).toBeTruthy();
+      (pollTick as unknown as () => void)();
       await new Promise((r) => setTimeout(r, 0));
       expect(listFetchCount).toBe(listFetchCountBeforePoll);
       expect(root.querySelector("[data-proposal-action-comment]")).toBe(textareaBeforePoll);


### PR DESCRIPTION
## 핵심

- Proposal 팀장 승인·반려 모달이 열린 동안 5초 자동 폴링을 멈춰 입력 포커스 탈취를 차단합니다.
- 결정 코멘트를 모달 상태에 보존해 예외적 재렌더에서도 입력값과 포커스를 복구합니다.
- 승인·반려가 공유하는 모달 경로와 실제 transition payload를 DOM 회귀 테스트로 검증합니다.

## 검증

- `bun test src/web/components/inboxAudit.dom.test.ts` — 9 pass
- `bun run typecheck` — pass
- `git diff --check` — pass

## 리뷰 요청

- 자동 폴링 중단 범위가 모달 입력 동안으로 제한되는지
- 승인·반려 공용 흐름의 입력값·포커스 보존이 충분한지
- 제출 성공/실패 및 archive 모달에 회귀가 없는지

Author: `codex`
