### PR TITLE
feat(server): 부팅 때 규칙 정본이 공개 템플릿과 벌어졌는지 본다

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { createBunWebSocket } from "hono/bun";
 import type { ServerWebSocket } from "bun";
 import { existsSync, readFileSync, statSync, copyFileSync } from "node:fs";
+import { missingFromLive } from "./lib/rulesDrift";
 import { join, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 import { openDb, migrate } from "./db/migrate";
@@ -159,6 +160,31 @@ try {
     }
   } catch (e) {
     console.warn("[teamos-render] SHARED.md 생성 실패(계속):", e instanceof Error ? e.message : e);
+  }
+
+  // ★규칙 정본이 공개 템플릿과 벌어졌는지 부팅 때 본다.★
+  //   rules/TEAM-OS.md 는 추적 대상이 아니라 업데이트와 함께 오지 않는다. 템플릿만 온다.
+  //   그래서 규칙이 바뀌어도 받는 쪽은 모른다 — 실제로 한 기계만 옛 규칙으로 돈 적이 있다.
+  //   배포 게이트에도 같은 검사가 있지만 ★게이트를 안 쓰는 설치본이 있다★(손으로 업데이트하는 팀).
+  //   서버는 어느 설치본에나 있으므로 여기서 한 번 더 본다. 고치지는 않는다 — 팀 사정 차이일 수 있다.
+  try {
+    const rulesLive = join(RULES_DIR, "TEAM-OS.md");
+    const rulesTemplate = join(RULES_DIR, "TEAM-OS.template.md");
+    if (existsSync(rulesLive) && existsSync(rulesTemplate)) {
+      const live = readFileSync(rulesLive, "utf8");
+      const tmpl = readFileSync(rulesTemplate, "utf8");
+      if (live !== tmpl) {
+        const missing = missingFromLive(live, tmpl);
+        console.warn(
+          `[teamos-rules] 규칙 정본이 공개 템플릿과 다릅니다 — 템플릿에만 있는 줄 ${missing.length}개.` +
+            " 팀 사정에 맞춘 차이면 그대로 두고, 공개본의 새 규칙이면 rules/TEAM-OS.md 에 옮기세요." +
+            " (scripts/rules-drift-check.sh 로 전체 diff 확인)",
+        );
+        appendAudit(db, "system", "rules_drift_detected", null, { missing_from_live: missing.length });
+      }
+    }
+  } catch (e) {
+    console.warn("[teamos-rules] 규칙 대조 실패(계속):", e instanceof Error ? e.message : e);
   }
   // 공개 빌드 부팅 백필(PUBLIC_BUILD 게이트) — 공개 사용자가 git 업데이트를 pull 한 뒤 재시작하면 기존
   //   멤버도 재영입 없이 최신을 받게. 라이브(PUBLIC_BUILD=false)는 글로벌 배선/실멤버 보호로 skip.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -167,14 +167,22 @@ try {
   //   그래서 규칙이 바뀌어도 받는 쪽은 모른다 — 실제로 한 기계만 옛 규칙으로 돈 적이 있다.
   //   배포 게이트에도 같은 검사가 있지만 ★게이트를 안 쓰는 설치본이 있다★(손으로 업데이트하는 팀).
   //   서버는 어느 설치본에나 있으므로 여기서 한 번 더 본다. 고치지는 않는다 — 팀 사정 차이일 수 있다.
