### PR TITLE
fix(bus): system 발신 @all 의 깨움을 되살린다

### DIFF
--- a/src/server/bus/wakeDispatcher.characterization.test.ts
+++ b/src/server/bus/wakeDispatcher.characterization.test.ts
@@ -187,6 +187,16 @@ describe("3c wake 경계 — comm 매트릭스", () => {
     expect(spy.calls).toBe(0); // 예시로 보여준 @all 은 마커가 아니다
   });
 
+  // ★system 은 팀원이 아니다 — 장애 통지·카드 알림이 여기로 온다.★
+  // 마커가 팀장님 전용이라는 계약은 ★팀원의 발신 수단★ 을 지우는 것이지 시스템 통지를 끄는 게 아니다.
+  // 수신행 축에는 이 계약이 시험으로 있는데 깨움 축에는 없어서 한 번 죽었다.
+  test("system 발신 + @all → wake (시스템 통지는 기존 동작 그대로)", async () => {
+    const row = pendingRowFor(db, "codex", { to_agent_id: "broadcast", type: "broadcast", body: "@all 장애 통지", explicit_recipients: ["codex"], source: "system" });
+    const spy = spyAdapter(() => ({ ok: true }));
+    await dispatch(db, row, { openclaw: spy.adapter });
+    expect(spy.calls).toBe(1); // 시스템 통지가 조용히 사라지면 안 된다
+  });
+
   // collect_only 경계 (Codex 적대리뷰 §3c): 수집형 위임 응답은 coordinator wake 억제, 일반 directed Q&A는 wake.
   const cRow = (over: Record<string, unknown>): PendingDispatchRow =>
     ({ agent_id: "bill", to_agent_id: "bill", type: "reply", thread_id: "t1", in_reply_to: null, parent_message_id: null, meta_json: null, ...over } as PendingDispatchRow);

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -1149,7 +1149,8 @@ function buildDispatchPlan(
   // 수신행 생성(db/inbox/messages.ts)에서만 걸려 있었고 여기서는 안 걸려 있었다. 그래서
   // 팀원 broadcast 에 수신행이 생기는 경로가 하나라도 생기면 팀원의 @all 이 전원을 다시 깨웠다.
   // 지금은 수신행이 0이라 우연히 안전할 뿐이다 — 우연에 기대지 않도록 같은 판정을 여기에도 건다.
-  // 두 곳이 같은 broadcastAudience 를 쓰므로 한쪽만 고쳐서 어긋나는 일이 없다.
+  // ★두 곳이 같은 함수를 쓰는 것은 아니다★ — 수신행 쪽은 messages.ts 가 source 를 직접 가른다.
+  // 같은 것은 ★축(발신자가 agent 인가)과 기본값(source 없으면 agent)★ 이다. 그 둘을 맞춰 둔다.
   const isBroadcast = row.to_agent_id === "broadcast" || row.type === "broadcast";
   if (isBroadcast && broadcastAudience(row.body, row.source).kind !== "all_hands") {
     db.prepare(

--- a/src/server/lib/teamRouter/ownerDecision.ts
+++ b/src/server/lib/teamRouter/ownerDecision.ts
@@ -63,7 +63,14 @@ export function broadcastAudience(text: string, source?: string): { kind: "all_h
   //   실측: 그날 팀원이 쓴 @all 중 전체공지 목적은 ★검증용 1건뿐★ 이고 나머지는 전부
   //   ★"@all 이라는 단어를 문장 안에서 언급"★ 한 것이었다(예: "결함은 그중 하나(@all)에만").
   //   ★언급만 해도 8명이 깨어났다.★ 인용해 답하는 경우도 같은 문제의 부분집합이다.
-  if (source !== "user") return { kind: "none" };
+  //
+  // ★막는 대상은 팀원(agent)이지 "팀장님이 아닌 전부" 가 아니다.★
+  //   system 은 발신 수단을 가진 팀원이 아니라 장애 통지·카드 알림 경로다.
+  //   'source !== "user"' 로 자르면 ★시스템 통지의 깨움이 같이 죽는다★ — 실제로 한 번 죽였다.
+  //   수신행 축(db/inbox/messages.ts)은 처음부터 'agent 인가' 로 갈랐다. 여기도 같은 축이어야 한다.
+  //   기본값도 수신행 축과 같게 둔다 — messages.ts 가 (source ?? "agent") 로 읽는다.
+  //   ★두 축의 기본값이 다르면 source 가 빠진 행에서 또 갈린다.★
+  if ((source ?? "agent") === "agent") return { kind: "none" };
   return { kind: hasBroadcastAllMarker(text) ? "all_hands" : "none" };
 }
 


### PR DESCRIPTION
`#223` 이 system 발신 broadcast 의 깨움을 같이 껐다. 되살린다.

바뀌는 것: `source=system` + `@all` 이 다시 깨운다(수신행은 원래 남아 있었다).
영향: 장애 통지·카드 알림을 받는 팀원 전원.
규모: 프로덕션 2파일, 조건 한 줄.

## 무엇이 문제인가

깨움 게이트가 `source !== "user"` 로 잘랐다. **`system` 도 거기 걸린다.**

실측(`dispatchRow` 실호출): 수정 전 wake 0회 / 수정 후 wake 1회.
수신행은 남고 깨움만 사라지므로 **조용한 유실**이다 — `db/inbox/systemWake.test.ts` 에 기록된
"카드 알림 29건 배달 0건" 과 같은 계열이다.

도달 경로는 실재한다. `routes/systemMessage.ts` 가 `to_agent_id=broadcast` 를 받고,
pendingDispatch 가 `m.source` 를 SELECT 하면서 system 을 통과시킨다.

## 왜 그렇게 되나

막아야 할 대상은 **팀원(agent)** 이지 "팀장님이 아닌 전부" 가 아니다.
`system` 은 발신 수단을 가진 팀원이 아니라 통지 경로다.

수신행 축(`db/inbox/messages.ts`)은 처음부터 `agent 인가` 로 갈랐는데,
깨움 축만 `user 인가` 로 갈랐다. **두 축의 기준이 달랐다.**

깨움 축에 이 계약의 시험이 없어서 검수 셋(리뷰 2인 + 하네스)이 모두 통과시켰다.
수신행 축에는 같은 계약의 시험이 있었다.

## 어떻게 고쳤나

- 깨움 게이트를 `(source ?? "agent") === "agent"` 로 — 수신행 축과 **같은 축, 같은 기본값**
- 깨움 축 시험 추가: `system` + `@all` → 깨움 발생
- 부정확한 주석 수정 — "두 곳이 같은 `broadcastAudience` 를 쓴다" 는 사실이 아니다.
  같은 것은 함수가 아니라 축과 기본값이다

## 검증 결과

뮤턴트 확인: 조건을 `source !== "user"` 로 되돌리면 새 시험이 죽는다.
신규 실패 0, 타입 신규 오류 0.

## 안 고친 것

- `broadcastRecipients.test.ts` 의 낡은 시험 이름 2건과 미사용 import 1건 — 사실이나 별건.
  핫픽스 범위를 넓히면 검수를 다시 받아야 한다

## 롤백

이 커밋을 되돌리면 `#223` 상태로 돌아간다. 직전 배포는 `f7ee3ea`.

Submitted-by: steve
