### PR TITLE
fix(hooks): 배포된 훅이 b3os .env 를 찾게 한다 — owner-skip 이 항상 fail-open 이었다

### DIFF
--- a/hooks/telegram-progress.py
+++ b/hooks/telegram-progress.py
@@ -47,15 +47,27 @@ def _react_self_id():
 
 
 def _team_group_env():
-    # team-collab/.env 의 TEAM_GROUP_ID 폴백 (소스에 실 chat_id 비노출). 없으면 "".
-    try:
-        envp = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".env")
-        with open(envp) as f:
-            for line in f:
-                if line.startswith("TEAM_GROUP_ID="):
-                    return line.split("=", 1)[1].strip()
-    except Exception:
-        pass
+    """b3os `.env` 의 TEAM_GROUP_ID (소스에 실 chat_id 비노출). 못 찾으면 "".
+
+    ★이 파일은 저장소 밖으로 복사돼서 돈다★ — 런처가 멤버 워크스페이스
+    `<멤버>/.claude/hooks/` 로 깐다. 그래서 자기 위치 기준 `../.env` 는 ★저장소 안에서만★
+    맞고 배포된 자리에서는 `<멤버>/.claude/.env` 를 가리켜 ★존재하지 않는다.★
+    빈 값이 되면 owner-skip 이 fail-open 이라 ★그룹방에서 전원이 반응한다.★
+    → 런처가 훅 커맨드에 실어주는 `B3OS_ROOT` 를 먼저 보고, 없으면 예전 경로로 떨어진다
+      (저장소 안에서 직접 부르는 경우가 그 폴백으로 그대로 산다).
+    """
+    root = os.environ.get("B3OS_ROOT", "")
+    here = os.path.dirname(os.path.abspath(__file__))
+    for envp in ([os.path.join(root, ".env")] if root else []) + [os.path.join(here, "..", ".env")]:
+        try:
+            with open(envp) as f:
+                for line in f:
+                    if line.startswith("TEAM_GROUP_ID="):
+                        v = line.split("=", 1)[1].strip()
+                        if v:
+                            return v
+        except Exception:
+            pass
     return ""
 
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -52,7 +52,7 @@ import { createSchedulerRoutes } from "./routes/scheduler";
 import { createCiStatusRoutes } from "./routes/ciStatus";
 import { ensureDailyTaskReviewJobs, ensureWeeklySelfLearningJobs } from "./scheduler/core";
 import { renderAndRepoint } from "./lib/teamOsRender";
-import { installProgressHook } from "./runtimes/claude/launcher";
+import { installProgressHook, repairProgressHook } from "./runtimes/claude/launcher";
 import { writeMemberPersona, savePersonaFile } from "./lib/writeMemberPersona";
 import { persistOwnerChatIdIfEmpty } from "./runtimes/codex/launcher";
 import { createApprovalsApp } from "./routes/approvals";
@@ -159,6 +159,13 @@ try {
     }
   } catch (e) {
     console.warn("[teamos-render] SHARED.md 생성 실패(계속):", e instanceof Error ? e.message : e);
+  }
+  // ★이미 깔린 progress 훅 배선 수리 — 게이트 밖★ (공개·라이브 공통).
+  //   위 백필은 `PUBLIC_BUILD` 뒤에 있어 라이브에서는 안 돈다. 그래서 ★이미 깔린 배선이 낡아도
+  //   아무도 안 고쳤고★, 훅 커맨드가 옛것으로 남아 owner-skip 이 fail-open 으로 돌았다.
+  //   여기서는 ★배선이 이미 있는 멤버만★ 저장소 기준으로 되맞춘다(새로 깔지 않으므로 실멤버 보호 유지).
+  for (const cid of claudeIds) {
+    try { repairProgressHook(cid); } catch { /* best-effort */ }
   }
   // 공개 빌드 부팅 백필(PUBLIC_BUILD 게이트) — 공개 사용자가 git 업데이트를 pull 한 뒤 재시작하면 기존
   //   멤버도 재영입 없이 최신을 받게. 라이브(PUBLIC_BUILD=false)는 글로벌 배선/실멤버 보호로 skip.

