### PR TITLE
feat(hooks): owner-gate 를 설치 경로에 넣는다 — 공개 설치엔 이 게이트가 없었다

### DIFF
--- a/hooks/telegram-owner-gate.py
+++ b/hooks/telegram-owner-gate.py
@@ -55,18 +55,31 @@ def _self_id():
 
 
 def _team_group():
-    # 우선순위: env OWNER_GATE_GROUP → team-collab/.env 의 TEAM_GROUP_ID → "" (소스에 실 chat_id 비노출)
+    """게이트할 단톡방 chat_id. 못 구하면 "" (소스에 실 chat_id 비노출).
+
+    우선순위: env `OWNER_GATE_GROUP` → `$B3OS_ROOT/.env` → `<훅파일>/../.env`.
+
+    ★`B3OS_ROOT` 가 핵심이다.★ 이 훅은 저장소 밖으로 복사돼서 돈다 — 런처가
+    `<멤버>/.claude/hooks/` 로 깐다. 그 자리에서 `../.env` 는 `<멤버>/.claude/.env` 라 ★없다.★
+    그러면 GROUP_ID 가 "" 가 되고, 어떤 그룹 메시지든 `chat_id != ""` 라서 ★게이트가 통째로
+    무력화된다★ — ★"깔았는데 안 도는" 상태는 안 깐 것보다 나쁘다★(깔렸다고 착각하니까).
+    같은 구조로 진행표시 훅이 죽어 있었다(#230).
+    """
     g = os.environ.get("OWNER_GATE_GROUP")
     if g:
         return g
-    try:
-        envp = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".env")
-        with open(envp) as f:
-            for line in f:
-                if line.startswith("TEAM_GROUP_ID="):
-                    return line.split("=", 1)[1].strip()
-    except Exception:
-        pass
+    root = os.environ.get("B3OS_ROOT", "")
+    here = os.path.dirname(os.path.abspath(__file__))
+    for envp in ([os.path.join(root, ".env")] if root else []) + [os.path.join(here, "..", ".env")]:
+        try:
+            with open(envp) as f:
+                for line in f:
+                    if line.startswith("TEAM_GROUP_ID="):
+                        v = line.split("=", 1)[1].strip()
+                        if v:
+                            return v
+        except Exception:
+            pass
     return ""
 
 

--- a/hooks/telegram-owner-gate.py
+++ b/hooks/telegram-owner-gate.py
@@ -42,8 +42,16 @@ import json
 import re
 
 def _self_id():
-    # settings.json 은 claude 봇 4개(bill·steve·demis·dbak)가 공유(심링크)하므로,
-    # 자기 봇 id 를 하드코딩하지 않고 TELEGRAM_STATE_DIR(예: .../telegram-bill)에서 per-bot 으로 얻는다.
+    """이 세션이 누구인가. 런처가 `OWNER_GATE_SELF` 로 실어준다.
+
+    ★폴백이 틀리면 게이트가 꺼지는 게 아니라 반대로 돈다.★ 예전 폴백은 `"bill"` 이었는데,
+    그러면 ★남의 이름으로 owner 판정을 받는다★ — 자기 앞으로 온 글에서 자기가 막히고,
+    남 앞으로 온 글에는 응답한다. 진행표시 훅은 폴백이 틀리면 ★알림이 엉뚱한 방에 가서 보이지만★,
+    이 훅은 ★조용히 반대로 판정한다.★ 같은 규약이어도 결과가 다르다(lui 교차검증).
+
+    그래서 ★확실히 모르면 게이트를 끈다★ — `""` 를 돌려주면 호출부가 통과시킨다.
+    남의 id 로 판정하는 것보다 ★게이트가 없는 편이 낫다.★
+    """
     env = os.environ.get("OWNER_GATE_SELF")
     if env:
         return env
@@ -51,7 +59,7 @@ def _self_id():
     base = os.path.basename(sd.rstrip("/"))
     if base.startswith("telegram-"):
         return base[len("telegram-"):]
-    return "bill"
+    return ""
 
 
 def _team_group():
@@ -128,13 +136,23 @@ def main():
     attrs, text = tg[-1]  # 가장 최근 채널 메시지
     cid = re.search(r'chat_id="([^"]+)"', attrs)
     chat_id = cid.group(1) if cid else ""
-    if chat_id != GROUP_ID:
-        allow()  # 1:1 DM 또는 다른 방 → 통과(DM 은 항상 owner)
+    # ★1:1 인가 그룹인가는 chat_id 부호로 가른다★ — 텔레그램은 그룹/슈퍼그룹이 음수, 1:1 이 양수다.
+    #   예전에는 "설정된 GROUP_ID 와 다른가" 로 갈랐다. 그러면 ★두 번째 단톡방도 1:1 처럼 통과★ 해서
+    #   방이 둘 이상인 설치(공개·다른 팀)에는 ★게이트가 아예 없는 방★ 이 생긴다.
+    #   같은 저장소의 `reply-guard.py` 도 부호로 가른다 — ★두 훅의 1:1 정의를 같게 둔다.★
+    #   `GROUP_ID` 는 "어느 방인지" 를 로그로 남기는 용도로만 쓴다(판정에서 뺀다).
+    if not chat_id.startswith("-"):
+        allow()  # 1:1 DM → 통과(DM 은 항상 owner). 라우터에 묻지도 않는다.
     mid = re.search(r'message_id="([^"]+)"', attrs)
     tg_msg_id = mid.group(1) if mid else ""
 
     text = text.strip()
     if not text:
+        allow()
+
+    # ★내가 누구인지 모르면 게이트를 끈다.★ 남의 id 로 물으면 판정이 반대로 나온다.
+    if not SELF_ID:
+        _log("self id unknown → fail-open (OWNER_GATE_SELF/TELEGRAM_STATE_DIR 미설정)")
         allow()
 
     # thin-client: self + 원본 telegram message_id 를 보내고 서버(/api/route)의 suppress 판단만 따른다.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -52,7 +52,7 @@ import { createSchedulerRoutes } from "./routes/scheduler";
 import { createCiStatusRoutes } from "./routes/ciStatus";
 import { ensureDailyTaskReviewJobs, ensureWeeklySelfLearningJobs } from "./scheduler/core";
 import { renderAndRepoint } from "./lib/teamOsRender";
