### PR TITLE
feat(bus): 명시 공지 플래그로 팀원 전원에게 전달

### DIFF
--- a/scripts/send-tools-honesty.test.sh
+++ b/scripts/send-tools-honesty.test.sh
@@ -114,24 +114,26 @@ else
   fail "페이로드를 잡지 못했다(테스트 하네스 문제 — 아래 단정은 신뢰할 수 없다)"
 fi
 
-echo "── A1-6: --notice 는 본문이 아닌 명시 플래그로 실린다 ──"
-PATH="$FAKEBIN:$PATH" "$SEND" --to broadcast --body "공지" --notice >/dev/null 2>&1
+echo "── A1-6: --notice/--공지 는 사유를 명시 필드로 싣는다 ──"
+PATH="$FAKEBIN:$PATH" "$SEND" --to broadcast --body "공지" --notice "서비스 점검" >/dev/null 2>&1
 CAPTURE="$CAPTURE" python3 - <<'PY' \
-  && pass "notice=true가 페이로드에 실림" \
-  || fail "notice 플래그가 페이로드에 없거나 true가 아님"
+  && pass "all_hands 사유가 페이로드에 실림" \
+  || fail "all_hands 사유가 페이로드에 없음"
 import json, os, sys
 p = json.load(open(os.environ["CAPTURE"]))
-sys.exit(0 if p.get("notice") is True and "@all" not in p.get("body", "") else 1)
+sys.exit(0 if p.get("all_hands") == "서비스 점검" and "notice" not in p and "@all" not in p.get("body", "") else 1)
 PY
-PATH="$FAKEBIN:$PATH" "$SEND" --to broadcast --body "공지" --공지 >/dev/null 2>&1
+PATH="$FAKEBIN:$PATH" "$SEND" --to broadcast --body "공지" --공지 "전원 확인 필요" >/dev/null 2>&1
 CAPTURE="$CAPTURE" python3 - <<'PY' \
-  && pass "--공지 별칭도 notice=true로 실림" \
-  || fail "--공지 별칭이 notice 플래그로 변환되지 않음"
+  && pass "--공지 별칭도 같은 all_hands 필드로 실림" \
+  || fail "--공지 별칭이 all_hands 사유로 변환되지 않음"
 import json, os, sys
 p = json.load(open(os.environ["CAPTURE"]))
-sys.exit(0 if p.get("notice") is True else 1)
+sys.exit(0 if p.get("all_hands") == "전원 확인 필요" else 1)
 PY
-out="$(PATH="$FAKEBIN:$PATH" "$SEND" --to lisa --body "공지" --notice 2>&1)"; rc=$?
+out="$(PATH="$FAKEBIN:$PATH" "$SEND" --to broadcast --body "공지" --notice 2>&1)"; rc=$?
+[ $rc -ne 0 ] && pass "사유 없는 --notice 거절" || fail "사유 없는 --notice를 허용했다"
+out="$(PATH="$FAKEBIN:$PATH" "$SEND" --to lisa --body "공지" --notice "사유" 2>&1)"; rc=$?
 [ $rc -ne 0 ] && pass "directed 메시지의 --notice 거절" || fail "--notice를 directed 메시지에 허용했다"
 
 echo "── A2-1: 접수 문구가 '보냈다' 라고 단정하지 않는다 ──"

--- a/scripts/send-tools-honesty.test.sh
+++ b/scripts/send-tools-honesty.test.sh
@@ -123,6 +123,14 @@ import json, os, sys
 p = json.load(open(os.environ["CAPTURE"]))
 sys.exit(0 if p.get("notice") is True and "@all" not in p.get("body", "") else 1)
 PY
+PATH="$FAKEBIN:$PATH" "$SEND" --to broadcast --body "공지" --공지 >/dev/null 2>&1
+CAPTURE="$CAPTURE" python3 - <<'PY' \
+  && pass "--공지 별칭도 notice=true로 실림" \
+  || fail "--공지 별칭이 notice 플래그로 변환되지 않음"
+import json, os, sys
+p = json.load(open(os.environ["CAPTURE"]))
+sys.exit(0 if p.get("notice") is True else 1)
+PY
 out="$(PATH="$FAKEBIN:$PATH" "$SEND" --to lisa --body "공지" --notice 2>&1)"; rc=$?
 [ $rc -ne 0 ] && pass "directed 메시지의 --notice 거절" || fail "--notice를 directed 메시지에 허용했다"
 

--- a/scripts/send-tools-honesty.test.sh
+++ b/scripts/send-tools-honesty.test.sh
@@ -114,6 +114,18 @@ else
   fail "페이로드를 잡지 못했다(테스트 하네스 문제 — 아래 단정은 신뢰할 수 없다)"
 fi
 
+echo "── A1-6: --notice 는 본문이 아닌 명시 플래그로 실린다 ──"
+PATH="$FAKEBIN:$PATH" "$SEND" --to broadcast --body "공지" --notice >/dev/null 2>&1
+CAPTURE="$CAPTURE" python3 - <<'PY' \
+  && pass "notice=true가 페이로드에 실림" \
+  || fail "notice 플래그가 페이로드에 없거나 true가 아님"
+import json, os, sys
+p = json.load(open(os.environ["CAPTURE"]))
+sys.exit(0 if p.get("notice") is True and "@all" not in p.get("body", "") else 1)
+PY
+out="$(PATH="$FAKEBIN:$PATH" "$SEND" --to lisa --body "공지" --notice 2>&1)"; rc=$?
+[ $rc -ne 0 ] && pass "directed 메시지의 --notice 거절" || fail "--notice를 directed 메시지에 허용했다"
+
 echo "── A2-1: 접수 문구가 '보냈다' 라고 단정하지 않는다 ──"
 out="$(PATH="$FAKEBIN:$PATH" "$SEND" --to lisa --body-file "$FIX" 2>&1)"
 grep -q "✓ sent" <<<"$out" && fail "아직 '✓ sent' 라고 단정한다" || pass "'✓ sent' 단정 제거됨"

--- a/skills/b3os-team-inbox/scripts/send.sh
+++ b/skills/b3os-team-inbox/scripts/send.sh
@@ -8,7 +8,7 @@
 #                                                   ★본문에 홑따옴표·백틱·$(cmd)·$VAR 가 있으면 --body-file 을 쓰세요★
 #                                                   — --body 로 넘기면 셸이 해석해서 본문이 조용히 훼손됩니다(실측 2건).
 #                                                   stdout=메시지 id · stderr=사람이 읽는 결과(파싱하는 코드 없음, 2026-07-30 확인)
-#                [--type dm|reply] [--priority low|normal|high] [--hop <n>] [--notice]
+#                [--type dm|reply] [--priority low|normal|high] [--hop <n>] [--notice|--공지 <reason>]
 #                [--direct-to-gd --source-thread <tg-...|group_id>] [--individual]
 #                                                   send ALL asks for one task on ONE --thread. The server
 #                                                   then gathers the replies and wakes you once with the
@@ -25,7 +25,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 BASE="${TEAM_BASE:-http://127.0.0.1:7878/team}"
 
 TO=""; BODY=""; THREAD=""; REPLY_TO=""; TYPE="dm"; PRIORITY="normal"; FROM=""; HOP=""; SYNC=""; DIRECT_TO_GD=""; SOURCE_THREAD=""; EXPECT_REPORT_BY=""; INDIVIDUAL=""; EPISODE=""
