### PR TITLE
fix(skill): github-workflow frontmatter 가 YAML 로 파싱 안 되던 것

### DIFF
--- a/skills/b3os-github-workflow/SKILL.md
+++ b/skills/b3os-github-workflow/SKILL.md
@@ -1,5 +1,6 @@
 ---
-name: b3os-github-workflow description: 팀원이 코드 변경을 GitHub PR로 올려 승인·머지까지 가는 절차. 브랜치·worktree 격리, 커밋 신원(팀원 이름 + 팀 계정), PR 작성 계정, 검증 근거를 PR에 남기기, tier별 승인 요청, 머지 후 실측 확인. 팀원이 git-추적 파일을 고쳐 main에 반영해야 할 때 사용. 승인·안전 정책 자체는 TEAM-OS가 정본이고 여기는 절차만 다룬다.
+name: b3os-github-workflow
+description: 팀원이 코드 변경을 GitHub PR로 올려 승인·머지까지 가는 절차. 브랜치·worktree 격리, 커밋 신원(팀원 이름 + 팀 계정), PR 작성 계정, 검증 근거를 PR에 남기기, tier별 승인 요청, 머지 후 실측 확인. 팀원이 git-추적 파일을 고쳐 main에 반영해야 할 때 사용. 승인·안전 정책 자체는 TEAM-OS가 정본이고 여기는 절차만 다룬다.
 ---
 # GitHub 워크플로 — 변경을 PR로 올려 머지까지
 


### PR DESCRIPTION
## 핵심 3줄

1. `skills/b3os-github-workflow/SKILL.md` 의 frontmatter 에서 `name:` 과 `description:` 이 한 줄로 붙어 YAML 로 파싱되지 않는다. GitHub 미리보기가 거부한다 — "mapping values are not allowed in this context at line 1 column 39".
2. 이 스킬을 고르는 판단이 `description` 을 읽는다. 파싱이 안 되면 그 값이 없는 것과 같다. 공개 저장소에 12시간 있었다.
3. 두 키를 다시 두 줄로 나눈다. 1줄 수정.

## 원인

문단 줄바꿈을 정리하는 스크립트가 frontmatter 를 본문과 같은 방식으로 다뤘다. `name:` 줄이 특수 줄로 분류되지 않아 다음 줄인 `description:` 이 이어 붙었다.

## 그때 검사가 왜 통과했나

확인은 공백 제외 글자 동일 대조였다. 바뀐 것이 줄바꿈뿐이라 통과한다. **frontmatter 가 파싱되는지는 재지 않았다.** 사람 리뷰 2인과 배포 후 실측(줄수·잔존 문자열·절 구조)도 같은 축을 보지 않았다.

## 검증

| 무엇을 | 결과 |
|---|---|
| 이 파일 frontmatter | `name` / `description` 두 줄로 분리 |
| 스킬 18개 전수 | 한 줄에 키 2개 이상 있는 파일 0건 |

검사 방법 — 각 `SKILL.md` 의 `---` 블록을 뽑아 각 줄에 `key:` 패턴이 둘 이상인지 본다.

## 미검증

에이전트가 이 스킬을 실제로 선택하는지는 재지 않았다. 파싱 가능 여부까지 확인했다.

## 롤백

이 커밋 revert.

Submitted-by: bill
