### PR TITLE
fix(types): 정규식 캡처를 검사 없이 인덱싱하던 5곳 — CI 타입체크 복구

### DIFF
--- a/src/server/lib/personaTemplates.ts
+++ b/src/server/lib/personaTemplates.ts
@@ -35,7 +35,7 @@ function mainWorktreeRoot(start: string): string {
       if (statSync(dotGit).isDirectory()) return dir;         // 메인 워크트리 — 여기가 정답
       const p = readFileSync(dotGit, "utf8").trim();           // "gitdir: /path/<main>/.git/worktrees/<name>"
       const m = /^gitdir:\s*(.+)$/.exec(p);
-      if (m) {
+      if (m?.[1]) {
         const common = m[1].replace(/\/worktrees\/[^/]+\/?$/, ""); // → <main>/.git
         const root = common.replace(/\/\.git\/?$/, "");            // → <main>
         if (root && existsSync(`${root}/rules`)) return root;
@@ -605,14 +605,15 @@ function readSkillTriggers(): Array<{ name: string; trigger: string; script: str
     let trigger = "";
     const head = readFileSync(md, "utf8").slice(0, 4000);
     const fm = /^---\n([\s\S]*?)\n---/.exec(head);
-    if (fm) {
-      const t = /^trigger:\s*(.+)$/m.exec(fm[1]);
-      if (t) trigger = t[1].trim().replace(/^["']|["']$/g, "");
+    const front = fm?.[1];
+    if (front) {
+      const t = /^trigger:\s*(.+)$/m.exec(front);
+      if (t?.[1]) trigger = t[1].trim().replace(/^["']|["']$/g, "");
     }
     let script = "";
-    if (fm) {
-      const e = /^entry:\s*(.+)$/m.exec(fm[1]);   // ★선언한 것만★ — 디렉터리를 뒤져 추측하지 않는다
-      if (e) script = e[1].trim().replace(/^["']|["']$/g, "");
+    if (front) {
+      const e = /^entry:\s*(.+)$/m.exec(front);   // ★선언한 것만★ — 디렉터리를 뒤져 추측하지 않는다
+      if (e?.[1]) script = e[1].trim().replace(/^["']|["']$/g, "");
     }
     if (!trigger) continue;   // ★선언하지 않은 스킬은 나가지 않는다★ — 새 스킬의 기본값은 '비공개'
     out.push({ name, trigger, script });


### PR DESCRIPTION
정규식 캡처 그룹을 검사 없이 인덱싱하던 5곳을 고친다.

바뀌는 것: **타입 좁히기만. 동작 변경 0.**
영향: CI 타입체크가 통과한다 — 지금은 모든 PR 이 머지 불가다.
규모: 1파일 +6 / −5.

## 무엇이 문제인가

`personaTemplates.ts` 에서 `exec()` 결과의 캡처 그룹을 `m[1]` · `fm[1]` 로 바로 쓴다.
`noUncheckedIndexedAccess` 아래에서 이 값은 `string | undefined` 다.

타입체크가 **오류 5건으로 실패한다.** `main` 에서도 같다.
그래서 `verify` 가 빨갛고 **열린 PR 전부가 BLOCKED** 다.

## 왜 그렇게 되나

`if (m)` 은 match 객체의 존재만 본다. 캡처 그룹이 있는지는 안 본다.
정규식에 그룹이 하나뿐이라 실제로는 항상 채워지지만, 타입 수준에서는 보장이 없다.

## 어떻게 고쳤나

- `if (m)` → `if (m?.[1])`
- `fm[1]` 을 지역 변수 `front` 로 받아 한 번만 좁힌다
- `if (t)` → `if (t?.[1])` · `if (e)` → `if (e?.[1])`

캡처가 비면 예전에도 그 분기를 안 탔다. **동작이 같다.**

## 검증 결과

타입 오류 **5 → 0**. `personaTemplates.test.ts` 41건 통과, 신규 실패 0.

## 롤백

이 커밋 revert. 타입체크가 다시 빨개진다.

Submitted-by: bill