-BODY_FILE=""; BODY_SET=""; CONFIRM=""; MENTIONS=""; NOTICE=""
+BODY_FILE=""; BODY_SET=""; CONFIRM=""; MENTIONS=""; ALL_HANDS=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -62,8 +62,8 @@ while [ $# -gt 0 ]; do
     --sync) SYNC="$2"; shift 2 ;;
     --direct-to-gd) DIRECT_TO_GD="1"; shift ;;
     # 팀원 broadcast를 방 게시 1건 + 정식·활성 전원 수신행으로 보낸다.
-    # 본문에 @all을 쓰는 것과 무관한 명시적 발신 옵션이다.
-    --notice|--공지) NOTICE="1"; shift ;;
+    # 사유를 감사에 남기며, 본문에 @all을 쓰는 것과 무관한 명시적 발신 옵션이다.
+    --notice|--공지) ALL_HANDS="${2:-}"; [ -n "$ALL_HANDS" ] || { echo "ERROR: $1 requires a reason" >&2; exit 1; }; shift 2 ;;
     # ★개별보고 위임 표시★ — "각자 GD께 직접 보고해라" 로 뿌릴 때 붙인다. 서버가 [마감] 독촉을 안 보낸다.
     #   안 붙여도 고장나지 않는다: 독촉이 한 번 올 뿐이고 그 본문이 "개별보고면 무시하세요" 라고 알려준다.
     --individual) INDIVIDUAL="1"; shift ;;