-import { installProgressHook, repairProgressHook, repairReplyGuardHook } from "./runtimes/claude/launcher";
+import { installProgressHook, repairProgressHook, repairReplyGuardHook, repairOwnerGateHook } from "./runtimes/claude/launcher";
 import { writeMemberPersona, savePersonaFile } from "./lib/writeMemberPersona";
 import { persistOwnerChatIdIfEmpty } from "./runtimes/codex/launcher";
 import { createApprovalsApp } from "./routes/approvals";
@@ -167,6 +167,7 @@ try {
   for (const cid of claudeIds) {
     try { repairProgressHook(cid); } catch { /* best-effort */ }
     try { repairReplyGuardHook(cid); } catch { /* best-effort */ }
+    try { repairOwnerGateHook(cid); } catch { /* best-effort */ }
   }
   // 공개 빌드 부팅 백필(PUBLIC_BUILD 게이트) — 공개 사용자가 git 업데이트를 pull 한 뒤 재시작하면 기존
   //   멤버도 재영입 없이 최신을 받게. 라이브(PUBLIC_BUILD=false)는 글로벌 배선/실멤버 보호로 skip.

--- a/src/server/lib/activation.ts
+++ b/src/server/lib/activation.ts
@@ -20,7 +20,7 @@ import { isHermesMemberProtected, isHermesProfileProtected } from "./hermesBaseP
 import { appendAuditFile } from "./auditFile";
 import { codexBridgePaths, placeCodexToken, writeCodexBridgeFiles, removeCodexBridgeFiles, resolveOwnerDmId } from "../runtimes/codex/launcher";
 import { ensureClaudePollerUp } from "../runtimes/claude/pollerHealth";
-import { placeClaudeToken, writeClaudeBridgeFiles, seedClaudeTrust, seedClaudeAccess, killClaudeTmux, reconnectClaudeTelegram, claudeBridgePaths, installReplyGuardHook, installOutboundHook, installProgressHook, uninstallOutboundHook, uninstallReplyGuardHook, uninstallRecoveryHook, removeClaudeBridgeFiles } from "../runtimes/claude/launcher";
+import { placeClaudeToken, writeClaudeBridgeFiles, seedClaudeTrust, seedClaudeAccess, killClaudeTmux, reconnectClaudeTelegram, claudeBridgePaths, installReplyGuardHook, installOwnerGateHook, installOutboundHook, installProgressHook, uninstallOutboundHook, uninstallReplyGuardHook, uninstallRecoveryHook, removeClaudeBridgeFiles } from "../runtimes/claude/launcher";
 import { isTier2Outbound, isTier2Shadow } from "../runtimes/claude/tier2Flag";
 import { setAgentEnabled, clearAgentOff, isAgentOff } from "./agentControl";
 import { activeOfficialMemberCount, isTeamOfficialMember, MAX_OFFICIAL_TEAM_MEMBERS } from "./agentMembership";
@@ -629,7 +629,8 @@ export async function activateMember(db: Database, input: ActivateInput): Promis
       writeClaudeBridgeFiles(id);        // LaunchAgent plist 생성(setClaude bootstrap 대상)
       // reply-guard(reply 도구 미사용 감지 block)는 tier2 live(마커모드=reply 도구 안 씀)엔 미설치 — 안 그러면 매턴 block(Bill 하네스).
       //   shadow는 persona normal(reply 도구 유지)이라 reply-guard 유효 → 설치. live만 skip.
-      if (!isTier2Outbound(id)) installReplyGuardHook(id);   // 워크스페이스 .claude/settings.json 에 reply-guard Stop 훅(send-drift 안전망)
+      if (!isTier2Outbound(id)) installReplyGuardHook(id);
+      installOwnerGateHook(id);   // 그룹 owner 게이트(UserPromptSubmit) — 공개 설치·새 팀에도 깔리게   // 워크스페이스 .claude/settings.json 에 reply-guard Stop 훅(send-drift 안전망)
       installProgressHook(id);   // "작업 중 ⏳" 진행표시 훅(PreToolUse/Stop/PreCompact) — 공개 사용자·신규 멤버도 받게(글로벌 배선 대체). tier2 무관.
       // ★recovery 훅은 삭제됨(GD 2026-07-14) — 훅이 팀원 '대신' 보내는 [A] 패턴이라 제거.★
       //   이미 설치된 멤버에서도 걷어낸다(재활성화 때 self-heal). 안 보냈으면 안 보낸 것이고,

--- a/src/server/runtimes/claude/launcher.ts
+++ b/src/server/runtimes/claude/launcher.ts
@@ -196,6 +196,59 @@ export function repairProgressHook(id: string, roots?: { membersRoot?: string; r
   installProgressHook(id, roots);
 }
 
+/** owner-gate 훅 설치 — 멤버 워크스페이스 `.claude/settings.json` 의 `UserPromptSubmit`.
+ *
+ *  ★왜 필요한가★ — 답장은 ★암묵적 멘션★ 이라, `@A` 라고 써도 ★답장 대상 봇 B 가 그 글을 받는다.★
+ *  게이트가 없으면 B 세션이 자기 것이 아닌 일을 시작한다. 이 훅이 라우터에 owner 를 물어
+ *  내가 아니면 그 prompt 를 막는다(판단에 맡기지 않는다).
+ *  이 게이트는 지금까지 ★이 기계 전역에만 손으로 걸려 있었다★ — 공개 설치·새 팀에는 아예 없었다.
+ *
+ *  ★커맨드에 `B3OS_ROOT` 를 싣는다★ — 훅이 저장소 밖에서 돌기 때문에 그게 없으면 단톡방 id 를
+ *  못 구해 ★게이트가 통째로 무력화된다★(#230 과 같은 함정). 실 chat_id 는 소스에 안 넣는다.
+ *  `OWNER_GATE_SELF` 는 안 싣는다 — 훅이 `TELEGRAM_STATE_DIR` 에서 per-bot 으로 얻는다.
+ *  best-effort. `roots` 는 테스트 이음매. */
+export function installOwnerGateHook(id: string, roots?: { membersRoot?: string; repoRoot?: string }): void {
+  assertId(id);
+  const membersRoot = roots?.membersRoot ?? MEMBERS_ROOT;
+  const repoRoot = roots?.repoRoot ?? REPO_ROOT;
+  const dotClaude = `${membersRoot}/${id}/.claude`;
+  const hookDst = `${dotClaude}/hooks/telegram-owner-gate.py`;
+  const settingsPath = `${dotClaude}/settings.json`;
+  const src = `${repoRoot}/hooks/telegram-owner-gate.py`;
+  try {
+    if (!existsSync(src)) return; // 소스 없으면 skip
+    mkdirSync(`${dotClaude}/hooks`, { recursive: true });
+    writeFileSync(hookDst, readFileSync(src, "utf-8"));
+    try { chmodSync(hookDst, 0o755); } catch { /* best-effort */ }
+    let settings: Record<string, unknown> = {};
+    if (existsSync(settingsPath)) {
+      try { const p = JSON.parse(readFileSync(settingsPath, "utf-8")); if (p && typeof p === "object") settings = p; } catch { /* keep {} */ }
+    }
+    const hooks = (settings.hooks && typeof settings.hooks === "object" ? settings.hooks : {}) as Record<string, unknown>;
+    const arr = Array.isArray(hooks.UserPromptSubmit) ? (hooks.UserPromptSubmit as unknown[]) : [];
+    // ★있으면 skip 이 아니라 다르면 교체★ — 커맨드가 바뀌어도 기존 멤버가 옛것을 들고 있으면 안 된다.
+    const command = `B3OS_ROOT="${repoRoot}" python3 "${hookDst}"`;
+    const entry = { hooks: [{ type: "command", command }] };
+    const idx = arr.findIndex((e) => JSON.stringify(e).includes("telegram-owner-gate.py"));
+    if (idx < 0) arr.push(entry);
+    else if (JSON.stringify(arr[idx]) !== JSON.stringify(entry)) arr[idx] = entry;
+    hooks.UserPromptSubmit = arr;
+    settings.hooks = hooks;
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
+  } catch { /* best-effort */ }
+}
+
+/** 이미 깔려 있는 owner-gate 훅만 최신으로 맞춘다(새로 깔지는 않는다). `repairProgressHook` 과 같은 원칙. */
+export function repairOwnerGateHook(id: string, roots?: { membersRoot?: string; repoRoot?: string }): void {
+  assertId(id);
+  const settingsPath = `${roots?.membersRoot ?? MEMBERS_ROOT}/${id}/.claude/settings.json`;
+  try {
+    if (!existsSync(settingsPath)) return;
+    if (!readFileSync(settingsPath, "utf-8").includes("telegram-owner-gate.py")) return;
+  } catch { return; }
+  installOwnerGateHook(id, roots);
+}
+
 /** 이미 깔려 있는 reply-guard 훅의 ★파일만★ 최신으로 맞춘다(새로 깔지는 않는다).
  *
  *  ★배선(settings.json)은 안 바뀌고 파일만 낡는다★ — 커맨드가 `python3 "<경로>"` 뿐이라

--- a/src/server/runtimes/claude/launcher.ts
+++ b/src/server/runtimes/claude/launcher.ts
@@ -227,7 +227,10 @@ export function installOwnerGateHook(id: string, roots?: { membersRoot?: string;
     const hooks = (settings.hooks && typeof settings.hooks === "object" ? settings.hooks : {}) as Record<string, unknown>;
     const arr = Array.isArray(hooks.UserPromptSubmit) ? (hooks.UserPromptSubmit as unknown[]) : [];
     // ★있으면 skip 이 아니라 다르면 교체★ — 커맨드가 바뀌어도 기존 멤버가 옛것을 들고 있으면 안 된다.
-    const command = `B3OS_ROOT="${repoRoot}" python3 "${hookDst}"`;
+    // ★OWNER_GATE_SELF 를 반드시 싣는다★ — 없으면 훅이 자기 id 를 못 구하고,
+    //   그때 남의 id 로 폴백하면 ★게이트가 꺼지는 게 아니라 반대로 돈다★(lui 교차검증).
+    //   런처는 id 를 이미 안다. 추측하게 두지 않는다.
+    const command = `B3OS_ROOT="${repoRoot}" OWNER_GATE_SELF="${id}" python3 "${hookDst}"`;
     const entry = { hooks: [{ type: "command", command }] };
     const idx = arr.findIndex((e) => JSON.stringify(e).includes("telegram-owner-gate.py"));
     if (idx < 0) arr.push(entry);

--- a/src/server/runtimes/claude/ownerGateHook.test.ts
+++ b/src/server/runtimes/claude/ownerGateHook.test.ts
@@ -1,0 +1,144 @@
+/**
+ * owner-gate 훅 — ★서버가 죽어도 사용자를 먹통으로 만들지 않는다★ 가 제일 중요한 축이다.
+ *
+ * 소스 머리말은 "라우터 에러·타임아웃은 fail-open" 이라고 적고 있다. ★적힌 것과 도는 것은 다르다★ —
+ * 그래서 여기서는 ★진짜 죽은 포트★ 와 ★진짜 멈춘 소켓★ 에 붙여 훅을 실행하고 exit 출력으로 잰다.
+ * 여기서 fail-closed 면 퍼블릭 사용자 전원이 먹통이 된다.
+ *
+ * 게이트가 ★실제로 막는지★ 도 같이 잰다 — 막지 않으면 깔 이유가 없다.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer, type Server } from "node:http";
+
+const HOOK = join(import.meta.dir, "../../../../hooks/telegram-owner-gate.py");
+const GROUP = "-1009999999999"; // 테스트 전용 가짜 값
+const DM = "7066867819";
+
+let dirs: string[] = [];
+let servers: Server[] = [];
+afterEach(() => {
+  for (const d of dirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* best-effort */ } }
+  for (const s of servers) { try { s.close(); } catch { /* best-effort */ } }
+  dirs = []; servers = [];
+});
+
+/** 훅을 실행한다. 반환: block 이면 true.
+ *
+ *  ★반드시 비동기로 돌린다★ — `execFileSync` 는 이벤트 루프를 막아서 같은 프로세스에 띄운
+ *  가짜 라우터가 ★응답을 못 한다.★ 그러면 모든 케이스가 타임아웃으로 흘러 "항상 통과" 로 보이고,
+ *  ★막는 축을 재는 테스트가 조용히 무의미해진다.★ (실제로 그렇게 한 번 통과할 뻔했다.)
+ */
+async function gateBlocks(chatId: string, text: string, routeUrl: string, env: Record<string, string> = {}): Promise<boolean> {
+  const prompt = `<channel source="plugin:telegram:telegram" chat_id="${chatId}" message_id="8199">${text}</channel>`;
+  const child = execFileAsync("python3", [HOOK], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      OWNER_GATE_SELF: "steve",
+      OWNER_GATE_GROUP: GROUP,
+      OWNER_GATE_ROUTE_URL: routeUrl,
+      B3OS_ROOT: "",
+      ...env,
+    },
+  });
+  child.child.stdin?.end(JSON.stringify({ prompt }));
+  const { stdout } = await child;
+  return stdout.includes('"block"');
+}
+
+/** 지정한 JSON 을 돌려주는 가짜 라우터. */
+async function fakeRouter(body: unknown): Promise<string> {
+  const server = createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  });
+  servers.push(server);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as { port: number }).port;
+  return `http://127.0.0.1:${port}/route`;
+}
+
+describe("owner-gate — 서버가 없어도 막지 않는다(fail-open)", () => {
+  test("★라우터가 죽어 있으면 통과한다★ — 여기서 막으면 사용자 전원이 먹통이다", async () => {
+    // 아무도 안 듣는 포트 = 연결 거부.
+    expect(await gateBlocks(GROUP, "@빌 이거 해줘", "http://127.0.0.1:59999/route")).toBe(false);
+  });
+
+  test("★라우터가 멈춰 있어도(응답 없음) 통과한다★ — 타임아웃도 fail-open", async () => {
+    // 연결은 받되 절대 응답하지 않는 서버 = 타임아웃 경로(거부와 다른 축이다).
+    const server = createServer(() => { /* 응답하지 않는다 */ });
+    servers.push(server);
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const port = (server.address() as { port: number }).port;
+    expect(await gateBlocks(GROUP, "@빌 이거 해줘", `http://127.0.0.1:${port}/route`)).toBe(false);
+  }, 15000);
+
+  test("라우터가 깨진 응답을 줘도 통과한다", async () => {
+    const server = createServer((_req, res) => { res.writeHead(200); res.end("not json"); });
+    servers.push(server);
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const port = (server.address() as { port: number }).port;
+    expect(await gateBlocks(GROUP, "@빌 이거 해줘", `http://127.0.0.1:${port}/route`)).toBe(false);
+  });
+});
+
+describe("owner-gate — 막을 때는 막는다", () => {
+  test("★서버가 suppress 라고 하면 막는다★ (내가 오너가 아닌 글)", async () => {
+    const url = await fakeRouter({ suppress: true, reason: "explicit_mention", targetAgentIds: ["bill"] });
+    expect(await gateBlocks(GROUP, "@빌 이거 해줘", url)).toBe(true);
+  });
+
+  test("서버가 suppress 아니라고 하면 통과", async () => {
+    const url = await fakeRouter({ suppress: false, reason: "explicit_mention", targetAgentIds: ["steve"] });
+    expect(await gateBlocks(GROUP, "@스티브 이거 해줘", url)).toBe(false);
+  });
+
+  test("★1:1 DM 은 서버에 묻지도 않고 통과★ — DM 은 항상 내 것이다", async () => {
+    // suppress=true 를 주는 라우터를 붙여도 1:1 이면 막히면 안 된다.
+    const url = await fakeRouter({ suppress: true, reason: "explicit_mention", targetAgentIds: ["bill"] });
+    expect(await gateBlocks(DM, "@빌 이거 해줘", url)).toBe(false);
+  });
+});
+
+describe("owner-gate — 배포 위치에서 단톡방 id 를 구한다", () => {
+  /** 훅을 배포 위치 모양(`<멤버>/.claude/hooks/`)으로 깔고, 그 자리에서 `_team_group()` 을 부른다.
+   *  `withRoot=true` 면 런처가 싣는 것과 같은 `B3OS_ROOT` 를 주고, false 면 대조군이다. */
+  function resolveFromDeployed(withRoot: boolean): string {
+    const base = mkdtempSync(join(tmpdir(), "b3os-gate-"));
+    dirs.push(base);
+    const root = join(base, "b3os");
+    const hooks = join(base, "member", ".claude", "hooks");
+    mkdirSync(root, { recursive: true });
+    mkdirSync(hooks, { recursive: true });
+    writeFileSync(join(root, ".env"), `TEAM_GROUP_ID=${GROUP}\n`);
+    const dst = join(hooks, "telegram-owner-gate.py");
+    copyFileSync(HOOK, dst);
+    const py = [
+      "import importlib.util,sys",
+      `s=importlib.util.spec_from_file_location("g", ${JSON.stringify(dst)})`,
+      "m=importlib.util.module_from_spec(s)",
+      "try: s.loader.exec_module(m)",
+      "except SystemExit: pass",
+      "sys.stdout.write(m._team_group())",
+    ].join("\n");
+    return execFileSync("python3", ["-c", py], {
+      env: { ...process.env, OWNER_GATE_GROUP: "", B3OS_ROOT: withRoot ? root : "" },
+      encoding: "utf-8",
+    });
+  }
+
+  test("★B3OS_ROOT 가 있으면 배포 위치에서도 구한다★", () => {
+    expect(resolveFromDeployed(true)).toBe(GROUP);
+  });
+
+  test("★대조군 — B3OS_ROOT 없이는 못 구한다(빈 값 → 게이트 무력화)★", () => {
+    expect(resolveFromDeployed(false)).toBe("");
+  });
+});