+  //
+  //   ★의도된 사각지대★: 정본에만 있는 줄은 세지 않는다. 그 대가로 ★공개본에서 삭제된 규칙이
+  //   그 팀에 계속 남아도 알리지 않는다.★ 팀 고유 규칙과 구분할 방법이 없어서 택한 쪽이다.
+  //   버그가 아니라 선택이다 — 반대로 하면 고유 규칙을 더한 팀이 영구 경고를 받는다.
   try {
     const rulesLive = join(RULES_DIR, "TEAM-OS.md");
     const rulesTemplate = join(RULES_DIR, "TEAM-OS.template.md");
     if (existsSync(rulesLive) && existsSync(rulesTemplate)) {
       const live = readFileSync(rulesLive, "utf8");
       const tmpl = readFileSync(rulesTemplate, "utf8");
-      if (live !== tmpl) {
-        const missing = missingFromLive(live, tmpl);
+      // ★게이트는 "다르다" 가 아니라 "안 받은 규칙이 있다" 여야 한다.★
+      //   팀이 고유 규칙을 한 줄만 더해도 live !== tmpl 은 늘 참이다. 그걸로 경고하면
+      //   "안 받은 줄 0개" 라는 ★할 일 없는 경고★ 가 재시작마다 영구히 뜬다.
+      //   사람은 매번 뜨는 경고를 안 읽게 되고, 정작 새 규칙이 왔을 때도 안 읽는다.
+      const missing = missingFromLive(live, tmpl);
+      if (missing.length > 0) {
         console.warn(
           `[teamos-rules] 규칙 정본이 공개 템플릿과 다릅니다 — 템플릿에만 있는 줄 ${missing.length}개.` +
             " 팀 사정에 맞춘 차이면 그대로 두고, 공개본의 새 규칙이면 rules/TEAM-OS.md 에 옮기세요." +

--- a/src/server/lib/rulesDrift.test.ts
+++ b/src/server/lib/rulesDrift.test.ts
@@ -16,3 +16,19 @@ test("빈 줄은 세지 않는다", () => {
   // 그때 trim 검사가 없으면 템플릿의 빈 줄이 전부 "새 규칙" 으로 세어진다.
   expect(missingFromLive("- a", "- a\n\n\n")).toEqual([]);
 });
+
+// steve 지적: 게이트를 "다르다" 로 두면 이 경우에 "0개" 경고가 영구히 뜬다.
+// 경고 조건은 missing.length > 0 이므로, 이 경우 조용해야 한다.
+test("팀이 고유 규칙만 더한 상태에서는 알릴 것이 없다", () => {
+  const tmpl = "- a\n- b\n";
+  const live = "- a\n- b\n- 우리 팀만의 규칙\n";
+  expect(live).not.toBe(tmpl);          // 파일은 분명히 다르다
+  expect(missingFromLive(live, tmpl)).toEqual([]);  // 그런데 안 받은 규칙은 없다
+});
+
+test("고유 규칙이 있어도 새 규칙이 오면 그것만 집는다", () => {
+  const tmpl = "- a\n- 새 규칙\n- b\n";
+  const live = "- a\n- b\n- 우리 팀만의 규칙\n";
+  expect(missingFromLive(live, tmpl)).toEqual(["- 새 규칙"]);
+});
+

--- a/src/server/lib/rulesDrift.test.ts
+++ b/src/server/lib/rulesDrift.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "bun:test";
+import { missingFromLive } from "./rulesDrift";
+
+test("같으면 0", () => {
+  const s = "- a\n- b\n";
+  expect(missingFromLive(s, s)).toEqual([]);
+});
+test("템플릿에만 있는 새 규칙을 잡는다", () => {
+  expect(missingFromLive("- a\n- b\n", "- a\n- 새 규칙\n- b\n")).toEqual(["- 새 규칙"]);
+});
+test("정본에만 있는 팀 고유 규칙은 차이로 세지 않는다", () => {
+  expect(missingFromLive("- a\n- 우리 팀만의 규칙\n", "- a\n")).toEqual([]);
+});
+test("빈 줄은 세지 않는다", () => {
+  // 정본이 개행으로 끝나지 않으면 정본 쪽 집합에 "" 가 없다.
+  // 그때 trim 검사가 없으면 템플릿의 빈 줄이 전부 "새 규칙" 으로 세어진다.
+  expect(missingFromLive("- a", "- a\n\n\n")).toEqual([]);
+});

--- a/src/server/lib/rulesDrift.ts
+++ b/src/server/lib/rulesDrift.ts
@@ -1,0 +1,13 @@
+/**
+ * 규칙 정본이 공개 템플릿과 벌어졌는지 본다.
+ *
+ * `rules/TEAM-OS.md` 는 추적 대상이 아니라 업데이트와 함께 오지 않는다. 템플릿만 온다.
+ * 그래서 규칙이 바뀌어도 받는 쪽은 모른다 — 실제로 한 기계만 옛 규칙으로 돈 적이 있다.
+ *
+ * ★한 방향만 센다★ — 템플릿에만 있는 줄(= 아직 안 받은 새 규칙).
+ * 정본에만 있는 줄은 그 팀이 의도적으로 더한 규칙일 수 있으므로 차이로 세지 않는다.
+ */
+export function missingFromLive(live: string, template: string): string[] {
+  const liveLines = new Set(live.split("\n"));
+  return template.split("\n").filter((l) => l.trim().length > 0 && !liveLines.has(l));
+}


### PR DESCRIPTION
## 문제

배포 게이트에 규칙 대조를 넣었다(#194). 그 게이트를 쓰지 않는 설치본이 있다.

손으로 업데이트하는 팀에는 `release-preflight.sh` 도 `deploy-live.sh` 도 오지 않는다.
`/scripts/*` 와 스킬 배치 방식 때문이다. 그 기계에서는 규칙이 벌어져도 알려주는 것이 없다.

실제로 한 대가 옛 규칙으로 돌았고, 그쪽에서 스스로 대조해서 찾았다.
찾지 않았으면 계속 돌았을 것이다.

## 고친 것

서버는 어느 설치본에나 있다. 부팅 때 한 번 더 본다.

- 템플릿에만 있는 줄만 센다. 정본에만 있는 줄은 그 팀이 의도적으로 더한 규칙일 수 있다.
- 고치지 않는다. 경고를 찍고 `audit_event` 에 남긴다.

## 검증

- 벌어진 짝을 만들어 실제 함수를 돌렸다. 템플릿에만 있는 그 줄을 집어낸다.
- 변이 2종을 걸었다. 차이를 못 찾게 하면 실패, 빈 줄 제외를 빼면 실패.
  두 번째는 **처음에 살아남았다** — 정본이 개행으로 끝나는 입력이라 빈 줄이 우연히 걸러졌다.
  정본이 개행으로 끝나지 않는 입력으로 바꾼 뒤에야 갈린다.