--- a/src/server/runtimes/claude/launcher.ts
+++ b/src/server/runtimes/claude/launcher.ts
@@ -131,13 +131,16 @@ export function installReplyGuardHook(id: string): void {
  *  PreToolUse(pre)=매 툴마다 진행 한 줄 append · Stop(stop)=턴 끝 진행 삭제 · PreCompact(compact)=압축 알림.
  *  봇 컨텍스트(어느 채팅에 쏠지)는 세션 env TELEGRAM_STATE_DIR(텔레그램 채널이 세팅)에서 읽으므로 별도
  *  래퍼/봇-스코프 case 불필요 — 워크스페이스 스코프라 오너·타 봇 무영향(글로벌 telegram-progress.sh 래퍼를
- *  ★공개 사용자·신규 멤버까지★ 대체). claude 런타임 전용. 멱등(evt별 includes 가드). best-effort. */
-export function installProgressHook(id: string): void {
+ *  ★공개 사용자·신규 멤버까지★ 대체). claude 런타임 전용. 멱등(evt별 reconcile). best-effort.
+ *  `roots` 는 ★테스트 이음매★ — 안 주면 실제 경로를 쓴다(실 FS 격리: seedGroupIntoClaudeMembers 와 같은 방식). */
+export function installProgressHook(id: string, roots?: { membersRoot?: string; repoRoot?: string }): void {
   assertId(id);
-  const dotClaude = `${MEMBERS_ROOT}/${id}/.claude`;
+  const membersRoot = roots?.membersRoot ?? MEMBERS_ROOT;
+  const repoRoot = roots?.repoRoot ?? REPO_ROOT;
+  const dotClaude = `${membersRoot}/${id}/.claude`;
   const hookDst = `${dotClaude}/hooks/telegram-progress.py`;
   const settingsPath = `${dotClaude}/settings.json`;
-  const src = `${REPO_ROOT}/hooks/telegram-progress.py`;
+  const src = `${repoRoot}/hooks/telegram-progress.py`;
   try {
     if (!existsSync(src)) return; // 소스 없으면 skip
     mkdirSync(`${dotClaude}/hooks`, { recursive: true });
@@ -148,21 +151,47 @@ export function installProgressHook(id: string): void {
       try { const p = JSON.parse(readFileSync(settingsPath, "utf-8")); if (p && typeof p === "object") settings = p; } catch { /* keep {} */ }
     }
     const hooks = (settings.hooks && typeof settings.hooks === "object" ? settings.hooks : {}) as Record<string, unknown>;
-    const addOnce = (evt: string, matcher: string, mode: string) => {
+    // ★"있으면 건너뛴다" 가 아니라 "달라졌으면 맞춘다".★ 예전 구현은 telegram-progress.py 가
+    //   settings.json 에 이미 있으면 통째로 skip 했다. 그래서 커맨드가 바뀌어도(예: env 추가)
+    //   ★기존 멤버는 옛 커맨드를 그대로 들고 있었다★ — 훅 파일만 새것이고 배선은 옛것이 된다.
+    //   실제로 그 상태에서 owner-skip 이 그룹 ID 를 못 구해 fail-open 으로 돌았다.
+    const reconcile = (evt: string, matcher: string, mode: string) => {
       const arr = Array.isArray(hooks[evt]) ? (hooks[evt] as unknown[]) : [];
-      if (!JSON.stringify(arr).includes("telegram-progress.py")) {
-        const entry: Record<string, unknown> = { hooks: [{ type: "command", command: `python3 "${hookDst}" ${mode}` }] };
-        if (matcher) entry.matcher = matcher; // Stop 은 matcher 없음(글로벌 배선과 동형)
-        arr.push(entry);
-      }
+      // ★B3OS_ROOT 를 실어 보낸다★ — 훅은 저장소 밖(멤버 워크스페이스)에서 돌기 때문에
+      //   자기 위치로는 b3os `.env`(TEAM_GROUP_ID)를 못 찾는다. 실 chat_id 는 소스에 안 박는다.
+      const command = `B3OS_ROOT="${repoRoot}" python3 "${hookDst}" ${mode}`;
+      const entry: Record<string, unknown> = { hooks: [{ type: "command", command }] };
+      if (matcher) entry.matcher = matcher; // Stop 은 matcher 없음(글로벌 배선과 동형)
+      const idx = arr.findIndex((e) => JSON.stringify(e).includes("telegram-progress.py"));
+      if (idx < 0) arr.push(entry);
+      else if (JSON.stringify(arr[idx]) !== JSON.stringify(entry)) arr[idx] = entry;
       hooks[evt] = arr;
     };
-    addOnce("PreToolUse", "*", "pre");
-    addOnce("Stop", "", "stop");
-    addOnce("PreCompact", "*", "compact");
+    reconcile("PreToolUse", "*", "pre");
+    reconcile("Stop", "", "stop");
+    reconcile("PreCompact", "*", "compact");
     settings.hooks = hooks;
     writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
   } catch { /* best-effort */ }
+}
+
+/** 이미 깔려 있는 telegram-progress 훅만 최신으로 맞춘다(새로 깔지는 않는다).
+ *
+ *  ★설치와 수리를 가른다.★ 부팅 백필(`installProgressHook`)은 `PUBLIC_BUILD` 게이트 뒤에 있어
+ *  라이브에서는 안 돈다 — 실멤버 배선 보호가 이유다. 그런데 그 때문에 ★이미 깔린 배선이
+ *  낡아도 아무도 안 고쳤다.★ 훅 파일은 활성화 때만 갱신되고, 커맨드는 위 reconcile 이전엔
+ *  아예 안 갱신됐다. 그 결과가 이번 fail-open 이다.
+ *  → 여기서는 ★배선이 이미 있는 멤버만★ 대상으로 파일·커맨드를 저장소 기준으로 되맞춘다.
+ *    안 깔린 멤버에게 새로 깔지 않으므로 라이브 보호 의도는 그대로다. 멱등이다.
+ */
+export function repairProgressHook(id: string, roots?: { membersRoot?: string; repoRoot?: string }): void {
+  assertId(id);
+  const settingsPath = `${roots?.membersRoot ?? MEMBERS_ROOT}/${id}/.claude/settings.json`;
+  try {
+    if (!existsSync(settingsPath)) return;
+    if (!readFileSync(settingsPath, "utf-8").includes("telegram-progress.py")) return; // 안 깔린 멤버는 건드리지 않는다
+  } catch { return; }
+  installProgressHook(id, roots);
 }
 
 /** telegram-progress 훅 제거 — settings.json 의 PreToolUse/Stop/PreCompact 에서 progress 항목 제거 + 훅 파일 삭제. best-effort. */

--- a/src/server/runtimes/claude/progressHookReconcile.test.ts
+++ b/src/server/runtimes/claude/progressHookReconcile.test.ts
@@ -1,0 +1,97 @@
+/**
+ * progress 훅 배선을 ★낡은 채로 두지 않는다.★
+ *
+ * 예전 구현은 settings.json 에 `telegram-progress.py` 가 있으면 통째로 skip 했다. 그래서
+ * 훅 ★파일★ 은 새것으로 덮이는데 ★커맨드★ 는 옛것이 남았다 — 그 상태로 `B3OS_ROOT` 가 안 실려
+ * owner-skip 이 fail-open 으로 돌았다. 파일만 고치고 배선을 안 고치면 같은 일이 반복된다.
+ *
+ * ★실 FS 격리★: mkdtemp 임시 dir 만 만진다(roots 이음매로 주입). 실 멤버 폴더는 안 건드린다.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { installProgressHook, repairProgressHook } from "./launcher";
+
+const ID = "testmember";
+let dirs: string[] = [];
+
+afterEach(() => {
+  for (const d of dirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* best-effort */ } }
+  dirs = [];
+});
+
+function setup(settings?: unknown): { membersRoot: string; repoRoot: string; settingsPath: string } {
+  const base = mkdtempSync(join(tmpdir(), "b3os-reconcile-"));
+  dirs.push(base);
+  const repoRoot = join(base, "b3os");
+  const membersRoot = join(base, "members");
+  mkdirSync(join(repoRoot, "hooks"), { recursive: true });
+  writeFileSync(join(repoRoot, "hooks", "telegram-progress.py"), "# stub\n");
+  const dotClaude = join(membersRoot, ID, ".claude");
+  mkdirSync(dotClaude, { recursive: true });
+  const settingsPath = join(dotClaude, "settings.json");
+  if (settings !== undefined) writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
+  return { membersRoot, repoRoot, settingsPath };
+}
+
+const commandsIn = (settingsPath: string): string[] => {
+  const s = JSON.parse(readFileSync(settingsPath, "utf-8"));
+  return Object.values(s.hooks as Record<string, Array<{ hooks: Array<{ command: string }> }>>)
+    .flat()
+    .flatMap((e) => e.hooks.map((h) => h.command));
+};
+
+/** 옛 배선 — `B3OS_ROOT` 없이 python3 만 부른다. 이게 라이브에 남아 있던 모양이다. */
+const staleSettings = (membersRoot: string) => ({
+  hooks: {
+    PreToolUse: [{ matcher: "*", hooks: [{ type: "command", command: `python3 "${membersRoot}/${ID}/.claude/hooks/telegram-progress.py" pre` }] }],
+    Stop: [{ hooks: [{ type: "command", command: `python3 "${membersRoot}/${ID}/.claude/hooks/telegram-progress.py" stop` }] }],
+    PreCompact: [{ matcher: "*", hooks: [{ type: "command", command: `python3 "${membersRoot}/${ID}/.claude/hooks/telegram-progress.py" compact` }] }],
+  },
+});
+
+describe("progress 훅 배선 reconcile", () => {
+  test("★낡은 커맨드를 새 커맨드로 바꾼다★ — 예전엔 있으면 skip 이라 영영 안 바뀌었다", () => {
+    const { membersRoot, repoRoot, settingsPath } = setup(null);
+    writeFileSync(settingsPath, JSON.stringify(staleSettings(membersRoot), null, 2) + "\n");
+
+    installProgressHook(ID, { membersRoot, repoRoot });
+
+    const cmds = commandsIn(settingsPath);
+    expect(cmds).toHaveLength(3);
+    for (const c of cmds) expect(c).toContain(`B3OS_ROOT="${repoRoot}"`);
+    // 옛 커맨드가 남아 있으면 안 된다 — 추가만 하고 안 지우면 훅이 두 번 돈다.
+    expect(cmds.some((c) => !c.includes("B3OS_ROOT"))).toBe(false);
+  });
+
+  test("두 번 돌려도 항목이 늘지 않는다 (멱등)", () => {
+    const { membersRoot, repoRoot, settingsPath } = setup({});
+    installProgressHook(ID, { membersRoot, repoRoot });
+    const first = readFileSync(settingsPath, "utf-8");
+    installProgressHook(ID, { membersRoot, repoRoot });
+    expect(readFileSync(settingsPath, "utf-8")).toBe(first);
+    expect(commandsIn(settingsPath)).toHaveLength(3);
+  });
+
+  test("다른 훅(reply-guard)은 건드리지 않는다", () => {
+    const { membersRoot, repoRoot, settingsPath } = setup({
+      hooks: { Stop: [{ hooks: [{ type: "command", command: `python3 "/x/reply-guard.py"` }] }] },
+    });
+    installProgressHook(ID, { membersRoot, repoRoot });
+    expect(commandsIn(settingsPath).filter((c) => c.includes("reply-guard.py"))).toHaveLength(1);
+  });
+
+  test("★repair 는 이미 깔린 멤버만 고친다★ — 안 깔린 멤버에 새로 깔지 않는다(라이브 보호)", () => {
+    const { membersRoot, repoRoot, settingsPath } = setup({ hooks: {} });
+    repairProgressHook(ID, { membersRoot, repoRoot });
+    expect(readFileSync(settingsPath, "utf-8")).not.toContain("telegram-progress.py");
+  });
+
+  test("repair 는 깔려 있으면 낡은 커맨드를 고친다", () => {
+    const { membersRoot, repoRoot, settingsPath } = setup(null);
+    writeFileSync(settingsPath, JSON.stringify(staleSettings(membersRoot), null, 2) + "\n");
+    repairProgressHook(ID, { membersRoot, repoRoot });
+    for (const c of commandsIn(settingsPath)) expect(c).toContain("B3OS_ROOT=");
+  });
+});