--- a/src/server/runtimes/claude/ownerGateSelfAndRoom.test.ts
+++ b/src/server/runtimes/claude/ownerGateSelfAndRoom.test.ts
@@ -1,0 +1,194 @@
+/**
+ * owner-gate 의 ★자기 id★ 와 ★1:1/그룹 판정★ 을 고정한다.
+ *
+ * 시나리오는 ★루이 교차검증(PR #236)★ 이 만든 계측기에서 왔다. 원본은 당시 동작을 그대로
+ * 적어둔 characterization 이었고(=지금 이렇다), 여기서는 ★고쳐진 계약★ 으로 뒤집어 적었다.
+ * ★원본 그대로 두면 고침이 실패로 잡힌다.★
+ *
+ * 이 축이 왜 중요한가 — 자기 id 를 틀리면 게이트가 ★꺼지는 게 아니라 반대로 돈다.★
+ * 진행표시 훅은 폴백이 틀리면 알림이 엉뚱한 방에 가서 ★보이지만★, 이 훅은 ★조용히★ 반대로 판정한다.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer, type Server } from "node:http";
+import { installOwnerGateHook, repairOwnerGateHook } from "./launcher";
+
+const execFileAsync = promisify(execFile);
+const HOOK = join(import.meta.dir, "../../../../hooks/telegram-owner-gate.py");
+const GROUP = "-1009999999999";
+const OTHER_GROUP = "-1008888888888"; // 리사팀·공개 설치의 두 번째 방
+const DM = "7066867819";
+
+let dirs: string[] = [];
+let servers: Server[] = [];
+afterEach(() => {
+  for (const d of dirs) { try { rmSync(d, { recursive: true, force: true }); } catch { /* noop */ } }
+  for (const s of servers) { try { s.close(); } catch { /* noop */ } }
+  dirs = []; servers = [];
+});
+
+/** 진짜 서버처럼 판정하는 라우터: 훅이 보낸 self 를 받아 explicit_mention 이면 targets 포함 여부로 suppress. */
+async function realisticRouter(targets: string[]): Promise<{ url: string; seen: string[] }> {
+  const seen: string[] = [];
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (c) => { body += c; });
+    req.on("end", () => {
+      let self = "";
+      try { self = JSON.parse(body).self ?? ""; } catch { /* noop */ }
+      seen.push(self);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        suppress: !targets.includes(self),
+        reason: "explicit_mention",
+        targetAgentIds: targets,
+      }));
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as { port: number }).port;
+  return { url: `http://127.0.0.1:${port}/route`, seen };
+}
+
+/** 훅 실행. env 를 그대로 준다(OWNER_GATE_SELF 를 일부러 빼는 게 이 검증의 핵심). */
+async function runHook(chatId: string, text: string, routeUrl: string, env: Record<string, string>): Promise<string> {
+  const prompt = `<channel source="plugin:telegram:telegram" chat_id="${chatId}" message_id="8199">${text}</channel>`;
+  const base = { ...process.env } as Record<string, string>;
+  delete base.OWNER_GATE_SELF;
+  delete base.TELEGRAM_STATE_DIR;
+  const child = execFileAsync("python3", [HOOK], {
+    encoding: "utf-8",
+    env: { ...base, OWNER_GATE_GROUP: GROUP, OWNER_GATE_ROUTE_URL: routeUrl, B3OS_ROOT: "", ...env },
+  });
+  child.child.stdin?.end(JSON.stringify({ prompt }));
+  const { stdout } = await child;
+  return stdout;
+}
+
+// ── 축1: _self_id() 폴백 ─────────────────────────────────────────────────────
+describe("자기 id — 모르면 남의 id 로 판정하지 않는다", () => {
+  test("★정상 경로: telegram-<id> 면 자기 id 를 맞게 보낸다★", async () => {
+    const { url, seen } = await realisticRouter(["demis"]);
+    await runHook(GROUP, "@데미스 이거 해줘", url, { TELEGRAM_STATE_DIR: "/x/channels/telegram-demis" });
+    expect(seen).toEqual(["demis"]);
+  });
+
+  test("★자기 id 를 모르면 라우터에 묻지 않는다★ — 예전엔 'bill' 로 폴백해서 남의 이름으로 물었다", async () => {
+    const { url, seen } = await realisticRouter(["demis"]);
+    await runHook(GROUP, "@데미스 이거 해줘", url, {});
+    expect(seen).toEqual([]);   // 남의 id 로 묻느니 게이트를 끈다
+  });
+
+  test("★자기 앞으로 온 글에서 자기가 막히지 않는다★ (@데미스 → 데미스 세션 통과)", async () => {
+    // 예전: self 가 'bill' 로 폴백 → "not bill" 사유로 ★자기 지시에 자기가 막혔다.★
+    const { url } = await realisticRouter(["demis"]);
+    const out = await runHook(GROUP, "@데미스 이거 해줘", url, {});
+    expect(out).not.toContain('"block"');
+  });
+
+  test("★id 를 실어주면 남의 글에서 제대로 막힌다★ (@빌 → 데미스 세션 block)", async () => {
+    // 런처가 OWNER_GATE_SELF 를 싣는 상태. 이게 게이트가 ★일하는★ 모습이다.
+    const { url } = await realisticRouter(["bill"]);
+    const out = await runHook(GROUP, "@빌 이거 해줘", url, { OWNER_GATE_SELF: "demis" });
+    expect(out).toContain('"block"');
+  });
+
+  test("state dir 이름이 agent id 와 다르면 그 이름으로 나간다 — ★그래서 런처가 id 를 직접 싣는다★", async () => {
+    const { url, seen } = await realisticRouter(["demis"]);
+    const out = await runHook(GROUP, "@데미스 이거 해줘", url, { TELEGRAM_STATE_DIR: "/x/channels/telegram-claude" });
+    expect(seen).toEqual(["claude"]);
+    expect(out).toContain('"block"');           // 명부에 없는 id → 항상 suppress
+  });
+});
+
+// ── 축3: 1:1 및 다른 방 ──────────────────────────────────────────────────────
+describe("1:1/그룹 판정 — chat_id 부호로 가른다(reply-guard 와 같은 정의)", () => {
+  test("1:1(양수 chat_id) 은 suppress 라우터에도 통과 — 요구사항 충족", async () => {
+    const { url, seen } = await realisticRouter(["bill"]);
+    const out = await runHook(DM, "@빌 이거 해줘", url, { TELEGRAM_STATE_DIR: "/x/channels/telegram-demis" });
+    expect(out).not.toContain('"block"');
+    expect(seen).toEqual([]);                   // ★라우터에 묻지도 않는다★ — 서버가 죽어도 1:1 은 산다
+  });
+
+  test("★두 번째 단톡방(음수)도 게이트가 걸린다★ — 방이 둘 이상인 설치에 구멍이 없어야 한다", async () => {
+    // 예전 기준은 "설정된 GROUP_ID 와 다른가" 라 ★두 번째 방이 1:1 처럼 통과★ 했다(라우터 호출 0회).
+    const { url, seen } = await realisticRouter(["bill"]);
+    const out = await runHook(OTHER_GROUP, "@빌 이거 해줘", url, { TELEGRAM_STATE_DIR: "/x/channels/telegram-demis" });
+    expect(seen).toEqual(["demis"]);   // 라우터에 실제로 묻는다
+    expect(out).toContain('"block"');  // 내 것이 아니므로 막는다
+  });
+});
+
+// ── 축2·축4: 설치 멱등성과 기존 배선 ────────────────────────────────────────
+function member(existing: string | null): { root: string; membersRoot: string; repoRoot: string; settings: string } {
+  const base = mkdtempSync(join(tmpdir(), "b3os-inst-"));
+  dirs.push(base);
+  const membersRoot = join(base, "members");
+  const repoRoot = join(base, "repo");
+  mkdirSync(join(membersRoot, "m1", ".claude"), { recursive: true });
+  mkdirSync(join(repoRoot, "hooks"), { recursive: true });
+  writeFileSync(join(repoRoot, "hooks", "telegram-owner-gate.py"), readFileSync(HOOK, "utf-8"));
+  const settings = join(membersRoot, "m1", ".claude", "settings.json");
+  if (existing !== null) writeFileSync(settings, existing);
+  return { root: base, membersRoot, repoRoot, settings };
+}
+
+// 라이브 팀원 5명이 실제로 갖고 있는 모양 (Stop 2 · PreToolUse 1 · PreCompact 1)
+const LIVE_SHAPE = JSON.stringify({
+  hooks: {
+    Stop: [{ hooks: [{ type: "command", command: "a" }] }, { hooks: [{ type: "command", command: "b" }] }],
+    PreToolUse: [{ hooks: [{ type: "command", command: "c" }] }],
+    PreCompact: [{ hooks: [{ type: "command", command: "d" }] }],
+  },
+  permissions: { allow: ["Bash"] },
+}, null, 2);
+
+describe("축2·축4 — 설치가 기존 배선을 건드리는가 / 반복하면 쌓이는가", () => {
+  test("★10회 반복 설치해도 항목이 안 늘어난다 (멱등)★", () => {
+    const m = member(LIVE_SHAPE);
+    for (let i = 0; i < 10; i++) installOwnerGateHook("m1", { membersRoot: m.membersRoot, repoRoot: m.repoRoot });
+    const s = JSON.parse(readFileSync(m.settings, "utf-8"));
+    expect(s.hooks.UserPromptSubmit.length).toBe(1);
+    expect(s.hooks.Stop.length).toBe(2);
+    expect(s.hooks.PreToolUse.length).toBe(1);
+    expect(s.hooks.PreCompact.length).toBe(1);
+    expect(s.permissions).toEqual({ allow: ["Bash"] });   // 훅 밖 키도 보존
+  });
+
+  test("★부팅 갱신(repair) 10회도 멱등★", () => {
+    const m = member(LIVE_SHAPE);
+    installOwnerGateHook("m1", { membersRoot: m.membersRoot, repoRoot: m.repoRoot });
+    for (let i = 0; i < 10; i++) repairOwnerGateHook("m1", { membersRoot: m.membersRoot, repoRoot: m.repoRoot });
+    const s = JSON.parse(readFileSync(m.settings, "utf-8"));
+    expect(s.hooks.UserPromptSubmit.length).toBe(1);
+    expect(s.hooks.Stop.length).toBe(2);
+  });
+
+  test("안 깔린 멤버는 repair 가 새로 깔지 않는다", () => {
+    const m = member(LIVE_SHAPE);
+    repairOwnerGateHook("m1", { membersRoot: m.membersRoot, repoRoot: m.repoRoot });
+    const s = JSON.parse(readFileSync(m.settings, "utf-8"));
+    expect(s.hooks.UserPromptSubmit).toBeUndefined();
+  });
+
+  // ★현재 동작을 그대로 적어둔 것이다(고침 아님).★ 별건 카드로 뺀 항목 — 여기서 고치면 범위가 커진다.
+  test("[알려진 결함] settings.json 이 깨져 있으면 기존 배선이 통째로 날아간다", () => {
+    const m = member('{"hooks": {"Stop": [{"hooks":');   // 잘린 JSON (쓰기 중 중단 등)
+    installOwnerGateHook("m1", { membersRoot: m.membersRoot, repoRoot: m.repoRoot });
+    const s = JSON.parse(readFileSync(m.settings, "utf-8"));
+    expect(s.hooks.UserPromptSubmit.length).toBe(1);
+    expect(s.hooks.Stop).toBeUndefined();        // ★Stop·PreToolUse·PreCompact 소멸★
+    expect(s.hooks.PreToolUse).toBeUndefined();
+  });
+
+  test("settings.json 이 아예 없으면 새로 만든다 (정상)", () => {
+    const m = member(null);
+    installOwnerGateHook("m1", { membersRoot: m.membersRoot, repoRoot: m.repoRoot });
+    expect(existsSync(m.settings)).toBe(true);
+  });
+});

