### PR TITLE
feat(hooks): react 배선을 멤버 스코프로 — 전역 래퍼의 손으로 박은 봇 목록에서 팀원이 빠졌다

### DIFF
--- a/src/server/runtimes/claude/launcher.ts
+++ b/src/server/runtimes/claude/launcher.ts
@@ -161,7 +161,10 @@ export function installProgressHook(id: string, roots?: { membersRoot?: string; 
       const arr = Array.isArray(hooks[evt]) ? (hooks[evt] as unknown[]) : [];
       // ★B3OS_ROOT 를 실어 보낸다★ — 훅은 저장소 밖(멤버 워크스페이스)에서 돌기 때문에
       //   자기 위치로는 b3os `.env`(TEAM_GROUP_ID)를 못 찾는다. 실 chat_id 는 소스에 안 박는다.
-      const command = `B3OS_ROOT="${repoRoot}" python3 "${hookDst}" ${mode}`;
+      // ★OWNER_GATE_SELF 도 싣는다★ — `react` 모드가 owner 판정을 하므로 자기 id 가 필요하다.
+      //   훅은 TELEGRAM_STATE_DIR 로도 유추하지만, ★유추가 틀리면 남의 이름으로 판정한다★
+      //   (owner-gate 에서 겪은 것). 런처는 id 를 아니까 추측하게 두지 않는다.
+      const command = `B3OS_ROOT="${repoRoot}" OWNER_GATE_SELF="${id}" python3 "${hookDst}" ${mode}`;
       const entry: Record<string, unknown> = { hooks: [{ type: "command", command }] };
       if (matcher) entry.matcher = matcher; // Stop 은 matcher 없음(글로벌 배선과 동형)
       const idx = arr.findIndex((e) => JSON.stringify(e).includes("telegram-progress.py"));
@@ -172,6 +175,11 @@ export function installProgressHook(id: string, roots?: { membersRoot?: string; 
     reconcile("PreToolUse", "*", "pre");
     reconcile("Stop", "", "stop");
     reconcile("PreCompact", "*", "compact");
+    // ★react 는 멤버 스코프에 있어야 한다.★ 지금까지 이 기계 전역 래퍼에만 걸려 있었고,
+    //   그 래퍼는 ★봇 목록이 손으로 박혀 있어 새 팀원이 빠졌다★(명부엔 있는데 목록엔 없음).
+    //   react 가 "이번 턴이 어느 방인가" 를 적어두므로, 빠진 팀원은 진행표시가 ★엉뚱한 방★ 에 찍힌다.
+    //   공개 설치에는 그 래퍼 자체가 없어서 ★전부 같은 상태★ 였다. 명부를 읽는 이 경로로 옮긴다.
+    reconcile("UserPromptSubmit", "", "react");
     settings.hooks = hooks;
     writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
   } catch { /* best-effort */ }

--- a/src/server/runtimes/claude/progressHookReconcile.test.ts
+++ b/src/server/runtimes/claude/progressHookReconcile.test.ts
@@ -59,7 +59,9 @@ describe("progress 훅 배선 reconcile", () => {
     installProgressHook(ID, { membersRoot, repoRoot });
 
     const cmds = commandsIn(settingsPath);
-    expect(cmds).toHaveLength(3);
+    // ★3 → 4.★ react(UserPromptSubmit)가 멤버 스코프로 들어오면서 하나 늘었다(의도된 계약 변경).
+    expect(cmds).toHaveLength(4);
+    expect(cmds.filter((c) => c.endsWith(" react"))).toHaveLength(1);
     for (const c of cmds) expect(c).toContain(`B3OS_ROOT="${repoRoot}"`);
     // 옛 커맨드가 남아 있으면 안 된다 — 추가만 하고 안 지우면 훅이 두 번 돈다.
     expect(cmds.some((c) => !c.includes("B3OS_ROOT"))).toBe(false);
@@ -71,7 +73,7 @@ describe("progress 훅 배선 reconcile", () => {
     const first = readFileSync(settingsPath, "utf-8");
     installProgressHook(ID, { membersRoot, repoRoot });
     expect(readFileSync(settingsPath, "utf-8")).toBe(first);
-    expect(commandsIn(settingsPath)).toHaveLength(3);
+    expect(commandsIn(settingsPath)).toHaveLength(4);   // pre·stop·compact·react
   });
 
   test("다른 훅(reply-guard)은 건드리지 않는다", () => {
@@ -199,5 +201,49 @@ describe("owner-gate 훅 설치·수리", () => {
     ensureOwnerGateHook(ID, { membersRoot, repoRoot });
     const s = JSON.parse(readFileSync(settingsPath, "utf-8"));
     expect((s.hooks.UserPromptSubmit as unknown[]).length).toBe(1);
+  });
+});
+
+describe("react 배선을 멤버 스코프로", () => {
+  const upsCommands = (settingsPath: string): string[] => {
+    const s = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    return ((s.hooks.UserPromptSubmit ?? []) as Array<{ hooks: Array<{ command: string }> }>)
+      .flatMap((e) => e.hooks.map((h) => h.command));
+  };
+
+  test("★UserPromptSubmit 에 react 가 배선된다★ — 지금까지 전역 래퍼에만 있었다", () => {
+    const { membersRoot, repoRoot, settingsPath } = setup({});
+    installProgressHook(ID, { membersRoot, repoRoot });
+    const react = upsCommands(settingsPath).filter((c) => c.includes("telegram-progress.py"));
+    expect(react).toHaveLength(1);
+    expect(react[0]).toMatch(/telegram-progress\.py" react$/);
+    // ★self 가 실려야 한다★ — react 는 owner 판정을 한다. 유추가 틀리면 남의 이름으로 판정한다.
+    expect(react[0]).toContain(`OWNER_GATE_SELF="${ID}"`);
+    expect(react[0]).toContain(`B3OS_ROOT="${repoRoot}"`);
+  });
+
+  test("★같은 이벤트에 있는 owner-gate 배선을 지우지 않는다★", () => {
+    const { membersRoot, repoRoot, settingsPath } = setup({
+      hooks: { UserPromptSubmit: [{ hooks: [{ type: "command", command: `python3 "/x/telegram-owner-gate.py"` }] }] },
+    });
+    installProgressHook(ID, { membersRoot, repoRoot });
+    const cmds = upsCommands(settingsPath);
+    expect(cmds.filter((c) => c.includes("telegram-owner-gate.py"))).toHaveLength(1);
+    expect(cmds.filter((c) => c.includes("telegram-progress.py"))).toHaveLength(1);
+  });
+
+  test("두 번 돌려도 react 가 하나뿐이다 (멱등)", () => {
+    const { membersRoot, repoRoot, settingsPath } = setup({});
+    installProgressHook(ID, { membersRoot, repoRoot });
+    installProgressHook(ID, { membersRoot, repoRoot });
+    expect(upsCommands(settingsPath).filter((c) => c.includes("telegram-progress.py"))).toHaveLength(1);
+  });
+
+  test("★기존 멤버(progress 만 배선된 상태)에도 repair 로 깔린다★ — 재영입 없이 받아야 한다", () => {
+    // 라이브 실측: 5명 전부 progress 가 배선돼 있다 → repairProgressHook 이 닿는다.
+    const { membersRoot, repoRoot, settingsPath } = setup(null);
+    writeFileSync(settingsPath, JSON.stringify(staleSettings(membersRoot), null, 2) + "\n");
+    repairProgressHook(ID, { membersRoot, repoRoot });
+    expect(upsCommands(settingsPath).filter((c) => c.includes("telegram-progress.py"))).toHaveLength(1);
   });
 });


### PR DESCRIPTION
`react` 가 이 기계 전역 래퍼에만 걸려 있고, 그 목록이 손으로 관리돼 팀원 하나가 빠졌다.

바뀌는 것: `installProgressHook` 이 `UserPromptSubmit` + `react` 도 배선한다.
영향: claude 런타임 팀원 전원 + 공개 설치(그쪽엔 래퍼가 아예 없다).
규모: 배선 1줄 + 커맨드에 `OWNER_GATE_SELF` 추가, 테스트 4건 추가·2건 기대값 갱신.

## 무엇이 문제인가

`react` 배선이 **전역 래퍼에만** 있고, 래퍼 안에 **봇 목록이 손으로 박혀 있다.**
명부(`agents.json`)에는 있는데 그 목록에는 없는 팀원이 생겼다.

`react` 는 **"이번 턴이 어느 방인가" 를 적어둔다.** 그게 없으면 진행표시가 방을 몰라
폴백으로 옛 메시지를 뒤지고 **엉뚱한 방에 찍힌다.**

**공개 설치에는 그 래퍼가 아예 없어서 전부 같은 상태다.**

## 왜 그렇게 되나

**같은 사실(누가 팀원인가)이 두 곳에 있었다** — 명부와 래퍼의 손 목록.
두 벌이면 언젠가 갈린다. 갈린 쪽이 조용해서 아무도 못 봤다.

## 어떻게 고쳤나

- `installProgressHook` 의 reconcile 에 `reconcile("UserPromptSubmit", "", "react")` 추가.
  **명부를 읽는 경로라 목록을 손으로 관리하지 않는다.**
- 커맨드에 `OWNER_GATE_SELF="${id}"` 추가. `react` 는 owner 판정을 하므로 self 가 필요하다.
  훅이 `TELEGRAM_STATE_DIR` 로 유추도 하지만 **유추가 틀리면 남의 이름으로 판정한다.**
- **기존 멤버도 재영입 없이 받는다** — 라이브 실측상 5명 전부 progress 가 배선돼 있어
  `repairProgressHook` 이 그대로 닿는다. 그래서 `ensure` 로 바꿀 필요가 없다.

## 검증 결과

| 되돌린 것 | 죽는 테스트 |
|---|---|
| `react` 배선 줄 제거 | **6** |
| 커맨드에서 `OWNER_GATE_SELF` 제거 | 1 |

- `UserPromptSubmit` 에 `react` 가 배선되고 `B3OS_ROOT`·`OWNER_GATE_SELF` 가 둘 다 실린다
- **같은 이벤트의 owner-gate 배선을 지우지 않는다**
- 멱등 · 기존 멤버(progress 만 배선된 상태)에 `repair` 로 깔린다

기대값 2건을 **갱신했다** — 커맨드 수가 3(`pre`·`stop`·`compact`)에서 4로 늘었다. 의도된 계약 변경이다.

전체 2290 pass · **신규 실패 0** · 타입 신규 오류 0.

## 배포 후 남는 일

전역에서 `react` 를 빼야 **두 번 돌지 않는다.** 순서가 반대면 react 가 없는 창이 생긴다.
전역 설정은 이 저장소 밖이라 여기서 건드리지 않는다.

## 안 건드린 것

`telegram-progress.sh` 래퍼 자체 · `telegram-ack-react.sh` · `Settings.ts`/`ThreadView.ts` 의
하드코딩 · 검사기 — 전부 별건이다.

## 롤백

되돌리면 `UserPromptSubmit` 배선이 새로 안 깔린다. 이미 깔린 항목은 자동 제거되지 않는다.

Submitted-by: steve