### PR TITLE
fix(bus): 참고용 주입을 두 경로 다 5건으로 — 주석은 5인데 값이 6이던 드리프트 정정

### DIFF
--- a/src/server/bus/contextMsgCount.test.ts
+++ b/src/server/bus/contextMsgCount.test.ts
@@ -1,0 +1,77 @@
+/**
+ * 참고용 주입은 ★두 경로 다 5건★ 이다 (GD 2026-07-16 "전부 5개로 해. 분기 타지 말고",
+ * 2026-08-02 재확인).
+ *
+ * ★숫자를 소스에서 읽지 않고 실제로 센다★ — 상수를 7로 바꾸면 이 테스트가 죽어야 한다.
+ * 상수를 grep 하는 테스트는 값이 바뀌어도 같이 바뀌므로 아무것도 못 잡는다.
+ *
+ * ★두 경로를 한 파일에서 잰다★ — "분기 타지 말고" 가 지시의 핵심이라, 한쪽만 재면
+ * 두 값이 갈라진 걸 못 본다(실제로 주석은 5인데 값이 6이었다).
+ */
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { migrate } from "../db/migrate";
+import { acceptInbound } from "../db/inbox/acceptInbound";
+import { buildTeamContext } from "./wakeDispatcher";
+import { buildCaptureTeamContext } from "../workers/telegramCapture";
+
+const GROUP = "tg--123";
+const WANT = 5;
+
+function setup(): Database {
+  const db = new Database(":memory:");
+  migrate(db);
+  for (const a of ["bill", "steve"]) {
+    db.prepare(
+      `INSERT INTO agent (id, display_name, role, runtime, status_provider, workspace_path, persona_file)
+       VALUES (?, ?, 'role', 'claude_channel', 'claude_tmux', '/tmp', 'p.md')`,
+    ).run(a, a);
+  }
+  db.prepare(
+    `INSERT INTO thread (id, title, kind, participants_json, opened_by)
+     VALUES ('${GROUP}','group','dm','["bill","steve"]','bill')`,
+  ).run();
+  return db;
+}
+
+/** 8건을 넣는다 — 상한(5)보다 넉넉히 많아야 상한을 잰다. 6건이면 7로 바꿔도 안 죽는다. */
+function fill(db: Database, from: string, to: string): void {
+  for (let i = 1; i <= 8; i++) {
+    acceptInbound(
+      db,
+      { thread_id: GROUP, from_agent_id: from, to_agent_id: to, body: `건${i}`, source: "agent", type: "dm" } as never,
+      { dedupeWindowSec: 0 },
+    );
+  }
+}
+
+const lines = (ctx: string): string[] =>
+  ctx.split("\n").filter((l) => /건\d/.test(l));
+
+describe("참고용 주입은 두 경로 다 5건", () => {
+  test("★팀버스 깨움 — 8건 넣으면 5건만 나온다★", () => {
+    const db = setup();
+    fill(db, "bill", "steve");
+    const got = lines(buildTeamContext(db, GROUP, "steve"));
+    expect(got).toHaveLength(WANT);
+    // 최신 5건이다 — 오래된 것부터 버린다.
+    expect(got[got.length - 1]).toContain("건8");
+    expect(got[0]).toContain("건4");
+  });
+
+  test("★단톡방 인입 — 8건 넣으면 5건만 나온다★", () => {
+    const db = setup();
+    fill(db, "bill", "steve");
+    const got = lines(buildCaptureTeamContext(db, GROUP));
+    expect(got).toHaveLength(WANT);
+    expect(got[got.length - 1]).toContain("건8");
+  });
+
+  test("★두 경로가 같은 수다 — 분기 없음★", () => {
+    const db = setup();
+    fill(db, "bill", "steve");
+    expect(lines(buildCaptureTeamContext(db, GROUP)).length).toBe(
+      lines(buildTeamContext(db, GROUP, "steve")).length,
+    );
+  });
+});

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -842,8 +842,15 @@ const CTX_TOTAL_CHARS = Number(process.env.CTX_TOTAL_CHARS ?? 8000);
 //   그대로 주면 판교·증시·민재 인사가 통째 붙어 팀원이 ★옛 일을 지금 일로 착각★한다(Ames·codex 실측).
 //   → 그룹방만 좁힌다: 자기것만 · 6시간 · 5건. (수집·작업 전용 스레드는 tg- 가 아니라 그대로 full)
 const CTX_HOURS_GROUP = Number(process.env.CTX_HOURS_GROUP ?? 6);