--- a/src/server/runtimes/claude/progressHookWiring.test.ts
+++ b/src/server/runtimes/claude/progressHookWiring.test.ts
@@ -1,0 +1,80 @@
+/**
+ * 배포된 훅이 b3os `.env`(TEAM_GROUP_ID)를 찾을 수 있어야 한다 — 못 찾으면 owner-skip 이
+ * fail-open 이 되어 ★그룹방에서 전원이 반응한다.★
+ *
+ * ★훅은 저장소 밖에서 돈다★ — 런처가 `<멤버>/.claude/hooks/` 로 복사한다. 그래서 이 테스트는
+ * 파일을 ★실제로 그 모양으로 복사한 뒤 거기서★ 실행한다. 저장소 안에서 재면 통과만 하고
+ * 배포된 자리의 고장을 못 본다 — 그게 이 결함이 안 잡힌 이유다.
+ */
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO = join(import.meta.dir, "../../../..");
+const HOOK_SRC = join(REPO, "hooks/telegram-progress.py");
+const GROUP = "-1009999999999"; // 테스트 전용 가짜 값 — 실 chat_id 아니다
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "b3os-hook-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** 훅 파일을 주어진 자리에 깔고, 그 자리에서 `_team_group_env()` 를 불러 결과를 돌려준다. */
+function resolveAt(hookPath: string, env: Record<string, string>): string {
+  copyFileSync(HOOK_SRC, hookPath);
+  const py = [
+    "import importlib.util,sys",
+    `s=importlib.util.spec_from_file_location("h", ${JSON.stringify(hookPath)})`,
+    "m=importlib.util.module_from_spec(s)",
+    "try: s.loader.exec_module(m)",
+    "except SystemExit: pass",
+    "sys.stdout.write(m._team_group_env())",
+  ].join("\n");
+  return execFileSync("python3", ["-c", py], {
+    env: { ...process.env, B3OS_ROOT: "", OWNER_GATE_GROUP: "", ...env },
+    encoding: "utf-8",
+  });
+}
+
+/** 저장소 루트 하나를 만들고 `.env` 에 그룹 ID 를 넣는다. */
+function makeRepo(): string {
+  const root = join(dir, "b3os");
+  mkdirSync(join(root, "hooks"), { recursive: true });
+  writeFileSync(join(root, ".env"), `TEAM_GROUP_ID=${GROUP}\n`);
+  return root;
+}
+
+/** 런처가 까는 자리 — `<멤버>/.claude/hooks/telegram-progress.py`. */
+function makeMemberHookPath(): string {
+  const hooks = join(dir, "member", ".claude", "hooks");
+  mkdirSync(hooks, { recursive: true });
+  return join(hooks, "telegram-progress.py");
+}
+
+describe("배포된 progress 훅의 그룹 ID 해결", () => {
+  test("★B3OS_ROOT 가 있으면 배포 위치에서도 찾는다★ — 없으면 owner-skip 이 fail-open 이다", () => {
+    const root = makeRepo();
+    expect(resolveAt(makeMemberHookPath(), { B3OS_ROOT: root })).toBe(GROUP);
+  });
+
+  test("B3OS_ROOT 가 없으면 배포 위치에서는 못 찾는다 — 옛 배선이 죽어 있던 이유", () => {
+    makeRepo();
+    // 배포 위치에서 `../.env` 는 `<멤버>/.claude/.env` 라 존재하지 않는다.
+    expect(resolveAt(makeMemberHookPath(), {})).toBe("");
+  });
+
+  test("★저장소 안에서 부르면 B3OS_ROOT 없이도 그대로 산다★ — 폴백을 안 깼다", () => {
+    const root = makeRepo();
+    expect(resolveAt(join(root, "hooks", "telegram-progress.py"), {})).toBe(GROUP);
+  });
+
+  test("★공개 저장소 소스에 실 chat_id 가 없다★", () => {
+    // 텔레그램 그룹 chat_id 는 `-100` 으로 시작하는 긴 음수다. 소스에 박히면 공개 노출이다.
+    expect(readFileSync(HOOK_SRC, "utf-8")).not.toMatch(/-100\d{10,}/);
+  });
+});


