### PR TITLE
fix(bus): 전체공지 CLI를 all-hands로 통일한다

### DIFF
--- a/scripts/send-tools-honesty.test.sh
+++ b/scripts/send-tools-honesty.test.sh
@@ -114,8 +114,8 @@ else
   fail "페이로드를 잡지 못했다(테스트 하네스 문제 — 아래 단정은 신뢰할 수 없다)"
 fi
 
-echo "── A1-6: --notice/--공지 는 사유를 명시 필드로 싣는다 ──"
-PATH="$FAKEBIN:$PATH" "$SEND" --to broadcast --body "공지" --notice "서비스 점검" >/dev/null 2>&1
+echo "── A1-6: --all-hands 는 사유를 명시 필드로 싣고 이전 표기는 옵션으로 받지 않는다 ──"
+PATH="$FAKEBIN:$PATH" "$SEND" --to broadcast --body "공지" --all-hands "서비스 점검" >/dev/null 2>&1
 CAPTURE="$CAPTURE" python3 - <<'PY' \
   && pass "all_hands 사유가 페이로드에 실림" \
   || fail "all_hands 사유가 페이로드에 없음"
@@ -123,18 +123,18 @@ import json, os, sys
 p = json.load(open(os.environ["CAPTURE"]))
 sys.exit(0 if p.get("all_hands") == "서비스 점검" and "notice" not in p and "@all" not in p.get("body", "") else 1)
 PY
-PATH="$FAKEBIN:$PATH" "$SEND" --to broadcast --body "공지" --공지 "전원 확인 필요" >/dev/null 2>&1
-CAPTURE="$CAPTURE" python3 - <<'PY' \
-  && pass "--공지 별칭도 같은 all_hands 필드로 실림" \
-  || fail "--공지 별칭이 all_hands 사유로 변환되지 않음"
-import json, os, sys
-p = json.load(open(os.environ["CAPTURE"]))
-sys.exit(0 if p.get("all_hands") == "전원 확인 필요" else 1)
-PY
-out="$(PATH="$FAKEBIN:$PATH" "$SEND" --to broadcast --body "공지" --notice 2>&1)"; rc=$?
-[ $rc -ne 0 ] && pass "사유 없는 --notice 거절" || fail "사유 없는 --notice를 허용했다"
-out="$(PATH="$FAKEBIN:$PATH" "$SEND" --to lisa --body "공지" --notice "사유" 2>&1)"; rc=$?
-[ $rc -ne 0 ] && pass "directed 메시지의 --notice 거절" || fail "--notice를 directed 메시지에 허용했다"
+out="$(PATH="$FAKEBIN:$PATH" "$SEND" --to broadcast --body "공지" --공지 "전원 확인 필요" 2>&1)"; rc=$?
+[ $rc -ne 0 ] && grep -q 'unknown arg: --공지' <<<"$out" \
+  && pass "--공지 는 unknown arg 로 크게 실패" \
+  || fail "--공지 를 조용히 받거나 오류가 불명확함: $out"
+out="$(PATH="$FAKEBIN:$PATH" "$SEND" --to broadcast --body "공지" --notice "전원 확인 필요" 2>&1)"; rc=$?
+[ $rc -ne 0 ] && grep -q 'unknown arg: --notice' <<<"$out" \
+  && pass "--notice 는 unknown arg 로 크게 실패" \
+  || fail "--notice 를 조용히 받거나 오류가 불명확함: $out"
+out="$(PATH="$FAKEBIN:$PATH" "$SEND" --to broadcast --body "공지" --all-hands 2>&1)"; rc=$?
+[ $rc -ne 0 ] && pass "사유 없는 --all-hands 거절" || fail "사유 없는 --all-hands를 허용했다"
+out="$(PATH="$FAKEBIN:$PATH" "$SEND" --to lisa --body "공지" --all-hands "사유" 2>&1)"; rc=$?
+[ $rc -ne 0 ] && pass "directed 메시지의 --all-hands 거절" || fail "--all-hands를 directed 메시지에 허용했다"
 
 echo "── A2-1: 접수 문구가 '보냈다' 라고 단정하지 않는다 ──"
 out="$(PATH="$FAKEBIN:$PATH" "$SEND" --to lisa --body-file "$FIX" 2>&1)"

--- a/skills/b3os-team-inbox/scripts/send.sh
+++ b/skills/b3os-team-inbox/scripts/send.sh
@@ -8,7 +8,7 @@
 #                                                   ★본문에 홑따옴표·백틱·$(cmd)·$VAR 가 있으면 --body-file 을 쓰세요★
 #                                                   — --body 로 넘기면 셸이 해석해서 본문이 조용히 훼손됩니다(실측 2건).
 #                                                   stdout=메시지 id · stderr=사람이 읽는 결과(파싱하는 코드 없음, 2026-07-30 확인)
