### PR TITLE
fix(hooks): owner-gate 는 없으면 새로 깐다 — repair 라 기존 설치본에 효과가 0이었다

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -52,7 +52,7 @@ import { createSchedulerRoutes } from "./routes/scheduler";
 import { createCiStatusRoutes } from "./routes/ciStatus";
 import { ensureDailyTaskReviewJobs, ensureWeeklySelfLearningJobs } from "./scheduler/core";
 import { renderAndRepoint } from "./lib/teamOsRender";
-import { installProgressHook, repairProgressHook, repairReplyGuardHook, repairOwnerGateHook } from "./runtimes/claude/launcher";
+import { installProgressHook, repairProgressHook, repairReplyGuardHook, ensureOwnerGateHook } from "./runtimes/claude/launcher";
 import { writeMemberPersona, savePersonaFile } from "./lib/writeMemberPersona";
 import { persistOwnerChatIdIfEmpty } from "./runtimes/codex/launcher";
 import { createApprovalsApp } from "./routes/approvals";
@@ -167,7 +167,8 @@ try {
   for (const cid of claudeIds) {
     try { repairProgressHook(cid); } catch { /* best-effort */ }
     try { repairReplyGuardHook(cid); } catch { /* best-effort */ }
-    try { repairOwnerGateHook(cid); } catch { /* best-effort */ }
+    // ★owner-gate 만 "없으면 깐다" 다★ — 위 둘과 목적이 반대다(주석은 launcher 쪽에).
+    try { ensureOwnerGateHook(cid); } catch { /* best-effort */ }
   }
   // 공개 빌드 부팅 백필(PUBLIC_BUILD 게이트) — 공개 사용자가 git 업데이트를 pull 한 뒤 재시작하면 기존
   //   멤버도 재영입 없이 최신을 받게. 라이브(PUBLIC_BUILD=false)는 글로벌 배선/실멤버 보호로 skip.

--- a/src/server/runtimes/claude/launcher.ts
+++ b/src/server/runtimes/claude/launcher.ts
@@ -241,14 +241,18 @@ export function installOwnerGateHook(id: string, roots?: { membersRoot?: string;
   } catch { /* best-effort */ }
 }
 
-/** 이미 깔려 있는 owner-gate 훅만 최신으로 맞춘다(새로 깔지는 않는다). `repairProgressHook` 과 같은 원칙. */
-export function repairOwnerGateHook(id: string, roots?: { membersRoot?: string; repoRoot?: string }): void {
+/** owner-gate 를 ★없으면 새로 깐다.★ 부팅 때 돈다.
+ *
+ *  ★`repairProgressHook`·`repairReplyGuardHook` 과 일부러 다르다.★ 그 둘은 "이미 배선된 멤버만"
+ *  손본다 — 안 깔린 멤버에게 새로 깔지 않는 게 실멤버 보호다. ★owner-gate 는 목적이 반대다★:
+ *  ★없는 곳에 넣는 것★ 이 이 훅의 존재 이유다(공개 설치·기존 팀에 게이트가 아예 없었다).
+ *  "이미 있는 멤버만" 으로 두면 ★아무도 없으니 전원 건너뛰어 효과가 0★ 이 된다(실측으로 확인).
+ *
+ *  ★그래서 이름이 repair 가 아니라 ensure 다.★ 다음 사람이 세 함수를 같은 것으로 읽지 않게.
+ *  멱등이다 — `installOwnerGateHook` 이 있으면 교체, 없으면 추가한다.
+ */
+export function ensureOwnerGateHook(id: string, roots?: { membersRoot?: string; repoRoot?: string }): void {
   assertId(id);
-  const settingsPath = `${roots?.membersRoot ?? MEMBERS_ROOT}/${id}/.claude/settings.json`;
-  try {
-    if (!existsSync(settingsPath)) return;
-    if (!readFileSync(settingsPath, "utf-8").includes("telegram-owner-gate.py")) return;
-  } catch { return; }
   installOwnerGateHook(id, roots);
 }
 

--- a/src/server/runtimes/claude/ownerGateSelfAndRoom.test.ts
+++ b/src/server/runtimes/claude/ownerGateSelfAndRoom.test.ts
@@ -15,7 +15,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer, type Server } from "node:http";
-import { installOwnerGateHook, repairOwnerGateHook } from "./launcher";
+import { installOwnerGateHook, ensureOwnerGateHook } from "./launcher";
 
 const execFileAsync = promisify(execFile);
 const HOOK = join(import.meta.dir, "../../../../hooks/telegram-owner-gate.py");
@@ -160,20 +160,25 @@ describe("축2·축4 — 설치가 기존 배선을 건드리는가 / 반복하�
     expect(s.permissions).toEqual({ allow: ["Bash"] });   // 훅 밖 키도 보존
   });
 