@@ -81,8 +81,8 @@ while [ $# -gt 0 ]; do
 done
 
 [ -z "$TO" ] && { echo "ERROR: --to required" >&2; exit 1; }
-[ -n "$NOTICE" ] && [ "$TO" != "broadcast" ] && {
-  echo "ERROR: --notice 는 --to broadcast 에만 사용할 수 있습니다" >&2
+[ -n "$ALL_HANDS" ] && [ "$TO" != "broadcast" ] && {
+  echo "ERROR: --notice/--공지 는 --to broadcast 에만 사용할 수 있습니다" >&2
   exit 1
 }
 
@@ -198,7 +198,7 @@ for _m in $MENTIONS; do
 done
 
 # Build JSON via python to handle escaping safely.
-PAYLOAD=$(MENTION_IDS="$MENTION_IDS" BODY="$BODY" FROM="$FROM" TO="$TO" THREAD="$THREAD" REPLY_TO="$REPLY_TO" TYPE="$TYPE" PRIORITY="$PRIORITY" HOP="$HOP" SYNC="$SYNC" DIRECT_TO_GD="$DIRECT_TO_GD" SOURCE_THREAD="$SOURCE_THREAD" EXPECT_REPORT_BY="$EXPECT_REPORT_BY" INDIVIDUAL="$INDIVIDUAL" EPISODE="$EPISODE" NOTICE="$NOTICE" python3 -c "
+PAYLOAD=$(MENTION_IDS="$MENTION_IDS" BODY="$BODY" FROM="$FROM" TO="$TO" THREAD="$THREAD" REPLY_TO="$REPLY_TO" TYPE="$TYPE" PRIORITY="$PRIORITY" HOP="$HOP" SYNC="$SYNC" DIRECT_TO_GD="$DIRECT_TO_GD" SOURCE_THREAD="$SOURCE_THREAD" EXPECT_REPORT_BY="$EXPECT_REPORT_BY" INDIVIDUAL="$INDIVIDUAL" EPISODE="$EPISODE" ALL_HANDS="$ALL_HANDS" python3 -c "
 import json, os
 p = {
   'from_agent_id': os.environ['FROM'],
@@ -212,7 +212,7 @@ if os.environ.get('THREAD'):    p['thread_id'] = os.environ['THREAD']
 if os.environ.get('REPLY_TO'):  p['in_reply_to'] = os.environ['REPLY_TO']
 if os.environ.get('HOP'):       p['hop_count'] = int(os.environ['HOP'])
 if os.environ.get('SYNC'):      p['sync'] = os.environ['SYNC']
-if os.environ.get('NOTICE'):    p['notice'] = True
+if os.environ.get('ALL_HANDS'): p['all_hands'] = os.environ['ALL_HANDS']
 meta = {}
 if os.environ.get('DIRECT_TO_GD'):
     src = os.environ.get('SOURCE_THREAD', '').strip()

--- a/skills/b3os-team-inbox/scripts/send.sh
+++ b/skills/b3os-team-inbox/scripts/send.sh
@@ -8,7 +8,7 @@
 #                                                   ★본문에 홑따옴표·백틱·$(cmd)·$VAR 가 있으면 --body-file 을 쓰세요★
 #                                                   — --body 로 넘기면 셸이 해석해서 본문이 조용히 훼손됩니다(실측 2건).
 #                                                   stdout=메시지 id · stderr=사람이 읽는 결과(파싱하는 코드 없음, 2026-07-30 확인)
-#                [--type dm|reply] [--priority low|normal|high] [--hop <n>]
+#                [--type dm|reply] [--priority low|normal|high] [--hop <n>] [--notice]
 #                [--direct-to-gd --source-thread <tg-...|group_id>] [--individual]
 #                                                   send ALL asks for one task on ONE --thread. The server
 #                                                   then gathers the replies and wakes you once with the
@@ -25,7 +25,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 BASE="${TEAM_BASE:-http://127.0.0.1:7878/team}"
 
 TO=""; BODY=""; THREAD=""; REPLY_TO=""; TYPE="dm"; PRIORITY="normal"; FROM=""; HOP=""; SYNC=""; DIRECT_TO_GD=""; SOURCE_THREAD=""; EXPECT_REPORT_BY=""; INDIVIDUAL=""; EPISODE=""
-BODY_FILE=""; BODY_SET=""; CONFIRM=""; MENTIONS=""
+BODY_FILE=""; BODY_SET=""; CONFIRM=""; MENTIONS=""; NOTICE=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -61,6 +61,9 @@ while [ $# -gt 0 ]; do
     --hop) HOP="$2"; shift 2 ;;
     --sync) SYNC="$2"; shift 2 ;;
     --direct-to-gd) DIRECT_TO_GD="1"; shift ;;
+    # 팀원 broadcast를 방 게시 1건 + 정식·활성 전원 수신행으로 보낸다.
+    # 본문에 @all을 쓰는 것과 무관한 명시적 발신 옵션이다.
+    --notice) NOTICE="1"; shift ;;
     # ★개별보고 위임 표시★ — "각자 GD께 직접 보고해라" 로 뿌릴 때 붙인다. 서버가 [마감] 독촉을 안 보낸다.
     #   안 붙여도 고장나지 않는다: 독촉이 한 번 올 뿐이고 그 본문이 "개별보고면 무시하세요" 라고 알려준다.
     --individual) INDIVIDUAL="1"; shift ;;
@@ -78,6 +81,10 @@ while [ $# -gt 0 ]; do
 done
 
 [ -z "$TO" ] && { echo "ERROR: --to required" >&2; exit 1; }
+[ -n "$NOTICE" ] && [ "$TO" != "broadcast" ] && {
+  echo "ERROR: --notice 는 --to broadcast 에만 사용할 수 있습니다" >&2
+  exit 1
+}
 
 # ─── 본문 확정: --body 또는 --body-file (둘 중 하나) ────────────────────────
 # ★둘 다 주면 거절한다★ — 어느 쪽이 이겼는지 조용히 정해지면, 보낸 사람은 자기가 보낸 줄 아는
@@ -191,7 +198,7 @@ for _m in $MENTIONS; do
 done
 
 # Build JSON via python to handle escaping safely.
-PAYLOAD=$(MENTION_IDS="$MENTION_IDS" BODY="$BODY" FROM="$FROM" TO="$TO" THREAD="$THREAD" REPLY_TO="$REPLY_TO" TYPE="$TYPE" PRIORITY="$PRIORITY" HOP="$HOP" SYNC="$SYNC" DIRECT_TO_GD="$DIRECT_TO_GD" SOURCE_THREAD="$SOURCE_THREAD" EXPECT_REPORT_BY="$EXPECT_REPORT_BY" INDIVIDUAL="$INDIVIDUAL" EPISODE="$EPISODE" python3 -c "
+PAYLOAD=$(MENTION_IDS="$MENTION_IDS" BODY="$BODY" FROM="$FROM" TO="$TO" THREAD="$THREAD" REPLY_TO="$REPLY_TO" TYPE="$TYPE" PRIORITY="$PRIORITY" HOP="$HOP" SYNC="$SYNC" DIRECT_TO_GD="$DIRECT_TO_GD" SOURCE_THREAD="$SOURCE_THREAD" EXPECT_REPORT_BY="$EXPECT_REPORT_BY" INDIVIDUAL="$INDIVIDUAL" EPISODE="$EPISODE" NOTICE="$NOTICE" python3 -c "
 import json, os
 p = {
   'from_agent_id': os.environ['FROM'],
@@ -205,6 +212,7 @@ if os.environ.get('THREAD'):    p['thread_id'] = os.environ['THREAD']
 if os.environ.get('REPLY_TO'):  p['in_reply_to'] = os.environ['REPLY_TO']
 if os.environ.get('HOP'):       p['hop_count'] = int(os.environ['HOP'])
 if os.environ.get('SYNC'):      p['sync'] = os.environ['SYNC']
+if os.environ.get('NOTICE'):    p['notice'] = True
 meta = {}
 if os.environ.get('DIRECT_TO_GD'):
     src = os.environ.get('SOURCE_THREAD', '').strip()

--- a/skills/b3os-team-inbox/scripts/send.sh
+++ b/skills/b3os-team-inbox/scripts/send.sh
@@ -63,7 +63,7 @@ while [ $# -gt 0 ]; do
     --direct-to-gd) DIRECT_TO_GD="1"; shift ;;
     # 팀원 broadcast를 방 게시 1건 + 정식·활성 전원 수신행으로 보낸다.
     # 본문에 @all을 쓰는 것과 무관한 명시적 발신 옵션이다.
-    --notice) NOTICE="1"; shift ;;
+    --notice|--공지) NOTICE="1"; shift ;;
     # ★개별보고 위임 표시★ — "각자 GD께 직접 보고해라" 로 뿌릴 때 붙인다. 서버가 [마감] 독촉을 안 보낸다.
     #   안 붙여도 고장나지 않는다: 독촉이 한 번 올 뿐이고 그 본문이 "개별보고면 무시하세요" 라고 알려준다.
     --individual) INDIVIDUAL="1"; shift ;;

--- a/src/server/bus/wakeDispatcher.characterization.test.ts
+++ b/src/server/bus/wakeDispatcher.characterization.test.ts
@@ -152,6 +152,17 @@ describe("3c wake 경계 — comm 매트릭스", () => {
     expect(rcpt(db, row.message_id, "codex")?.last_error).toBe("broadcast_inbox_only_no_wake_marker");
   });
 
+  test("broadcast + notice 플래그 + 팀원 발신 → 본문 마커 없이 wake", async () => {
+    const row = pendingRowFor(db, "codex", {
+      to_agent_id: "broadcast", type: "broadcast", body: "팀 공지", explicit_recipients: ["codex"],
+    });
+    db.prepare(`UPDATE message SET meta_json = ? WHERE id = ?`).run(JSON.stringify({ notice: true }), row.message_id);
+    row.meta_json = JSON.stringify({ notice: true });
+    const spy = spyAdapter(() => ({ ok: true }));
+    await dispatch(db, row, { openclaw: spy.adapter });
+    expect(spy.calls).toBe(1);
+  });
+
   // ★기대값을 뒤집었다 — 옛 기대값(1회 깨움)은 사양 위반을 정답으로 고정하고 있었다.★
   // 마커를 쓸 수 있는 것은 팀장님뿐이라는 계약은 수신행 생성에만 걸려 있었고 깨움에는 없었다.
   // 그래서 이 시험은 "팀원이 @all 로 전원을 깨운다" 를 지키고 있었다 — 룰에 근거가 없는 동작이다.

--- a/src/server/bus/wakeDispatcher.characterization.test.ts
+++ b/src/server/bus/wakeDispatcher.characterization.test.ts
@@ -152,12 +152,12 @@ describe("3c wake 경계 — comm 매트릭스", () => {
     expect(rcpt(db, row.message_id, "codex")?.last_error).toBe("broadcast_inbox_only_no_wake_marker");
   });
 
-  test("broadcast + notice 플래그 + 팀원 발신 → 본문 마커 없이 wake", async () => {
+  test("broadcast + all_hands 사유 + 팀원 발신 → 본문 마커 없이 wake", async () => {
     const row = pendingRowFor(db, "codex", {
       to_agent_id: "broadcast", type: "broadcast", body: "팀 공지", explicit_recipients: ["codex"],
     });
-    db.prepare(`UPDATE message SET meta_json = ? WHERE id = ?`).run(JSON.stringify({ notice: true }), row.message_id);
-    row.meta_json = JSON.stringify({ notice: true });
+    db.prepare(`UPDATE message SET meta_json = ? WHERE id = ?`).run(JSON.stringify({ all_hands: "운영 점검" }), row.message_id);
+    row.meta_json = JSON.stringify({ all_hands: "운영 점검" });
     const spy = spyAdapter(() => ({ ok: true }));
     await dispatch(db, row, { openclaw: spy.adapter });
     expect(spy.calls).toBe(1);

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -77,10 +77,11 @@ function attachmentsFromRow(row: PendingDispatchRow): BusAttachment[] | undefine
   }
 }
 
-function isNoticeBroadcast(row: PendingDispatchRow): boolean {
+function isAgentAllHandsBroadcast(row: PendingDispatchRow): boolean {
   if (row.source !== "agent" || !row.meta_json) return false;
   try {
-    return (JSON.parse(row.meta_json) as { notice?: unknown }).notice === true;
+    const reason = (JSON.parse(row.meta_json) as { all_hands?: unknown }).all_hands;
+    return typeof reason === "string" && reason.length > 0;
   } catch {
     return false;
   }
@@ -1160,7 +1161,7 @@ function buildDispatchPlan(
   // 지금은 수신행이 0이라 우연히 안전할 뿐이다 — 우연에 기대지 않도록 같은 판정을 여기에도 건다.
   // 두 곳이 같은 broadcastAudience 를 쓰므로 한쪽만 고쳐서 어긋나는 일이 없다.
   const isBroadcast = row.to_agent_id === "broadcast" || row.type === "broadcast";
-  if (isBroadcast && !isNoticeBroadcast(row) && broadcastAudience(row.body, row.source).kind !== "all_hands") {
+  if (isBroadcast && !isAgentAllHandsBroadcast(row) && broadcastAudience(row.body, row.source).kind !== "all_hands") {
     db.prepare(
       `UPDATE message_recipient
        SET delivery_state = 'completed',

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -77,6 +77,15 @@ function attachmentsFromRow(row: PendingDispatchRow): BusAttachment[] | undefine
   }
 }
 
+function isNoticeBroadcast(row: PendingDispatchRow): boolean {
+  if (row.source !== "agent" || !row.meta_json) return false;
+  try {
+    return (JSON.parse(row.meta_json) as { notice?: unknown }).notice === true;
+  } catch {
+    return false;
+  }
+}
+
 // ─── Config ──────────────────────────────────────────────────────────────────
 
 // ★기본 ON★ (GD 2026-07-19): 협업/위임은 dispatcher 가 팀원을 깨워야 성립한다. 명시적으로 "false" 일 때만 shadow.
@@ -1151,7 +1160,7 @@ function buildDispatchPlan(
   // 지금은 수신행이 0이라 우연히 안전할 뿐이다 — 우연에 기대지 않도록 같은 판정을 여기에도 건다.
   // 두 곳이 같은 broadcastAudience 를 쓰므로 한쪽만 고쳐서 어긋나는 일이 없다.
   const isBroadcast = row.to_agent_id === "broadcast" || row.type === "broadcast";
-  if (isBroadcast && broadcastAudience(row.body, row.source).kind !== "all_hands") {
+  if (isBroadcast && !isNoticeBroadcast(row) && broadcastAudience(row.body, row.source).kind !== "all_hands") {
     db.prepare(
       `UPDATE message_recipient
        SET delivery_state = 'completed',

--- a/src/server/db/inbox/broadcastRecipients.test.ts
+++ b/src/server/db/inbox/broadcastRecipients.test.ts
@@ -71,11 +71,12 @@ function broadcastFrom(
   from: string,
   source = "user",
   body = "@all 공지",
-  notice = false,
+  allHands = "",
 ): string[] {
   const { thread_id } = ensureThread(db, { from_agent_id: from, to_agent_id: "broadcast", type: "broadcast", body } as never);
   const stored = insertMessage(db, {
-    from_agent_id: from, to_agent_id: "broadcast", type: "broadcast", body, thread_id, source, notice,
+    from_agent_id: from, to_agent_id: "broadcast", type: "broadcast", body, thread_id, source,
+    ...(allHands ? { all_hands: allHands } : {}),
   } as never);
   return db
     .prepare(`SELECT agent_id FROM message_recipient WHERE message_id = ? ORDER BY agent_id`)
@@ -85,30 +86,31 @@ function broadcastFrom(
 
 describe("★팀원 broadcast 팬아웃은 @all 과 같은 규칙을 쓴다★", () => {
 
-  describe("★팀원 공지는 본문이 아니라 notice 플래그로만 전원 전달한다★", () => {
-    test("notice 있음 → 정식·활성 전원, 발신자 제외", () => {
+  describe("★팀원 공지는 본문이 아니라 all_hands 사유로만 전원 전달한다★", () => {
+    test("all_hands 사유 있음 → 정식·활성 전원, 발신자 제외", () => {
       const db = withRoster(ROSTER);
-      expect(broadcastFrom(db, "sender", "agent", "서비스 점검 안내", true)).toEqual(["member"]);
+      expect(broadcastFrom(db, "sender", "agent", "서비스 점검 안내", "운영 점검")).toEqual(["member"]);
     });
 
-    test("notice 없음 → 수신행 0", () => {
+    test("all_hands 사유 없음 → 수신행 0", () => {
       const db = withRoster(ROSTER);
       expect(broadcastFrom(db, "sender", "agent", "서비스 점검 안내")).toEqual([]);
     });
 
-    test("본문에 @all만 있고 notice 없음 → 수신행 0", () => {
+    test("본문에 @all만 있고 all_hands 사유 없음 → 수신행 0", () => {
       const db = withRoster(ROSTER);
       expect(broadcastFrom(db, "sender", "agent", "@all 서비스 점검 안내")).toEqual([]);
     });
 
-    test("notice 사용자는 수신자와 함께 감사기록에 남는다", () => {
+    test("all_hands 사유가 message meta에 보존된다", () => {
       const db = withRoster(ROSTER);
-      broadcastFrom(db, "sender", "agent", "서비스 점검 안내", true);
-      const path = join(dir, `audit-${new Date().toISOString().slice(0, 10)}.log`);
-      const log = readFileSync(path, "utf8");
-      expect(log).toContain("agent_broadcast_notice");
-      expect(log).toContain('"actor":"sender"');
-      expect(log).toContain('"recipient_ids":["member"]');
+      const { thread_id } = ensureThread(db, { from_agent_id: "sender", to_agent_id: "broadcast", type: "broadcast", body: "공지" } as never);
+      const stored = insertMessage(db, {
+        from_agent_id: "sender", to_agent_id: "broadcast", type: "broadcast", body: "공지",
+        thread_id, source: "agent", all_hands: "운영 점검",
+      } as never);
+      const row = db.prepare(`SELECT meta_json FROM message WHERE id = ?`).get(stored.id) as { meta_json: string };
+      expect(JSON.parse(row.meta_json).all_hands).toBe("운영 점검");
     });
 
     test("공개 설치의 플래그 없는 명부 → 발신자 제외 전원", () => {
@@ -118,7 +120,7 @@ describe("★팀원 broadcast 팬아웃은 @all 과 같은 규칙을 쓴다★",
         { id: "b", display_name: "B", role: "r", runtime: "claude_channel" },
       ];
       const db = withRoster(flagless);
-      expect(broadcastFrom(db, "sender", "agent", "공지", true)).toEqual(["a", "b"]);
+      expect(broadcastFrom(db, "sender", "agent", "공지", "전원 확인")).toEqual(["a", "b"]);
     });
   });
 

--- a/src/server/db/inbox/broadcastRecipients.test.ts
+++ b/src/server/db/inbox/broadcastRecipients.test.ts
@@ -66,9 +66,17 @@ function withRoster(roster: Array<Record<string, unknown>>): Database {
   return db;
 }
 
-function broadcastFrom(db: Database, from: string, source = "user", body = "@all 공지"): string[] {
+function broadcastFrom(
+  db: Database,
+  from: string,
+  source = "user",
+  body = "@all 공지",
+  notice = false,
+): string[] {
   const { thread_id } = ensureThread(db, { from_agent_id: from, to_agent_id: "broadcast", type: "broadcast", body } as never);
-  const stored = insertMessage(db, { from_agent_id: from, to_agent_id: "broadcast", type: "broadcast", body, thread_id, source } as never);
+  const stored = insertMessage(db, {
+    from_agent_id: from, to_agent_id: "broadcast", type: "broadcast", body, thread_id, source, notice,
+  } as never);
   return db
     .prepare(`SELECT agent_id FROM message_recipient WHERE message_id = ? ORDER BY agent_id`)
     .all(stored.id)
@@ -76,6 +84,43 @@ function broadcastFrom(db: Database, from: string, source = "user", body = "@all
 }
 
 describe("★팀원 broadcast 팬아웃은 @all 과 같은 규칙을 쓴다★", () => {
+
+  describe("★팀원 공지는 본문이 아니라 notice 플래그로만 전원 전달한다★", () => {
+    test("notice 있음 → 정식·활성 전원, 발신자 제외", () => {
+      const db = withRoster(ROSTER);
+      expect(broadcastFrom(db, "sender", "agent", "서비스 점검 안내", true)).toEqual(["member"]);
+    });
+
+    test("notice 없음 → 수신행 0", () => {
+      const db = withRoster(ROSTER);
+      expect(broadcastFrom(db, "sender", "agent", "서비스 점검 안내")).toEqual([]);
+    });
+
+    test("본문에 @all만 있고 notice 없음 → 수신행 0", () => {
+      const db = withRoster(ROSTER);
+      expect(broadcastFrom(db, "sender", "agent", "@all 서비스 점검 안내")).toEqual([]);
+    });
+
+    test("notice 사용자는 수신자와 함께 감사기록에 남는다", () => {
+      const db = withRoster(ROSTER);
+      broadcastFrom(db, "sender", "agent", "서비스 점검 안내", true);
+      const path = join(dir, `audit-${new Date().toISOString().slice(0, 10)}.log`);
+      const log = readFileSync(path, "utf8");
+      expect(log).toContain("agent_broadcast_notice");
+      expect(log).toContain('"actor":"sender"');
+      expect(log).toContain('"recipient_ids":["member"]');
+    });
+
+    test("공개 설치의 플래그 없는 명부 → 발신자 제외 전원", () => {
+      const flagless = [
+        { id: "sender", display_name: "S", role: "r", runtime: "claude_channel" },
+        { id: "a", display_name: "A", role: "r", runtime: "claude_channel" },
+        { id: "b", display_name: "B", role: "r", runtime: "claude_channel" },
+      ];
+      const db = withRoster(flagless);
+      expect(broadcastFrom(db, "sender", "agent", "공지", true)).toEqual(["a", "b"]);
+    });
+  });
 
   test("★슬랙 스레드 답신은 팀원 수신행을 만들지 않는다 (멘션 기준)★", () => {
     // 슬랙은 멘션된 글만 들어온다 → 그 대화의 우리 쪽 당사자는 발신자 한 명뿐이다.

--- a/src/server/db/inbox/messages.ts
+++ b/src/server/db/inbox/messages.ts
@@ -4,6 +4,8 @@ import type { EnvelopeInbound, EnvelopeStored } from "../../../shared/envelopeSc
 import { MAX_HOPS_DEFAULT } from "../../../shared/envelopeSchema";
 import { type MessageRow, type ThreadRow, rowToEnvelope } from "./_shared";
 import { appendAuditFile } from "../../lib/auditFile";
+import { broadcastRecipientIds } from "../../lib/agentMembership";
+import { ambientAgents } from "../../lib/registry";
 import { applyAckClose, applyActivityAutoAck } from "../../bus/ackClose";
 
 export function ensureThread(
@@ -47,7 +49,10 @@ export function insertMessage(
 ): EnvelopeStored {
   const id = nanoid(12);
   const attachments_json = env.attachments ? JSON.stringify(env.attachments) : null;
-  const meta_json = env.meta ? JSON.stringify(env.meta) : null;
+  // notice는 DB 컬럼을 늘리지 않고 message meta에 함께 보존한다. 디스패처가 본문을
+  // 해석하지 않고 명시적 발신 옵션만으로 전원 알림 여부를 판정한다.
+  const persistedMeta = env.notice ? { ...(env.meta ?? {}), notice: true } : env.meta;
+  const meta_json = persistedMeta ? JSON.stringify(persistedMeta) : null;
   // v1.2 issue 3 (anti-pingpong fix): parent_message_id is used by countAutoRounds to
   // trace the bot↔bot chain. Previously it was left NULL when agents only set in_reply_to.
   // We now derive parent_message_id from in_reply_to when not explicitly set: agents that
@@ -188,7 +193,9 @@ export function insertMessage(
         || !!(env.meta as { slack?: { channel?: string } } | undefined)?.slack?.channel;
 
       let recipients: string[] = [];
-      if (!isSlackThread && env.explicit_recipients !== undefined) {
+      if (env.notice) {
+        recipients = broadcastRecipientIds(ambientAgents(), env.from_agent_id);
+      } else if (!isSlackThread && env.explicit_recipients !== undefined) {
         recipients = env.explicit_recipients.filter((agentId) => agentId !== env.from_agent_id);
       }
 
@@ -207,6 +214,13 @@ export function insertMessage(
         });
       }
       for (const agentId of recipients) insertRcpt.run(id, agentId, rcptState);
+      if (env.notice) {
+        appendAuditFile(env.from_agent_id, "agent_broadcast_notice", id, {
+          thread_id: env.thread_id,
+          recipient_ids: recipients,
+          recipient_count: recipients.length,
+        });
+      }
     }
   } else {
     // Team Bus v1: also insert a message_recipient row for direct (non-broadcast) messages

--- a/src/server/db/inbox/messages.ts
+++ b/src/server/db/inbox/messages.ts
@@ -49,9 +49,9 @@ export function insertMessage(
 ): EnvelopeStored {
   const id = nanoid(12);
   const attachments_json = env.attachments ? JSON.stringify(env.attachments) : null;
-  // notice는 DB 컬럼을 늘리지 않고 message meta에 함께 보존한다. 디스패처가 본문을
-  // 해석하지 않고 명시적 발신 옵션만으로 전원 알림 여부를 판정한다.
-  const persistedMeta = env.notice ? { ...(env.meta ?? {}), notice: true } : env.meta;
+  // all_hands 사유는 DB 컬럼을 늘리지 않고 message meta에 함께 보존한다. 디스패처가
+  // 본문을 해석하지 않고 명시적 사유가 기록된 팀원 공지만 wake하도록 판정한다.
+  const persistedMeta = env.all_hands ? { ...(env.meta ?? {}), all_hands: env.all_hands } : env.meta;
   const meta_json = persistedMeta ? JSON.stringify(persistedMeta) : null;
   // v1.2 issue 3 (anti-pingpong fix): parent_message_id is used by countAutoRounds to
   // trace the bot↔bot chain. Previously it was left NULL when agents only set in_reply_to.
@@ -193,8 +193,9 @@ export function insertMessage(
         || !!(env.meta as { slack?: { channel?: string } } | undefined)?.slack?.channel;
 
       let recipients: string[] = [];
-      if (env.notice) {
-        recipients = broadcastRecipientIds(ambientAgents(), env.from_agent_id);
+      if (env.all_hands) {
+        recipients = env.explicit_recipients
+          ?? broadcastRecipientIds(ambientAgents(), env.from_agent_id);
       } else if (!isSlackThread && env.explicit_recipients !== undefined) {
         recipients = env.explicit_recipients.filter((agentId) => agentId !== env.from_agent_id);
       }
@@ -214,13 +215,6 @@ export function insertMessage(
         });
       }
       for (const agentId of recipients) insertRcpt.run(id, agentId, rcptState);
-      if (env.notice) {
-        appendAuditFile(env.from_agent_id, "agent_broadcast_notice", id, {
-          thread_id: env.thread_id,
-          recipient_ids: recipients,
-          recipient_count: recipients.length,
-        });
-      }
     }
   } else {
     // Team Bus v1: also insert a message_recipient row for direct (non-broadcast) messages

--- a/src/server/routes/broadcastGate.test.ts
+++ b/src/server/routes/broadcastGate.test.ts
@@ -10,7 +10,7 @@
  * ★그래서 룰이 아니라 게이트로 막는다.★ 판단을 9명에게 맡기지 않고 coordinator 한 곳으로 모은다.
  *
  * 계약 두 개:
- *  ① 팀원 broadcast = coordinator 능력 + `--all-hands "<이유>"` 둘 다 있어야 한다
+ *  ① 팀원 전체공지 = 정식·활성 자격 + `all_hands` 사유가 있어야 한다
  *  ② broadcast 에 대한 답은 broadcast 로 못 한다 (coordinator 라도) — 연쇄의 직접 고리
  */
 import { describe, expect, it } from "bun:test";
@@ -25,10 +25,10 @@ const ROSTER: AgentRecord[] = [
   { id: "lui", display_name: "Lui", role: "dev" },
 ] as never;
 
-function app() {
+function app(roster: AgentRecord[] = ROSTER, routeRoster: AgentRecord[] = roster) {
   const db = new Database(":memory:");
   migrate(db);
-  for (const a of ROSTER) {
+  for (const a of roster) {
     db.prepare(
       `INSERT OR IGNORE INTO agent (id, display_name, role, runtime, status_provider, workspace_path, persona_file)
        VALUES (?,?,?,'claude_channel','claude_tmux','/tmp','p.md')`,
@@ -41,8 +41,8 @@ function app() {
   const h = createInboxRoutes({
     db,
     broadcast: () => {},
-    registeredAgentIds: () => new Set(ROSTER.map((a) => a.id)),
-    agents: () => ROSTER,
+    registeredAgentIds: () => new Set(roster.map((a) => a.id)),
+    agents: () => routeRoster,
   } as never);
   return { h, db };
 }
@@ -89,5 +89,85 @@ describe("★팀장님 경로는 이 게이트를 타지 않는다★", () => {
     const { h } = app();
     const res = await send(h, { from_agent_id: "user", source: "user" });
     expect(res.status, "★팀장님 @all 을 막으면 안 된다★").not.toBe(403);
+  });
+});
+
+describe("★all_hands 전체공지는 사유·발신자격·감사를 강제한다★", () => {
+  it("정식·활성 팀원은 보내고 사유·수신자 수를 DB 감사에 남긴다", async () => {
+    const { h, db } = app();
+    const res = await send(h, { from_agent_id: "steve", all_hands: "운영 점검" });
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(503);
+    const row = db.prepare(
+      `SELECT detail_json FROM audit_event WHERE actor='steve' AND action='agent_broadcast_all_hands' ORDER BY id DESC LIMIT 1`,
+    ).get() as { detail_json: string };
+    expect(JSON.parse(row.detail_json)).toMatchObject({
+      reason: "운영 점검",
+      recipient_count: 2,
+      eligible_recipient_count: 2,
+      zero_reason: null,
+    });
+  });
+
+  it("비정식 팀원은 전체공지를 보내지 못한다", async () => {
+    const roster = [
+      { ...ROSTER[0]! },
+      { ...ROSTER[1]!, team_official_member: false, lead_eligible: false },
+    ] as AgentRecord[];
+    const { h } = app(roster);
+    const res = await send(h, { from_agent_id: "steve", all_hands: "운영 점검" });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe("all_hands_sender_ineligible");
+  });
+
+  it("꺼진 팀원은 전체공지를 보내지 못한다", async () => {
+    const roster = [
+      { ...ROSTER[0]! },
+      { ...ROSTER[1]!, enabled: false },
+    ] as AgentRecord[];
+    const { h } = app(roster);
+    const res = await send(h, { from_agent_id: "steve", all_hands: "운영 점검" });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe("all_hands_sender_ineligible");
+  });
+
+  it("명부에서 발신자를 확인하지 못하면 성공시키지 않는다", async () => {
+    const { h, db } = app(ROSTER, []);
+    const res = await send(h, { from_agent_id: "steve", all_hands: "운영 점검" });
+    expect(res.status).toBe(503);
+    expect((await res.json()).error).toBe("all_hands_roster_unavailable");
+    const audit = db.prepare(
+      `SELECT detail_json FROM audit_event WHERE action='agent_all_hands_blocked' ORDER BY id DESC LIMIT 1`,
+    ).get() as { detail_json: string };
+    expect(JSON.parse(audit.detail_json).error).toBe("sender_missing_from_registry");
+  });
+
+  it("발신자만 있는 명부의 수신행 0은 sender_only로 기록한다", async () => {
+    const roster = [{ ...ROSTER[0]! }] as AgentRecord[];
+    const { h, db } = app(roster);
+    const res = await send(h, { from_agent_id: "bill", all_hands: "개인 설치 확인" });
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(503);
+    const row = db.prepare(
+      `SELECT detail_json FROM audit_event WHERE action='agent_broadcast_all_hands' ORDER BY id DESC LIMIT 1`,
+    ).get() as { detail_json: string };
+    expect(JSON.parse(row.detail_json)).toMatchObject({ recipient_count: 0, zero_reason: "sender_only" });
+  });
+
+  it("명부 수신자가 DB에 없어 수신행 0이면 registry_db_out_of_sync로 기록한다", async () => {
+    const dbRoster = [{ ...ROSTER[1]! }] as AgentRecord[];
+    const routeRoster = [{ ...ROSTER[1]! }, { ...ROSTER[0]! }] as AgentRecord[];
+    const { h, db } = app(dbRoster, routeRoster);
+    const res = await send(h, { from_agent_id: "steve", all_hands: "명부 동기화 확인" });
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(503);
+    const row = db.prepare(
+      `SELECT detail_json FROM audit_event WHERE action='agent_broadcast_all_hands' ORDER BY id DESC LIMIT 1`,
+    ).get() as { detail_json: string };
+    expect(JSON.parse(row.detail_json)).toMatchObject({
+      recipient_count: 0,
+      eligible_recipient_count: 1,
+      zero_reason: "registry_db_out_of_sync",
+    });
   });
 });

--- a/src/server/routes/broadcastGate.test.ts
+++ b/src/server/routes/broadcastGate.test.ts
@@ -120,6 +120,37 @@ describe("★all_hands 전체공지는 사유·발신자격·감사를 강제한
     expect((await res.json()).error).toBe("all_hands_sender_ineligible");
   });
 
+  it("source를 user로 속여도 all_hands 판정·감사를 우회하지 못한다", async () => {
+    const roster = [
+      { ...ROSTER[0]! },
+      { ...ROSTER[1]!, team_official_member: false, lead_eligible: false },
+    ] as AgentRecord[];
+    const { h, db } = app(roster);
+    const res = await send(h, { from_agent_id: "steve", source: "user", all_hands: "우회 시도" });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe("all_hands_sender_ineligible");
+    const audit = db.prepare(
+      `SELECT detail_json FROM audit_event WHERE action='agent_all_hands_blocked' ORDER BY id DESC LIMIT 1`,
+    ).get() as { detail_json: string };
+    expect(JSON.parse(audit.detail_json)).toMatchObject({
+      reason: "우회 시도",
+      identity_basis: "claimed_from_agent_id",
+    });
+  });
+
+  it("인증 신원이 없는 현재 API에서는 정식 팀원 from_agent_id 사칭을 구분하지 못함을 고정한다", async () => {
+    const { h, db } = app();
+    const res = await send(h, { from_agent_id: "steve", source: "user", all_hands: "사칭 한계 기록" });
+    expect(res.status).not.toBe(403);
+    const audit = db.prepare(
+      `SELECT detail_json FROM audit_event WHERE action='agent_broadcast_all_hands' ORDER BY id DESC LIMIT 1`,
+    ).get() as { detail_json: string };
+    expect(JSON.parse(audit.detail_json)).toMatchObject({
+      reason: "사칭 한계 기록",
+      identity_basis: "claimed_from_agent_id",
+    });
+  });
+
   it("꺼진 팀원은 전체공지를 보내지 못한다", async () => {
     const roster = [
       { ...ROSTER[0]! },

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -156,18 +156,22 @@ export function createInboxRoutes(deps: InboxRouteDeps): Hono {
     //   룰에는 이미 "결과는 TERMINAL, 확인 답장 금지" 가 있었지만 지켜지지 않았다(내가 47건 중 5건).
     //   → 판단을 9명에게 맡기지 않고 ★coordinator 한 곳으로 모은다.★
     //
-    // 무엇: 팀원(source=agent)이 전원 수신행+wake를 요청하면 ★all_hands 사유 + 정식·활성 자격★을 본다.
+    // 무엇: 전원 수신행+wake를 요청하는 단일 키 `all_hands`가 있으면
+    //   ★source 값과 무관하게★ 사유 + 정식·활성 명부 자격을 본다. source는 인바운드 값이라
+    //   신뢰 경계로 쓸 수 없고, 생략 시 agent가 기본값이라 게이트 조건으로도 의미가 없다.
+    //   현재 /api/inbox에는 서버가 인증한 호출자 신원이 없다. 따라서 from_agent_id 명부 검사는
+    //   등록되지 않았거나 비활성인 claimed sender를 막지만, 정식 팀원 id 사칭까지 막는 인증은 아니다.
     //   coordinator 전용은 아니다. 최근 지시는 "팀원용 --공지"이고, 사유가 남아 사후 판정이 가능하다.
     //   팀장님(source=user)의 @all 은 이 게이트를 타지 않는다 — 라우터가 따로 판정한다.
     // ★슬랙은 제외한다★ (2026-08-01 devon 실측 — 배포 직후 슬랙 답신이 막혔다).
     //   슬랙 스레드에 답하는 유일한 경로가 `--to broadcast` 다(룰: kind="slack" → --to broadcast).
     //   게이트의 목적은 ★단톡방 연쇄★ 를 끊는 것이지 슬랙 응답을 막는 것이 아니다.
     //   ★내가 고치려던 것과 무관한 경로를 같이 잘랐다★ — 범위를 좁힌다.
-    if (env.source === "agent" && env.to_agent_id === "broadcast" && env.all_hands) {
+    if (env.to_agent_id === "broadcast" && env.all_hands) {
       const roster = deps.agents?.() ?? ambientAgents();
       const sender = roster.find((agent) => agent.id === env.from_agent_id);
       if (!sender) {
-        const detail = { reason: env.all_hands, error: "sender_missing_from_registry" };
+        const detail = { reason: env.all_hands, error: "sender_missing_from_registry", identity_basis: "claimed_from_agent_id" };
         appendAudit(deps.db, env.from_agent_id, "agent_all_hands_blocked", null, detail);
         appendAuditFile(env.from_agent_id, "agent_all_hands_blocked", null, detail);
         return c.json({
@@ -180,6 +184,7 @@ export function createInboxRoutes(deps: InboxRouteDeps): Hono {
           reason: env.all_hands,
           team_official_member: isTeamOfficialMember(sender),
           enabled: sender.enabled !== false,
+          identity_basis: "claimed_from_agent_id",
         };
         appendAudit(deps.db, env.from_agent_id, "agent_all_hands_blocked", null, detail);
         appendAuditFile(env.from_agent_id, "agent_all_hands_blocked", null, detail);
@@ -246,6 +251,7 @@ export function createInboxRoutes(deps: InboxRouteDeps): Hono {
             recipient_count: recipientIds.length,
             eligible_recipient_count: allHandsEligibleRecipients.length,
             zero_reason: zeroReason,
+            identity_basis: "claimed_from_agent_id",
           };
           appendAudit(deps.db, env.from_agent_id, "agent_broadcast_all_hands", stored.id, allHandsDetail);
           appendAuditFile(env.from_agent_id, "agent_broadcast_all_hands", stored.id, allHandsDetail);

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -19,6 +19,8 @@ import { appendAudit } from "../db/queries";
 import { recordReportDelivery } from "../bus/deliveryRecord";
 import { appendAuditFile } from "../lib/auditFile";
 import { maybeCreatePendingFollowup, createSelfFollowup } from "../bus/followupTracker";
+import { broadcastRecipientIds, isTeamOfficialMember } from "../lib/agentMembership";
+import { ambientAgents } from "../lib/registry";
 
 import { MAX_HOPS_DEFAULT } from "../../shared/envelopeSchema";
 import { loadAgentCreds } from "../lib/slack";
@@ -55,7 +57,7 @@ export function createInboxRoutes(deps: InboxRouteDeps): Hono {
     if (!parsed.success) {
       return c.json({ error: "schema_validation", issues: parsed.error.issues }, 400);
     }
-    let env: EnvelopeInbound = parsed.data;
+    let env: EnvelopeInbound & { explicit_recipients?: string[] } = parsed.data;
     // Validate agent ids against registry (except special values)
     const known = deps.registeredAgentIds();
     const reserved = new Set(["user", "system", "moderator", "broadcast"]);
@@ -144,6 +146,8 @@ export function createInboxRoutes(deps: InboxRouteDeps): Hono {
         .get(env.in_reply_to) as { thread_id: string } | undefined;
       if (parentThread?.thread_id) env = { ...env, thread_id: parentThread.thread_id };
     }
+    let allHandsEligibleRecipients: string[] | null = null;
+
     // ★팀원 broadcast 게이트 (GD 2026-08-01)★
     //
     // 왜: `--to broadcast` 는 ★누구나 아무 때나★ 칠 수 있었고 검사도 기록도 없었다.
@@ -152,12 +156,42 @@ export function createInboxRoutes(deps: InboxRouteDeps): Hono {
     //   룰에는 이미 "결과는 TERMINAL, 확인 답장 금지" 가 있었지만 지켜지지 않았다(내가 47건 중 5건).
     //   → 판단을 9명에게 맡기지 않고 ★coordinator 한 곳으로 모은다.★
     //
-    // 무엇: 팀원(source=agent)이 broadcast 하려면 ★coordinator 능력 + --all-hands 사유★ 둘 다 필요.
+    // 무엇: 팀원(source=agent)이 전원 수신행+wake를 요청하면 ★all_hands 사유 + 정식·활성 자격★을 본다.
+    //   coordinator 전용은 아니다. 최근 지시는 "팀원용 --공지"이고, 사유가 남아 사후 판정이 가능하다.
     //   팀장님(source=user)의 @all 은 이 게이트를 타지 않는다 — 라우터가 따로 판정한다.
     // ★슬랙은 제외한다★ (2026-08-01 devon 실측 — 배포 직후 슬랙 답신이 막혔다).
     //   슬랙 스레드에 답하는 유일한 경로가 `--to broadcast` 다(룰: kind="slack" → --to broadcast).
     //   게이트의 목적은 ★단톡방 연쇄★ 를 끊는 것이지 슬랙 응답을 막는 것이 아니다.
     //   ★내가 고치려던 것과 무관한 경로를 같이 잘랐다★ — 범위를 좁힌다.
+    if (env.source === "agent" && env.to_agent_id === "broadcast" && env.all_hands) {
+      const roster = deps.agents?.() ?? ambientAgents();
+      const sender = roster.find((agent) => agent.id === env.from_agent_id);
+      if (!sender) {
+        const detail = { reason: env.all_hands, error: "sender_missing_from_registry" };
+        appendAudit(deps.db, env.from_agent_id, "agent_all_hands_blocked", null, detail);
+        appendAuditFile(env.from_agent_id, "agent_all_hands_blocked", null, detail);
+        return c.json({
+          error: "all_hands_roster_unavailable",
+          detail: "전체공지 발신자 자격을 명부에서 확인할 수 없습니다. 명부를 복구한 뒤 다시 보내세요.",
+        }, 503);
+      }
+      if (!isTeamOfficialMember(sender) || sender.enabled === false) {
+        const detail = {
+          reason: env.all_hands,
+          team_official_member: isTeamOfficialMember(sender),
+          enabled: sender.enabled !== false,
+        };
+        appendAudit(deps.db, env.from_agent_id, "agent_all_hands_blocked", null, detail);
+        appendAuditFile(env.from_agent_id, "agent_all_hands_blocked", null, detail);
+        return c.json({
+          error: "all_hands_sender_ineligible",
+          detail: "전체공지는 정식·활성 팀원만 보낼 수 있습니다.",
+        }, 403);
+      }
+      allHandsEligibleRecipients = broadcastRecipientIds(roster, env.from_agent_id);
+      env = { ...env, explicit_recipients: allHandsEligibleRecipients };
+    }
+
     const slackMetaForGate = findSlackMetaForThread(deps.db, env.thread_id ?? "");
     if (env.source === "agent" && env.to_agent_id === "broadcast" && !slackMetaForGate) {
       // ★예외는 없다.★ coordinator 도 마찬가지다 (GD 2026-08-01: "coordinator 도 예외 없어").
@@ -197,6 +231,25 @@ export function createInboxRoutes(deps: InboxRouteDeps): Hono {
         const auditDetail = { thread_id: stored.thread_id, to: env.to_agent_id, type: env.type };
         appendAudit(deps.db, env.from_agent_id, "message_sent", stored.id, auditDetail);
         appendAuditFile(env.from_agent_id, "message_sent", stored.id, auditDetail);
+        if (allHandsEligibleRecipients) {
+          const recipientIds = (deps.db
+            .prepare(`SELECT agent_id FROM message_recipient WHERE message_id = ? ORDER BY agent_id`)
+            .all(stored.id) as Array<{ agent_id: string }>).map((row) => row.agent_id);
+          const zeroReason = recipientIds.length > 0
+            ? null
+            : allHandsEligibleRecipients.length === 0
+              ? "sender_only"
+              : "registry_db_out_of_sync";
+          const allHandsDetail = {
+            reason: env.all_hands,
+            recipient_ids: recipientIds,
+            recipient_count: recipientIds.length,
+            eligible_recipient_count: allHandsEligibleRecipients.length,
+            zero_reason: zeroReason,
+          };
+          appendAudit(deps.db, env.from_agent_id, "agent_broadcast_all_hands", stored.id, allHandsDetail);
+          appendAuditFile(env.from_agent_id, "agent_broadcast_all_hands", stored.id, allHandsDetail);
+        }
         // ★배달 기록 (ingress) — 에이전트가 ★자기 발신 도구로★ 보낸 것도 남긴다.★ (2026-07-13)
         //
         // ★왜 필요한가★: 서버가 대신 발송하는 런타임(게이트웨이 hermes·openclaw)만 배달 기록이 남았다.

--- a/src/shared/envelopeSchema.ts
+++ b/src/shared/envelopeSchema.ts
@@ -79,9 +79,6 @@ export const envelopeInboundSchema = z.object({
    * (실측: 게이트 없던 70분에 팀원 broadcast 47건 → wake 517회)
    */
   all_hands: z.string().min(1).max(200).optional(),
-  // 팀원 broadcast를 정식·활성 전원에게 알리는 명시적 발신 옵션.
-  // 본문 마커(@all 등)는 이 값을 대신하지 않는다.
-  notice: z.boolean().optional(),
   priority: prioritySchema.default("normal"),
   sync: syncLevelSchema.optional(), // 생략 시 insertMessage 가 'none' 처리 (미설정=미러 안 함)
   dedupe_key: z.string().min(1).max(128).nullable().optional(),

--- a/src/shared/envelopeSchema.ts
+++ b/src/shared/envelopeSchema.ts
@@ -79,6 +79,9 @@ export const envelopeInboundSchema = z.object({
    * (실측: 게이트 없던 70분에 팀원 broadcast 47건 → wake 517회)
    */
   all_hands: z.string().min(1).max(200).optional(),
+  // 팀원 broadcast를 정식·활성 전원에게 알리는 명시적 발신 옵션.
+  // 본문 마커(@all 등)는 이 값을 대신하지 않는다.
+  notice: z.boolean().optional(),
   priority: prioritySchema.default("normal"),
   sync: syncLevelSchema.optional(), // 생략 시 insertMessage 가 'none' 처리 (미설정=미러 안 함)
   dedupe_key: z.string().min(1).max(128).nullable().optional(),


### PR DESCRIPTION
## 핵심 3줄
1. 정식·활성 팀원이 `--to broadcast --notice "<사유>"`로 보내면 방 게시와 함께 정식·활성 팀원 전원(발신자 제외)에게 수신행을 만들고 깨웁니다.
2. 기존 `all_hands` 필드를 판정·팬아웃·wake·감사의 단일 키로 사용하며, 발신자가 정하는 `source`는 게이트에 쓰지 않습니다.
3. 8파일 `+287/-15`이며, 플래그 없는 broadcast와 user/system 경로는 유지합니다.

## 동작 계약

- `--notice "<사유>"`는 사유가 필수이며 payload의 `all_hands` 문자열로 전송됩니다.
- `all_hands`가 있으면 `source` 값과 무관하게 같은 자격 판정·팬아웃·감사 경로를 탑니다. `source` 생략 시 기본값도 `agent`이므로 신뢰 조건으로 사용하지 않습니다.
- 명부상 정식·활성 팀원만 전체공지를 보낼 수 있습니다. 비정식·비활성 claimed sender는 403, 명부에서 확인할 수 없으면 503으로 실패합니다. coordinator 전용 제한은 두지 않습니다.
- 전체공지는 정식·활성 수신자에게만 수신행을 만들고 wake합니다. 발신자는 제외합니다.
- 사유·수신자 목록·수신자 수·대상 후보 수·수신행 0 원인을 파일 감사와 DB `audit_event`에 함께 남깁니다. 0명은 `sender_only`와 `registry_db_out_of_sync`를 구분합니다.
- hop/ping-pong 검사, directed 메시지 거절, user/system 경로, 플래그 없는 broadcast 동작은 유지합니다.

## 신원 경계

현재 `/api/inbox`에는 인증 미들웨어나 서버가 확정한 호출자 신원이 없습니다. `from_agent_id`와 `source`는 모두 인바운드 payload이며, 명부 검사는 등록되지 않았거나 비활성인 claimed sender를 거절할 뿐 정식 팀원 ID 사칭을 막는 인증이 아닙니다. 감사에는 `identity_basis: claimed_from_agent_id`를 기록합니다. 서버 인증 신원 도입은 이 PR 범위 밖입니다.

## 왜

`all_hands`는 전체공지 사유 기록용으로 이미 선언되어 있었지만 서버에서 사용되지 않았습니다. 새 필드를 병렬로 두면 같은 의미가 둘로 갈립니다. 기존 필드를 판정·수신자 생성·wake·감사에 연결해 사유와 동작을 한 키로 맞춥니다.

## 검증

- `bun run typecheck`: 통과
- `bash scripts/send-tools-honesty.test.sh`: ALL PASS
- 전체공지·수신자·wake 관련 4파일: 72 pass / 0 fail
- 지원하지 않는 한글 옵션 입력: `unknown arg`와 non-zero 종료 확인
- `source=user + all_hands` 우회 시도: 비정식 claimed sender 403 + DB 감사 생성
- 인증 부재 한계: 정식 팀원 `from_agent_id` 사칭은 현재 구분할 수 없음을 테스트로 고정
- CI `verify`: push 후 GitHub 재측정 중

## 미검증

- 라이브 서버 배포 후 여러 런타임의 실제 동시 wake
- 서버가 인증한 발신자 신원에 의한 사칭 방지(현재 API에 해당 신원 없음)
- 빈도 제한(감사 데이터만 이번 변경에서 마련)
- `explicit_recipients` 직접 입력 우회는 별도 카드 범위

## 롤백

이 PR을 revert하면 `all_hands` 기반 팀원 전체공지 수신행·wake·명부 검사·이중 감사와 CLI 옵션이 제거되고 기존 broadcast 동작으로 돌아갑니다.

Submitted-by: Codex
