### PR TITLE
fix(hooks): reply-guard 가 단톡방을 1:1 로 오인해 막던 것 — chat_id 로 가른다

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -52,7 +52,7 @@ import { createSchedulerRoutes } from "./routes/scheduler";
 import { createCiStatusRoutes } from "./routes/ciStatus";
 import { ensureDailyTaskReviewJobs, ensureWeeklySelfLearningJobs } from "./scheduler/core";
 import { renderAndRepoint } from "./lib/teamOsRender";
-import { installProgressHook, repairProgressHook } from "./runtimes/claude/launcher";
+import { installProgressHook, repairProgressHook, repairReplyGuardHook } from "./runtimes/claude/launcher";
 import { writeMemberPersona, savePersonaFile } from "./lib/writeMemberPersona";
 import { persistOwnerChatIdIfEmpty } from "./runtimes/codex/launcher";
 import { createApprovalsApp } from "./routes/approvals";
@@ -166,6 +166,7 @@ try {
   //   여기서는 ★배선이 이미 있는 멤버만★ 저장소 기준으로 되맞춘다(새로 깔지 않으므로 실멤버 보호 유지).
   for (const cid of claudeIds) {
     try { repairProgressHook(cid); } catch { /* best-effort */ }
+    try { repairReplyGuardHook(cid); } catch { /* best-effort */ }
   }
   // 공개 빌드 부팅 백필(PUBLIC_BUILD 게이트) — 공개 사용자가 git 업데이트를 pull 한 뒤 재시작하면 기존
   //   멤버도 재영입 없이 최신을 받게. 라이브(PUBLIC_BUILD=false)는 글로벌 배선/실멤버 보호로 skip.

--- a/src/server/runtimes/claude/launcher.ts
+++ b/src/server/runtimes/claude/launcher.ts
@@ -101,12 +101,14 @@ export function writeClaudeBridgeFiles(id: string): ClaudeBridgePaths {
  *  1:1 텔레그램 DM 턴을 reply 없이 끝내려 하면 차단·재프롬프트(Claude send-drift 안전망, GD 2026-07-03).
  *  워크스페이스 스코프라 user 전역 ~/.claude·오너 Claude Code엔 영향 0. 기존 settings.json 있으면 Stop 배열에 병합(중복 방지).
  *  best-effort — 설치 실패해도 활성화는 막지 않는다. */
-export function installReplyGuardHook(id: string): void {
+export function installReplyGuardHook(id: string, roots?: { membersRoot?: string; repoRoot?: string }): void {
   assertId(id);
-  const dotClaude = `${MEMBERS_ROOT}/${id}/.claude`;
+  const membersRoot = roots?.membersRoot ?? MEMBERS_ROOT;
+  const repoRoot = roots?.repoRoot ?? REPO_ROOT;
+  const dotClaude = `${membersRoot}/${id}/.claude`;
   const hookDst = `${dotClaude}/hooks/reply-guard.py`;
   const settingsPath = `${dotClaude}/settings.json`;
-  const src = `${REPO_ROOT}/src/server/runtimes/claude/reply-guard.py`;
+  const src = `${repoRoot}/src/server/runtimes/claude/reply-guard.py`;
   try {
     if (!existsSync(src)) return; // 소스 없으면 skip
     mkdirSync(`${dotClaude}/hooks`, { recursive: true });
@@ -192,6 +194,23 @@ export function repairProgressHook(id: string, roots?: { membersRoot?: string; r
     if (!readFileSync(settingsPath, "utf-8").includes("telegram-progress.py")) return; // 안 깔린 멤버는 건드리지 않는다
   } catch { return; }
   installProgressHook(id, roots);
+}
+
+/** 이미 깔려 있는 reply-guard 훅의 ★파일만★ 최신으로 맞춘다(새로 깔지는 않는다).
+ *
+ *  ★배선(settings.json)은 안 바뀌고 파일만 낡는다★ — 커맨드가 `python3 "<경로>"` 뿐이라
+ *  저장소에서 훅을 고쳐도 활성화를 다시 하지 않으면 멤버 폴더의 사본이 옛날 것으로 남는다.
+ *  실제로 그래서 ★단톡방 글을 1:1 로 오인해 막는 판★ 이 팀원 5명에게 그대로 남아 있었다.
+ *  `repairProgressHook` 과 같은 원칙: ★배선이 이미 있는 멤버만★ 대상(라이브 보호 유지), 멱등.
+ */
+export function repairReplyGuardHook(id: string, roots?: { membersRoot?: string; repoRoot?: string }): void {
+  assertId(id);
+  const settingsPath = `${roots?.membersRoot ?? MEMBERS_ROOT}/${id}/.claude/settings.json`;
+  try {
+    if (!existsSync(settingsPath)) return;
+    if (!readFileSync(settingsPath, "utf-8").includes("reply-guard.py")) return; // 안 깔린 멤버는 건드리지 않는다
+  } catch { return; }
+  installReplyGuardHook(id, roots);
 }
 
 /** telegram-progress 훅 제거 — settings.json 의 PreToolUse/Stop/PreCompact 에서 progress 항목 제거 + 훅 파일 삭제. best-effort. */

--- a/src/server/runtimes/claude/progressHookReconcile.test.ts
+++ b/src/server/runtimes/claude/progressHookReconcile.test.ts
@@ -11,7 +11,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { installProgressHook, repairProgressHook } from "./launcher";
+import { installProgressHook, repairProgressHook, repairReplyGuardHook } from "./launcher";
 
 const ID = "testmember";
 let dirs: string[] = [];
@@ -93,5 +93,38 @@ describe("progress 훅 배선 reconcile", () => {
     writeFileSync(settingsPath, JSON.stringify(staleSettings(membersRoot), null, 2) + "\n");
     repairProgressHook(ID, { membersRoot, repoRoot });
     for (const c of commandsIn(settingsPath)) expect(c).toContain("B3OS_ROOT=");
+  });
+});
+
+describe("reply-guard 훅 파일 수리", () => {
+  /** reply-guard 는 커맨드가 `python3 "<경로>"` 뿐이라 ★배선은 안 낡고 파일만 낡는다.★ */
+  function setupGuard(settings?: unknown): { membersRoot: string; repoRoot: string; hookPath: string } {
+    const base = mkdtempSync(join(tmpdir(), "b3os-guard-repair-"));
+    dirs.push(base);
+    const repoRoot = join(base, "b3os");
+    const membersRoot = join(base, "members");
+    mkdirSync(join(repoRoot, "src/server/runtimes/claude"), { recursive: true });
+    writeFileSync(join(repoRoot, "src/server/runtimes/claude/reply-guard.py"), "# NEW\n");
+    const dotClaude = join(membersRoot, ID, ".claude");
+    mkdirSync(join(dotClaude, "hooks"), { recursive: true });
+    writeFileSync(join(dotClaude, "hooks", "reply-guard.py"), "# OLD\n");
+    if (settings !== undefined) writeFileSync(join(dotClaude, "settings.json"), JSON.stringify(settings, null, 2) + "\n");
+    return { membersRoot, repoRoot, hookPath: join(dotClaude, "hooks", "reply-guard.py") };
+  }
+  const wired = (membersRoot: string) => ({
+    hooks: { Stop: [{ hooks: [{ type: "command", command: `python3 "${membersRoot}/${ID}/.claude/hooks/reply-guard.py"` }] }] },
+  });
+
+  test("★배선이 있으면 낡은 훅 파일을 저장소판으로 덮는다★ — 이게 없으면 고쳐도 안 나간다", () => {
+    const { membersRoot, repoRoot, hookPath } = setupGuard(null);
+    writeFileSync(join(membersRoot, ID, ".claude", "settings.json"), JSON.stringify(wired(membersRoot), null, 2) + "\n");
+    repairReplyGuardHook(ID, { membersRoot, repoRoot });
+    expect(readFileSync(hookPath, "utf-8")).toBe("# NEW\n");
+  });
+
+  test("배선이 없는 멤버에는 새로 깔지 않는다 (라이브 보호)", () => {
+    const { membersRoot, repoRoot, hookPath } = setupGuard({ hooks: {} });
+    repairReplyGuardHook(ID, { membersRoot, repoRoot });
+    expect(readFileSync(hookPath, "utf-8")).toBe("# OLD\n"); // 안 건드림
   });
 });

--- a/src/server/runtimes/claude/reply-guard.py
+++ b/src/server/runtimes/claude/reply-guard.py
@@ -17,7 +17,10 @@
   · 무한루프 방지: 같은 턴 최대 2회만 block(그 뒤엔 통과 — 유실 감수하되 세션 안 막음).
   · 어떤 에러도 턴을 막지 않는다(항상 allow=exit0).
 """
-import sys, json, os
+import sys, json, os, re
+
+CHANNEL_TAG_RE = re.compile(r'<channel\b[^>]*>')
+CHAT_ID_RE = re.compile(r'chat_id="(-?\d+)"')
 
 
 def allow():
@@ -58,6 +61,20 @@ def _reply_or_edit_toolcall(content):
     return False
 
 
+def _telegram_chat_id(text):
+    """플러그인 <channel …> 태그의 chat_id. 못 찾으면 None.
+
+    ★텔레그램은 그룹/슈퍼그룹 chat_id 가 음수, 1:1 이 양수다.★ 그게 유일하게 믿을 수 있는 구분이다.
+    """
+    for tag in CHANNEL_TAG_RE.findall(text or ""):
+        if "plugin:telegram" not in tag:
+            continue
+        m = CHAT_ID_RE.search(tag)
+        if m:
+            return m.group(1)
+    return None
+
+
 def main():
     try:
         data = json.loads(sys.stdin.read() or "{}")
@@ -90,8 +107,17 @@ def main():
     if last_user_idx is None:
         return allow()
 
-    # 2) 1:1 텔레그램 DM 턴인가? (그룹 external_message 는 owner 아니면 침묵이 정상 → 관여 안 함)
+    # 2) 1:1 텔레그램 DM 턴인가? (그룹은 owner 아니면 침묵이 정상 → 관여 안 함)
     if '<channel source="plugin:telegram' not in last_user_text:
+        return allow()
+
+    # ★단톡방이면 관여하지 않는다.★ 예전에는 이 검사가 없어서 ★플러그인으로 들어온 단톡방 글까지
+    #   1:1 로 쳤다.★ 단톡방은 답하는 방법이 다르다 — `send.sh --to broadcast` 다. 그런데 가드가
+    #   "reply 로 보내라" 고 막으면, 시키는 대로 한 봇이 ★자기 글을 방에 올리고 캡처가 못 봐서
+    #   기록이 0건★ 이 된다. 즉 가드가 룰 위반을 유도한다.
+    # ★모르면 1:1 로 친다★ — 단톡방 오탐보다 ★1:1 미답이 훨씬 나쁘다★ (퍼블릭 사용자는 주로 1:1 이다).
+    chat_id = _telegram_chat_id(last_user_text)
+    if chat_id is not None and chat_id.startswith("-"):
         return allow()
 
     # 3) 이 턴에 reply/edit_message 툴콜이 있었나?

--- a/src/server/runtimes/claude/replyGuardScope.test.ts
+++ b/src/server/runtimes/claude/replyGuardScope.test.ts
@@ -1,0 +1,100 @@
+/**
+ * reply-guard 는 ★1:1 텔레그램 DM 만★ 지킨다. 단톡방에는 관여하지 않는다.
+ *
+ * 단톡방은 답하는 방법이 다르다 — `send.sh --to broadcast` 다. 가드가 "reply 로 보내라" 고 막으면
+ * 시키는 대로 한 봇이 ★자기 글을 방에 올리고 캡처가 못 봐서 기록이 0건★ 이 된다.
+ *
+ * ★1:1 방어가 죽는 것이 단톡방 오탐보다 훨씬 나쁘다★ — 퍼블릭 사용자는 주로 1:1 을 쓴다.
+ * 그래서 2번 케이스(1:1 + 미전송 → 여전히 막힘)가 이 파일의 핵심이다.
+ *
+ * ★훅을 실제로 실행해서 잰다★ — 소스 문자열이 아니라 exit 출력으로 판정한다.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const HOOK = join(import.meta.dir, "reply-guard.py");
+const GROUP_CHAT = "-1009999999999"; // 텔레그램 그룹은 음수
+const DM_CHAT = "7066867819";        // 1:1 은 양수
+
+let dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* best-effort */ } }
+  dirs = [];
+});
+
+/** transcript(jsonl)를 만들고 훅을 돌린다. 반환: block 이면 true. */
+function guardBlocks(events: unknown[]): boolean {
+  const dir = mkdtempSync(join(tmpdir(), "b3os-guard-"));
+  dirs.push(dir);
+  const tp = join(dir, "transcript.jsonl");
+  writeFileSync(tp, events.map((e) => JSON.stringify(e)).join("\n") + "\n");
+  const out = execFileSync("python3", [HOOK], {
+    input: JSON.stringify({ transcript_path: tp }),
+    encoding: "utf-8",
+  });
+  return out.includes('"block"');
+}
+
+const userTurn = (chatId: string) => ({
+  type: "user",
+  message: {
+    role: "user",
+    content: `<channel source="plugin:telegram:telegram" chat_id="${chatId}" message_id="1" user="gd">테스트</channel>`,
+  },
+});
+
+/** send.sh 로 답한 턴 — Bash 툴콜이지 reply 툴콜이 아니다. */
+const answeredViaSendSh = {
+  type: "assistant",
+  message: {
+    role: "assistant",
+    content: [{ type: "tool_use", name: "Bash", input: { command: "send.sh --to broadcast --thread tg--1 --body '답'" } }],
+  },
+};
+
+const answeredViaReply = {
+  type: "assistant",
+  message: {
+    role: "assistant",
+    content: [{ type: "tool_use", name: "mcp__plugin_telegram_telegram__reply", input: { text: "답" } }],
+  },
+};
+
+const answeredOnlyInTranscript = {
+  type: "assistant",
+  message: { role: "assistant", content: [{ type: "text", text: "답을 여기에만 썼다" }] },
+};
+
+describe("reply-guard 는 1:1 만 지킨다", () => {
+  test("① 단톡방 글 + send.sh 로 답 → ★통과★ (예전엔 막혔다)", () => {
+    expect(guardBlocks([userTurn(GROUP_CHAT), answeredViaSendSh])).toBe(false);
+  });
+
+  test("② ★1:1 글 + 아무것도 안 보냄 → 여전히 막힌다★ (이 방어가 죽으면 안 된다)", () => {
+    expect(guardBlocks([userTurn(DM_CHAT), answeredOnlyInTranscript])).toBe(true);
+  });
+
+  test("③ 1:1 글 + reply 로 보냄 → 통과", () => {
+    expect(guardBlocks([userTurn(DM_CHAT), answeredViaReply])).toBe(false);
+  });
+
+  test("④ ★1:1 인데 send.sh 로만 답한 것은 답이 아니다★ — 여전히 막힌다", () => {
+    // 1:1 DM 은 reply 툴콜만 도달한다. send.sh 는 그 방에 안 간다.
+    expect(guardBlocks([userTurn(DM_CHAT), answeredViaSendSh])).toBe(true);
+  });
+
+  test("⑤ 단톡방 글 + 아무것도 안 보냄 → 통과 (오너 아니면 침묵이 정상)", () => {
+    expect(guardBlocks([userTurn(GROUP_CHAT), answeredOnlyInTranscript])).toBe(false);
+  });
+
+  test("⑥ ★chat_id 를 못 읽으면 1:1 로 친다★ — 모를 땐 1:1 방어 쪽으로 기운다", () => {
+    const noChatId = {
+      type: "user",
+      message: { role: "user", content: `<channel source="plugin:telegram:telegram" message_id="1">테스트</channel>` },
+    };
+    expect(guardBlocks([noChatId, answeredOnlyInTranscript])).toBe(true);
+  });
+});


### PR DESCRIPTION
reply-guard 가 단톡방 글을 1:1 로 오인해 막았다. 시키는 대로 하면 룰 위반이 된다.

바뀌는 것: 단톡방(음수 `chat_id`) 턴에는 가드가 관여하지 않는다.
영향: claude 런타임 팀원 전원. 1:1 방어는 그대로다.
규모: 훅 1함수 + 부팅 수리 1줄, 신규 테스트 8건.

## 무엇이 문제인가

가드의 문서화된 계약은 "**1:1 DM 만**" 인데, 코드가 그걸 검사하지 않았다.

```python
# 2) 1:1 텔레그램 DM 턴인가? (그룹 … 관여 안 함)
if '<channel source="plugin:telegram' not in last_user_text:
    return allow()
```

`grep -c chat_id reply-guard.py` = **0**. 플러그인 태그만 보므로 **단톡방 글도 똑같이 1:1 로 친다.**

단톡방은 답하는 방법이 다르다 — `send.sh --to broadcast` 다. 그런데 가드는 "reply 로 보내라"
고 막는다. **시키는 대로 하면 봇이 자기 글을 방에 올리고, 캡처가 못 봐서 기록이 0건이 된다.**
즉 **가드가 룰 위반을 유도한다.**

## 왜 그렇게 되나

주석이 말하는 계약을 **테스트가 재지 않았다.** 그래서 코드가 그 계약을 안 지켜도 아무것도
안 깨졌다. 가드는 "1:1 을 놓치지 않는가" 만 보장했고 **"단톡방에 관여하지 않는가" 는 아무도 안 쟀다.**

## 어떻게 고쳤나

- 태그에서 `chat_id` 를 읽어 **음수(그룹)면 `allow()`**. 텔레그램은 그룹이 음수, 1:1 이 양수다.
- **모르면 1:1 로 친다** — `chat_id` 를 못 읽으면 막는 쪽으로 기운다.
  단톡방 오탐보다 **1:1 미답이 훨씬 나쁘다**(퍼블릭 사용자는 주로 1:1 이다).
- `repairReplyGuardHook()` 을 부팅 시 게이트 밖에서 돌린다. **배선이 이미 있는 멤버만** 대상이라
  안 깔린 멤버에게 새로 깔지 않는다. 멱등이다.

**저장소로 옮기지 않았다 — 이미 저장소에 있다.** `src/server/runtimes/claude/reply-guard.py` 이고
`installReplyGuardHook` 이 활성화 때 배포한다. 멤버 5명의 사본은 저장소판과 **바이트까지 같다**
(손복사가 아니라 설치기가 깐 것이다). 없던 것은 **부팅 시 파일을 새로 고치는 경로** 뿐이다 —
커맨드가 `python3 "<경로>"` 뿐이라 배선은 안 낡고 **파일만 낡는다.**

## 검증 결과

**세 가지 통과 조건 — 훅을 실제로 실행해서 잰다**(소스 문자열이 아니라 exit 출력):

| | 결과 |
|---|---|
| ① 단톡방 + `send.sh` 로 답 | **통과**(예전엔 막힘) |
| ② **1:1 + 아무것도 안 보냄** | **여전히 막힘** |
| ③ 1:1 + `reply` 로 보냄 | 통과 |
| ④ 1:1 + `send.sh` 로만 답 | 막힘(그 방에 안 간다) |
| ⑤ 단톡방 + 침묵 | 통과 |
| ⑥ `chat_id` 없음 | 막힘(1:1 로 침) |

**뮤턴트 2종, 둘 다 ①⑤ 만 죽인다:**

| 되돌린 것 | 죽는 테스트 |
|---|---|
| `chat_id` 판정 무력화(항상 1:1) | ① ⑤ |
| **배포 중인 옛 파일 그대로**(`origin/main`) | ① ⑤ |

**②③④⑥ 은 옛 판에서도 통과한다** — 그게 **1:1 방어가 이 변경으로 안 바뀐다는 증거**다.
두 번째 뮤턴트는 합성이 아니라 **실제로 돌고 있던 파일**이라, ① 이 "예전엔 막혔다" 는 재현이기도 하다.

전체 2260 pass · **신규 실패 0** · 타입 신규 오류 0. 테스트는 `mkdtemp` 만 만진다.

## 같이 확인한 것 — 진행표시 훅이 두 벌 돈다

훅 로그 실측:

```
09:49:15 clear src=stop sid=… mid=None
09:49:15 clear src=stop sid=… mid=None      ← 같은 초, 두 번
10:00:44 pre first-send mid=8554 tool=Bash
10:00:44 pre first-send mid=8555 tool=Bash  ← ★서로 다른 메시지 2개를 실제로 보냈다★
```

로그 중복이 아니라 **텔레그램 메시지가 두 개 나간다.** 배선이 두 곳이다:

```
글로벌 ~/.claude/settings.json   telegram-progress.sh   pre·stop·compact + ★react★
멤버   <멤버>/.claude/settings.json  telegram-progress.py   pre·stop·compact
```

**뺄 쪽은 글로벌의 `pre`·`stop`·`compact` 다** — 멤버 스코프가 그걸 대체하려고 만들어졌다
(`installProgressHook` 주석이 "글로벌 telegram-progress.sh 배선 대체" 라고 적고 있다).
**`react` 는 빼면 안 된다** — 멤버 스코프에는 `react` 가 없어서, 글로벌을 통째로 지우면
👀 owner-suppress 가 죽는다. **별건이므로 이 PR 에서는 안 건드렸다.**

## 안 고친 것

- `telegram-owner-gate.py` 를 설치 대상에 넣는 것 — 결정 대기 중이다.
- 진행표시 이중 실행 제거 — 위 사유로 별건.

## 롤백

이 커밋을 되돌리면 가드가 다시 단톡방까지 막는다. 되돌린 뒤 재시작하면 `repairReplyGuardHook`
이 없으므로 멤버 폴더의 훅 파일은 **자동 복구되지 않는다** — 재활성화 또는 수동 복사가 필요하다.

Submitted-by: steve
