### PR TITLE
docs(team-os): 배포 후 라이브 확인을 핵심 규칙에 넣는다

### DIFF
--- a/rules/TEAM-OS.template.md
+++ b/rules/TEAM-OS.template.md
@@ -52,7 +52,8 @@ Safety and security rules always win.
 - Approval gate: before big changes, DB schema changes, restarts, self-mod, external sends, public posts, payments, deletion, security config, or credentials, announce scope/reason and get team lead approval.
 - **"External send" means leaving the team**: public post, outsider email/DM, or third-party API call. **Team-bus messaging is NOT an external send** — fan-out, requester synthesis, and `--direct-to-gd` need no approval. Self-mod also needs direct terminal instruction or explicit confirmation.
 - Reports include changed files, verification, unverified scope, and rollback where relevant; distinguish created from visible.
-- SECTION_CORE_RULE: verify before deploy, merge, publish, or public release; scale member review/harness to risk, and use both for critical external/public work. After deploying, confirm it actually runs live; if you cannot reach live, verify the closest way and record what you could not measure. Trivial mechanical edits are exempt.
+- SECTION_CORE_RULE: verify before deploy, merge, publish, or public release; scale member review/harness to risk, and use both for critical external/public work. Trivial mechanical edits are exempt.
+- After deploying, confirm it actually runs live; if you cannot reach live, verify in the closest way you can and record what you could not measure. No exemption.
 - AI code: non-trivial AI-generated/modified code needs applicable safety review before merge/deploy; solo tests are insufficient for risky changes.
 - BWF closes team-lead-confirmed execution/delegation: plan/card -> assign/ack -> execute+quality -> verify -> report/close -> learning. Detail: `skills/b3os-bwf/SKILL.md`.
 

--- a/rules/TEAM-OS.template.md
+++ b/rules/TEAM-OS.template.md
@@ -52,7 +52,7 @@ Safety and security rules always win.
 - Approval gate: before big changes, DB schema changes, restarts, self-mod, external sends, public posts, payments, deletion, security config, or credentials, announce scope/reason and get team lead approval.
 - **"External send" means leaving the team**: public post, outsider email/DM, or third-party API call. **Team-bus messaging is NOT an external send** — fan-out, requester synthesis, and `--direct-to-gd` need no approval. Self-mod also needs direct terminal instruction or explicit confirmation.
 - Reports include changed files, verification, unverified scope, and rollback where relevant; distinguish created from visible.
-- SECTION_CORE_RULE: verify before deploy, merge, publish, or public release; scale member review/harness to risk, and use both for critical external/public work. Trivial mechanical edits are exempt.
+- SECTION_CORE_RULE: verify before deploy, merge, publish, or public release; scale member review/harness to risk, and use both for critical external/public work. After deploying, confirm it actually runs live; if you cannot reach live, verify the closest way and record what you could not measure. Trivial mechanical edits are exempt.
 - AI code: non-trivial AI-generated/modified code needs applicable safety review before merge/deploy; solo tests are insufficient for risky changes.
 - BWF closes team-lead-confirmed execution/delegation: plan/card -> assign/ack -> execute+quality -> verify -> report/close -> learning. Detail: `skills/b3os-bwf/SKILL.md`.
 

--- a/rules/TEAM-OS.template.md
+++ b/rules/TEAM-OS.template.md
@@ -52,8 +52,7 @@ Safety and security rules always win.
 - Approval gate: before big changes, DB schema changes, restarts, self-mod, external sends, public posts, payments, deletion, security config, or credentials, announce scope/reason and get team lead approval.
 - **"External send" means leaving the team**: public post, outsider email/DM, or third-party API call. **Team-bus messaging is NOT an external send** — fan-out, requester synthesis, and `--direct-to-gd` need no approval. Self-mod also needs direct terminal instruction or explicit confirmation.
 - Reports include changed files, verification, unverified scope, and rollback where relevant; distinguish created from visible.
-- SECTION_CORE_RULE: verify before deploy, merge, publish, or public release; scale member review/harness to risk, and use both for critical external/public work. Trivial mechanical edits are exempt.
-- After deploying, confirm it actually runs live; if you cannot reach live, verify in the closest way you can and record what you could not measure. No exemption.
+- SECTION_CORE_RULE: verify before deploy, merge, publish, or public release; scale member review/harness to risk, and use both for critical external/public work. Trivial mechanical edits are exempt. After deploying, confirm it actually runs live; if you cannot access live, verify by the closest means available and record what you could not measure — no exemption.
 - AI code: non-trivial AI-generated/modified code needs applicable safety review before merge/deploy; solo tests are insufficient for risky changes.
 - BWF closes team-lead-confirmed execution/delegation: plan/card -> assign/ack -> execute+quality -> verify -> report/close -> learning. Detail: `skills/b3os-bwf/SKILL.md`.
 


### PR DESCRIPTION
## 문제

`SECTION_CORE_RULE` 은 배포·머지·공개 **전** 검증만 요구한다.
배포한 뒤 실제로 도는지 보는 단계가 없어, 테스트와 교차검증을 모두 통과한 결함이 라이브에 남는다.

## 고친 것

핵심 규칙 한 줄에 두 문장을 더한다.

- 배포 후 라이브에서 실제로 도는지 확인한다.
- 라이브에 닿을 수 없으면 가장 가까운 방법으로 확인하고, 무엇을 못 쟀는지 남긴다.

뒷문장은 건너뛰기를 막는다. 건너뛴 것과 못 한 것이 구분돼야 다음 사람이 안다.

## 반영 범위

정본 `rules/TEAM-OS.md` 는 추적 대상이 아니며 이미 같은 문장으로 반영했다.
팀원 작업 폴더의 `TEAM-OS.md` 는 정본 심링크라 즉시 반영된다(4개 확인).
이 PR 은 공개 템플릿을 정본과 맞춘다.
