### PR TITLE
chore(web): 맥 앱 다운로드 태그를 v0.6.0 으로

### DIFF
--- a/src/web/components/MetricsBar.ts
+++ b/src/web/components/MetricsBar.ts
@@ -25,7 +25,7 @@ function isMacClient(): boolean {
 //   외부 사용자가 신고할 때까지 ★하루 동안 아무 경고도 없었다.★
 //   그래서 ★자산이 실제로 붙어 있는 태그★ 를 가리킨다. 앱을 새로 공증해 릴리스에 첨부할 때 이 값을 올린다.
 //   (release-preflight 에 'latest 에 b3os.app.zip 이 있는가' 가드를 넣기 전까지는 latest 로 되돌리지 않는다)
-export const MAC_APP_DOWNLOAD_TAG = "v0.5.0";
+export const MAC_APP_DOWNLOAD_TAG = "v0.6.0";
 export const MAC_APP_DOWNLOAD_URL =
   `https://github.com/b3rys/b3rys-team-os/releases/download/${MAC_APP_DOWNLOAD_TAG}/b3os.app.zip`;
 


### PR DESCRIPTION
## 문제

대시보드 다운로드 링크가 `v0.5.0` 자산을 가리킨다. 그 빌드에는 단일 앱 통합과 주소 3개 저장이 없다.
가이드 문서는 그 기능을 설명하므로, 링크로 받은 앱과 문서가 어긋난다.

## 변경

`MAC_APP_DOWNLOAD_TAG` 를 `v0.6.0` 으로 바꾼다. 자산은 이미 올라가 있다.

## 검증

**자산을 먼저 올리고, 공개 URL 에서 실제로 내려받아 대조한 뒤 태그를 바꿨다.**
태그만 바꾸고 자산이 없으면 링크가 404 가 되는데 테스트로는 잡히지 않는다 —
`macAppDownloadUrl.test.ts` 는 태그 형식과 URL 문자열만 단정하고 자산 존재는 보지 않는다.

```
GET releases/download/v0.6.0/b3os.app.zip
  HTTP 200 · 460,235 bytes
  SHA-256 0949eb1c7a9dee5fda1a69a8286d2579b723bcc4944a516c05774c742b5fbc0a  (로컬 산출물과 일치)
```

| 항목 | 결과 |
|---|---|
| `stapler validate` | The validate action worked! |
| `spctl -a -vv` | accepted · Notarized Developer ID · Developer ID Application: GUE DON JUNG (7NTC94U74E) |
| 번들 | 0.6.0 / build 2 / com.b3rys.b3os |
| 기능 문자열 | `shell.saveFile` 1 · `origin_not_allowed` 1 · `dashboards` 5 · 원격 오류 문구 1 |

`bun test src/web/components/macAppDownloadUrl.test.ts` 2 pass.