### PR TITLE
docs: 정지·재시작 규칙을 팀원 이름이 아니라 코디네이터로 설명한다

### DIFF
--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1395,7 +1395,7 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     return c.json({ ok: res.ok, bot_username: res.bot_username, error: res.error, detail: res.detail, warning: res.warning }, status);
   });
 
-  // 전체 재시작 (대시보드 — Settings에서 한 번에). 빌·정지팀원 제외, 빌 맨 마지막.
+  // 전체 재시작 (대시보드 — Settings에서 한 번에). ★코디네이터★·정지팀원 제외, ★코디네이터 맨 마지막★.
   app.post("/members/restart-all", async (c) => {
     let list: any[] = [];
     try { list = readAgents(); } catch (e) { return c.json({ ok: false, error: "read_failed", detail: e instanceof Error ? e.message : String(e) }, 500); }
@@ -1405,7 +1405,7 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     return c.json({ ok: true, results });
   });
 
-  // 비상 전체 정지 (대시보드 빨강 버튼·더블컨펌). 빌 제외 전원 정지.
+  // 비상 전체 정지 (대시보드 빨강 버튼·더블컨펌). ★코디네이터★ 제외 전원 정지.
   app.post("/members/stop-all", async (c) => {
     let list: any[] = [];
     try { list = readAgents(); } catch (e) { return c.json({ ok: false, error: "read_failed", detail: e instanceof Error ? e.message : String(e) }, 500); }

--- a/src/server/workers/telegramCapture.ts
+++ b/src/server/workers/telegramCapture.ts
@@ -838,7 +838,7 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
       return;
     }
 
-    // 전체 재시작 콜백 (rsall) — 빌·정지 팀원 제외, openclaw 게이트웨이 1회.
+    // 전체 재시작 콜백 (rsall) — ★코디네이터★·정지 팀원 제외, openclaw 게이트웨이 1회.
     if (data === "rsall") {
       if (!isAuthorized()) { await tg("answerCallbackQuery", { callback_query_id: cb.id, text: pick(locale, "권한 없음", "Not authorized"), show_alert: true }); appendAuditFile("capture", "callback_denied", data, { from: fromId }); return; }
       await tg("answerCallbackQuery", { callback_query_id: cb.id, text: pick(locale, "전체 재시작 중…", "Restarting all…") });

--- a/src/web/components/Settings.ts
+++ b/src/web/components/Settings.ts
@@ -961,7 +961,7 @@ function wire(): void {
   });
   refreshRollback(); // 페이지 로드 시: 6시간 내면 버튼 노출 + 카운트다운 시작
 
-  // 🔄 전체 재시작 — 빌·정지팀원 제외 전원 재시작(빌 맨 마지막).
+  // 🔄 전체 재시작 — ★코디네이터★·정지팀원 제외 전원 재시작(★코디네이터 맨 마지막★).
   const restartAll = _root.querySelector<HTMLButtonElement>("#restart-all");
   restartAll?.addEventListener("click", async () => {
     if (!await showConfirm(pick("정지 팀원 제외 전원을 재시작할까요?\n새 페르소나/상태를 로드합니다. openclaw 게이트웨이는 ~1분 깜빡, 복구 코디네이터는 맨 마지막(이 대화 ~15s 깜빡 후 복귀).", "Restart everyone except stopped members?\nThey reload fresh persona/state. The openclaw gateway blinks ~1 min; the recovery coordinator is last (this chat blinks ~15s, then returns)."))) return;
@@ -980,7 +980,7 @@ function wire(): void {
     _busy();
   });
 
-  // 🔴 전체 정지 (비상) — 빌 제외 전원 정지. 더블컨펌(강한 경고).
+  // 🔴 전체 정지 (비상) — ★코디네이터★ 제외 전원 정지. 더블컨펌(강한 경고).
   const stopAll = _root.querySelector<HTMLButtonElement>("#stop-all");
   stopAll?.addEventListener("click", async () => {
     if (!await showConfirm({ message: pick("🔴 비상 정지\n\n복구 코디네이터를 제외한 모든 팀원을 즉시 정지합니다.\n폭주·이상 상황의 서킷브레이커입니다. 정말 전원 정지할까요?\n\n(다시 켜려면 각 팀원 🟢 기동 또는 /onoff)", "🔴 Emergency stop\n\nImmediately stops every member except the recovery coordinator.\nThis is the circuit breaker for runaway/abnormal situations. Really stop everyone?\n\n(To turn them back on, use each member's 🟢 Start or /onoff)"), danger: true })) return;


### PR DESCRIPTION
코드는 `coordinator` 로 판정하는데 주석이 특정 팀원 이름으로 규칙을 설명하고 있었다.

바뀌는 것: 주석 5곳. 동작 변화 없음.
영향: 이 저장소를 읽는 사람 — 공개 저장소다.
규모: 주석만.

## 무엇이 문제인가

`#241` 로 판정이 `coordinator` 능력으로 바뀌었는데 주석은 이름 그대로였다.

```
routes/settings.ts:1408    비상 전체 정지 … 빌 제외 전원 정지
routes/settings.ts:1398    전체 재시작 … 빌·정지팀원 제외, 빌 맨 마지막
web/Settings.ts:983        🔴 전체 정지 — 빌 제외 전원 정지
web/Settings.ts:964        🔄 전체 재시작 — 빌·정지팀원 제외(빌 맨 마지막)
workers/telegramCapture.ts:841  전체 재시작 콜백 — 빌·정지 팀원 제외
```

**공개 설치에는 그런 이름의 팀원이 없다.** 읽는 사람은 규칙을 특정 이름의 성질로 이해하게 된다.
오늘 실제로 다른 팀이 같은 모양의 주석(`telegram-owner-gate.py`)을 읽고 **기본값을 틀리게 알았다.**

## 왜 그렇게 되나

**주석이 코드보다 뒤처진다.** 판정 기준이 바뀔 때 주석은 같이 안 바뀌고, 그 상태로 배포된다.
그리고 **주석은 테스트가 없다** — 틀려도 아무것도 안 깨진다.

## 어떻게 고쳤나

규칙을 능력 이름으로 쓴다. `빌 제외` → `★코디네이터★ 제외`.

**보고된 3곳 외에 같은 종류 2곳을 더 찾아 함께 고쳤다** — 둘 다 재시작 규칙이고,
`빌 맨 마지막` 이라고 적혀 있었다. 정지 쪽만 고치면 **재시작 쪽이 그대로 남는다.**

**안 건드린 것** — 규칙이 아니라 **사실을 적은 주석**은 그대로 둔다:
- 사고 기록("빌이 스티브에게 보낸 4건이 …") — 그때 실제로 있었던 일이다
- 현재 명부 사실("애매한 오너는 `ambiguous_owner` 보유자 — GD 2026-07-10 결정: 빌") —
  능력 이름을 이미 함께 적고 있어 이름은 예시다

## 검증 결과

주석만이라 동작 검증은 없다. 전체 2303 pass · 신규 실패 0 · 타입 신규 오류 0(변화 없음).

**테스트는 만들지 않았다.** "주석에 팀원 이름이 없다" 를 재려면 소스 문자열 검사가 되는데,
위 "안 건드린 것" 처럼 **이름이 정당하게 들어가는 주석과 구분할 수 없다.** 판별력 없는 검사기는
다음 사람이 정당한 주석을 지우게 만든다. 검사기 건은 별도 카드로 있다.

## 롤백

주석만 되돌린다. 동작에 영향 없음.

Submitted-by: steve