### PR TITLE
fix(bus): coordinator 게이트 제거 — 연쇄 차단만 남긴다

### DIFF
--- a/src/server/routes/broadcastGate.test.ts
+++ b/src/server/routes/broadcastGate.test.ts
@@ -57,26 +57,9 @@ const send = (h: ReturnType<typeof createInboxRoutes>, body: Record<string, unkn
     }),
   });
 
-describe("★팀원 broadcast 는 coordinator + --all-hands 가 있어야 나간다★", () => {
-  it("coordinator 가 아니면 거부한다 — 오늘 47건 중 42건이 여기 걸린다", async () => {
-    const { h } = app();
-    const res = await send(h, { from_agent_id: "steve", all_hands: "서버 내립니다" });
-    expect(res.status, "★비-coordinator 의 broadcast 가 통과했다★").toBe(403);
-    expect((await res.json()).error).toBe("broadcast_not_allowed");
-  });
-
-  it("coordinator 라도 --all-hands 이유가 없으면 거부한다", async () => {
-    const { h } = app();
-    const res = await send(h, { from_agent_id: "bill" });
-    expect(res.status, "★이유 없이 broadcast 가 통과했다★").toBe(403);
-  });
-
-  it("coordinator + 이유가 있으면 나간다 — 진짜 전체공지는 막지 않는다", async () => {
-    const { h } = app();
-    const res = await send(h, { from_agent_id: "bill", all_hands: "서버 20:00 정지" });
-    expect(res.status, "★정당한 전체공지까지 막으면 안 된다★").not.toBe(403);
-  });
-});
+// ★coordinator 요구는 뺐다 (2026-08-01)★ — 넣었더니 방이 통째로 조용해졌다.
+//   팀장님 "@all 다들 인지했어?" 에 아무도 방에 답하지 못했다. 과녁은 ★연쇄★ 였지 발언 자체가 아니었다.
+//   그래서 그 계약을 검사하던 시험도 같이 지운다. 남는 계약은 아래 하나뿐이다.
 
 describe("★broadcast 에 대한 답은 broadcast 로 못 한다★ — 연쇄의 직접 고리", () => {
   it("부모가 broadcast 면 coordinator 라도 거부한다 (연쇄는 발신자를 안 가린다)", async () => {

--- a/src/server/routes/broadcastToGroup.test.ts
+++ b/src/server/routes/broadcastToGroup.test.ts
@@ -163,24 +163,14 @@ describe("--to broadcast → 언제나 단톡방", () => {
       }),
     });
 
-    // ★계약이 바뀌었다 (GD 2026-08-01)★: 1:1 질문에 broadcast 로 답하는 것은 ★거부★ 한다.
-    //   예전엔 그대로 방에 올렸다("서버가 몰래 고치지 않는다"). 그 정신은 유지하되 —
-    //   ★서버가 주소를 고쳐주지도, 조용히 버리지도 않는다. 이유를 붙여 거부하고 팀원이 다시 보낸다.★
-    //   오늘 이 형태가 소음의 본체였다(70분간 47건 → wake 517회).
-    expect(res.status).toBe(403);
-    const body = (await res.json()) as { error?: string; detail?: string };
-    expect(body.error).toBe("broadcast_not_allowed");
-    expect(body.detail, "★어떻게 보내야 하는지 알려줘야 한다 — 거부만 하면 팀원이 헤맨다★")
-      .toContain("--to <이름>");
-    // ★조용히 사라지지 않는다★ — 저장도 안 된다(거부이므로). 팀원은 에러를 보고 다시 보낸다.
-    const row = db.prepare(`SELECT to_agent_id FROM message WHERE in_reply_to='ASK1'`).get() as
-      | { to_agent_id: string }
-      | undefined;
-    expect(row ?? undefined, "★거부했으면 저장하면 안 된다★").toBeUndefined();
-    // ★방에도 안 뜬다★ — 거부했으니 게시할 것이 없다.
-    //   예전 계약은 "잘못 보냈어도 방에 뜬다(숨기지 않는다)" 였다. 지금은 ★애초에 안 받는다.★
-    //   숨기는 것과 다르다 — 팀원은 403 과 이유를 받고 `--to <이름>` 으로 다시 보낸다.
-    expect(sent, "★거부한 메시지가 방에 나갔다★").toHaveLength(0);
+    // ★잘못 보낸 주소는 서버가 고치지 않는다★ — 그대로 방에 뜬다(원래 계약 복귀).
+    //   coordinator 게이트를 뺐으므로 이 경로는 다시 통과한다. 막는 건 ★broadcast 답장★ 하나뿐이다.
+    expect(res.status).toBe(201);
+    const row = db.prepare(`SELECT to_agent_id FROM message WHERE in_reply_to='ASK1'`).get() as {
+      to_agent_id: string;
+    };
+    expect(row.to_agent_id).toBe("broadcast");
+    expect(sent).toHaveLength(1);
   });
 
   test("팀원에게 보내는 건(--to steve) 방에 안 나간다 — 버스는 함수호출 채널이다", async () => {

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -188,22 +188,10 @@ export function createInboxRoutes(deps: InboxRouteDeps): Hono {
           }, 403);
         }
       }