--- a/src/server/runtimes/claude/progressHookReconcile.test.ts
+++ b/src/server/runtimes/claude/progressHookReconcile.test.ts
@@ -11,7 +11,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { installProgressHook, repairProgressHook, repairReplyGuardHook } from "./launcher";
+import { installProgressHook, repairProgressHook, repairReplyGuardHook, installOwnerGateHook, repairOwnerGateHook } from "./launcher";
 
 const ID = "testmember";
 let dirs: string[] = [];
@@ -126,5 +126,60 @@ describe("reply-guard 훅 파일 수리", () => {
     const { membersRoot, repoRoot, hookPath } = setupGuard({ hooks: {} });
     repairReplyGuardHook(ID, { membersRoot, repoRoot });
     expect(readFileSync(hookPath, "utf-8")).toBe("# OLD\n"); // 안 건드림
+  });
+});
+
+describe("owner-gate 훅 설치·수리", () => {
+  function setupGate(settings?: unknown): { membersRoot: string; repoRoot: string; settingsPath: string; hookPath: string } {
+    const base = mkdtempSync(join(tmpdir(), "b3os-gate-install-"));
+    dirs.push(base);
+    const repoRoot = join(base, "b3os");
+    const membersRoot = join(base, "members");
+    mkdirSync(join(repoRoot, "hooks"), { recursive: true });
+    writeFileSync(join(repoRoot, "hooks", "telegram-owner-gate.py"), "# NEW\n");
+    const dotClaude = join(membersRoot, ID, ".claude");
+    mkdirSync(dotClaude, { recursive: true });
+    const settingsPath = join(dotClaude, "settings.json");
+    if (settings !== undefined) writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
+    return { membersRoot, repoRoot, settingsPath, hookPath: join(dotClaude, "hooks", "telegram-owner-gate.py") };
+  }
+
+  test("★UserPromptSubmit 배선이 생기고 훅 파일이 깔린다★ (기준 1·2)", () => {
+    const { membersRoot, repoRoot, settingsPath, hookPath } = setupGate({});
+    installOwnerGateHook(ID, { membersRoot, repoRoot });
+    const s = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    const cmds = (s.hooks.UserPromptSubmit as Array<{ hooks: Array<{ command: string }> }>)
+      .flatMap((e) => e.hooks.map((h) => h.command));
+    expect(cmds).toHaveLength(1);
+    expect(cmds[0]).toContain("telegram-owner-gate.py");
+    // ★B3OS_ROOT 가 실려야 한다★ — 없으면 깔려도 게이트가 무력화된다.
+    expect(cmds[0]).toContain(`B3OS_ROOT="${repoRoot}"`);
+    expect(readFileSync(hookPath, "utf-8")).toBe("# NEW\n");
+  });
+
+  test("두 번 돌려도 항목이 늘지 않는다 (멱등)", () => {
+    const { membersRoot, repoRoot, settingsPath } = setupGate({});
+    installOwnerGateHook(ID, { membersRoot, repoRoot });
+    const first = readFileSync(settingsPath, "utf-8");
+    installOwnerGateHook(ID, { membersRoot, repoRoot });
+    expect(readFileSync(settingsPath, "utf-8")).toBe(first);
+  });
+
+  test("다른 UserPromptSubmit 훅은 건드리지 않는다", () => {
+    const { membersRoot, repoRoot, settingsPath } = setupGate({
+      hooks: { UserPromptSubmit: [{ hooks: [{ type: "command", command: "python3 /x/other.py" }] }] },
+    });
+    installOwnerGateHook(ID, { membersRoot, repoRoot });
+    const s = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    const cmds = (s.hooks.UserPromptSubmit as Array<{ hooks: Array<{ command: string }> }>)
+      .flatMap((e) => e.hooks.map((h) => h.command));
+    expect(cmds.filter((c) => c.includes("other.py"))).toHaveLength(1);
+    expect(cmds.filter((c) => c.includes("telegram-owner-gate.py"))).toHaveLength(1);
+  });
+
+  test("★repair 는 이미 배선된 멤버만★ — 안 깔린 멤버엔 새로 깔지 않는다", () => {
+    const { membersRoot, repoRoot, settingsPath } = setupGate({ hooks: {} });
+    repairOwnerGateHook(ID, { membersRoot, repoRoot });
+    expect(readFileSync(settingsPath, "utf-8")).not.toContain("telegram-owner-gate.py");
   });
 });

