### PR TITLE
feat(bus): 주입 문맥의 줄마다 출처를 붙인다 — 단체·1:1·팀버스·시스템

### DIFF
--- a/src/server/bus/contextLineOrigin.test.ts
+++ b/src/server/bus/contextLineOrigin.test.ts
@@ -1,0 +1,106 @@
+// 주입 문맥의 줄마다 출처를 붙인다 — 단체 · 팀버스 · 1:1 · 시스템.
+//
+// 한 스레드에 세 가지가 섞여 들어오는데 줄 모양이 같아서, 버스로만 간 줄을
+// 방에 올라간 것으로 읽는 일이 실제로 있었다. in-memory sqlite, 라이브 무관.
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { migrate } from "../db/migrate";
+import { acceptInbound } from "../db/inbox/acceptInbound";
+import { buildTeamContext } from "./wakeDispatcher";
+import { teamContextLabel } from "../channels/registry";
+
+const GROUP = "tg--123";
+
+function setup(): Database {
+  const db = new Database(":memory:");
+  migrate(db);
+  for (const a of ["bill", "steve", "codex"]) {
+    db.prepare(
+      `INSERT INTO agent (id, display_name, role, runtime, status_provider, workspace_path, persona_file)
+       VALUES (?, ?, 'role', 'claude_channel', 'claude_tmux', '/tmp', 'p.md')`,
+    ).run(a, a);
+  }
+  db.prepare(
+    `INSERT INTO thread (id, title, kind, participants_json, opened_by)
+     VALUES ('${GROUP}','group','dm','["bill","steve","codex"]','bill')`,
+  ).run();
+  db.prepare(
+    `INSERT INTO thread (id, title, kind, participants_json, opened_by)
+     VALUES ('task-1','task','dm','["bill","steve"]','bill')`,
+  ).run();
+  return db;
+}
+
+const put = (
+  db: Database,
+  thread: string,
+  from: string,
+  to: string,
+  body: string,
+  source: string,
+  type = "dm",
+) =>
+  acceptInbound(
+    db,
+    { thread_id: thread, from_agent_id: from, to_agent_id: to, body, source, type } as never,
+    { dedupeWindowSec: 0 },
+  );
+
+/** 그 본문이 실린 줄 하나를 꺼낸다. */
+function lineFor(ctx: string, needle: string): string {
+  const line = ctx.split("\n").find((l) => l.includes(needle));
+  expect(line, `문맥에 '${needle}' 줄이 없다`).toBeDefined();
+  return line!;
+}
+
+describe("주입 문맥은 줄마다 출처를 밝힌다", () => {
+  test("★버스로만 간 줄이 단체로 보이면 안 된다★ — 이 혼동이 잘못된 보고를 만들었다", () => {
+    const db = setup();
+    // 같은 스레드에 둘 다 넣는다. 지금까지 이 둘은 줄 모양이 똑같았다.
+    //
+    // ★남이 방에 올린 글로는 이 축을 못 잰다★ — 문맥 필터가 `from=나 OR to=나` 라
+    // `bill → broadcast` 는 steve 문맥에 아예 안 들어온다(GD 2026-07-16 "자기것 + 나에게 온 것만").
+    // 그래서 ★내가 방에 올린 글★ 을 쓴다. 실측에서도 이 모양이 제일 흔하다
+    // (`<나> → broadcast`, type=dm — 팀원 방 게시의 정상 모양이다).
+    put(db, GROUP, "bill", "steve", "버스로만 보낸 지시다", "agent");
+    put(db, GROUP, "steve", "broadcast", "방에 올린 공지다", "agent");
+
+    const ctx = buildTeamContext(db, GROUP, "steve");
+
+    expect(lineFor(ctx, "버스로만 보낸 지시다")).toContain("팀버스");
+    expect(lineFor(ctx, "방에 올린 공지다")).toContain("단체");
+    // 두 줄이 서로 다르게 보여야 한다 — 같은 라벨이면 가른 게 아니다.
+    expect(lineFor(ctx, "버스로만 보낸 지시다")).not.toContain("단체");
+  });
+
+  test("팀장님이 방에 올린 글은 수신자가 개인이어도 단체다", () => {
+    const db = setup();
+    // 팀장님이 방에서 한 명을 지목하면 to_agent_id 가 그 사람이 된다.
+    // to_agent_id 만 보면 팀버스로 오인한다 — source 를 함께 봐야 한다.
+    put(db, GROUP, "user", "steve", "@스티브 이것 좀 봐줘", "user");
+
+    expect(lineFor(buildTeamContext(db, GROUP, "steve"), "이것 좀 봐줘")).toContain("단체");
+  });
+
+  test("팀장님 개인 방(그룹 아님)은 1:1", () => {
+    const db = setup();
+    put(db, "task-1", "user", "steve", "개인적으로 묻는다", "user");
+
+    expect(lineFor(buildTeamContext(db, "task-1", "steve"), "개인적으로 묻는다")).toContain("1:1");
+  });
+
+  test("시스템 통지는 사람 발언과 갈린다", () => {
+    const db = setup();
+    put(db, GROUP, "system", "steve", "슬랙 게시 실패", "system");
+
+    expect(lineFor(buildTeamContext(db, GROUP, "steve"), "슬랙 게시 실패")).toContain("시스템");
+  });
+
+  test("머리말이 스레드 이름만 보고 전부를 단톡방이라고 말하지 않는다", () => {
+    // ★머리말은 buildTeamContext 가 만들지 않는다★ — teamContextLabel 이 만들어 앞에 붙인다.
+    // 그래서 이 축은 그 함수에 직접 물어야 한다. buildTeamContext 로 재면 어떤 구현이든 통과한다.
+    // 스레드 이름은 그대로 `tg-` 다 — 그런데도 "단톡방" 이라고 단정하지 않아야 한다.
+    expect(teamContextLabel("ko")).not.toContain("단톡방");
+    expect(teamContextLabel("en")).not.toContain("Group-room");
+  });
+});

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -48,7 +48,7 @@ function ownerDmChatId(db: Database): string | undefined {
 }
 import { injectOpenclawTelegramTurn, injectOpenclawDirectedTurn } from "../lib/openclawBridge";
 import { reactTelegramAsHermes, runHermesTeamTurn, HERMES_TURN_TIMEOUT_MS } from "../lib/hermesBridge";
