### PR TITLE
fix(bus): 수집 마감 기본값을 10분으로 맞춘다

### DIFF
--- a/src/server/bus/collectionDeadline.test.ts
+++ b/src/server/bus/collectionDeadline.test.ts
@@ -136,6 +136,18 @@ describe("★막힌 수집을 찾는다 — 정확히 그것만★", () => {
     msg(db, "t7", "steve", "hermes", 1);
     expect(findStalledCollections(db, AGENTS)).toHaveLength(0);
   });
+
+  it("★6분 경과는 아직 재촉하지 않는다★ — 10분 기본값을 숫자로 고정", () => {
+    msg(db, "deadline-6", "steve", "demis", 6);
+    msg(db, "deadline-6", "steve", "hermes", 6);
+    expect(findStalledCollections(db, AGENTS)).toHaveLength(0);
+  });
+
+  it("★11분 경과면 재촉한다★ — 10분 기본값을 숫자로 고정", () => {
+    msg(db, "deadline-11", "steve", "demis", 11);
+    msg(db, "deadline-11", "steve", "hermes", 11);
+    expect(findStalledCollections(db, AGENTS)).toHaveLength(1);
+  });
 });
 
 
@@ -256,7 +268,7 @@ describe("★윈도 경계 — 훼손된 시야로 멀쩡한 팀원을 고발하
     expect(findStalledCollections(db, AGENTS)).toHaveLength(0);   // ★깨우면 안 된다★
   });
 
-  it("★너무 늦은 건 깨우지 않는다★ — 5분 마감인데 90분 뒤 재촉은 소음이다", () => {
+  it("★너무 늦은 건 깨우지 않는다★ — 10분 마감인데 90분 뒤 재촉은 소음이다", () => {
     msg(db, "w2", "steve", "demis", 89);
     msg(db, "w2", "steve", "hermes", 89);
     // hermes 가 진짜로 안 왔지만 ★89분이 지났다★ → 지금 깨워봐야 도움이 안 된다

--- a/src/server/bus/collectionDeadline.ts
+++ b/src/server/bus/collectionDeadline.ts
@@ -34,9 +34,9 @@ import { insertMessage } from "../db/inboxQueries";
 import { appendAudit } from "../db/queries";
 import { appendAuditFile } from "../lib/auditFile";
 
-/** 위임 후 이 시간이 지나도 종합이 안 나오면 collector 를 깨운다. */
-export const COLLECTION_DEADLINE_MIN = Number(process.env.COLLECTION_DEADLINE_MIN ?? 5);
-/** ★이보다 오래된 건 깨우지 않는다★ — 5분 마감인데 90분 뒤 재촉은 도움이 아니라 소음이다. */
+/** 위임 후 이 시간이 지나도 종합이 안 나오면 collector 를 깨운다. 팀 과제 기본 단위가 10분이라 재촉도 맞춘다. */
+export const COLLECTION_DEADLINE_MIN = Number(process.env.COLLECTION_DEADLINE_MIN ?? 10);
+/** ★이보다 오래된 건 깨우지 않는다★ — 10분 마감인데 90분 뒤 재촉은 도움이 아니라 소음이다. */
 export const MAX_DEADLINE_AGE_MIN = Number(process.env.MAX_DEADLINE_AGE_MIN ?? 60);
 
 interface StalledCollection {
@@ -218,9 +218,9 @@ export function findStalledCollections(db: Database, agents: AgentRecord[]): Sta
       const minsSince = (db.prepare(`SELECT CAST((julianday('now') - julianday(?)) * 1440 AS INTEGER) AS m`)
         .get(lastAsk) as { m: number }).m;
       if (minsSince < COLLECTION_DEADLINE_MIN) continue;
-      // ★너무 늦은 건 깨우지 않는다★ — 마감이 5분인데 ★90분 뒤에★ 재촉하는 건 도움이 아니라 소음이다.
+      // ★너무 늦은 건 깨우지 않는다★ — 마감이 10분인데 ★90분 뒤에★ 재촉하는 건 도움이 아니라 소음이다.
       //   윈도 경계에서 시야가 훼손되는 구간이 바로 여기(윈도 끝자락)라서, 그 구간을 아예 안 쓴다.
-      //   (정상 경로는 5분에 잡힌다. 여기까지 온 건 감지가 뭔가 놓친 것이다 → ★조용히 넘긴다★)
+      //   (정상 경로는 10분에 잡힌다. 여기까지 온 건 감지가 뭔가 놓친 것이다 → ★조용히 넘긴다★)
       if (minsSince > MAX_DEADLINE_AGE_MIN) continue;
 
       // 마지막 질문 이후 보고했나 — 판단은 hasReportedSince() 한 곳에서만 한다(아래 정의).


### PR DESCRIPTION
## 핵심 3줄
1. 수집 `[마감]` 재촉 기본값을 5분에서 10분으로 늘립니다.
2. 팀 과제 기본 단위인 10분에 맞춰 진행 중인 수집을 성급하게 재촉하지 않습니다.
3. 2파일 `+18/-6`이며 환경변수 오버라이드와 60분 상한은 유지합니다.

## 무엇을 바꿨나

- `COLLECTION_DEADLINE_MIN` 기본값을 10으로 변경했습니다.
- 6분 경과에서는 수집을 잡지 않고 11분 경과에서는 잡는 테스트를 숫자로 고정했습니다.
- 10분 기준의 이유와 오래된 수집 제외 주석을 갱신했습니다.

## 검증

- `bun test src/server/bus/collectionDeadline.test.ts`: 38 pass / 0 fail
- `bun run typecheck`: 통과
- mutation: 기본값을 5로 되돌리면 6분 무재촉 테스트 1건 실패
- `MAX_DEADLINE_AGE_MIN`: 60 유지
- `process.env.COLLECTION_DEADLINE_MIN`: 유지

## 미검증

- 라이브 서버에서 실제 10분 경과 후 wake

## 롤백

이 PR의 단일 커밋을 revert하면 기본 마감이 5분으로 돌아갑니다.

Submitted-by: Codex