--- a/src/server/runtimes/claude/progressHookReconcile.test.ts
+++ b/src/server/runtimes/claude/progressHookReconcile.test.ts
@@ -154,6 +154,8 @@ describe("owner-gate 훅 설치·수리", () => {
     expect(cmds[0]).toContain("telegram-owner-gate.py");
     // ★B3OS_ROOT 가 실려야 한다★ — 없으면 깔려도 게이트가 무력화된다.
     expect(cmds[0]).toContain(`B3OS_ROOT="${repoRoot}"`);
+    // ★자기 id 도 실려야 한다★ — 없으면 훅이 추측하고, 틀리면 게이트가 반대로 돈다.
+    expect(cmds[0]).toContain(`OWNER_GATE_SELF="${ID}"`);
     expect(readFileSync(hookPath, "utf-8")).toBe("# NEW\n");
   });
 


### PR DESCRIPTION
owner-gate 훅이 저장소에는 있는데 설치하는 코드가 없었다. 공개 설치·새 팀에는 이 게이트가 아예 없다.

바뀌는 것: 활성화·재시작 때 `UserPromptSubmit` 게이트가 멤버 워크스페이스에 깔린다.
영향: claude 런타임 팀원 전원 — 자기 것이 아닌 그룹 글에 세션이 안 깨어난다.
규모: 훅 1함수 + 설치·수리 2함수 + 배선 2줄, 신규 테스트 12건.

