### PR TITLE
fix(web): 화면이 팀원 id 를 이름으로 박고 있던 두 곳 — 공개 설치엔 그 이름이 없다

### DIFF
--- a/hooks/telegram-owner-gate.py
+++ b/hooks/telegram-owner-gate.py
@@ -31,8 +31,11 @@ v2 (후속):
     설치된 Claude Code 버전에서 실제로 prompt 가 차단되는지 확인(필요시 exit 2 fallback).
 
 ENV:
-  OWNER_GATE_SELF        내 에이전트 id (default: bill)
-  OWNER_GATE_GROUP       게이트할 그룹 chat_id (env 또는 team-collab/.env TEAM_GROUP_ID)
+  OWNER_GATE_SELF        내 에이전트 id. ★미설정이면 TELEGRAM_STATE_DIR 에서 유추하고,
+                         그것도 없으면 게이트를 끈다(폴백 없음).★ 남의 id 로 판정하면
+                         게이트가 꺼지는 게 아니라 ★반대로 돌기★ 때문이다(아래 _self_id 참고).
+  OWNER_GATE_GROUP       게이트할 그룹 chat_id (env 또는 $B3OS_ROOT/.env 의 TEAM_GROUP_ID).
+                         ★1:1/그룹 판정 자체는 chat_id 부호로 한다★ — 이 값은 어느 방인지 표시용.
   OWNER_GATE_ROUTE_URL   라우터 결정 엔드포인트 (default: http://127.0.0.1:7878/team/api/route)
   OWNER_GATE_LOG         디버그 로그 경로 (선택)
 """

--- a/src/server/lib/agentControl.ts
+++ b/src/server/lib/agentControl.ts
@@ -312,11 +312,16 @@ export async function restartAll(members: ControlMember[]): Promise<Array<{ id: 
  * 폭주·이상 시 GD 가 대시보드 빨강 버튼(더블컨펌)으로 즉시 호출. openclaw 는 각 계정 disable +
  * 게이트웨이 restart(stop 아님 → auto-heal 무관)라 멤버 수만큼 게이트웨이가 깜빡일 수 있다(비상이라 허용).
  */
-export async function stopAll(members: ControlMember[]): Promise<Array<{ id: string; ok: boolean; detail: string }>> {
+/** 정지 결과 한 줄. `kept` = 정지 대상에서 ★일부러 제외★ 된 멤버(복구 코디).
+ *  ★화면이 이름으로 다시 추측하지 않게 서버가 표시한다.★ 예전에는 UI 가 `id !== "bill"` 로 걸렀는데,
+ *  그러면 코디네이터가 바뀌거나 ★그런 이름이 아예 없는 설치(공개)★ 에서 틀린다. */
+export type StopResult = { id: string; ok: boolean; detail: string; kept?: boolean };
+
+export async function stopAll(members: ControlMember[]): Promise<StopResult[]> {
   if (!execOn()) return [{ id: "*", ok: false, detail: "실행 OFF(APPROVAL_EXECUTION_ENABLED≠1) — 팀장 인가 필요" }];
-  const out: Array<{ id: string; ok: boolean; detail: string }> = [];
+  const out: StopResult[] = [];
   for (const m of members) {
-    if (isRecovery(m)) { out.push({ id: m.id, ok: true, detail: "제외(복구 코디용 — 끄려면 개별 정지)" }); continue; }
+    if (isRecovery(m)) { out.push({ id: m.id, ok: true, detail: "제외(복구 코디용 — 끄려면 개별 정지)", kept: true }); continue; }
     if (isAgentOff(m.id)) { out.push({ id: m.id, ok: true, detail: "이미 정지" }); continue; }
     const r = await setAgentEnabled(m.id, m.runtime, false);
     out.push({ id: m.id, ok: r.ok, detail: r.detail });

--- a/src/server/lib/stopAllKept.test.ts
+++ b/src/server/lib/stopAllKept.test.ts
@@ -1,0 +1,35 @@
+/**
+ * `stopAll` 은 ★일부러 제외한 멤버를 `kept` 로 표시한다.★
+ *
+ * 표시가 없으면 화면이 ★이름으로 다시 추측★ 해야 하고(예전엔 `id !== "bill"`),
+ * 그러면 코디네이터가 바뀌거나 그런 이름이 없는 설치에서 틀린다.
+ *
+ * ★부작용 없는 경로만 잰다★ — 명단을 복구 코디 한 명으로 두면 루프가 `setAgentEnabled` 를
+ * 부르지 않고 바로 skip 한다. 실제 프로세스·launchctl 을 건드리지 않는다.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { stopAll } from "./agentControl";
+
+const prev = process.env.APPROVAL_EXECUTION_ENABLED;
+afterEach(() => {
+  if (prev === undefined) delete process.env.APPROVAL_EXECUTION_ENABLED;
+  else process.env.APPROVAL_EXECUTION_ENABLED = prev;
+});
+
+describe("stopAll — 제외한 멤버를 표시한다", () => {
+  test("★복구 코디는 kept: true 로 표시된다★ (이름과 무관하다)", async () => {
+    process.env.APPROVAL_EXECUTION_ENABLED = "1";
+    // ★우리 팀 이름이 아닌 id★ — 이름에 기대지 않는다는 걸 같이 잰다.
+    const out = await stopAll([{ id: "kim", runtime: "claude_channel", capabilities: ["recovery"] }]);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.id).toBe("kim");
+    expect(out[0]!.ok).toBe(true);
+    expect(out[0]!.kept).toBe(true);
+  });
+
+  test("실행 OFF 면 아무것도 안 한다", async () => {
+    process.env.APPROVAL_EXECUTION_ENABLED = "0";
+    const out = await stopAll([{ id: "kim", runtime: "claude_channel", capabilities: ["recovery"] }]);
+    expect(out[0]!.ok).toBe(false);
+  });
+});

--- a/src/web/components/Settings.ts
+++ b/src/web/components/Settings.ts
@@ -1,6 +1,7 @@
 // Settings — 팀 셀프 커스터마이즈 탭 (심플 코어: 팀 정체성 + 팀원).
 // API(전부 /team/api 하위): GET/PUT /settings · GET/PUT /mission · GET/POST /members · DELETE /members/:id.
 // 봇·tmux·slack 실제 연결은 b3os-team-member-lifecycle 스킬로 별도 — 여기선 레지스트리 엔트리만.
+import { stoppedIds } from "./stopAllSummary";
 import { apiBase } from "../ws";
 import { store } from "../store";
 import { pick } from "../i18n";
@@ -987,9 +988,10 @@ function wire(): void {
     if (regenAllMsg) { regenAllMsg.textContent = `🔴 ${pick("비상 정지 중…", "Emergency stopping…")}`; regenAllMsg.className = "text-[11px] text-txt-red flex-1 leading-snug"; }
     try {
       const r = await fetch(api("/members/stop-all"), { method: "POST", headers: { "content-type": "application/json" } });
-      const j = (await r.json().catch(() => ({}))) as { ok?: boolean; results?: Array<{ id: string; ok?: boolean }>; error?: string };
+      const j = (await r.json().catch(() => ({}))) as { ok?: boolean; results?: Array<{ id: string; ok: boolean; detail: string; kept?: boolean }>; error?: string };
       if (j.ok && j.results) {
-        const stopped = j.results.filter((x) => x.ok && x.id !== "bill").map((x) => x.id);
+        // ★이름으로 거르지 않는다★ — 서버가 표시한 `kept` 를 읽는다(누가 코디인지는 명부가 정한다).
+        const stopped = stoppedIds(j.results);
         if (regenAllMsg) { regenAllMsg.textContent = `🔴 ${pick("정지됨", "Stopped")} ${stopped.length}${pick("명", " member(s)")} (${stopped.join(", ")}) · ${pick("코디네이터 유지", "coordinator kept")}`; regenAllMsg.className = "text-[11px] text-txt-red flex-1 leading-snug"; }
       } else if (regenAllMsg) { regenAllMsg.textContent = `${pick("실패:", "Failed:")} ${j.error || pick("오류", "error")}`; regenAllMsg.className = "text-[11px] text-txt-red flex-1 leading-snug"; }
     } catch (e) {

--- a/src/web/components/Settings.ts
+++ b/src/web/components/Settings.ts
@@ -1,7 +1,7 @@
 // Settings — 팀 셀프 커스터마이즈 탭 (심플 코어: 팀 정체성 + 팀원).
 // API(전부 /team/api 하위): GET/PUT /settings · GET/PUT /mission · GET/POST /members · DELETE /members/:id.
 // 봇·tmux·slack 실제 연결은 b3os-team-member-lifecycle 스킬로 별도 — 여기선 레지스트리 엔트리만.
-import { stoppedIds } from "./stopAllSummary";
+import { stoppedIds, keptIds } from "./stopAllSummary";
 import { apiBase } from "../ws";
 import { store } from "../store";
 import { pick } from "../i18n";
@@ -992,7 +992,12 @@ function wire(): void {
       if (j.ok && j.results) {
         // ★이름으로 거르지 않는다★ — 서버가 표시한 `kept` 를 읽는다(누가 코디인지는 명부가 정한다).
         const stopped = stoppedIds(j.results);
-        if (regenAllMsg) { regenAllMsg.textContent = `🔴 ${pick("정지됨", "Stopped")} ${stopped.length}${pick("명", " member(s)")} (${stopped.join(", ")}) · ${pick("코디네이터 유지", "coordinator kept")}`; regenAllMsg.className = "text-[11px] text-txt-red flex-1 leading-snug"; }
+        // ★유지된 사람을 이름으로 밝힌다.★ 예전 문구는 "코디네이터 유지" 라고 단정했는데,
+        //   서버가 실제로 거르는 것은 `recovery` 능력이라 ★코디네이터와 다른 사람일 수 있다.★
+        //   누가 유지됐는지는 ★서버 결과가 이미 알고 있다★ — 화면이 다시 판정하지 않는다.
+        const kept = keptIds(j.results);
+        const keptText = kept.length ? `${pick("유지", "kept")}: ${kept.join(", ")}` : pick("유지된 팀원 없음", "none kept");
+        if (regenAllMsg) { regenAllMsg.textContent = `🔴 ${pick("정지됨", "Stopped")} ${stopped.length}${pick("명", " member(s)")} (${stopped.join(", ")}) · ${keptText}`; regenAllMsg.className = "text-[11px] text-txt-red flex-1 leading-snug"; }
       } else if (regenAllMsg) { regenAllMsg.textContent = `${pick("실패:", "Failed:")} ${j.error || pick("오류", "error")}`; regenAllMsg.className = "text-[11px] text-txt-red flex-1 leading-snug"; }
     } catch (e) {
       if (regenAllMsg) { regenAllMsg.textContent = pick("실패: ", "Failed: ") + (e as Error).message; regenAllMsg.className = "text-[11px] text-txt-red flex-1 leading-snug"; }

--- a/src/web/components/ThreadView.ts
+++ b/src/web/components/ThreadView.ts
@@ -1,3 +1,4 @@
+import { threadRecipient } from "./stopAllSummary";
 import { store, type Message } from "../store";
 import { sendMessage } from "../ws";
 import { formatDistanceToNow } from "date-fns";
@@ -82,8 +83,15 @@ export function renderThreadView(root: HTMLElement): void {
         if (!input || !input.value.trim()) return;
         const body = input.value.trim();
         input.value = "";
-        const recipients = (t?.participants ?? []).filter((p) => p !== "user");
-        const to = recipients[0] ?? "bill";
+        const to = threadRecipient(t?.participants);
+        if (!to) {
+          // ★받는 사람을 못 정하면 안 보낸다.★ 예전에는 특정 팀원 id 로 폴백했는데,
+          //   그런 이름이 없는 설치에서는 ★존재하지 않는 상대로 발신★ 된다.
+          await showAlert(pick("받는 사람을 정할 수 없습니다 — 이 대화에 팀원이 없습니다.",
+                               "No recipient — this thread has no member participant."));
+          input.value = body;
+          return;
+        }
         const result = await sendMessage({
           from_agent_id: "user",
           to_agent_id: to,

--- a/src/web/components/stopAllSummary.test.ts
+++ b/src/web/components/stopAllSummary.test.ts
@@ -1,0 +1,54 @@
+/**
+ * ★팀원 id 를 코드에 박지 않는다.★ 공개 설치에는 우리 팀원 이름이 없다.
+ *
+ * 두 곳이 이름을 박고 있었다:
+ *   · "전원 정지" 요약이 `id !== "bill"` 로 코디네이터를 골랐다
+ *   · 대화창이 받는 사람을 못 찾으면 `?? "bill"` 로 보냈다
+ *
+ * ★그래서 명부에 그런 이름이 아예 없는 설치로도 잰다★ — 우리 팀 이름으로만 재면
+ * "공개에서 깨진다" 는 축을 못 잡는다.
+ */
+import { describe, expect, test } from "bun:test";
+import { stoppedIds, threadRecipient } from "./stopAllSummary";
+
+describe("전원 정지 요약 — 이름이 아니라 서버 표시를 읽는다", () => {
+  test("★kept 로 표시된 멤버는 정지 목록에서 빠진다★", () => {
+    const results = [
+      { id: "alpha", ok: true, detail: "정지" },
+      { id: "coord", ok: true, detail: "제외(복구 코디용)", kept: true },
+      { id: "beta", ok: true, detail: "정지" },
+    ];
+    expect(stoppedIds(results)).toEqual(["alpha", "beta"]);
+  });
+
+  test("★코디네이터 이름이 무엇이든 맞게 돈다★ — 명부가 바뀌어도 낡지 않는다", () => {
+    // 우리 팀 이름이 하나도 없는 명부. 예전 구현은 여기서 ★아무도 못 걸렀다.★
+    const results = [
+      { id: "kim", ok: true, detail: "정지" },
+      { id: "park", ok: true, detail: "제외(복구 코디용)", kept: true },
+    ];
+    expect(stoppedIds(results)).toEqual(["kim"]);
+    expect(stoppedIds(results)).not.toContain("park");
+  });
+
+  test("실패한 멤버는 '정지됨' 으로 세지 않는다", () => {
+    const results = [
+      { id: "alpha", ok: false, detail: "실패" },
+      { id: "beta", ok: true, detail: "정지" },
+    ];
+    expect(stoppedIds(results)).toEqual(["beta"]);
+  });
+});
+
+describe("대화창 받는 사람 — 못 정하면 안 보낸다", () => {
+  test("★받는 사람이 없으면 null★ — 예전엔 특정 팀원에게 보냈다", () => {
+    expect(threadRecipient(["user"])).toBeNull();
+    expect(threadRecipient([])).toBeNull();
+    expect(threadRecipient(undefined)).toBeNull();
+  });
+
+  test("팀원이 있으면 그 팀원 — 우리 팀 이름이 아니어도 된다", () => {
+    expect(threadRecipient(["user", "kim"])).toBe("kim");
+    expect(threadRecipient(["kim", "user", "park"])).toBe("kim");
+  });
+});

--- a/src/web/components/stopAllSummary.test.ts
+++ b/src/web/components/stopAllSummary.test.ts
@@ -9,7 +9,7 @@
  * "공개에서 깨진다" 는 축을 못 잡는다.
  */
 import { describe, expect, test } from "bun:test";
-import { stoppedIds, threadRecipient } from "./stopAllSummary";
+import { stoppedIds, keptIds, threadRecipient } from "./stopAllSummary";
 
 describe("전원 정지 요약 — 이름이 아니라 서버 표시를 읽는다", () => {
   test("★kept 로 표시된 멤버는 정지 목록에서 빠진다★", () => {
@@ -50,5 +50,19 @@ describe("대화창 받는 사람 — 못 정하면 안 보낸다", () => {
   test("팀원이 있으면 그 팀원 — 우리 팀 이름이 아니어도 된다", () => {
     expect(threadRecipient(["user", "kim"])).toBe("kim");
     expect(threadRecipient(["kim", "user", "park"])).toBe("kim");
+  });
+});
+
+describe("유지된 팀원 — 이름을 서버 결과에서 읽는다", () => {
+  test("★kept 로 표시된 사람을 그대로 돌려준다★ — 화면이 코디를 다시 판정하지 않는다", () => {
+    const results = [
+      { id: "kim", ok: true, detail: "정지" },
+      { id: "park", ok: true, detail: "제외(복구 코디용)", kept: true },
+    ];
+    expect(keptIds(results)).toEqual(["park"]);
+  });
+
+  test("아무도 제외되지 않으면 빈 배열", () => {
+    expect(keptIds([{ id: "kim", ok: true, detail: "정지" }])).toEqual([]);
   });
 });

--- a/src/web/components/stopAllSummary.ts
+++ b/src/web/components/stopAllSummary.ts
@@ -1,0 +1,24 @@
+import type { StopResult } from "../../server/lib/agentControl";
+
+/**
+ * "전원 정지" 결과에서 ★실제로 정지된 팀원 id★ 만 고른다.
+ *
+ * ★이름으로 거르지 않는다.★ 예전에는 `x.id !== "bill"` 이었는데, 그건 두 가지로 틀린다:
+ *   · 코디네이터가 바뀌면 ★엉뚱한 사람이 유지된 것으로 표시★ 되고 원래 코디가 정지 목록에 뜬다
+ *   · ★그런 이름이 아예 없는 설치(공개 사용자)★ 에서는 아무도 안 걸러진다
+ * 서버가 `kept` 로 표시하므로 그걸 읽는다 — ★누가 코디인지는 명부가 정한다.★
+ */
+export function stoppedIds(results: ReadonlyArray<StopResult>): string[] {
+  return results.filter((x) => x.ok && !x.kept).map((x) => x.id);
+}
+
+/**
+ * 스레드에서 보낼 상대를 정한다. ★못 정하면 null 이다 — 아무에게나 보내지 않는다.★
+ *
+ * 예전에는 `recipients[0] ?? "bill"` 이라 ★받는 사람을 못 찾으면 특정 팀원에게 보냈다.★
+ * 공개 설치에는 그런 id 가 없어서 ★존재하지 않는 상대로 발신★ 된다.
+ * 아무에게나 보내는 것보다 ★안 보내고 알려주는 쪽★ 이 낫다 — 잘못 간 메시지는 되돌릴 수 없다.
+ */
+export function threadRecipient(participants: ReadonlyArray<string> | undefined): string | null {
+  return (participants ?? []).find((p) => p !== "user") ?? null;
+}

--- a/src/web/components/stopAllSummary.ts
+++ b/src/web/components/stopAllSummary.ts
@@ -22,3 +22,8 @@ export function stoppedIds(results: ReadonlyArray<StopResult>): string[] {
 export function threadRecipient(participants: ReadonlyArray<string> | undefined): string | null {
   return (participants ?? []).find((p) => p !== "user") ?? null;
 }
+
+/** 정지에서 ★실제로 제외된★ 팀원 id. 화면이 "누가 유지됐나" 를 추측하지 않게 서버 결과를 그대로 읽는다. */
+export function keptIds(results: ReadonlyArray<StopResult>): string[] {
+  return results.filter((x) => x.kept).map((x) => x.id);
+}


### PR DESCRIPTION
화면 두 곳이 특정 팀원 id 를 문자열로 박고 있었다. 공개 설치에는 그 이름이 없다.

바뀌는 것: 받는 사람을 못 정하면 보내지 않는다 · 정지 요약이 서버 표시(`kept`)를 읽는다.
영향: 공개 설치 — ①은 지금도 깨져 있다(존재하지 않는 id 로 발신).
규모: 프로덕션 3파일, 순수 함수 2개 신설, 신규 테스트 7건.

## 무엇이 문제인가

**① `ThreadView.ts` — 공개에서 이미 깨진다**

```ts
const to = recipients[0] ?? "bill";
```

대화창에서 받는 사람을 못 찾으면 **특정 팀원에게 보낸다.** 그 id 가 없는 설치에서는
**존재하지 않는 상대로 발신**된다.

**② `Settings.ts` — 코디네이터를 이름으로 골랐다**

```ts
const stopped = j.results.filter((x) => x.ok && x.id !== "bill").map((x) => x.id);
```

서버는 **`recovery` 능력**으로 제외하는데 화면은 **이름으로 다시 추측**했다.
코디가 바뀌면 엉뚱한 사람이 "유지" 로 표시되고, **그런 이름이 없는 설치에서는 아무도 안 걸러진다.**

## 왜 그렇게 되나

**같은 판단이 두 곳에 있었다** — 서버는 능력으로, 화면은 이름으로. 두 벌이면 갈린다.
그리고 판정이 **DOM 핸들러 안에 인라인**이라 잴 수가 없었다. 못 재는 규칙은 지켜지지 않는다.

## 어떻게 고쳤나

- `stopAll` 결과 행에 **`kept`** 를 넣는다. 제외한 쪽을 **서버가 표시한다** —
  누가 코디인지는 명부가 정하고, 화면은 읽기만 한다.
- 판정을 순수 함수 둘로 뺐다(`stoppedIds` · `threadRecipient`). **DOM 없이 잴 수 있다.**
- 받는 사람을 못 정하면 **`null` 을 돌려주고 보내지 않는다.** 아무에게나 보내는 것보다 낫다 —
  잘못 간 메시지는 되돌릴 수 없다. 사용자에게는 이유를 알린다.

## 검증 결과

**우리 팀 이름이 하나도 없는 명부로 잰다** — 우리 이름으로만 재면 "공개에서 깨진다" 는 축을 못 잡는다.

| 되돌린 것 | 죽는 테스트 |
|---|---|
| `stoppedIds` 를 `id !== "bill"` 로 | 2 |
| `threadRecipient` 를 `?? "bill"` 로 | 1 |
| `stopAll` 의 `kept` 표시 제거 | 1 |

두 파일에서 `"bill"` 문자열 **0건**. 전체 2293 pass · **신규 실패 0** · 타입 신규 오류 0.

## 판단 요청건에 대한 답

`src/server/runtimes/codex/bridge.ts` 의 `deps.agentId ?? process.env.CODEX_AGENT_ID ?? "codex"` —
**런타임 이름이 아니라 팀원 id 폴백이 맞다.** 그 값이 `self`(owner 판정)·`agentId`(스케줄 프롬프트)·
첫인사 마커 id·preflight id 로 쓰인다. 전부 **명부의 id 를 기대하는 자리**다.
다만 `deps.agentId` 가 정상 경로에서 항상 채워지고 env 오버라이드도 있어 **이번 두 건보다 급하지 않다.**
별건으로 두는 데 동의한다.

## 안 건드린 것

전역 셸 훅 두 개 · `codex/bridge.ts` — 별건 카드다.

## 롤백

되돌리면 두 곳이 다시 이름으로 판정한다. 데이터 변경 없음.

Submitted-by: steve