### PR DESCRIPTION
배포된 훅이 b3os `.env` 를 못 찾아 owner-skip 이 항상 fail-open 이었다. 그룹방에서 팀원 전원이 반응한다.

바뀌는 것: 런처가 훅 커맨드에 `B3OS_ROOT` 를 싣고, 훅이 그걸 먼저 본다.
영향: claude 런타임 팀원 전원의 그룹방 리액션.
규모: 프로덕션 3파일(훅 1함수·런처 배선·부팅 수리 1루프), 신규 테스트 9건.

## 무엇이 문제인가

`_react_owner_skip()` 은 그룹 ID 를 못 구하면 `False` 로 빠진다(fail-open). 그 그룹 ID 를
`_team_group_env()` 가 **`<훅파일>/../.env`** 에서 읽는데, **훅은 저장소 밖에서 돈다** —
런처가 `<멤버>/.claude/hooks/` 로 복사한다.

| 훅이 있는 자리 | `../.env` 가 가리키는 곳 | 결과 |
|---|---|---|
| `b3os/hooks/` (저장소 안) | `b3os/.env` | 찾는다 |
| `<멤버>/.claude/hooks/` (배포) | `<멤버>/.claude/.env` | **없다** |

대체 경로로 보이는 `OWNER_GATE_GROUP` 은 **소스 어디에서도 set 하지 않는다.** 읽는 곳만 둘이고
launchd plist·셸 환경에도 없다. 그래서 배포된 자리에서는 항상 빈 값이다.