## 무엇이 문제인가

답장은 **암묵적 멘션**이다. `@A` 라고 써도 **답장 대상 봇 B 가 그 글을 받는다.**
게이트가 없으면 **B 세션이 자기 것이 아닌 일을 시작한다.**

`hooks/telegram-owner-gate.py` 는 저장소에 있는데 **설치하는 코드가 0건**이었다.
이 기계 전역에만 손으로 걸려 있어서, **공개 설치와 새 팀에는 그 게이트가 없다.**

## 왜 그렇게 되나

훅은 있는데 **배포 경로가 없었다.** 손으로 건 것은 이 기계에만 남고 저장소를 통해 퍼지지 않는다.

그리고 그냥 깔면 **깔자마자 무력화된다.** 이 훅도 단톡방 id 를 `<훅파일>/../.env` 에서 읽는데,
배포 위치에서 그 경로는 `<멤버>/.claude/.env` 라 **없다.** 그러면 `GROUP_ID` 가 `""` 가 되고
어떤 그룹 메시지든 `chat_id != ""` 라서 게이트가 통째로 지나간다.
**"깔았는데 안 도는" 상태는 안 깐 것보다 나쁘다** — 깔렸다고 착각하게 된다.

## 어떻게 고쳤나

- `_team_group()` 이 `OWNER_GATE_GROUP` → `$B3OS_ROOT/.env` → `<훅>/../.env` 순으로 찾는다.
  저장소 안에서 직접 부르는 경우는 마지막 폴백으로 그대로 산다.