-// ★참고용 주입은 '자기것만' · 5건 (그룹·버스 통일, 분기 없음)★ (GD 2026-07-16 "전부 5개로 해. 분기 타지 말고").
+// ★이 주입은 '내 일 이어가기' 용이다.★ 답하는 질문: ★"내가 하던 일이 어디까지 왔나".★
+//   대상 = ★팀원 전원★ · 자기것만(from=나 OR to=나) · 한 건 800자(CTX_MSG_CHARS).
 //   from=나 OR to=나만 남기고 최근 5건. 남의 딴-대화(예: codex→demis 리뷰 팬아웃)를 걷어낸다.
+//   (GD 2026-07-16 "전부 5개로 해. 분기 타지 말고" · 2026-08-02 재확인)
+//
+// ★`CAPTURE_CTX_MSGS`(telegramCapture.ts)와 값이 같아도 합치지 마라.★ 답하는 질문이 다르다 —
+//   저쪽은 "팀에 지금 무슨 일이 도나"(감독용)라서 ★자기것 필터가 없다.★
+//   ★필터 유무가 그 증거다★: 목적이 같다면 한쪽만 필터를 걸 이유가 없다.
+//   지금 둘 다 5인 것은 우연이고, 목적이 갈리면 값도 다시 갈린다.
 const CTX_MSGS_OWN = Number(process.env.CTX_MSGS_OWN ?? 5);
 
 export function buildTeamContext(db: Database, threadId: string, agentId?: string): string {

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -840,11 +840,11 @@ const CTX_MSG_CHARS = Number(process.env.CTX_MSG_CHARS ?? 800);
 const CTX_TOTAL_CHARS = Number(process.env.CTX_TOTAL_CHARS ?? 8000);
 // ★단톡방(그룹 스레드) 전용 상한★ (GD 2026-07-16): 그룹방은 스레드 하나에 전 과제가 섞여, 12건·24h 를
 //   그대로 주면 판교·증시·민재 인사가 통째 붙어 팀원이 ★옛 일을 지금 일로 착각★한다(Ames·codex 실측).
-//   → 그룹방만 좁힌다: 자기것만 · 6시간 · 6건. (수집·작업 전용 스레드는 tg- 가 아니라 그대로 full)
+//   → 그룹방만 좁힌다: 자기것만 · 6시간 · 5건. (수집·작업 전용 스레드는 tg- 가 아니라 그대로 full)
 const CTX_HOURS_GROUP = Number(process.env.CTX_HOURS_GROUP ?? 6);
 // ★참고용 주입은 '자기것만' · 5건 (그룹·버스 통일, 분기 없음)★ (GD 2026-07-16 "전부 5개로 해. 분기 타지 말고").
 //   from=나 OR to=나만 남기고 최근 5건. 남의 딴-대화(예: codex→demis 리뷰 팬아웃)를 걷어낸다.
-const CTX_MSGS_OWN = Number(process.env.CTX_MSGS_OWN ?? 6);
+const CTX_MSGS_OWN = Number(process.env.CTX_MSGS_OWN ?? 5);
 
 export function buildTeamContext(db: Database, threadId: string, agentId?: string): string {
   try {

--- a/src/server/workers/telegramCapture.ts
+++ b/src/server/workers/telegramCapture.ts
@@ -56,7 +56,7 @@ let GROUP_ID = getCaptureGroupId() ?? "";
 // injection 킬스위치 — 이제 *라이브 읽기*(isRouterEnabled(deps.db)). UI 토글 즉시 반영, 재시작 불요. (P0)
 // OFF면 결정 로깅만(shadow). store(setting router_enabled) 우선, 없으면 env(ROUTER_ENABLED) fallback.
 // 단톡방 인입 문맥 예산 — 팀버스 경로(CTX_*)와 값이 다르다. ★한 건 200자는 기존 동작이라 유지한다.★
-const CAPTURE_CTX_MSGS = 10;
+const CAPTURE_CTX_MSGS = 5;
 const CAPTURE_CTX_HOURS = 6;
 const CAPTURE_CTX_MSG_CHARS = 200;
 const OFFSET_PATH = process.env.CAPTURE_OFFSET_PATH ?? `${process.cwd()}/logs/telegram-capture-offset.txt`;

--- a/src/server/workers/telegramCapture.ts
+++ b/src/server/workers/telegramCapture.ts
@@ -55,7 +55,20 @@ let TOKEN = getCaptureToken();
 let GROUP_ID = getCaptureGroupId() ?? "";
 // injection 킬스위치 — 이제 *라이브 읽기*(isRouterEnabled(deps.db)). UI 토글 즉시 반영, 재시작 불요. (P0)
 // OFF면 결정 로깅만(shadow). store(setting router_enabled) 우선, 없으면 env(ROUTER_ENABLED) fallback.
-// 단톡방 인입 문맥 예산 — 팀버스 경로(CTX_*)와 값이 다르다. ★한 건 200자는 기존 동작이라 유지한다.★
+// ★이 주입은 '감독' 용이다.★ 답하는 질문: ★"팀에 지금 무슨 일이 도나".★
+//   대상 = ★`full_context` 보유 팀원만★ · 방 전체(★자기것 필터 없음★) · 한 건 200자.
+//
+// ★이 값은 `full_context` 보유 팀원에게만 적용된다 — 나머지는 게이트에 막혀 0건이다.★
+//   (`teamContextForAgent` 가 미보유자에게 "" 를 준다. 아래 수신자별 루프에서 걸린다.)
+//   이걸 모르면 "10건은 너무 많다 → 줄이자" 로 읽게 되는데, 그건 ★일반 팀원 부담을 줄이는 게 아니라
+//   감독하라고 준 시야를 깎는 것★ 이다. 실제로 그렇게 읽은 적이 있다.
+//   ★"N명만" 이라고 적지 마라★ — 명부가 바뀌면 숫자는 낡는다. 기준은 언제나 `full_context` 보유다.
+//
+// ★자기것 필터를 넣지 마라.★ 넣는 순간 이 주입의 목적이 사라진다 — 남의 얘기까지 봐야
+//   팀 리드가 판단할 수 있다는 게 `full_context` 의 뜻이다 (GD 2026-08-02).
+// ★`CTX_MSGS_OWN`(wakeDispatcher.ts)과 값이 같아도 합치지 마라.★ 저쪽은 '내 일 이어가기' 용이라
+//   자기것 필터가 있다. ★필터 유무가 목적이 다르다는 증거다.★ 지금 둘 다 5인 것은 우연이다.
+//   (GD 2026-08-02 "둘 다 5" — 감독용도 5로 줄인다는 결정. 목적이 같아졌다는 뜻이 아니다.)
 const CAPTURE_CTX_MSGS = 5;
 const CAPTURE_CTX_HOURS = 6;
 const CAPTURE_CTX_MSG_CHARS = 200;


### PR DESCRIPTION
참고용 주입을 두 경로 다 5건으로 맞춘다. 팀버스 쪽은 주석이 5인데 값이 6이던 드리프트 정정이다.

바뀌는 것: `CTX_MSGS_OWN` 6 → 5, `CAPTURE_CTX_MSGS` 10 → 5.
영향: 깨어나는 팀원이 받는 참고용 문맥의 줄 수.
규모: 상수 2개 + 드리프트 주석 1줄, 신규 테스트 3건.

## 무엇이 문제인가

두 경로가 서로 다른 수를 쓰고 있었다 — 팀버스 6건, 단톡방 10건. 지시는
"전부 5개로 해. **분기 타지 말고**"(GD 2026-07-16)였다.

팀버스 쪽은 그때 지시가 **반만 들어갔다.** 상수 바로 위 주석은 이미 5라고 적고 있는데
값은 6이었다.

```
// ★참고용 주입은 '자기것만' · 5건 (그룹·버스 통일, 분기 없음)★ (GD 2026-07-16 …)
const CTX_MSGS_OWN = Number(process.env.CTX_MSGS_OWN ?? 6);
```

**주석과 값이 갈리면 읽는 사람마다 다른 걸 사실로 믿는다.** 이 축을 재는 테스트가 없어서
1년 가까이 아무도 못 봤다.

## 왜 그렇게 되나

숫자를 고정하는 테스트가 없었다. 있는 테스트는 상수 **이름**을 소스에서 grep 했는데,
그건 값이 바뀌어도 같이 통과한다 — 판별력이 0이다.

## 어떻게 고쳤나

- `CTX_MSGS_OWN` 6 → 5, `CAPTURE_CTX_MSGS` 10 → 5
- 위쪽 주석의 "6시간 · 6건" 도 5건으로 정정(같은 드리프트)
- **숫자를 실제로 세는 테스트** 3건: 8건을 넣고 5줄만 나오는지, 그리고 **두 경로가 같은 수인지**

8건을 넣는 이유는 상한을 재기 위해서다 — 6건만 넣으면 상한을 7로 바꿔도 안 죽는다.

시간창·"자기것만" 필터·메시지 선별은 안 건드렸다.

## 검증 결과

**뮤턴트 — 각 상수를 7로 바꾸면:**

| 되돌린 것 | 죽는 테스트 |
|---|---|
| `CTX_MSGS_OWN` → 7 | 2 (팀버스 + 분기없음) |
| `CAPTURE_CTX_MSGS` → 7 | 2 (단톡방 + 분기없음) |

두 상수가 각자 자기 경로를 죽이고, **둘 다 공통으로 "분기 없음" 을 죽인다** — 값이
갈라지는 순간 잡힌다는 뜻이다.

전체 2250 pass · **신규 실패 0** · 타입 신규 오류 0.

## 확인한 것 — 수집이 깨지는가

**5건 안에 기여자 답이 다 들어오는가**를 라이브 DB 로 쟀다(최근 21일, 실제 수집 스레드).
각 스레드에서 **마지막 답이 도착한 시점** 기준으로 `from=나 OR to=나` 창을 재구성했다.

| 스레드 / collector | 답한 사람 | N=5 | N=6(현행) | N=10 |
|---|---|---|---|---|
| `react-owner-check` / bill | 9 | 5/9 | 6/9 | 9/9 |
| 단톡방 / hermes | 11 | 2/11 | 2/11 | 2/11 |
| 단톡방 / bill | 11 | 1/11 | 1/11 | 1/11 |
| 단톡방 / ames | 10 | 2/10 | 3/10 | 4/10 |
| 단톡방 / codex | 9 | 2/9 | 2/9 | 2/9 |

**5로 내려서 생기는 문제가 아니다** — 대규모 수집은 현행 6에서도, 10에서도 이미 안 담긴다.
단톡방은 다른 대화가 섞여 들어와 6이든 10이든 1~4건뿐이다.

기여자 3명 규모에서는 5로 충분하다(답이 항상 최신이라 창에 남는다). 큰 수집에서 창에
의존하면 안 되는 것은 **이 변경 전부터** 그랬고, 그래서 문맥 블록이 이미
`(더 이전 이력이 필요하면: thread.sh <thread_id>)` 를 안내한다.

측정 방법의 한계: 시간창(6h/24h)을 적용하지 않고 스레드 전체로 근사했다. 창을 적용하면
보이는 건수는 **더 줄어들 뿐** 늘지 않으므로 위 표는 낙관적 상한이다.

## 롤백

상수 2개를 되돌리면 끝이다. 데이터 변경 없음.

Submitted-by: steve