실측(배포된 사본을 import 해서 함수를 직접 호출):

```
BEFORE 라이브 배포본        그룹ID해결 아니오   _react_owner_skip -> False
대조군 글로벌(하드코딩판)     그룹ID해결 하드코딩  _react_owner_skip -> True
```

## 왜 그렇게 되나

**자기 위치를 기준으로 삼는 경로는 파일이 복사되는 순간 틀린다.** 이 훅은 복사되는 것이
전제인 파일인데 기준점이 자기 위치였다.

배선이 낡은 채로 남은 이유는 따로 있다. `installProgressHook` 이 `settings.json` 에
`telegram-progress.py` 가 **있으면 통째로 skip** 했다. 그래서 훅 **파일**은 활성화 때 덮이는데
**커맨드**는 한 번 쓰이면 영영 안 바뀐다. 파일만 새것이고 배선은 옛것이 되는 구조였다.

부팅 백필은 `PUBLIC_BUILD` 게이트 뒤에 있어 라이브에서는 아예 안 돈다. 그 게이트의 의도는
실멤버 보호인데, 결과적으로 **이미 깔린 배선을 아무도 안 고쳤다.**

## 어떻게 고쳤나

- 런처가 훅 커맨드에 `B3OS_ROOT="<repo>"` 를 싣는다. 훅은 `$B3OS_ROOT/.env` → `<훅>/../.env`
  순으로 찾는다 — **저장소 안에서 직접 부르는 경우는 폴백으로 그대로 산다.**
