### PR TITLE
fix(hooks): 진행 메시지 방 결정을 토큰 검사보다 먼저 한다

### DIFF
--- a/hooks/telegram-progress.py
+++ b/hooks/telegram-progress.py
@@ -93,6 +93,26 @@ def _pick_emoji(text):
     return "👀"
 
 
+def _pick_turn_key(tags, ext):
+    """이 턴의 진행 메시지를 띄울 방 → (chat_id, message_id). 없으면 None.
+    ★토큰이 필요 없는 순수 계산★ — 그래서 handle_react 가 토큰 검사보다 먼저 부른다.
+    DM(<channel>) 우선, 없으면 그룹 주입(<external_message>). 같은 종류가 여럿이면 마지막 것."""
+    for attrs, _ in reversed(tags):
+        cid = re.search(r'chat_id="([^"]+)"', attrs)
+        mid = re.search(r'message_id="([^"]+)"', attrs)
+        if cid and mid:
+            return (cid.group(1), mid.group(1))
+    for attrs, _ in reversed(ext):
+        tgmsg = re.search(r'tg_msg_id="([^"]+)"', attrs)
+        thread = re.search(r'thread="([^"]+)"', attrs)
+        if tgmsg and thread:
+            chat = thread.group(1)
+            if chat.startswith("tg-"):
+                chat = chat[3:]
+            return (chat, tgmsg.group(1))
+    return None
+
+
 def handle_react(state_dir, data):
     """들어온 텔레그램 메시지에 즉시 내용기반 ack 이모지 — 툴이 없는 텍스트 답변에도 '받았어요' 신호.
     UserPromptSubmit 는 prompt 안에 <channel> 태그가 들어옴(transcript 아님).
@@ -103,6 +123,24 @@ def handle_react(state_dir, data):
     # <external_message>(capture 주입, 그룹 @별칭 등) — 주입 = 그 봇이 owner 확정이라 무조건 👀(owner-check 불필요).
     ext = [(a, b) for a, b in re.findall(r"<external_message\b([^>]*)>(.*?)</external_message>", prompt, re.DOTALL) if "telegram" in a]
     _dbg(state_dir, f"react entry plen={len(prompt)} tags={len(tags)} ext={len(ext)}")
+    # ── 이 턴의 방을 먼저 확정한다 (★토큰 검사보다 위★) ──────────────────────
+    # ★방을 정하는 데 토큰이 필요 없다★ — 프롬프트에서 뽑아 파일에 쓰거나 지우는 것뿐이다.
+    # 아래(리액션 전송)에 두면 ★토큰을 못 읽는 턴에 방이 갱신도 삭제도 안 되고 옛값이 남는다.★
+    # 그러면 다음 턴에 handle_pre 가 그 옛값을 읽어 ★엉뚱한 방에 진행 메시지를 띄운다★ —
+    # 버스로 깨운 작업의 명령줄이 단톡방에 찍힌 적이 있다. ★터지면 공개된다.★
+    # Stop 에서도 지우지만 인터럽트 등으로 Stop 이 안 터지면 남는다.
+    #
+    # ★한 프롬프트에 DM(<channel>)과 그룹 주입이 같이 오면 DM 을 쓴다.★
+    #   근거: 틀렸을 때 손해가 작은 쪽이다. DM 에 잘못 뜨면 당사자만 보지만 단톡방은 공개다.
+    #   같은 종류가 여럿이면 마지막 것을 쓴다.
+    # 방 정보가 아예 없으면(버스 깨움 등) ★지운다★ → handle_pre 는 기존 폴백으로 내려간다.
+    turn_key = _pick_turn_key(tags, ext)
+    _sid = data.get("session_id", "default")
+    if turn_key:
+        _save_turn_channel(state_dir, _sid, turn_key[0], turn_key[1])
+    else:
+        _clear_turn_channel(state_dir, _sid)
+
     if not tags and not ext:
         return
     token = read_token(state_dir)
@@ -111,14 +149,12 @@ def handle_react(state_dir, data):
     # 배치/인터럽트로 여러 메시지가 한 prompt 에 묶이면 전부 react (마지막만 X). fix 2026-05-25.
     # 극단 batch 오버헤드 방어로 마지막 6개만.
     seen = set()
-    last_key = None
     for attrs, body in tags[-6:]:
         cid = re.search(r'chat_id="([^"]+)"', attrs)
         mid = re.search(r'message_id="([^"]+)"', attrs)
         if not (cid and mid):
             continue
         key = (cid.group(1), mid.group(1))
-        last_key = key
         if key in seen:
             continue
         seen.add(key)
@@ -142,9 +178,8 @@ def handle_react(state_dir, data):
         seen.add(key)
         _dbg(state_dir, f"react send (injected) chat={key[0]} msg={key[1]}")
         tg_react(token, key[0], key[1], _pick_emoji(body))
-    # 이 turn 의 채널 기억 → handle_pre 가 progress 를 '작업한 방'에만 띄움 (방별 분리, 2026-05-27 GD).
-    if last_key:
-        _save_turn_channel(state_dir, data.get("session_id", "default"), last_key[0], last_key[1])
+    # 이 turn 의 채널은 ★위(토큰 검사 전)에서 이미 저장·삭제했다★ — _pick_turn_key 참조.
+    # 여기서 다시 저장하지 않는다. 저장을 토큰 뒤에 두면 토큰 없는 턴에 옛 방이 남는다.
 
 
 # ── PreToolUse ──────────────────────────────────────────────


### PR DESCRIPTION
버스로 깨운 턴의 진행 메시지가 엉뚱한 방에 찍히는 것을 막고, 단톡방 작업에도 진행 표시가 뜨게 한다.

바뀌는 것: 진행 메시지를 띄울 방을 토큰 검사 전에 확정한다.
영향: 클로드 런타임 팀원 전원(영입 시 이 파일이 각 팀원 폴더로 복사된다).
규모: 훅 1파일, 함수 1개 추가 + 호출 순서 변경.

## 무엇이 문제인가

`handle_react` 가 방 번호를 **토큰 검사 뒤에서** 저장했다. 두 가지가 따라온다.

- **버스로 깨운 턴**은 프롬프트에 방 정보가 없다. 저장도 삭제도 안 되어 **이전 턴의 방 번호가 남는다.**
  다음 턴에 `handle_pre` 가 그 값을 읽어 그 방에 진행 메시지를 띄운다 —
  버스로 깨운 작업의 명령줄이 단톡방에 찍힌 적이 있다. **터지면 공개된다.**
- **그룹 주입만 온 턴**은 방을 아예 저장하지 않아 **단톡방 작업에 진행 표시가 안 떴다.**

## 왜 그렇게 되나

방을 정하는 일과 리액션을 보내는 일이 한 덩어리였다.
리액션은 토큰이 필요하지만 **방을 정하는 데는 토큰이 필요 없다** — 프롬프트에서 뽑아 파일에 쓰거나 지우는 것뿐이다.
토큰을 못 읽는 턴에는 둘 다 건너뛰므로 방이 옛값으로 남았다.

`Stop` 에서도 지우지만 인터럽트 등으로 `Stop` 이 안 터지면 남는다.

## 어떻게 고쳤나

- `_pick_turn_key(tags, ext)` — 토큰이 필요 없는 순수 계산으로 분리
- `handle_react` 는 **토큰 검사 위에서** 방을 확정해 저장 또는 삭제까지 끝낸다. 아래는 리액션 전송만
- 한 프롬프트에 DM 과 그룹 주입이 같이 오면 **DM 을 쓴다** — 틀렸을 때 손해가 작은 쪽이다

## 검증 결과

**고장난 판(main)에서 실제로 실패하는 것을 먼저 확인했다:**
그룹 주입 → 옛값 유지 · 버스 깨움 → 옛값 유지.

이 브랜치의 **저장소 파일을 직접 로드해** 측정(발신 0건):
그룹 주입 → 그 방 저장 · 토큰 없이 DM 턴 → DM 으로 갱신 · 버스 깨움 → 삭제 ·
DM+그룹 → DM 우선 · DM 단독 회귀 없음. `py_compile` 통과.

## 안 고친 것

- 리액션 동작·owner 판정 — 손대지 않았다
- 팀원 폴더 사본 5개 — 이 PR 머지 뒤에 맞춘다

## 롤백

이 커밋을 되돌리면 된다.

Submitted-by: steve
