### PR TITLE
docs: record Claude tool-call log path

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -77,6 +77,17 @@ bun run src/server/index.ts
 OpenClaw Codex 세션의 도구 호출은 `~/.openclaw/agents/<계정>/agent/codex-home/sessions/YYYY/MM/DD/rollout-*.jsonl` 에 기록됩니다.
 `custom_tool_call`의 도구 이름과 입력을 함께 확인해 실제 파일 읽기 명령의 대상과 대화·검색에 포함된 단순 경로 언급을 구분합니다.
 
+### Claude 도구 호출 로그
+
+Claude 세션의 도구 호출은 `~/.claude/projects/<작업 디렉터리 경로를 -로 바꾼 이름>/<세션 UUID>.jsonl` 에 기록됩니다. 한 줄이 JSON 하나이고, 도구 호출은 `message.content[]` 안의 `type: "tool_use"` 항목에 `name`(도구)과 `input`(인자)으로 남습니다.
+
+**이름이 인자에 들어 있는 것은 읽었다는 뜻이 아닙니다.** 그 파일을 화제로 삼아 메시지를 보내거나 이름으로 검색하기만 해도 같은 문자열이 `Bash` 인자에 그대로 찍힙니다. 이쪽이 실제 읽기보다 두 자릿수 배 많아서, 이름 매칭만으로 세면 **모두가 모든 파일을 읽은 것으로 나옵니다.** 읽었는지는 아래 둘로만 셉니다.
+
+- `name` 이 `Read` 이고 `input.file_path` 가 그 파일을 가리킨다
+- `name` 이 `Skill` 이고 `input.skill` 이 그 스킬이다
+
+`Bash` 인자에 이름만 있는 것은 언급으로 봅니다. 그 명령이 읽기였는지 가리려면 명령 문자열을 해석해야 하는데, 한 명령 안에 메시지 본문이 함께 들어 있는 경우가 많아 자동 판정에는 쓰지 않습니다.
+
 > 💡 **직접 외우거나 적어둘 것이 없습니다.** `team-os` 가 알아서 찾습니다.
 >
 > - **자동실행 이름**(`com.<사용자>.…`)은 설치마다 다릅니다 →


### PR DESCRIPTION
Claude 런타임의 도구 호출 로그 경로가 어디에도 적혀 있지 않아 매번 다시 찾아야 한다. #208 이 Codex 경로를 적은 자리에 Claude 경로를 나란히 추가한다.

## 넣은 것

- 경로: `~/.claude/projects/<작업 디렉터리 경로를 -로 바꾼 이름>/<세션 UUID>.jsonl`
- 형식: 한 줄이 JSON 하나. 도구 호출은 `message.content[]` 의 `type: "tool_use"` 에 `name` + `input`.
- 읽기와 언급을 가르는 기준.

## 왜 기준이 필요한가

파일 이름이 `input` 에 들어 있다고 그 파일을 읽은 것이 아니다. 그 파일을 화제로 메시지를 보내거나 이름으로 검색하기만 해도 같은 문자열이 `Bash` 인자에 남는다. 실측하면 이 언급이 실제 읽기보다 두 자릿수 배 많다. 이름 매칭만으로 세면 모든 팀원이 모든 파일을 읽은 것으로 나온다.

그래서 읽기는 두 가지로만 센다.

- `name` == `Read` 이고 `input.file_path` 가 그 파일
- `name` == `Skill` 이고 `input.skill` 이 그 스킬

## 검증

- 이 저장소의 Claude 세션 로그 전수에 두 판정식을 적용해 `Bash` 인자 매칭과 결과를 비교했다. 이름 매칭은 세 자릿수, 판정식 통과는 두 자릿수로 갈린다.
- 문서 변경만이라 코드 영향 없음.

Submitted-by: steve