- `addOnce` 를 **reconcile** 로 바꿨다: 항목이 없으면 추가, 있는데 다르면 **교체**.
  추가만 하고 안 지우면 훅이 두 번 돈다.
- `repairProgressHook()` 을 부팅 시 게이트 밖에서 돌린다. **배선이 이미 있는 멤버만** 대상이라
  안 깔린 멤버에게 새로 깔지 않는다(라이브 보호 의도 유지). 멱등이다.
- 실 chat_id 는 소스에 안 넣는다. 공개 저장소 기준 그대로다.

재프로비저닝은 **자동**이다 — 다음 재시작에 `repairProgressHook` 이 5명 `settings.json` 을
저장소 기준으로 되맞춘다. 수동 절차 없음.

## 검증 결과

**배포 위치 before/after (대조군 포함).** 훅을 배포 위치 모양으로 깔고 실제 함수를 호출했다:

| | 그룹 ID 해결 | `_react_owner_skip` |
|---|---|---|
| BEFORE 라이브 배포본 | 아니오 | **False** |
| AFTER 새 훅 + `B3OS_ROOT` | 예 | **True** |
| AFTER 새 훅, `B3OS_ROOT` 없음 | 아니오 | False |
| 대조군 글로벌(하드코딩판) | 하드코딩 | True |

세 번째 줄이 **원인을 파일 교체가 아니라 `B3OS_ROOT` 로 못박는다.**

**뮤턴트 4종 전부 테스트를 죽인다:**

| 되돌린 것 | 죽는 테스트 |
|---|---|
| 훅에서 `B3OS_ROOT` 조회 제거 | 1 |
| 커맨드에서 `B3OS_ROOT` 제거 | 2 |
| reconcile 을 옛 `addOnce` 로 | 2 |
| `repair` 의 "이미 깔린 멤버만" 가드 제거 | 1 |

신규 테스트 9건 · 전체 2228 pass(main 2219 대비 +9 = 신규분) · **신규 실패 0** ·
타입 신규 오류 0. 테스트는 `mkdtemp` 임시 dir 만 만진다(실 멤버 폴더 무접촉).

## 안 고친 것

- 그룹방 리액션의 다른 원인(텔레그램 플러그인의 암묵적 reply-멘션 규칙) — 별건이다.
- `hooks/telegram-owner-gate.py` 도 `OWNER_GATE_GROUP` 을 읽지만 **배포되지 않는다**(저장소에만 있다).

## 롤백

이 커밋을 되돌리면 커맨드가 옛 형태로 돌아간다. 되돌린 뒤 재시작하면 `repairProgressHook` 이
없으므로 `settings.json` 은 **옛 커맨드로 자동 복구되지 않는다** — 멤버당 한 줄 수동 정정이 필요하다.

Submitted-by: steve