-      // 팀장님 @all 에 대한 답이면 coordinator·사유 요구도 면제한다 — 위와 같은 이유.
-      const replyingToLeadCall = env.in_reply_to
-        ? ((deps.db.prepare(`SELECT source, to_agent_id FROM message WHERE id = ?`)
-            .get(env.in_reply_to) as { source?: string; to_agent_id?: string } | undefined)?.source === "user"
-           && (deps.db.prepare(`SELECT to_agent_id FROM message WHERE id = ?`)
-            .get(env.in_reply_to) as { to_agent_id?: string } | undefined)?.to_agent_id === "broadcast")
-        : false;
-      if (rosterKnown && !replyingToLeadCall && (!isCoordinator || reason.length === 0)) {
-        return c.json({
-          error: "broadcast_not_allowed",
-          detail: !isCoordinator
-            ? "broadcast 는 coordinator 만 보낼 수 있습니다. 답/결과는 요청자에게 --to <이름>, 팀장님께는 --direct-to-gd 로 보내십시오."
-            : "broadcast 에는 --all-hands \"<이유>\" 가 필요합니다. 전원이 봐야 하는 사실인지 한 줄로 적으십시오.",
-          coordinator: coordinatorId(roster) ?? null,
-        }, 403);
-      }
+      // ★coordinator 요구는 뺐다 (2026-08-01 실측)★ — 넣었더니 ★방이 통째로 조용해졌다.★
+      //   팀장님 "@all 다들 인지했어?" 에 아무도 방에 답하지 못했다(전원 1:1 로 우회).
+      //   내가 막으려던 것은 ★연쇄★ 지 방에서 말하는 것 자체가 아니었다. 과녁을 잘못 잡았다.
+      //   → 남기는 규칙은 ★하나뿐★: broadcast 에 broadcast 로 답하지 않는다(위 검사). 그게 고리다.
     }
 
     // Phase 2a: dedupe(60s) + ensureThread + insertMessage + (audit) + broadcast → 공통 acceptInbound (P2)


### PR DESCRIPTION
fix(bus): coordinator 게이트 제거 — 방을 통째로 막았다. 연쇄 차단만 남긴다

★실측: 배포 후 팀장님 '@all 다들 인지했어?' 에 방으로 답한 사람 0명.★
11명 전원이 broadcast_not_allowed 로 막혀 1:1 로 우회했다. 팀장님: '답이 그 방으로 다들 와야지'.

내가 막으려던 것은 ★팀원끼리의 연쇄★ 였는데 ★방에서 말하는 것 자체★ 를 막았다. 과녁이 틀렸다.
오늘 과잉 차단 세 번째다(슬랙 → 팀장 @all 답 → 방 전체).

남기는 규칙은 ★하나뿐★: broadcast 에 broadcast 로 답하지 않는다.
그게 연쇄의 고리다(47건 중 18건). 나머지는 룰과 팀원 판단에 맡긴다.
★게이트로 막을 것과 룰로 맡길 것을 내가 잘못 갈랐다.★

Submitted-by: bill