-import { getChannel, resolveThreadKind } from "../channels/registry";
+import { getChannel, lineOrigin, resolveThreadKind } from "../channels/registry";
 import { coordinatorId } from "../lib/capabilities";
 import { ambientAgents } from "../lib/registry";
 import { buildDedupeKey } from "../../shared/envelopeSchema";
@@ -848,7 +848,10 @@ export function buildTeamContext(db: Database, threadId: string, agentId?: strin
       // ★언제 일인지 안 알려주고 있었다.★ (GD 2026-07-13: "오래된걸 주면 안좋은거 아냐?")
       //   ★맞다 — 오래됐다는 걸 ★모르게★ 주면 나쁘다.★ 3일 전 대화를 지금 일로 착각하면 엉뚱한 걸 실행한다.
       //   ★알려주면 팀원이 판단한다.★ ("이건 어제 얘기구나") — 빈 문맥보다 낫고, 무표시 옛 문맥보다 안전하다.
-      const line = `${mine ? "★" : " "}(${timeAgo(m.created_at)})[${who(m.from_agent_id)} → ${who(m.to_agent_id)}] ${body}`;
+      // ★줄마다 출처를 밝힌다★ (GD 2026-08-02 "출처별로 나누던지(1:1 / 단체 / 팀버스)").
+      //   한 스레드에 방 글·버스 DM·시스템 통지가 ★섞여서★ 들어오는데 줄 모양이 같았다.
+      //   머리말 하나로 뭉뚱그리면 섞인 주입에서 또 틀린다 — 그래서 블록이 아니라 줄에 붙인다.
+      const line = `${mine ? "★" : " "}(${timeAgo(m.created_at)})[${lineOrigin(m, isGroupRoom)} · ${who(m.from_agent_id)} → ${who(m.to_agent_id)}] ${body}`;
       if (budget - line.length < 0 && lines.length > 0) break;
       budget -= line.length;
       lines.unshift(line);

--- a/src/server/channels/registry.ts
+++ b/src/server/channels/registry.ts
@@ -35,9 +35,42 @@ export function groupChatIdFromThread(threadId: string): string | null {
   return resolveThreadKind(threadId) === "telegram_group" ? threadId.replace(/^tg-/, "") : null;
 }
 
-// 주입문 문맥 라벨 — 그룹방이면 "단톡방" 명시(참고용=상황파악용). 간결 (GD 2026-07-16).
-export function teamContextLabel(threadId: string, locale: Locale | undefined): string {
-  return resolveThreadKind(threadId) === "telegram_group"
-    ? pick(locale, "[단톡방 대화 — 참고용]", "[Group-room chat — for reference]")
-    : pick(locale, "[최근 팀 대화 — 참고용]", "[Recent team chat — for reference]");
+/**
+ * 주입된 한 줄이 ★어디를 거쳐 왔는지★. 읽는 쪽이 알아야 하는 것은 딱 하나다 —
+ * ★이 말이 방에 떠 있는가, 나한테만 왔는가.★ 그걸 못 가르면 버스로만 받은 지시를
+ * "방에서 다들 봤다" 로 읽는다.
+ *
+ * 한국어 고정이다 — 줄 본문이 이미 한국어 고정("너", "…(잘림: 원문 N자)")이라 여기만
+ * 번역하면 한 줄에 두 언어가 섞인다. 머리말(`teamContextLabel`)은 locale 을 따른다.
+ */
+export type LineOrigin = "단체" | "1:1" | "팀버스" | "시스템";
+
+/**
+ * ★한 줄의 출처.★ 스레드 이름만으로는 못 정한다 — 같은 `tg-` 스레드에 방 글과
+ * 버스 DM 이 ★섞여서★ 들어오기 때문이다. 그래서 발신 축(`source`)과 수신 축을 함께 본다.
+ *
+ *   `system`        → 시스템 (사람 발언이 아니다)
+ *   팀장님(`user`)  → 그룹 스레드면 단체, 아니면 1:1
+ *   팀원(`agent`)   → broadcast 면 방에 올라간 글이므로 단체, 개인 수신자면 팀버스
+ *
+ * ★그룹 스레드 여부를 인자로 받는다★ — 호출부가 이미 `resolveThreadKind` 를 계산해 두므로
+ * 같은 판정을 두 번 하지 않는다(그리고 판정이 갈릴 여지를 안 만든다).
+ */
+export function lineOrigin(
+  m: { source?: string | null; to_agent_id?: string | null; type?: string | null },
+  isGroupThread: boolean,
+): LineOrigin {
+  if (m.source === "system") return "시스템";
+  const inRoom = m.to_agent_id === "broadcast" || m.type === "broadcast";
+  if (m.source === "user") return isGroupThread ? "단체" : "1:1";
+  return isGroupThread && inRoom ? "단체" : "팀버스";
+}
+
+/**
+ * 주입문 머리말. ★출처를 단정하지 않는다★ — 출처는 줄마다 붙는다(`lineOrigin`).
+ * 예전에는 스레드 이름이 `tg-` 로 시작하면 블록 전체를 "단톡방 대화" 라고 했는데,
+ * 그 스레드로 들어온 ★버스 DM 까지 방에 올라간 글로 보였다.★
+ */
+export function teamContextLabel(locale: Locale | undefined): string {
+  return pick(locale, "[최근 팀 대화 — 참고용]", "[Recent team chat — for reference]");
 }

--- a/src/server/lib/hermesBridge.ts
+++ b/src/server/lib/hermesBridge.ts
@@ -152,7 +152,7 @@ export function buildPrompt(opts: HermesTurnOptions): string {
   const msgIsSafe = SAFE_THREAD_RE.test(opts.messageId);
 
   const context = opts.teamContext
-    ? `${teamContextLabel(opts.threadId, locale)}\n${opts.teamContext}\n\n`
+    ? `${teamContextLabel(locale)}\n${opts.teamContext}\n\n`
     : "";
   // (2026-07-10 제거, GD 결정): directReportNote(자가발송 금지 문구)는 hermes 자가발송을 막으려 넣었으나,
   //   이중발송의 진짜 원인은 hermes 자가발송이 아니라 어댑터 double-post(makeHermesAdapter insertMessage+surface)

--- a/src/server/lib/openclawBridge.ts
+++ b/src/server/lib/openclawBridge.ts
@@ -571,7 +571,7 @@ export async function injectOpenclawDirectedTurn(opts: InjectOpenclawDirectedOpt
   await ensureTelegramRouterSession(opts.agent, key); // create-or-continue (label 충돌은 무시)
   const locale = opts.locale;
   const teamContextBlock = opts.teamContext
-    ? `${teamContextLabel(opts.threadId, locale)}\n${opts.teamContext}\n\n`
+    ? `${teamContextLabel(locale)}\n${opts.teamContext}\n\n`
     : "";
   const attachmentBlock = opts.attachments?.length
     ? pick(locale, `[첨부 파일 — 팀 내부 media URL/경로, 필요하면 직접 열람]\n`, `[Attachments — internal team media URL/path, open directly if needed]\n`) +
@@ -649,7 +649,7 @@ export async function injectOpenclawTelegramTurn(opts: InjectOpenclawTelegramOpt
   await ensureTelegramRouterSession(opts.agent, key);
   const locale = opts.locale;
   const teamContextBlock = opts.teamContext
-    ? `${teamContextLabel(opts.threadId, locale)}\n${opts.teamContext}\n\n`
+    ? `${teamContextLabel(locale)}\n${opts.teamContext}\n\n`
     : "";
   const attachmentBlock = opts.attachments?.length
     ? pick(locale, `[첨부 파일 — 팀 내부 media URL/경로, 필요하면 직접 열람]\n`, `[Attachments — internal team media URL/path, open directly if needed]\n`) +

--- a/src/server/lib/tmuxInject.ts
+++ b/src/server/lib/tmuxInject.ts
@@ -247,7 +247,7 @@ export function buildTmuxInjectionPrompt(opts: InjectPromptOptions): string {
         ` Follow the canonical send/read rules.`);
   // Visibility Stage C: show the shared bus's recent team conversation as context first (for reference — not a command).
   const teamContextBlock = opts.teamContext
-    ? `${teamContextLabel(opts.threadId, locale)}\n${opts.teamContext}\n\n`
+    ? `${teamContextLabel(locale)}\n${opts.teamContext}\n\n`
     : "";
   const attachmentBlock = opts.attachments?.length
     ? pick(locale, `[첨부 파일 — 팀 내부 media URL/경로, 필요하면 직접 열람]\n`, `[Attachments — internal team media URL/path, open directly if needed]\n`) +


### PR DESCRIPTION
주입 문맥의 줄마다 출처를 붙인다 — `단체` · `1:1` · `팀버스` · `시스템`.

바뀌는 것: 줄 머리가 `[bill → 너]` 에서 `[팀버스 · bill → 너]` 로. 머리말은 출처를 단정하지 않는다.
영향: 버스로 깨어나는 팀원 전원의 주입문.
규모: 프로덕션 5파일(판정 함수 1개 신설·줄 형식 1줄·호출부 4곳), 신규 테스트 5건.

## 무엇이 문제인가

한 스레드에 **방에 올라간 글·버스 DM·시스템 통지가 섞여** 들어오는데 줄 모양이 똑같았다.

```
 (방금)[bill → 너] …      ← 버스로만 온 지시
 (방금)[user → 너] …      ← 방에 올라간 글
```

머리말은 `teamContextLabel()` 이 붙이는데 **스레드 이름의 `tg-` 접두사만 보고** 블록 전체를
`[단톡방 대화]` 라고 했다. 그래서 그 스레드로 온 버스 DM 까지 방에 올라간 글로 보였다.

실측(최근 3일, 단톡방 스레드): 팀원→개인 수신자 DM 이 이 스레드에만 **50건** 있다.
전부 `[단톡방 대화]` 아래 방 글과 같은 모양으로 찍혔다.

## 왜 그렇게 되나

**출처는 스레드 속성이 아니라 메시지 속성이다.** 스레드는 그릇이고, 그 안에 세 경로가 섞인다.
그래서 스레드 하나에 라벨 하나를 붙이는 구조로는 애초에 표현할 수 없었다.

가르는 축도 하나가 아니다. `to_agent_id` 만 보면 팀장님이 방에서 한 명을 지목한 글
(`user → steve`, 실측 6건)이 개인 DM 으로 보인다. **발신 축(`source`)과 수신 축을 함께** 봐야 한다.

## 어떻게 고쳤나

`lineOrigin(message, isGroupThread)` 한 곳에서 판정한다(`channels/registry.ts` — 스레드/채널 판정의 정본).

| 발신 | 수신 | 출처 |
|---|---|---|
| `system` | — | 시스템 |
| `user`(팀장님) | 그룹 스레드 | 단체 |
| `user`(팀장님) | 그 외 | 1:1 |
| `agent`(팀원) | `broadcast` + 그룹 스레드 | 단체 |
| `agent`(팀원) | 개인 | 팀버스 |

- 줄 형식: `[${출처} · ${from} → ${to}]` — 블록이 아니라 **줄**에 붙인다. 머리말 하나로 뭉뚱그리면
  섞인 주입에서 다시 틀린다.
- `teamContextLabel()` 에서 `단톡방` 분기를 걷어내고 `threadId` 인자를 제거했다(더 이상 안 본다).
  호출부 3파일 4곳을 함께 고쳤다.
- 출처 라벨은 한국어 고정이다 — 줄 본문이 이미 한국어 고정(`너`, `…(잘림: 원문 N자)`)이라
  여기만 번역하면 한 줄에 두 언어가 섞인다. 머리말은 기존대로 locale 을 따른다.

## 검증 결과

뮤턴트 5종 전부 테스트를 죽인다 — 판별력 확인:

| 되돌린 것 | 죽는 테스트 |
|---|---|
| 줄에서 출처 제거(옛 형식) | 4 |
| 머리말을 `단톡방` 으로 | 1 |
| `lineOrigin` 이 항상 `단체` | 3 |
| 팀장님 축에서 그룹 여부 무시 | 1 |
| `broadcast` 축 무시 | 1 |

전체 2224 pass · 1 fail — 그 1건은 `runtimeOptions.test.ts` 로 **main 에서도 같이 실패**한다(별건).
타입 신규 오류 0(잔여 `personaTemplates` 5건은 main 것 — PR #227).
기존 주입 형식을 고정한 `threadContext.test.ts` 는 통과 — 줄 머리 형식(`★`/시각)을 그대로 뒀다.

## 롤백

이 커밋을 되돌리면 줄 형식과 머리말이 그대로 복원된다. 데이터 변경 없음.

Submitted-by: steve
