### PR TITLE
docs(bus): all-hands 공지 사용법을 안내한다

### DIFF
--- a/skills/b3os-team-inbox/SKILL.md
+++ b/skills/b3os-team-inbox/SKILL.md
@@ -101,6 +101,21 @@ skills/b3os-team-inbox/scripts/send.sh \
 
 서버가 **DB 에 기록하고 그 방에 게시한다.** (`--thread` 는 그 방의 thread id — 주입문이 알려준다)
 
+**기본 `--to broadcast` 는 방에만 올라가고 팀원을 깨우지 않는다.** 전원이 반드시 봐야 하는 공지는
+사유를 한 줄로 적어 `--all-hands` 를 명시한다:
+
+```bash
+skills/b3os-team-inbox/scripts/send.sh \
+  --to broadcast --thread <그룹 thread> \
+  --all-hands "전원이 봐야 하는 이유" \
+  --body "공지 내용"
+```
+
+- 사유는 필수다.
+- 정식·활성 팀원 전원에게 수신행을 만들고 실제로 깨운다(발신자 제외).
+- 사유·수신자·수신자 수가 감사 기록에 남는다. 남용도 그대로 보인다.
+- `--all-hands` 없는 broadcast는 방 게시만 하며 아무도 깨우지 않는 것이 기본이다.
+
 **응답**
 | 결과 | 뜻 |
 |---|---|


### PR DESCRIPTION
## 핵심 3줄
1. 팀원이 읽는 `b3os-team-inbox/SKILL.md`에 `--all-hands` 사용법을 추가합니다.
2. 사유 필수·정식 활성 전원 wake·감사 기록을 설명합니다.
3. 플래그 없는 broadcast는 방 게시만 하고 아무도 깨우지 않는 기본 동작을 명시합니다.

## 무엇을 바꿨나

- 실제 방 ID 없이 `--all-hands "<사유>"` 예시를 추가했습니다.
- 발신자 제외 수신 범위와 감사 기록을 설명했습니다.
- 일반 broadcast와 전원 공지의 전달 차이를 함께 적었습니다.

## 검증

- `grep -rn "all-hands" skills/ rules/ docs/`: `skills/b3os-team-inbox/SKILL.md`에서 확인
- 폐기된 옵션 표기: 해당 SKILL.md 0건
- YAML frontmatter: Ruby `YAML.safe_load` 통과
- `git diff --check`: 통과

## 미검증

- 팀원 런타임에서 갱신된 스킬 문서가 실제 주입되는 시점

## 롤백

이 PR의 단일 커밋을 revert하면 문서 섹션만 제거됩니다.

Submitted-by: Codex