-#                [--type dm|reply] [--priority low|normal|high] [--hop <n>] [--notice|--공지 <reason>]
+#                [--type dm|reply] [--priority low|normal|high] [--hop <n>] [--all-hands <reason>]
 #                [--direct-to-gd --source-thread <tg-...|group_id>] [--individual]
 #                                                   send ALL asks for one task on ONE --thread. The server
 #                                                   then gathers the replies and wakes you once with the
@@ -63,7 +63,7 @@ while [ $# -gt 0 ]; do
     --direct-to-gd) DIRECT_TO_GD="1"; shift ;;
     # 팀원 broadcast를 방 게시 1건 + 정식·활성 전원 수신행으로 보낸다.
     # 사유를 감사에 남기며, 본문에 @all을 쓰는 것과 무관한 명시적 발신 옵션이다.
-    --notice|--공지) ALL_HANDS="${2:-}"; [ -n "$ALL_HANDS" ] || { echo "ERROR: $1 requires a reason" >&2; exit 1; }; shift 2 ;;
+    --all-hands) ALL_HANDS="${2:-}"; [ -n "$ALL_HANDS" ] || { echo "ERROR: $1 requires a reason" >&2; exit 1; }; shift 2 ;;
     # ★개별보고 위임 표시★ — "각자 GD께 직접 보고해라" 로 뿌릴 때 붙인다. 서버가 [마감] 독촉을 안 보낸다.
     #   안 붙여도 고장나지 않는다: 독촉이 한 번 올 뿐이고 그 본문이 "개별보고면 무시하세요" 라고 알려준다.
     --individual) INDIVIDUAL="1"; shift ;;
@@ -82,7 +82,7 @@ done
 
 [ -z "$TO" ] && { echo "ERROR: --to required" >&2; exit 1; }
 [ -n "$ALL_HANDS" ] && [ "$TO" != "broadcast" ] && {
-  echo "ERROR: --notice/--공지 는 --to broadcast 에만 사용할 수 있습니다" >&2
+  echo "ERROR: --all-hands 는 --to broadcast 에만 사용할 수 있습니다" >&2
   exit 1
 }
 

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -161,7 +161,7 @@ export function createInboxRoutes(deps: InboxRouteDeps): Hono {
     //   신뢰 경계로 쓸 수 없고, 생략 시 agent가 기본값이라 게이트 조건으로도 의미가 없다.
     //   현재 /api/inbox에는 서버가 인증한 호출자 신원이 없다. 따라서 from_agent_id 명부 검사는
     //   등록되지 않았거나 비활성인 claimed sender를 막지만, 정식 팀원 id 사칭까지 막는 인증은 아니다.
-    //   coordinator 전용은 아니다. 최근 지시는 "팀원용 --공지"이고, 사유가 남아 사후 판정이 가능하다.
+    //   coordinator 전용은 아니다. 팀원용 명시 공지 옵션이며, 사유가 남아 사후 판정이 가능하다.
     //   팀장님(source=user)의 @all 은 이 게이트를 타지 않는다 — 라우터가 따로 판정한다.
     // ★슬랙은 제외한다★ (2026-08-01 devon 실측 — 배포 직후 슬랙 답신이 막혔다).
     //   슬랙 스레드에 답하는 유일한 경로가 `--to broadcast` 다(룰: kind="slack" → --to broadcast).


### PR DESCRIPTION
## 핵심 3줄
1. 전체공지 CLI 표기를 `--all-hands "<사유>"` 하나로 통일합니다.
2. 기존 `--notice`와 지원하지 않는 한글 옵션은 `unknown arg`와 non-zero 종료로 크게 실패합니다.
3. 3파일 `+18/-18`이며 `all_hands` 전송·팬아웃·wake 기능은 바뀌지 않습니다.

## 무엇을 바꿨나

- `send.sh`의 헤더·case·오류 문구를 `--all-hands`로 갱신했습니다.
- `--all-hands` 사유가 payload의 `all_hands`에 실리는 테스트를 추가했습니다.
- 두 이전 표기가 모두 `unknown arg`로 실패하는 테스트를 추가했습니다.

## 왜

envelope 필드 `all_hands`, 감사 action `agent_broadcast_all_hands`, 판정 함수 `isAgentAllHandsBroadcast`와 CLI 이름을 하나로 맞춥니다.

## 검증

- `bash scripts/send-tools-honesty.test.sh`: ALL PASS
- `bun run typecheck`: 통과
- 이전 표기 2종: 각각 `unknown arg` 출력 + non-zero 종료

## 미검증

- 라이브 설치본에서의 CLI 실행

## 롤백

이 PR의 단일 커밋을 revert하면 이전 CLI 표기가 복구됩니다.

Submitted-by: Codex