-  test("★부팅 갱신(repair) 10회도 멱등★", () => {
+  test("★부팅 갱신(ensure) 10회도 멱등★", () => {
     const m = member(LIVE_SHAPE);
     installOwnerGateHook("m1", { membersRoot: m.membersRoot, repoRoot: m.repoRoot });
-    for (let i = 0; i < 10; i++) repairOwnerGateHook("m1", { membersRoot: m.membersRoot, repoRoot: m.repoRoot });
+    for (let i = 0; i < 10; i++) ensureOwnerGateHook("m1", { membersRoot: m.membersRoot, repoRoot: m.repoRoot });
     const s = JSON.parse(readFileSync(m.settings, "utf-8"));
     expect(s.hooks.UserPromptSubmit.length).toBe(1);
     expect(s.hooks.Stop.length).toBe(2);
   });
 
-  test("안 깔린 멤버는 repair 가 새로 깔지 않는다", () => {
+  test("★안 깔린 멤버에도 부팅 때 깔린다★ — 기존 설치본이 이 PR 의 대상이다", () => {
+    // ★기대값을 뒤집었다.★ 예전에는 "새로 깔지 않는다" 를 고정하고 있었는데, 그러면
+    // ★배선이 하나도 없는 기존 설치본에서 전원 건너뛰어 효과가 0★ 이 된다(배포 후 5명 실측).
+    // owner-gate 는 progress·reply-guard 와 목적이 반대다 — ★없는 곳에 넣는 게 존재 이유★ 다.
     const m = member(LIVE_SHAPE);
-    repairOwnerGateHook("m1", { membersRoot: m.membersRoot, repoRoot: m.repoRoot });
+    ensureOwnerGateHook("m1", { membersRoot: m.membersRoot, repoRoot: m.repoRoot });
     const s = JSON.parse(readFileSync(m.settings, "utf-8"));
-    expect(s.hooks.UserPromptSubmit).toBeUndefined();
+    expect(s.hooks.UserPromptSubmit.length).toBe(1);
+    expect(s.hooks.Stop.length).toBe(2);          // 기존 배선은 그대로
+    expect(s.hooks.PreToolUse.length).toBe(1);
   });
 
   // ★현재 동작을 그대로 적어둔 것이다(고침 아님).★ 별건 카드로 뺀 항목 — 여기서 고치면 범위가 커진다.

--- a/src/server/runtimes/claude/progressHookReconcile.test.ts
+++ b/src/server/runtimes/claude/progressHookReconcile.test.ts
@@ -11,7 +11,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { installProgressHook, repairProgressHook, repairReplyGuardHook, installOwnerGateHook, repairOwnerGateHook } from "./launcher";
+import { installProgressHook, repairProgressHook, repairReplyGuardHook, installOwnerGateHook, ensureOwnerGateHook } from "./launcher";
 
 const ID = "testmember";
 let dirs: string[] = [];
@@ -179,9 +179,25 @@ describe("owner-gate 훅 설치·수리", () => {
     expect(cmds.filter((c) => c.includes("telegram-owner-gate.py"))).toHaveLength(1);
   });
 
-  test("★repair 는 이미 배선된 멤버만★ — 안 깔린 멤버엔 새로 깔지 않는다", () => {
+  test("★ensure 는 안 깔린 멤버에도 새로 깐다★ — 이게 progress·reply-guard 와 반대인 지점이다", () => {
+    // "이미 배선된 멤버만" 으로 두면 ★아무도 없으니 전원 건너뛰어 효과가 0★ 이 된다(실측으로 확인됨).
+    const { membersRoot, repoRoot, settingsPath, hookPath } = setupGate({ hooks: {} });
+    ensureOwnerGateHook(ID, { membersRoot, repoRoot });
+    expect(readFileSync(settingsPath, "utf-8")).toContain("telegram-owner-gate.py");
+    expect(readFileSync(hookPath, "utf-8")).toBe("# NEW\n");
+  });
+
+  test("★settings.json 이 아예 없는 멤버에도 깐다★", () => {
+    const { membersRoot, repoRoot, settingsPath } = setupGate();
+    ensureOwnerGateHook(ID, { membersRoot, repoRoot });
+    expect(readFileSync(settingsPath, "utf-8")).toContain("telegram-owner-gate.py");
+  });
+
+  test("안 깔린 상태에서 두 번 돌려도 1개만 (멱등)", () => {
     const { membersRoot, repoRoot, settingsPath } = setupGate({ hooks: {} });
-    repairOwnerGateHook(ID, { membersRoot, repoRoot });
-    expect(readFileSync(settingsPath, "utf-8")).not.toContain("telegram-owner-gate.py");
+    ensureOwnerGateHook(ID, { membersRoot, repoRoot });
+    ensureOwnerGateHook(ID, { membersRoot, repoRoot });
+    const s = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    expect((s.hooks.UserPromptSubmit as unknown[]).length).toBe(1);
   });
 });


### PR DESCRIPTION
`#236` 이 게이트를 깔지 못했다. 배포 후 5명 전원 미설치였다.

바뀌는 것: 부팅 때 owner-gate 를 ★없으면 새로 깐다★(`repair` → `ensure`).
영향: 기존 설치본 전체 — 공개·다른 팀이 이 PR 의 대상이다.
규모: 함수 1개 의미 변경 + 배선 1줄, 테스트 4건 추가·1건 기대값 뒤집음.

## 무엇이 문제인가

`repairOwnerGateHook` 이 **"이미 배선된 멤버만"** 손봤다.

```ts
if (!readFileSync(settingsPath,"utf-8").includes("telegram-owner-gate.py")) return;
```

**배선이 하나도 없는 상태가 바로 이 PR 의 대상**이라, 전원 건너뛴다. 배포 후 실측에서
`bill · steve · demis · lui · dbak` **5명 전부 `UserPromptSubmit` 0개 · 훅 파일 없음** 이었다.

설치 경로가 **영입(활성화) 때뿐**이었으므로 **기존 설치본은 영원히 못 받는다.**

## 왜 그렇게 되나

`repairProgressHook`·`repairReplyGuardHook` 의 패턴을 그대로 가져왔다.
그 둘은 **"안 깔린 멤버에게 새로 깔지 않는다"** 가 맞다 — 실멤버 보호다.

**owner-gate 는 목적이 반대다.** 없는 곳에 넣는 것이 존재 이유인데, 보호 규칙을 같이 복사했다.
세 함수가 같은 이름꼴(`repair*`)이라 **같은 것으로 읽힌 것**이 원인이다.

## 어떻게 고쳤나

- `ensureOwnerGateHook` — 조건 없이 설치한다. 멱등이다(있으면 교체, 없으면 추가).
- **이름을 `repair` 가 아니라 `ensure` 로** 두었다. 다음 사람이 세 함수를 같은 것으로 읽지 않게.
- `repairProgressHook`·`repairReplyGuardHook` 은 **그대로 뒀다.**

## 검증 결과

**뮤턴트 — `ensure` 를 옛 `repair` 로 되돌리면 4건이 죽는다:**

| | |
|---|---|
| 안 깔린 멤버에도 깔린다 | ✅ |
| `settings.json` 이 아예 없는 멤버에도 깔린다 | ✅ |
| 안 깔린 상태에서 두 번 돌려도 1개 (멱등) | ✅ |
| 기존 배선(`Stop`·`PreToolUse`·`PreCompact`) 보존 | ✅ |

기대값을 하나 **뒤집었다** — "안 깔린 멤버는 새로 깔지 않는다" 가 계약으로 박혀 있었다.
그게 이 결함을 정답으로 고정하고 있었다.

전체 2286 pass · **신규 실패 0** · 타입 신규 오류 0.

## 배포 후 남는 일

이 기계 전역(`~/.claude/settings.json`)에 owner-gate 가 **이미 1개 있다.** 멤버 스코프에 깔리면
**게이트가 두 번 돈다.** 배포·확인 뒤 **전역에서 owner-gate 항목을 빼야 한다** — 순서가 반대면
게이트가 없는 창이 생긴다. 이 PR 범위 밖이고, 라이브 기계 설정이라 별도로 처리한다.

## 롤백

되돌리면 다시 "이미 배선된 멤버만" 이 된다. 이미 깔린 배선은 자동 제거되지 않는다.

Submitted-by: steve