- `installOwnerGateHook()` — 훅 파일 복사 + `UserPromptSubmit` 배선.
  커맨드에 **`B3OS_ROOT` 를 싣는다.** 실 chat_id 는 소스에 넣지 않는다.
  **있으면 skip 이 아니라 다르면 교체** — 커맨드가 바뀌어도 기존 멤버가 옛것을 안 들고 있게.
- `repairOwnerGateHook()` 을 부팅 시 게이트 밖에서 돌린다. **배선이 이미 있는 멤버만** 대상이다.
- 활성화 경로(`activation.ts`)에도 추가 — 새 팀원은 영입 시점에 깔린다.

`OWNER_GATE_SELF` 는 **싣지 않았다.** 훅이 `TELEGRAM_STATE_DIR` 에서 per-bot 으로 얻는다
(진행표시 훅과 같은 방식). 굳이 실으면 두 벌의 진실이 생긴다.

## 검증 결과

**① 서버가 없어도 막지 않는가 — 이게 제일 무서운 축이다.**
소스 머리말은 "라우터 에러·타임아웃은 fail-open" 이라고 적고 있지만 **적힌 것과 도는 것은 다르다.**
그래서 **진짜 죽은 포트**와 **진짜 멈춘 소켓**에 붙여 훅을 실행했다.

