### PR TITLE
fix(bus): 단톡방 인입 주입문도 줄마다 출처를 붙인다 — 줄 빌더를 하나로 모은다

### DIFF
--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -801,6 +801,36 @@ async function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Pro
  *   ★유사도 같은 걸로 서버가 막지 않는다★ (GD). ★팀원이 볼 수 있으면 팀원이 판단한다.★
  */
 
+/**
+ * ★주입문 한 줄을 만드는 곳은 여기 하나다.★
+ *
+ * 왜 함수로 뺐나 — 줄을 만드는 곳이 ★두 군데★ 였다. 팀버스 깨움(`buildTeamContext`)과
+ * 단톡방 인입(`telegramCapture`). 출처 표시를 앞쪽에만 붙였더니 ★단톡방으로 들어오는 주입문은
+ * 그대로 이름만 찍혔다★ — 같은 일을 하는 곳이 둘인데 하나만 고친 것이고, 그게 출처 표시가
+ * 고치려던 결함과 같은 종류다. 판정(`lineOrigin`)만 공유하면 형식이 다시 갈라지므로 ★줄 전체★ 를 공유한다.
+ *
+ * `agentId` 를 주면 자기 글에 ★ 를 붙이고 자신을 "너" 로 부른다. 안 주면(방 전체용 문맥)
+ * 그냥 이름으로 찍는다. `maxChars` 는 호출부가 정한다 — 경로마다 예산이 다르다.
+ */
+export function renderContextLine(
+  m: { from_agent_id?: string | null; to_agent_id?: string | null; body: string; created_at: string; source?: string | null; type?: string | null },
+  opts: { agentId?: string; isGroupThread: boolean; maxChars: number },
+): string {
+  const agentId = opts.agentId;
+  const who = (id: string | null | undefined): string => (id && id === agentId ? "너" : (id ?? "?"));
+  const full = m.body.replace(/\n/g, " ");
+  const cut = full.length > opts.maxChars;
+  const body = cut ? `${full.slice(0, opts.maxChars)} …(잘림: 원문 ${full.length}자)` : full;
+  const mine = m.from_agent_id === agentId;
+  // ★언제 일인지 안 알려주고 있었다.★ (GD 2026-07-13: "오래된걸 주면 안좋은거 아냐?")
+  //   ★맞다 — 오래됐다는 걸 ★모르게★ 주면 나쁘다.★ 3일 전 대화를 지금 일로 착각하면 엉뚱한 걸 실행한다.
+  //   ★알려주면 팀원이 판단한다.★ ("이건 어제 얘기구나") — 빈 문맥보다 낫고, 무표시 옛 문맥보다 안전하다.
+  // ★줄마다 출처를 밝힌다★ (GD 2026-08-02 "출처별로 나누던지(1:1 / 단체 / 팀버스)").
+  //   한 스레드에 방 글·버스 DM·시스템 통지가 ★섞여서★ 들어오는데 줄 모양이 같았다.
+  //   머리말 하나로 뭉뚱그리면 섞인 주입에서 또 틀린다 — 그래서 블록이 아니라 줄에 붙인다.
+  return `${mine ? "★" : " "}(${timeAgo(m.created_at)})[${lineOrigin(m, opts.isGroupThread)} · ${who(m.from_agent_id)} → ${who(m.to_agent_id)}] ${body}`;
+}
+
 /** 문맥에 담는 메시지 수 · 시간창 · 한 건 상한 · 전체 예산. ★실측으로 정했다 (추측 아님)★:
  *   · 한 건 200자였는데 ★웹조사 답변(258자·219자)이 잘렸다★ → 800자
  *   · 전체 예산 8,000자 — 그룹방 최근 12건 실측이 761자였으니 평소엔 근처도 안 간다. ★폭주 방지용 상한.★ */
@@ -842,7 +872,6 @@ export function buildTeamContext(db: Database, threadId: string, agentId?: strin
     }
     if (!recent.length) return "";
 
