### PR TITLE
fix(bus): 팀원 본문의 멘션이 라우팅을 정하던 동작 제거 — 룰에 근거가 없다

### DIFF
--- a/src/server/bus/wakeDispatcher.characterization.test.ts
+++ b/src/server/bus/wakeDispatcher.characterization.test.ts
@@ -152,11 +152,26 @@ describe("3c wake 경계 — comm 매트릭스", () => {
     expect(rcpt(db, row.message_id, "codex")?.last_error).toBe("broadcast_inbox_only_no_wake_marker");
   });
 
-  test("broadcast + @all 마커 → wake (마커 있으면 깨움)", async () => {
-    const row = pendingRowFor(db, "codex", { to_agent_id: "broadcast", type: "broadcast", body: "@all 다들 확인", explicit_recipients: ["codex"] });
+  // ★기대값을 뒤집었다 — 옛 기대값(1회 깨움)은 사양 위반을 정답으로 고정하고 있었다.★
+  // 마커를 쓸 수 있는 것은 팀장님뿐이라는 계약은 수신행 생성에만 걸려 있었고 깨움에는 없었다.
+  // 그래서 이 시험은 "팀원이 @all 로 전원을 깨운다" 를 지키고 있었다 — 룰에 근거가 없는 동작이다.
+  // 되돌리기 전에 broadcastAudience 의 계약을 먼저 보라. 발신자와 마커를 함께 본다.
+  test("broadcast + @all 마커 + 팀원 발신 → no-wake (마커는 팀장님 전용)", async () => {
+    const row = pendingRowFor(db, "codex", { to_agent_id: "broadcast", type: "broadcast", body: "@all 다들 확인", explicit_recipients: ["codex"], source: "agent" });
     const spy = spyAdapter(() => ({ ok: true }));
     await dispatch(db, row, { openclaw: spy.adapter });
-    expect(spy.calls).toBe(1); // @all 마커 = wake
+    expect(spy.calls).toBe(0); // 팀원의 @all = 효력 없음
+  });
+
+  // ★반대쪽 축 — 팀장님 @all 이 조용해지면 그게 제일 큰 사고다.★
+  // dispatcher 가 팀원 것만 처리한다는 주석은 사실이 아니다: startup cleanup 이
+  // runtime IN ('b3os_native','codex') 인 팀원의 user-source pending 행을 ★일부러 남긴다★.
+  // 그 런타임은 팀장님 메시지를 버스로 받는다 — 이 경로가 실재한다는 증거다.
+  test("broadcast + @all 마커 + 팀장님 발신 → wake (이 경로는 살아 있어야 한다)", async () => {
+    const row = pendingRowFor(db, "codex", { to_agent_id: "broadcast", type: "broadcast", body: "@all 다들 확인", explicit_recipients: ["codex"], source: "user" });
+    const spy = spyAdapter(() => ({ ok: true }));
+    await dispatch(db, row, { openclaw: spy.adapter });
+    expect(spy.calls).toBe(1); // 팀장님의 @all = 깨움
   });
 
   // collect_only 경계 (Codex 적대리뷰 §3c): 수집형 위임 응답은 coordinator wake 억제, 일반 directed Q&A는 wake.

--- a/src/server/bus/wakeDispatcher.characterization.test.ts
+++ b/src/server/bus/wakeDispatcher.characterization.test.ts
@@ -174,6 +174,19 @@ describe("3c wake 경계 — comm 매트릭스", () => {
     expect(spy.calls).toBe(1); // 팀장님의 @all = 깨움
   });
 
+  // ★통일이 동작으로 고정되는 지점 — 이 시험이 없으면 인라인 정규식을 되넣어도 아무것도 안 깨진다.★
+  // 깨움 판정을 hasBroadcastAllMarker 로 모은 것의 ★유일한 관측 가능한 차이★ 가 여기다.
+  // 인라인 정규식은 본문을 날것으로 봐서 코드펜스 안의 예시까지 마커로 쳤다.
+  // ★인용줄(> @all)로는 이 축을 못 잰다★ — stripQuotedForRouting 이 인용줄을 제거 대상으로 안 잡아
+  // 옛 판정과 새 판정이 ★똑같이 true★ 다. 판별되는 것은 코드펜스·구분선뿐이다.
+  // 발신자를 팀장님으로 두는 것도 의도다 — 그래야 "팀원이라서 0" 이 아니라 ★"마커가 아니라서 0"★ 을 잰다.
+  test("팀장님 발신이어도 ★코드펜스 안의 @all 은 안 깨운다★ — 라우팅과 같은 계약", async () => {
+    const row = pendingRowFor(db, "codex", { to_agent_id: "broadcast", type: "broadcast", body: "이렇게 씁니다:\n```\n@all 다들 확인\n```", explicit_recipients: ["codex"], source: "user" });
+    const spy = spyAdapter(() => ({ ok: true }));
+    await dispatch(db, row, { openclaw: spy.adapter });
+    expect(spy.calls).toBe(0); // 예시로 보여준 @all 은 마커가 아니다
+  });
+
   // collect_only 경계 (Codex 적대리뷰 §3c): 수집형 위임 응답은 coordinator wake 억제, 일반 directed Q&A는 wake.
   const cRow = (over: Record<string, unknown>): PendingDispatchRow =>
     ({ agent_id: "bill", to_agent_id: "bill", type: "reply", thread_id: "t1", in_reply_to: null, parent_message_id: null, meta_json: null, ...over } as PendingDispatchRow);

--- a/src/server/bus/wakeDispatcher.characterization.test.ts
+++ b/src/server/bus/wakeDispatcher.characterization.test.ts
@@ -153,7 +153,7 @@ describe("3c wake 경계 — comm 매트릭스", () => {
   });
 
   test("broadcast + @all 마커 → wake (마커 있으면 깨움)", async () => {
-    const row = pendingRowFor(db, "codex", { to_agent_id: "broadcast", type: "broadcast", body: "@all 다들 확인" });
+    const row = pendingRowFor(db, "codex", { to_agent_id: "broadcast", type: "broadcast", body: "@all 다들 확인", explicit_recipients: ["codex"] });
     const spy = spyAdapter(() => ({ ok: true }));
     await dispatch(db, row, { openclaw: spy.adapter });
     expect(spy.calls).toBe(1); // @all 마커 = wake

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -34,6 +34,7 @@ import { insertMessage } from "../db/inboxQueries";
 import { recoverB3osNativeInflight } from "../runtimes/b3osNative/recovery";
 import { recoverCodexInflight } from "../runtimes/codex/recovery";
 import { appendAuditFile } from "../lib/auditFile";
+import { hasBroadcastAllMarker } from "../lib/teamRouter/ownerDecision";
 import { checkPingpong } from "./antiPingpong";
 import { recordReportDelivery } from "./deliveryRecord";
 import { applySync, mirrorDeadLetter } from "./syncPolicy";
@@ -155,6 +156,7 @@ export function inFlightGraceForRuntime(runtime: string | undefined): number {
   return IN_FLIGHT_GRACE_MS;
 }
 const UNKNOWN_SIDE_EFFECT_DETAIL = "execute_timeout_maybe_partial";
+// ★마커 판정은 한 곳(ownerDecision)만 쓴다★ — 같은 정규식이 두 곳에 있으면 한쪽만 고쳐진다.
 // pre-widen: allowlist of agent IDs to wake-dispatch.
 // BUS_DISPATCH_AGENTS="bill,codex,demis" → only those recipients get dispatched.
 // Recipients not in the list are skipped (row stays 'pending' until they're added).
@@ -1144,7 +1146,7 @@ function buildDispatchPlan(
   // Direct messages (to_agent_id != 'broadcast') always wake the addressed recipient.
   // (user-source broadcasts are already excluded upstream by the source='agent' scope.)
   const isBroadcast = row.to_agent_id === "broadcast" || row.type === "broadcast";
-  if (isBroadcast && !/@(all|b3rys|group)\b/i.test(row.body)) {
+  if (isBroadcast && !hasBroadcastAllMarker(row.body)) {
     db.prepare(
       `UPDATE message_recipient
        SET delivery_state = 'completed',

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -34,7 +34,7 @@ import { insertMessage } from "../db/inboxQueries";
 import { recoverB3osNativeInflight } from "../runtimes/b3osNative/recovery";
 import { recoverCodexInflight } from "../runtimes/codex/recovery";
 import { appendAuditFile } from "../lib/auditFile";
-import { hasBroadcastAllMarker } from "../lib/teamRouter/ownerDecision";
+import { broadcastAudience } from "../lib/teamRouter/ownerDecision";
 import { checkPingpong } from "./antiPingpong";
 import { recordReportDelivery } from "./deliveryRecord";
 import { applySync, mirrorDeadLetter } from "./syncPolicy";
@@ -1140,13 +1140,18 @@ function buildDispatchPlan(
     return { kind: "skip" };
   }
 
-  // @all-gating (GD 2026-05-27): a broadcast message wakes every recipient ONLY when its body
-  // carries an explicit wake-all marker (@all / @ALL / @b3rys / @group). Without the marker a
-  // broadcast is inbox-only — it lands in each inbox (visible) but does NOT proactively wake.
+  // @all-gating: a broadcast wakes every recipient ONLY when the team lead wrote it AND the body
+  // carries a wake-all marker (@all / @ALL / @b3rys / @group). Without both, a broadcast is
+  // inbox-only — it lands in each inbox (visible) but does NOT proactively wake.
   // Direct messages (to_agent_id != 'broadcast') always wake the addressed recipient.
-  // (user-source broadcasts are already excluded upstream by the source='agent' scope.)
+  //
+  // ★발신자를 함께 본다 — 마커만 보면 안 된다.★ 마커를 쓸 수 있는 것은 팀장님뿐이라는 계약은
+  // 수신행 생성(db/inbox/messages.ts)에서만 걸려 있었고 여기서는 안 걸려 있었다. 그래서
+  // 팀원 broadcast 에 수신행이 생기는 경로가 하나라도 생기면 팀원의 @all 이 전원을 다시 깨웠다.
+  // 지금은 수신행이 0이라 우연히 안전할 뿐이다 — 우연에 기대지 않도록 같은 판정을 여기에도 건다.
+  // 두 곳이 같은 broadcastAudience 를 쓰므로 한쪽만 고쳐서 어긋나는 일이 없다.
   const isBroadcast = row.to_agent_id === "broadcast" || row.type === "broadcast";
-  if (isBroadcast && !hasBroadcastAllMarker(row.body)) {
+  if (isBroadcast && broadcastAudience(row.body, row.source).kind !== "all_hands") {
     db.prepare(
       `UPDATE message_recipient
        SET delivery_state = 'completed',

--- a/src/server/db/inbox/broadcastComplete.test.ts
+++ b/src/server/db/inbox/broadcastComplete.test.ts
@@ -30,7 +30,7 @@ const isActionRequired = (rows: ReturnType<typeof rcpts>) => rows.some((r) => r.
 describe("broadcast complete — FYI 수신행은 action-required로 안 쌓임", () => {
   test("@all(agent broadcast) 수신행은 acknowledged(broadcast_fyi), open 아님", () => {
     const db = setup();
-    const m = insertMessage(db, { thread_id: "t1", from_agent_id: "gd", to_agent_id: "broadcast", type: "broadcast", body: "@all 인사", source: "agent" } as never);
+    const m = insertMessage(db, { thread_id: "t1", from_agent_id: "gd", to_agent_id: "broadcast", type: "broadcast", body: "@all 인사", source: "agent", explicit_recipients: ["bill","steve","demis","dbak"] } as never);
     const rows = rcpts(db, m.id);
     expect(rows.length).toBe(4); // bill·steve·demis·dbak (sender gd 제외)
     for (const r of rows) {
@@ -63,7 +63,7 @@ describe("broadcastOpenBackfill — 기존 open broadcast 행 일회 정리", ()
   test("기존 open broadcast 행 → acknowledged(broadcast_fyi), directed open은 유지", () => {
     const db = setup();
     // 옛 broadcast 행을 강제로 open 으로(fix 전 상태 재현)
-    const m = insertMessage(db, { thread_id: "t1", from_agent_id: "gd", to_agent_id: "broadcast", type: "broadcast", body: "@all 옛인사", source: "agent" } as never);
+    const m = insertMessage(db, { thread_id: "t1", from_agent_id: "gd", to_agent_id: "broadcast", type: "broadcast", body: "@all 옛인사", source: "agent", explicit_recipients: ["steve"] } as never);
     db.prepare(`UPDATE message_recipient SET recipient_state='open', close_reason=NULL WHERE message_id=?`).run(m.id);
     // directed open 도 하나
     const d = insertMessage(db, { thread_id: "t1", from_agent_id: "gd", to_agent_id: "steve", type: "dm", body: "directed", source: "agent" } as never);
@@ -75,7 +75,7 @@ describe("broadcastOpenBackfill — 기존 open broadcast 행 일회 정리", ()
 
   test("idempotent: flag-guard로 2회차 no-op", () => {
     const db = setup();
-    const m = insertMessage(db, { thread_id: "t1", from_agent_id: "gd", to_agent_id: "broadcast", type: "broadcast", body: "@all", source: "agent" } as never);
+    const m = insertMessage(db, { thread_id: "t1", from_agent_id: "gd", to_agent_id: "broadcast", type: "broadcast", body: "@all", source: "agent", explicit_recipients: ["steve"] } as never);
     db.prepare(`UPDATE message_recipient SET recipient_state='open' WHERE message_id=?`).run(m.id);
     broadcastOpenBackfill(db); // migrate()가 이미 한 번 돌려 flag set 됨 → 이건 no-op일 수 있음
     db.prepare(`DELETE FROM runtime_lock WHERE key='broadcast_open_close_v1'`).run();

--- a/src/server/db/inbox/broadcastRecipients.test.ts
+++ b/src/server/db/inbox/broadcastRecipients.test.ts
@@ -66,7 +66,7 @@ function withRoster(roster: Array<Record<string, unknown>>): Database {
   return db;
 }
 
-function broadcastFrom(db: Database, from: string, source = "agent", body = "@all 공지"): string[] {
+function broadcastFrom(db: Database, from: string, source = "user", body = "@all 공지"): string[] {
   const { thread_id } = ensureThread(db, { from_agent_id: from, to_agent_id: "broadcast", type: "broadcast", body } as never);
   const stored = insertMessage(db, { from_agent_id: from, to_agent_id: "broadcast", type: "broadcast", body, thread_id, source } as never);
   return db
@@ -76,15 +76,6 @@ function broadcastFrom(db: Database, from: string, source = "agent", body = "@al
 }
 
 describe("★팀원 broadcast 팬아웃은 @all 과 같은 규칙을 쓴다★", () => {
-  test("비정식·정지 팀원에게는 수신행이 생기지 않는다", () => {
-    const db = withRoster(ROSTER);
-    const got = broadcastFrom(db, "sender");
-    // 기대값 = 같은 명부에서 규칙으로 다시 계산 (하드코딩 아님)
-    expect(got).toEqual(broadcastRecipientIds(ROSTER as never, "sender").slice().sort());
-    expect(got, "★꺼둔 팀원이 깨어난다★ — 이게 원래 결함이었다").not.toContain("paused");
-    expect(got, "비정식 팀원은 대상이 아니다").not.toContain("observer");
-    expect(got, "발신자는 자기 글을 안 받는다").not.toContain("sender");
-  });
 
   test("★슬랙 스레드 답신은 팀원 수신행을 만들지 않는다 (멘션 기준)★", () => {
     // 슬랙은 멘션된 글만 들어온다 → 그 대화의 우리 쪽 당사자는 발신자 한 명뿐이다.
@@ -126,23 +117,42 @@ describe("★팀원 broadcast 팬아웃은 @all 과 같은 규칙을 쓴다★",
     expect(broadcastFrom(db, "sender", "agent", "@member 이거 봐줘")).toEqual([]);
   });
 
-  test("★@all 은 정식·활성 팀원 전원에게 간다★", () => {
-    const db = withRoster(ROSTER);
-    const got = broadcastFrom(db, "sender", "agent", "@all 다들 확인");
-    expect(got).toEqual(broadcastRecipientIds(ROSTER as never, "sender").slice().sort());
-    expect(got).not.toContain("paused");
-    expect(got).not.toContain("observer");
+  // ★@all 은 팀장님 전용이다.★ (GD 2026-08-01: "멘션은 팀장만 하는 거라고" · "원래 그랬어")
+  //   코드가 룰을 안 따르고 있었다 — 팀원이 @all 을 쓰면 전원이 깨어났다.
+  //   실측: 그날 팀원이 쓴 @all 중 전체공지 목적은 검증용 1건뿐이고, 나머지는 전부
+  //   ★"@all 이라는 단어를 문장 안에서 언급"★ 한 것이었다. ★언급만 해도 8명이 깨어났다.★
+  describe("★@all 마커는 팀장님(source=user) 전용★", () => {
+    test("팀원이 @all 을 써도 수신행 0", () => {
+      const db = withRoster(ROSTER);
+      expect(broadcastFrom(db, "sender", "agent", "@all 다들 확인")).toEqual([]);
+    });
+
+    test("★단어로 언급만 한 경우도 0★ — 그날 실제로 있던 형태", () => {
+      const db = withRoster(ROSTER);
+      expect(broadcastFrom(db, "sender", "agent", "결함은 그중 하나(@all)에만 있습니다")).toEqual([]);
+    });
+
+    test("@b3rys · @group 도 같다", () => {
+      const db = withRoster(ROSTER);
+      expect(broadcastFrom(db, "sender", "agent", "@b3rys 확인")).toEqual([]);
+      expect(broadcastFrom(db, "sender", "agent", "@group 확인")).toEqual([]);
+    });
+
+    test("★coordinator 도 예외 없다★ — 판정은 source 하나로만 한다", () => {
+      // capability 를 보는 순간 그게 유일한 구멍이 된다.
+      const withCoord = ROSTER.map((a) => (a.id === "sender" ? { ...a, capabilities: ["coordinator"] } : a));
+      const db = withRoster(withCoord);
+      expect(broadcastFrom(db, "sender", "agent", "@all 공지")).toEqual([]);
+    });
+
+    test("팀장님(source=user)이 쓰면 예전 그대로 — 전원", () => {
+      const db = withRoster(ROSTER);
+      const all = (db.prepare(`SELECT id FROM agent WHERE id != ?`).all("sender") as Array<{ id: string }>).map((r) => r.id).sort();
+      expect(broadcastFrom(db, "sender", "user", "@all 다들 확인")).toEqual(all);
+    });
   });
 
-  test("★@all 대상이 명부 플래그를 따른다 — 팬아웃과 @all 이 같은 답을 낸다★", () => {
-    // 소스를 grep 하지 않는다. ★함수명만 바꿔도 깨지고, 다른 파일에 판정이 생기면 못 본다★(하네스 지적).
-    // 대신 ★플래그를 바꿨을 때 결과가 따라오는지★ 로 잰다 — 판정이 둘이면 한쪽만 따라온다.
-    const flipped = ROSTER.map((a) => (a.id === "observer" ? { ...a, team_official_member: true } : a));
-    const db = withRoster(flipped);
-    const got = broadcastFrom(db, "sender", "agent", "@all 공지");
-    expect(got, "★명부 플래그를 켰는데 팬아웃이 안 따라온다 = 판정이 둘이다★").toContain("observer");
-    expect(got).toEqual(broadcastRecipientIds(flipped as never, "sender").slice().sort());
-  });
+
 
   test("★명부 파일이 없으면 DB 로 되돌아간다 — 아무에게도 안 가는 게 최악이다★", () => {
     // `agents.json` 은 gitignore 라 새 clone·공개 설치·테스트에 ★존재하지 않는다.★
@@ -155,15 +165,17 @@ describe("★팀원 broadcast 팬아웃은 @all 과 같은 규칙을 쓴다★",
     expect(got).not.toContain("sender");
   });
 
-  test("★명부에만 있고 DB 에 없는 팀원은 조용히 빠지지 않는다 — 감사에 남는다★", () => {
-    // 교집합으로 FK 사고는 막되, ★싱크가 깨진 사실은 남긴다.★ 안 남기면 아무도 모른다.
-    const extra = [...ROSTER, { id: "ghost", display_name: "Ghost", role: "r", runtime: "claude_channel", team_official_member: true }];
-    const path = join(dir, "roster-with-ghost.json");
-    writeFileSync(path, JSON.stringify(extra));
-    const db = withRoster(ROSTER);         // DB 에는 ghost 가 없다
-    process.env.TEAM_AGENT_REGISTRY = path; // 명부에는 있다
-    const got = broadcastFrom(db, "sender", "agent", "@all 공지");
-    expect(got, "DB 에 없는 id 를 넣으면 FK 로 삽입 전체가 터진다").not.toContain("ghost");
+  test("★DB 에 없는 수신자는 조용히 빠지지 않는다 — 감사에 남는다★", () => {
+    // 라우터가 준 명단에 DB 가 모르는 id 가 섞이면(명부↔DB 어긋남) ★FK 로 삽입 전체가 터진다.★
+    // 교집합으로 막되 ★깨진 사실은 남긴다★ — 안 남기면 아무도 모른다.
+    const db = withRoster(ROSTER);
+    const { thread_id } = ensureThread(db, { from_agent_id: "sender", to_agent_id: "broadcast", type: "broadcast", body: "x" } as never);
+    const m = insertMessage(db, {
+      from_agent_id: "sender", to_agent_id: "broadcast", type: "broadcast", body: "공지",
+      thread_id, source: "agent", explicit_recipients: ["member", "ghost"],
+    } as never);
+    const got = (db.prepare(`SELECT agent_id FROM message_recipient WHERE message_id=? ORDER BY agent_id`).all(m.id) as Array<{ agent_id: string }>).map((r) => r.agent_id);
+    expect(got, "DB 에 없는 id 를 넣으면 FK 로 삽입 전체가 터진다").toEqual(["member"]);
 
     const f = join(dir, `audit-${new Date().toISOString().slice(0, 10)}.log`);
     const log = existsSync(f) ? readFileSync(f, "utf8") : "";
@@ -173,7 +185,7 @@ describe("★팀원 broadcast 팬아웃은 @all 과 같은 규칙을 쓴다★",
 
   test("★빠진 사람이 없으면 아무것도 안 남긴다★ — 평상시 잡음이 되면 아무도 안 본다", () => {
     const db = withRoster(ROSTER);
-    broadcastFrom(db, "sender", "agent", "@all 공지");
+    broadcastFrom(db, "sender", "user", "@all 공지");
     const f = join(dir, `audit-${new Date().toISOString().slice(0, 10)}.log`);
     const log = existsSync(f) ? readFileSync(f, "utf8") : "";
     expect(log, "★정상인데 싱크 경고가 남았다★").not.toContain("registry_db_out_of_sync");

--- a/src/server/db/inbox/messages.ts
+++ b/src/server/db/inbox/messages.ts
@@ -4,9 +4,6 @@ import type { EnvelopeInbound, EnvelopeStored } from "../../../shared/envelopeSc
 import { MAX_HOPS_DEFAULT } from "../../../shared/envelopeSchema";
 import { type MessageRow, type ThreadRow, rowToEnvelope } from "./_shared";
 import { appendAuditFile } from "../../lib/auditFile";
-import { broadcastRecipientIds } from "../../lib/agentMembership";
-import { broadcastAudience } from "../../lib/teamRouter/ownerDecision";
-import { ambientAgents } from "../../lib/registry";
 import { applyAckClose, applyActivityAutoAck } from "../../bus/ackClose";
 
 export function ensureThread(
@@ -175,42 +172,33 @@ export function insertMessage(
         for (const r of rows) insertRcpt.run(id, r.id, rcptState);
       }
     } else {
-      // ── 팀원 방 발언 ──
-      //   "단톡방에선 내가 멘션한 사람만 얘기하는 거야. ★팀원끼리는 팀버스로.★" (GD)
-      //   방 게시·슬랙 릴레이는 그대로 나간다 — 여기서 만드는 건 ★수신행뿐★ 이다.
-      //   ★예외 하나: 본문에 @all★ → 정식·활성 팀원 전원.
-      //   실측(오늘 방 broadcast 82건): 멘션 없는 발언 51건 중 ★답이 달린 것 0건★ — 잘라도 안 끊긴다.
+      // ── 팀원 방 발언: ★수신행 0. 예외 없다.★ ──
+      //   "단톡방에선 내가 멘션한 사람만 얘기하는 거야. ★팀원끼리는 팀버스로.★" (GD 2026-08-01)
+      //   ★@all 도 팀장님 전용이다★ ("멘션은 팀장만 하는 거라고" · "원래 그랬어") — coordinator 도 예외 없다.
+      //   ★방 게시·슬랙 릴레이는 그대로 나간다.★ 여기서 만드는 건 수신행뿐이다.
+      //
+      //   실측: 그날 팀원이 쓴 @all 중 전체공지 목적은 검증용 1건뿐이고 나머지는 전부
+      //   ★"@all 이라는 단어를 문장 안에서 언급"★ 한 것이었다("결함은 그중 하나(@all)에만 있습니다" 등).
+      //   ★언급만 해도 8명이 깨어났다.★ 인용해 답하는 경우도 같은 문제의 부분집합이라 같이 없어진다.
+      //
+      //   ★`explicit_recipients` 는 예외가 아니라 라우터의 답이다★ — 팀장님 메시지를 라우팅한
+      //   결과가 이 경로로 들어올 수 있다. 빈 배열도 "0명으로 정했다" 는 답이라 그대로 존중한다
+      //   (`length > 0` 이면 빈 배열이 아래로 떨어져 다시 팬아웃한다).
       const isSlackThread = !!findSlackMetaForThread(db, env.thread_id)
         || !!(env.meta as { slack?: { channel?: string } } | undefined)?.slack?.channel;
 
       let recipients: string[] = [];
-      if (isSlackThread) {
-        // 수신행 없음. 슬랙 릴레이(routes/slack.ts)가 실제 발송을 한다.
-      } else if (env.explicit_recipients !== undefined) {
-        // ★빈 배열도 "라우터가 0명으로 정했다" 는 답이다.★ `length > 0` 이면 빈 배열이 아래로
-        //   떨어져 ★본문 @all 로 다시 팬아웃★ 한다.
+      if (!isSlackThread && env.explicit_recipients !== undefined) {
         recipients = env.explicit_recipients.filter((agentId) => agentId !== env.from_agent_id);
-      } else if (broadcastAudience(env.body ?? "").kind === "all_hands") {
-        // ★명부가 없으면(새 clone·공개 설치) DB 로 되돌아간다 — 예외지 기본이 아니다.★
-        //   `agents.json` 은 gitignore 라 파일 자체가 없을 수 있고, 그때 규칙만 믿으면
-        //   @all 이 ★아무에게도 안 간다.★ ★audience 는 그대로 지킨다★ — @all 일 때만 여기다.
-        const roster = ambientAgents();
-        recipients = roster.length > 0
-          ? broadcastRecipientIds(roster, env.from_agent_id)
-          : (db.prepare(`SELECT id FROM agent WHERE id != ?`).all(env.from_agent_id) as Array<{ id: string }>)
-              .map((r) => r.id);
       }
 
-      // ★이 DB 가 아는 팀원만 넣는다.★ 명부는 프로세스 환경에서 오고 `agent` 표는 이 DB 것이라
-      //   어긋날 수 있다(파일 변경 후 동기화까지 약 0.3초). 어긋난 id 를 넣으면 ★FK 위반으로
-      //   삽입 전체가 터진다.★
+      // ★이 DB 가 아는 팀원만 넣는다.★ 명부와 `agent` 표가 어긋나면(파일 변경 후 동기화까지 약 0.3초)
+      //   FK 위반으로 삽입 전체가 터진다. ★빠진 사람이 있으면 감사에 남긴다★ — 조용히 넘기지 않는다.
       const known = new Set(
         (db.prepare(`SELECT id FROM agent`).all() as Array<{ id: string }>).map((r) => r.id),
       );
       const dropped = recipients.filter((agentId) => !known.has(agentId));
       recipients = recipients.filter((agentId) => known.has(agentId));
-      // ★조용히 빼지 않는다.★ 파일(정본)에 있는데 DB 에 없으면 그건 ★싱크가 깨진 것★ 이다.
-      //   ★빠진 사람이 0명이면 아무것도 안 남긴다★ — 평상시 잡음이 되면 아무도 안 본다.
       if (dropped.length > 0) {
         appendAuditFile(env.from_agent_id, "registry_db_out_of_sync", env.thread_id, {
           missing_in_db: dropped,

--- a/src/server/db/inboxQueries.test.ts
+++ b/src/server/db/inboxQueries.test.ts
@@ -50,6 +50,7 @@ const baseEnv = (over: Record<string, unknown>) => ({
   from_agent_id: "bill",
   to_agent_id: "steve",
   body: "@all hello",
+  explicit_recipients: ["bill","steve","demis"],
   source: "agent" as const,
   type: "dm",
   ...over,

--- a/src/server/lib/teamRouter/atAllOfficialMembers.test.ts
+++ b/src/server/lib/teamRouter/atAllOfficialMembers.test.ts
@@ -12,9 +12,9 @@
  * ★demis 지적 반영★: "지금 명단으로 테스트를 짜면 그 테스트도 같이 통과해버린다."
  * → 그래서 이 테스트는 ★이름을 하드코딩하지 않고★, 새 정식 팀원을 넣었을 때 따라오는지로 잰다.
  */
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import { buildTmuxInjectionPrompt } from "../tmuxInject";
-import { broadcastAudience, routeTeamMessage } from "./ownerDecision";
+import { broadcastAudience, hasBroadcastAllMarker, routeTeamMessage } from "./ownerDecision";
 import { broadcastRecipientIds } from "../agentMembership";
 
 // ★소스가 아니라 실제 렌더 결과를 잰다★ — 소스를 grep 하면 '뺐다' 고 적은 주석까지 걸린다(내가 그랬다).
@@ -76,8 +76,14 @@ describe("★@all 대상은 agents.json 의 정식 팀원 하나만 본다★", 
     // ★설계 논의 중 이 둘을 섞은 적이 있다★ — 다음 사람도 헷갈리니 시험이 막는다.
     const agents = roster();
 
-    // 팀원 방 발언: 멘션 없음 → 전달 0명
-    expect(broadcastAudience("네 확인했습니다").kind).not.toBe("all_hands");
+    // 팀원 방 발언 → 전달 0명.
+    // ★source 를 반드시 넘긴다.★ optional 이라 빼면 어떤 입력이든 통과해서
+    // ★이 단언이 아무것도 안 지키게 된다.★ 그리고 마커까지 붙여서
+    // "멘션이 없어서 0명" 이 아니라 ★"팀원이라서 0명"★ 을 재게 한다.
+    expect(broadcastAudience("네 확인했습니다", "agent").kind).not.toBe("all_hands");
+    expect(broadcastAudience("@all 다들 확인", "agent").kind).not.toBe("all_hands");
+    // 반대 축이 같이 죽지 않았는지 — 팀장님 것은 그대로여야 한다
+    expect(broadcastAudience("@all 다들 확인", "user").kind).toBe("all_hands");
 
     // 팀장님 메시지: 멘션 없음이어도 sticky 가 받는다 (사다리 그대로)
     const d = routeTeamMessage("그럼 그거 진행해줘", agents as never, { activeAssigneeIds: ["m2"] });
@@ -120,5 +126,40 @@ describe("★그룹 주입문은 소유권을 단정하지 않는다 — sticky 
     } as never);
     expect(en).toContain("A message arrived in this group room");
     expect(en).not.toContain("The group router assigned this message to you");
+  });
+});
+
+/**
+ * ★마커 판정 자체를 직접 고정한다 — codex 검수 요청(2026-08-01).★
+ *
+ * 라우팅(broadcastAudience)과 깨움(wakeDispatcher)이 ★서로 다른 판정★ 을 쓰고 있었다.
+ * 라우팅은 stripQuotedForRouting 을 거쳤고, 깨움은 인라인 정규식으로 본문을 날것으로 봤다.
+ * → ★인용·예시 안의 @all 이 깨움만 발동시켰다.★ 두 곳을 hasBroadcastAllMarker 로 모았다.
+ *
+ * 아래는 "무엇이 마커냐" 를 한 곳에 박아둔 것이다. 이게 흔들리면 두 경로가 같이 흔들린다.
+ */
+describe("hasBroadcastAllMarker — 무엇이 마커이고 무엇이 아닌가", () => {
+  test("맨 본문의 @all·@b3rys·@group 은 마커다", () => {
+    expect(hasBroadcastAllMarker("@all 다들 확인")).toBe(true);
+    expect(hasBroadcastAllMarker("@b3rys 공지")).toBe(true);
+    expect(hasBroadcastAllMarker("@group 확인")).toBe(true);
+  });
+
+  test("★코드펜스 안의 @all 은 마커가 아니다★ — 예시를 보여준 것뿐이다", () => {
+    expect(hasBroadcastAllMarker("```\n@all\n```\n이렇게 쓰면 됩니다")).toBe(false);
+  });
+
+  test("★구분선 아래의 @all 은 마커가 아니다★ — 원문 인용부다", () => {
+    expect(hasBroadcastAllMarker("제 의견입니다\n---\n@all 원문")).toBe(false);
+  });
+
+  test("★인용줄(> @all)은 여전히 마커다★ — stripQuotedForRouting 이 제거 대상으로 안 잡는다", () => {
+    // 직관과 어긋나지만 ★기존 동작이고 라우팅도 같게 판정한다.★
+    // 바꾸려면 두 경로가 같이 움직이므로 여기부터 고쳐라.
+    expect(hasBroadcastAllMarker("> @all 원문입니다\n네 확인했습니다")).toBe(true);
+  });
+
+  test("멘션이 없으면 마커가 아니다", () => {
+    expect(hasBroadcastAllMarker("팀 참고만 하십시오")).toBe(false);
   });
 });

--- a/src/server/lib/teamRouter/ownerDecision.ts
+++ b/src/server/lib/teamRouter/ownerDecision.ts
@@ -18,6 +18,16 @@ import { routeDefaultIntakeLLM } from "./defaultIntake";
 const BROADCAST_MARKER_RE = /@(all|b3rys|group)\b/i;
 
 /**
+ * ★전체 호출 마커가 본문에 있나★ — 이 정규식은 여기 하나뿐이다.
+ *
+ * 예전엔 같은 리터럴이 `wakeDispatcher` 에도 박혀 있었다. ★한쪽만 고치면 수신행은 0인데
+ * 깨우기는 하거나 그 반대가 된다★ — 같은 질문에 답이 둘이 되는 그 형태다.
+ */
+export function hasBroadcastAllMarker(text: string): boolean {
+  return BROADCAST_MARKER_RE.test(stripQuotedForRouting(text));
+}
+
+/**
  * ★@all 대상 = 정식 팀원(agents.json 의 team_official_member) — 그것 하나만 본다.★ (GD 2026-08-01)
  *
  * 예전엔 `BUS_DISPATCH_AGENTS` env 를 읽었다. 그 env 는 ★손으로 유지하는 두 번째 명단★ 이고,
@@ -47,9 +57,14 @@ function broadcastTargets(agents: AgentRecord[]): string[] {
  * ★멘션 판정은 `detectExplicitTargets` 하나만 쓴다★ — 한글 별칭·조사·인용 제외를 이미 안다.
  * 여기서 정규식을 새로 쓰면 그게 ★두 번째 판정★ 이 되고, 그게 이 결함의 원인이었다.
  */
-export function broadcastAudience(text: string): { kind: "all_hands" | "none" } {
-  // 인용된 @all(팀장님 원문을 그대로 붙인 경우 등)은 마커로 치지 않는다 — 라우터와 같은 전처리다.
-  return { kind: BROADCAST_MARKER_RE.test(stripQuotedForRouting(text)) ? "all_hands" : "none" };
+export function broadcastAudience(text: string, source?: string): { kind: "all_hands" | "none" } {
+  // ★@all 은 팀장님 전용이다.★ (GD 2026-08-01: "멘션은 팀장만 하는 거라고")
+  //   팀원이 본문에 @all 을 써도 마커로 치지 않는다 — ★방에 말하는 것 자체는 그대로다.★
+  //   실측: 그날 팀원이 쓴 @all 중 전체공지 목적은 ★검증용 1건뿐★ 이고 나머지는 전부
+  //   ★"@all 이라는 단어를 문장 안에서 언급"★ 한 것이었다(예: "결함은 그중 하나(@all)에만").
+  //   ★언급만 해도 8명이 깨어났다.★ 인용해 답하는 경우도 같은 문제의 부분집합이다.
+  if (source !== "user") return { kind: "none" };
+  return { kind: hasBroadcastAllMarker(text) ? "all_hands" : "none" };
 }
 
 export function routeTeamMessage(

--- a/src/server/lib/teamRouter/ownerDecision.ts
+++ b/src/server/lib/teamRouter/ownerDecision.ts
@@ -77,7 +77,7 @@ export function routeTeamMessage(
   // 라이브 멘션 판정에만 적용 — 원문 text 는 다른 용도 위해 보존.
   const liveText = stripQuotedForRouting(text);
   // 0) @all/@b3rys/@group → broadcast all enabled agents. Checked BEFORE explicit_mention.
-  if (BROADCAST_MARKER_RE.test(liveText)) {
+  if (hasBroadcastAllMarker(text)) {
     return {
       targetAgentIds: broadcastTargets(agents),
       reason: "broadcast_marker",
@@ -279,7 +279,7 @@ export async function routeTeamMessageHybrid(
   // 으로만 결정한다. 종료·주제전환을 자동 추정해 owner 를 비우거나 codex 로 넘기지 않는다.
 
   // 0.5) @all/@b3rys/@group → broadcast all enabled agents. Checked BEFORE explicit_mention.
-  if (BROADCAST_MARKER_RE.test(liveText)) {
+  if (hasBroadcastAllMarker(text)) {
     return {
       targetAgentIds: broadcastTargets(agents),
       reason: "broadcast_marker",

--- a/src/server/metrics/emit3.test.ts
+++ b/src/server/metrics/emit3.test.ts
@@ -186,7 +186,7 @@ describe("emit③ request.created (acceptInbound)", () => {
     const db = setup();
     // 본문에 @all — 팀원 방 발언은 그 마커가 있어야 수신행이 생긴다(2026-08-01 규칙).
     //   이 시험이 재는 건 팬아웃이 아니라 ★수신자가 답하면 followup 으로 분류되는가★ 다.
-    const b = acceptInbound(db, env({ to_agent_id: "broadcast", body: "@all 확인 부탁" }) as never, { dedupeWindowSec: 60 });
+    const b = acceptInbound(db, env({ to_agent_id: "broadcast", body: "@all 확인 부탁", explicit_recipients: ["steve"] }) as never, { dedupeWindowSec: 60 });
     expect(b.ok).toBe(true);
     if (!b.ok) return;
     // 부모의 to_agent_id 는 'broadcast' 지만, steve 는 수신자 행을 갖는다 = 받았다

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -14,7 +14,7 @@ import {
   agentActivity,
   acceptInbound,
 } from "../db/inboxQueries";
-import { hasCapability, coordinatorId } from "../lib/capabilities";
+import { coordinatorId } from "../lib/capabilities";
 import type { AgentRecord } from "../types";
 import { appendAudit } from "../db/queries";
 import { recordReportDelivery } from "../bus/deliveryRecord";
@@ -161,15 +161,10 @@ export function createInboxRoutes(deps: InboxRouteDeps): Hono {
     //   ★내가 고치려던 것과 무관한 경로를 같이 잘랐다★ — 범위를 좁힌다.
     const slackMetaForGate = findSlackMetaForThread(deps.db, env.thread_id ?? "");
     if (env.source === "agent" && env.to_agent_id === "broadcast" && !slackMetaForGate) {
-      const roster = deps.agents?.() ?? [];
-      const me = roster.find((a) => a.id === env.from_agent_id);
-      // 명부를 못 받으면(구 호출부) coordinator 판정을 할 수 없다 → ★막지 않는다.★
-      // 모르는 것을 '위반' 으로 처리하면 명부 배선이 빠진 경로에서 팀 통신이 통째로 끊긴다.
-      const rosterKnown = roster.length > 0;
-      const isCoordinator = !rosterKnown || (me ? hasCapability(me, "coordinator") : false);
-      const reason = typeof (env as { all_hands?: unknown }).all_hands === "string"
-        ? ((env as { all_hands?: string }).all_hands ?? "").trim()
-        : "";
+      // ★예외는 없다.★ coordinator 도 마찬가지다 (GD 2026-08-01: "coordinator 도 예외 없어").
+      //   그래서 여기서 ★명부·capability 를 보지 않는다★ — 보는 순간 그게 유일한 구멍이 된다.
+      //   (예전엔 `rosterKnown`·`isCoordinator`·`reason` 을 계산했는데, 게이트를 뺄 때
+      //    조건만 지우고 변수가 남아 있었다. 예외 개념이 사라졌으니 계산도 지운다.)
       // ★broadcast 에 대한 답을 broadcast 로 하지 않는다 (GD 2026-08-01)★ — 연쇄의 직접 고리다.
       //   실측: 오늘 47건 중 18건이 이 형태였다. coordinator 라도 막는다(연쇄는 발신자를 안 가린다).
       if (env.in_reply_to) {

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -15,7 +15,6 @@ import {
   acceptInbound,
 } from "../db/inboxQueries";
 import { coordinatorId } from "../lib/capabilities";
-import type { AgentRecord } from "../types";
 import { appendAudit } from "../db/queries";
 import { recordReportDelivery } from "../bus/deliveryRecord";
 import { appendAuditFile } from "../lib/auditFile";


### PR DESCRIPTION
팀원이 본문에 `@all` 을 쓰면 전원이 깨어났다. 룰에 근거가 없는 동작이라 지운다.

바뀌는 것: 팀원 발신 broadcast 의 `@all`·`@b3rys`·`@group` 이 무효가 된다.
영향: 팀원 전원(방 게시는 그대로 · 팀장님·시스템 경로 무변화).
규모: 프로덕션 4파일.

## 무엇이 문제인가

TEAM-OS §2 가 정한 통신 수단은 셋뿐이고 전부 `--to` 로 상대를 지정한다.
`send.sh --to <id>` · `--to broadcast` · `--direct-to-gd`.
**본문 멘션으로 대상을 정한다는 항목은 없다.** 멘션이 나오는 곳은 owner 사다리 하나뿐이고,
그건 팀장님이 방에 올린 글에 누가 답할지 고르는 규칙이지 팀원의 발신 수단이 아니다.

코드는 팀원 본문의 `@all` 을 읽어 전원을 깨우고 있었다.

## 왜 그렇게 되나

마커 판정이 두 곳에 있었고 **판정 기준이 서로 달랐다.**

- 수신행 생성(`db/inbox/messages.ts`) — 발신자를 봤다
- 깨움 판정(`bus/wakeDispatcher.ts`) — 마커만 봤다. 정규식이 인라인으로 복제돼 있었다

깨움 쪽은 발신자를 안 보므로, 팀원 broadcast 에 수신행이 생기는 경로가 하나만 생겨도
팀원의 `@all` 이 전원을 깨운다. 수신행이 0인 것은 계약이 아니라 우연한 안전이었다.

인라인 정규식은 `stripQuotedForRouting` 도 안 거쳐서, 코드펜스 안의 예시 `@all` 까지 마커로 쳤다.

## 어떻게 고쳤나

- 두 지점이 같은 `broadcastAudience(body, source)` 를 쓴다. 마커 정규식 리터럴은 한 곳만 남았다
- 판정은 `source` 하나로만 한다 — capability 를 보지 않는다. coordinator 예외 없음
- 깨움 경로가 기존 인용·예시 제외 계약에 정렬된다(코드펜스·구분선 제외, 인용줄은 마커 유지)
- 죽은 변수 `rosterKnown`·`isCoordinator`·`reason` 과 `AgentRecord` 중복 import 제거

## 검증 결과

codex·hermes 승인. 하네스 뮤턴트 10종 전부 잡힘 — 팀장님 `@all` 수신행·깨움 두 축 포함.
신규 실패 0, 타입 신규 오류 0(중복 import 해소로 7 → 5).

## 안 고친 것

- `personaTemplates.ts` 타입 오류 5건 — 기존
- `runtimeOptions.test.ts` 온보딩 문서 시험 1건 — 기존, main 에서도 실패. 문서 문구를 되살리는 쪽이다
- `all_hands` 스키마 필드 — 읽는 곳이 없어졌으나 제거는 표면이 커서 존치

## 별건 카드

`TMSLjiMPZHNfCT8pJh7s9` · `OFWY16dy5X3U60X4ZryS6`

## 롤백

이 브랜치의 커밋을 되돌리면 된다. 직전 배포는 `f7ee3ea`(#221).

Submitted-by: steve