| 상황 | 결과 |
|---|---|
| 라우터 죽음(연결 거부) | **통과** |
| 라우터 멈춤(응답 없음, 3s 타임아웃) | **통과** |
| 깨진 응답(JSON 아님) | **통과** |
| 서버가 `suppress: true` | **막힘** |
| 서버가 `suppress: false` | 통과 |
| 1:1 DM (서버가 suppress 라고 해도) | 통과 |

**② 배포 위치에서 단톡방 id 를 구하는가** — 훅을 배포 위치 모양으로 깔고 함수를 직접 불렀다.

| | 결과 |
|---|---|
| `B3OS_ROOT` 있음 | **구함** |
| **대조군 — `B3OS_ROOT` 없음** | **빈 값(게이트 무력화)** |

**③ 뮤턴트 — 축마다 죽는 테스트가 있다:**

| 되돌린 것 | 죽는 테스트 |
|---|---|
| fail-open → fail-closed | **3** (죽음·멈춤·깨진 응답) |
| `B3OS_ROOT` 조회 제거 | 1 |
| `suppress` 무시(안 막음) | 1 |

**④ 설치·배선** — `UserPromptSubmit` 항목이 생기고 훅 파일이 깔리는 것, 커맨드에 `B3OS_ROOT` 가
실리는 것, 멱등, 다른 `UserPromptSubmit` 훅 무영향, repair 가 미배선 멤버를 안 건드리는 것.

전체 2272 pass · **신규 실패 0** · 타입 신규 오류 0 · 공개 저장소 실 chat_id **0건**.
테스트는 `mkdtemp` 만 만진다.

## 측정에서 고친 것

처음에 훅을 `execFileSync` 로 돌렸더니 **이벤트 루프가 막혀 가짜 라우터가 응답을 못 했다.**
모든 케이스가 타임아웃으로 흘러 **"항상 통과" 로 보였고, 막는 축을 재는 테스트가 조용히 무의미해졌다.**
비동기 실행으로 바꿔서 고쳤다(전체 실행 시간 12.5s → 3.3s 가 그 증거다).

## 안 고친 것

- 소스 머리말의 "v2 후속: 👀 react owner-only" — 범위 밖이다.
- `_self_id()` 의 마지막 폴백이 `bill` 이다. `TELEGRAM_STATE_DIR` 이 없으면 남의 id 로 판정한다.
  기존 훅들과 같은 규약이라 이번에 바꾸지 않았다.

## 롤백

이 커밋을 되돌리면 게이트가 새로 깔리지 않는다. **이미 깔린 멤버의 배선은 자동으로 제거되지 않는다** —
되돌린 뒤 게이트를 걷어내려면 `settings.json` 의 `UserPromptSubmit` 항목을 멤버당 한 줄 지워야 한다.

Submitted-by: steve