-    const who = (id: string | null | undefined): string => (id && id === agentId ? "너" : (id ?? "?"));
     // ★잘림이 진짜 답을 잘랐다★ (GD 질문: "메시지가 크면?"). 실측: 최근 121건 중 4건이 200자 초과인데
     //   ★하필 웹조사 답변들이었다★ (라이프치히 258자 · 한스아이슬러 219자) → collector 가 ★잘린 답으로 종합★.
     //   → 한 건 상한을 올리고(800자), ★전체 예산★ 으로 막는다(무한정 커지지 않게).
@@ -851,17 +880,7 @@ export function buildTeamContext(db: Database, threadId: string, agentId?: strin
     let budget = CTX_TOTAL_CHARS;
     for (let i = recent.length - 1; i >= 0; i--) {   // 최신부터 담고, 예산 다 쓰면 옛 것을 버린다
       const m = recent[i]!;
-      const full = m.body.replace(/\n/g, " ");
-      const cut = full.length > CTX_MSG_CHARS;
-      const body = cut ? `${full.slice(0, CTX_MSG_CHARS)} …(잘림: 원문 ${full.length}자)` : full;
-      const mine = m.from_agent_id === agentId;
-      // ★언제 일인지 안 알려주고 있었다.★ (GD 2026-07-13: "오래된걸 주면 안좋은거 아냐?")
-      //   ★맞다 — 오래됐다는 걸 ★모르게★ 주면 나쁘다.★ 3일 전 대화를 지금 일로 착각하면 엉뚱한 걸 실행한다.
-      //   ★알려주면 팀원이 판단한다.★ ("이건 어제 얘기구나") — 빈 문맥보다 낫고, 무표시 옛 문맥보다 안전하다.
-      // ★줄마다 출처를 밝힌다★ (GD 2026-08-02 "출처별로 나누던지(1:1 / 단체 / 팀버스)").
-      //   한 스레드에 방 글·버스 DM·시스템 통지가 ★섞여서★ 들어오는데 줄 모양이 같았다.
-      //   머리말 하나로 뭉뚱그리면 섞인 주입에서 또 틀린다 — 그래서 블록이 아니라 줄에 붙인다.
-      const line = `${mine ? "★" : " "}(${timeAgo(m.created_at)})[${lineOrigin(m, isGroupRoom)} · ${who(m.from_agent_id)} → ${who(m.to_agent_id)}] ${body}`;
+      const line = renderContextLine(m, { agentId, isGroupThread: isGroupRoom, maxChars: CTX_MSG_CHARS });
       if (budget - line.length < 0 && lines.length > 0) break;
       budget -= line.length;
       lines.unshift(line);

--- a/src/server/workers/captureContextOrigin.test.ts
+++ b/src/server/workers/captureContextOrigin.test.ts
@@ -1,0 +1,85 @@
+/**
+ * 단톡방 인입 경로의 주입 문맥도 줄마다 출처를 밝힌다.
+ *
+ * ★이 파일은 `telegramCapture` 쪽 줄을 잰다★ — 팀버스 쪽(`buildTeamContext`)만 보는 테스트는
+ * 이 축을 못 잡는다. 실제로 출처 표시를 팀버스에만 붙였을 때, 팀버스 테스트는 전부 통과하는데
+ * ★팀장님이 실제로 받으시는 주입문은 그대로 `[이름] 본문`★ 이었다.
+ */
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { migrate } from "../db/migrate";
+import { acceptInbound } from "../db/inbox/acceptInbound";
+import { buildCaptureTeamContext } from "./telegramCapture";
+
+const GROUP = "tg--123";
+
+function setup(): Database {
+  const db = new Database(":memory:");
+  migrate(db);
+  for (const a of ["bill", "steve"]) {
+    db.prepare(
+      `INSERT INTO agent (id, display_name, role, runtime, status_provider, workspace_path, persona_file)
+       VALUES (?, ?, 'role', 'claude_channel', 'claude_tmux', '/tmp', 'p.md')`,
+    ).run(a, a);
+  }
+  db.prepare(
+    `INSERT INTO thread (id, title, kind, participants_json, opened_by)
+     VALUES ('${GROUP}','group','dm','["bill","steve"]','bill')`,
+  ).run();
+  return db;
+}
+
+const put = (db: Database, from: string, to: string, body: string, source: string) =>
+  acceptInbound(
+    db,
+    { thread_id: GROUP, from_agent_id: from, to_agent_id: to, body, source, type: "dm" } as never,
+    { dedupeWindowSec: 0 },
+  );
+
+function lineFor(ctx: string, needle: string): string {
+  const line = ctx.split("\n").find((l) => l.includes(needle));
+  expect(line, `문맥에 '${needle}' 줄이 없다`).toBeDefined();
+  return line!;
+}
+
+describe("단톡방 인입 주입문도 줄마다 출처를 밝힌다", () => {
+  test("★팀장님 발언은 단체, 팀버스 메시지는 팀버스★ — 한 문맥 안에서 갈린다", () => {
+    const db = setup();
+    put(db, "user", "bill", "@빌 다 끝났어?", "user");
+    put(db, "bill", "steve", "버스로만 보낸 지시다", "agent");
+
+    const ctx = buildCaptureTeamContext(db, GROUP);
+
+    expect(lineFor(ctx, "다 끝났어?")).toContain("단체");
+    expect(lineFor(ctx, "버스로만 보낸 지시다")).toContain("팀버스");
+    // 두 줄이 서로 달라야 한다 — 같은 라벨이면 가른 게 아니다.
+    expect(lineFor(ctx, "버스로만 보낸 지시다")).not.toContain("단체");
+  });
+
+  test("시스템 통지는 사람 발언과 갈린다", () => {
+    const db = setup();
+    put(db, "system", "steve", "슬랙 게시 실패", "system");
+    expect(lineFor(buildCaptureTeamContext(db, GROUP), "슬랙 게시 실패")).toContain("시스템");
+  });
+
+  test("★수신자가 하나로 안 정해지는 자리라 '너' 가 없다★ — 방 전체용 문맥이다", () => {
+    const db = setup();
+    put(db, "bill", "steve", "누구에게 갈지 모른다", "agent");
+    expect(buildCaptureTeamContext(db, GROUP)).not.toContain("너");
+  });
+
+  test("기존 동작 — 200자에서 자르고 줄바꿈을 공백으로 바꾼다", () => {
+    const db = setup();
+    put(db, "bill", "steve", "가".repeat(250) + "\n" + "끝", "agent");
+
+    const ctx = buildCaptureTeamContext(db, GROUP);
+    expect(ctx.split("\n")).toHaveLength(1); // 본문의 줄바꿈이 줄을 늘리지 않는다
+    expect(ctx).toContain("가".repeat(200));
+    expect(ctx).not.toContain("가".repeat(201));
+    expect(ctx).toContain("잘림: 원문 252자"); // 조용히 자르지 않는다
+  });
+
+  test("빈 스레드는 빈 문자열", () => {
+    expect(buildCaptureTeamContext(setup(), GROUP)).toBe("");
+  });
+});

--- a/src/server/workers/telegramCapture.ts
+++ b/src/server/workers/telegramCapture.ts
@@ -6,6 +6,8 @@ import { appendAuditFile } from "../lib/auditFile";
 import { injectPrompt } from "../lib/tmuxInject";
 import { injectOpenclawTelegramTurn } from "../lib/openclawBridge";
 import { recordReportDelivery } from "../bus/deliveryRecord";
+import { renderContextLine } from "../bus/wakeDispatcher";
+import { resolveThreadKind } from "../channels/registry";
 import { postTelegramAsHermes, reactTelegramAsHermes, runHermesTeamTurn } from "../lib/hermesBridge";
 import { teamContextForAgent } from "../lib/teamContextPolicy";
 import { hasCapability } from "../lib/capabilities";
@@ -53,7 +55,27 @@ let TOKEN = getCaptureToken();
 let GROUP_ID = getCaptureGroupId() ?? "";
 // injection 킬스위치 — 이제 *라이브 읽기*(isRouterEnabled(deps.db)). UI 토글 즉시 반영, 재시작 불요. (P0)
 // OFF면 결정 로깅만(shadow). store(setting router_enabled) 우선, 없으면 env(ROUTER_ENABLED) fallback.
+// 단톡방 인입 문맥 예산 — 팀버스 경로(CTX_*)와 값이 다르다. ★한 건 200자는 기존 동작이라 유지한다.★
+const CAPTURE_CTX_MSGS = 10;
+const CAPTURE_CTX_HOURS = 6;
+const CAPTURE_CTX_MSG_CHARS = 200;
 const OFFSET_PATH = process.env.CAPTURE_OFFSET_PATH ?? `${process.cwd()}/logs/telegram-capture-offset.txt`;
+/** 단톡방 인입 경로의 주입 문맥(최대 10건/6h) — 현재 메시지 적재 전 = 직전 맥락.
+ *
+ *  ★줄은 `renderContextLine` 한 곳에서 만든다★ — 예전에는 여기서 따로 `[이름] 본문` 을 찍었다.
+ *  그래서 팀버스 쪽에만 출처를 붙였을 때 ★이 경로는 그대로 이름만 나왔다.★ 팀장님이 실제로 쓰시는
+ *  경로가 여기라서, 고쳤다고 보고된 뒤에도 팀장님 화면에는 안 고쳐진 형식이 계속 갔다.
+ *  ★수신자(agentId)가 하나로 정해지지 않는 자리다★ — 방 전체용 문맥이라 "너" 없이 이름으로 찍는다.
+ *  ★함수로 뺀 이유는 재기 위해서다★ — 워커 안에 인라인으로 두면 이 줄을 직접 재는 테스트를 못 쓴다. */
+export function buildCaptureTeamContext(db: Database, threadId: string): string {
+  const recent = recentThreadMessages(db, threadId, CAPTURE_CTX_MSGS, CAPTURE_CTX_HOURS);
+  if (!recent.length) return "";
+  const isGroupThread = resolveThreadKind(threadId) === "telegram_group";
+  return recent
+    .map((m) => renderContextLine(m, { isGroupThread, maxChars: CAPTURE_CTX_MSG_CHARS }))
+    .join("\n");
+}
+
 export function mediaUrlBase(): string {
   const publicBase = (process.env.TEAM_PUBLIC_BASE_URL ?? process.env.TEAM_BASE_URL ?? "").replace(/\/$/, "");
   const basePath = (process.env.BASE_PATH ?? "/team").replace(/\/$/, "");
@@ -923,12 +945,7 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
     // 가시성 Stage C: 깨우기 전 공유 버스의 최근 팀 맥락(최대 10건/6h)을 모은다 — 현재 메시지 적재 전 = 직전 맥락.
     let teamContext = "";
     try {
-      const recent = recentThreadMessages(deps.db, threadId, 10, 6);
-      if (recent.length) {
-        teamContext = recent
-          .map((m) => `[${m.from_agent_id}] ${m.body.slice(0, 200).replace(/\n/g, " ")}`)
-          .join("\n");
-      }
+      teamContext = buildCaptureTeamContext(deps.db, threadId);
     } catch (e) {
       console.error("[capture] team context fetch failed:", (e as Error).message);
     }


### PR DESCRIPTION
주입문 줄을 만드는 곳이 두 군데였다. `#229` 는 그중 하나만 고쳤다.

바뀌는 것: 단톡방 인입 주입문도 줄마다 출처가 붙는다.
영향: 팀장님이 단톡방에 글을 올릴 때 깨어나는 팀원 전원.
규모: 프로덕션 2파일(공유 렌더러 1개 신설 · 호출부 2곳), 신규 테스트 5건.

## 무엇이 문제인가

`#229` 는 `wakeDispatcher.buildTeamContext` 에 출처를 붙였다. 그런데 **단톡방 인입 경로는
`telegramCapture` 가 따로 줄을 만들고 있었다.**

```ts
.map((m) => `[${m.from_agent_id}] ${m.body.slice(0, 200).replace(/\n/g, " ")}`)
```

이름만 찍는다. 시각도 방향도 출처도 없다. 머리말은 같은 `teamContextLabel` 을 쓰므로
**머리말만 고쳐지고 줄은 안 고쳐진 상태**가 됐다.

**`#229` 가 없애려던 결함과 같은 종류다** — 같은 판단을 하는 곳이 둘인데 하나만 고친 것.

## 왜 그렇게 되나

두 경로는 목적이 달라서 갈라져 있었다. 팀버스 깨움은 **한 팀원에게** 주는 문맥이라
자기 글에 `★`, 자신을 `너` 로 부른다. 단톡방 인입은 **아직 수신자가 안 정해진** 시점에
방 전체용으로 한 번 만든다.

그 차이가 형식 전체를 따로 두는 이유가 됐고, 그래서 한쪽만 고쳐도 아무것도 안 깨졌다.
**판정(`lineOrigin`)만 공유하면 형식은 다시 갈라진다.**

## 어떻게 고쳤나

**줄 전체를 한 함수로 모았다** — `renderContextLine(m, { agentId?, isGroupThread, maxChars })`.

- `agentId` 를 주면 `★`/`너`, 안 주면 이름으로 찍는다. 두 경로의 차이를 **인자로** 흡수한다.
- `maxChars` 는 호출부가 정한다 — 팀버스 800자, 단톡방 200자(기존 값 유지).
- `telegramCapture` 의 인라인 map 을 `buildCaptureTeamContext(db, threadId)` 로 빼서
  **그 줄을 직접 재는 테스트**가 가능하게 했다. 워커 안에 인라인이면 못 잰다.

결과:

```
[최근 팀 대화 — 참고용]
 (방금)[단체 · demis → broadcast] ✦ 6am 과제 리뷰 — 정리했습니다
 (방금)[단체 · user → bill] @빌 다 끝났어?
 (방금)[단체 · bill → broadcast] ✦ 네, 끝났습니다.
 (방금)[팀버스 · bill → steve] 버스로만 보낸 위임이다
 (방금)[시스템 · system → steve] 슬랙 게시 실패
```

## 검증 결과

**뮤턴트 — 두 경로가 실제로 한 렌더러를 쓰는지가 핵심이다:**

| 되돌린 것 | 죽는 테스트 |
|---|---|
| `telegramCapture` 를 옛 줄 형식으로 | 3 (단톡방 테스트) |
| **공유 렌더러에서 출처 제거** | **6 — 팀버스 4 + 단톡방 2** |

두 번째가 **한 곳을 건드리면 양쪽이 같이 죽는다**는 증거다. 갈라져 있으면 한쪽만 죽는다.

기존 동작 유지도 쟀다 — 200자 자르기, `\n` → 공백, 빈 스레드 → 빈 문자열.
(자를 때 `…(잘림: 원문 N자)` 가 붙는 것은 **바뀐 점**이다. 상한 200자는 그대로고,
조용히 자르지 않는 쪽이 팀버스 경로와 같은 계약이다.)

전체 2247 pass(base 2242 대비 +5 = 신규분) · **신규 실패 0** · 타입 신규 오류 0.
`threadContext.test.ts` 통과 — 줄 형식을 소스 문자열로 고정한 테스트라 렌더러를 같은 파일에 뒀다.

## 안 고친 것

- 두 경로의 **메시지 선별**(건수·시간창·수신자 필터)은 그대로다. 목적이 달라 합치면 동작이 바뀐다.
  합친 것은 **줄을 만드는 방식**이다.

## 롤백

이 커밋을 되돌리면 두 경로가 각자 줄을 만드는 상태로 돌아간다. 데이터 변경 없음.

Submitted-by: steve
