### PR TITLE
docs(hooks): owner-gate 머리말의 틀린 사실 3가지 — 따라 하면 이중 배선이 된다

### DIFF
--- a/hooks/telegram-owner-gate.py
+++ b/hooks/telegram-owner-gate.py
@@ -18,13 +18,18 @@ v1 범위 (안전 우선):
 v2 (후속):
   - reply/sticky 게이팅: 경로 A엔 reply 원문/sticky 가 없으니, 캡처가 버스에 적재한
     reply_to_agent + activeAssigneeId 를 끌어와 /api/route 에 넣어 T4(코덱스 답장→codex) 등도 차단.
-  - 👀 react owner-only: 현재 telegram-progress react 가 모든 그룹 메시지에 👀 를 단다.
-    owner 일 때만 달도록 react 훅과 통합 필요(이 게이트의 owner 판정 공유).
+  (👀 react owner-only 는 ★이미 되어 있다★ — telegram-progress 의 `_react_owner_skip` 이
+   owner 가 아니면 리액션을 건너뛴다. 이 항목은 남은 과제가 아니다.)
 
-설치 (터미널 = self-mod, 채널 OK로는 분류기가 막음):
-  cp hooks/telegram-owner-gate.py ~/.claude/hooks/
-  ~/.claude/settings.json 의 UserPromptSubmit 에 등록(telegram-progress react 보다 먼저 권장)
-  빌 poller 재시작 후 T1~T6 로 라이브 검증.
+설치:
+  ★손으로 복사하지 마라. 서버가 자동으로 깐다★ — `installOwnerGateHook`(launcher)이 멤버
+  워크스페이스 `.claude/` 에 훅 파일과 `UserPromptSubmit` 배선을 넣고, 부팅 때 `ensureOwnerGateHook`
+  이 없으면 새로 깐다. 커맨드에 `B3OS_ROOT`·`OWNER_GATE_SELF` 도 서버가 실어준다.
+
+  ★전역(`~/.claude/settings.json`)에 손으로 걸지 마라.★ 멤버 스코프와 양쪽에 걸리면
+  ★게이트가 두 번 돈다.★ 예전 안내가 전역 등록이었고, 그 이중 배선을 걷어낸 적이 있다.
+
+  라이브 확인이 필요하면 ★해당 멤버★ 의 poller 를 재시작한 뒤 본다.
 
 ⚠ 설치/테스트 시 검증할 것:
   - UserPromptSubmit block 계약: 이 버전은 stdout JSON {"decision":"block"} 을 쓴다.


### PR DESCRIPTION
머리말이 **지금은 틀린 설치 절차**를 안내하고 있었다. 따라 하면 게이트가 두 번 돈다.

바뀌는 것: 머리말 문구. 동작 변화 없음.
영향: 이 파일을 읽는 사람 — **다른 팀이 실제로 읽고 있다.**
규모: 주석만.

## 무엇이 문제인가

**① 설치 절차가 지금은 해로운 지시다**

```
머리말:  cp hooks/telegram-owner-gate.py ~/.claude/hooks/
         ~/.claude/settings.json 의 UserPromptSubmit 에 등록
실제:    installOwnerGateHook(launcher) 이 멤버 스코프에 자동 설치
```

**그대로 따라 하면 전역과 멤버 양쪽에 걸려 게이트가 두 번 돈다.** 오늘 `react` 에서
정확히 그 이중 배선을 걷어냈다. **기본값이 틀린 것보다 이쪽이 위험하다** —
기본값은 안 실릴 때만 문제인데, 이건 **읽는 사람이 그대로 실행한다.**

**② 이미 한 일이 "후속 과제" 로 남아 있다**

"react 가 모든 그룹 메시지에 👀 를 단다 → owner 일 때만 달도록 통합 필요" 라고 적혀 있는데,
`telegram-progress.py` 의 `_react_owner_skip` 이 **이미 owner 가 아니면 건너뛴다.**

**③ 재시작 안내가 특정 팀원 이름이다** — 공개 설치에는 그런 이름이 없다.

## 왜 그렇게 되나

**주석은 테스트가 없어서 코드가 바뀌어도 안 깨진다.** 특히 "설치 절차" 같은 문단은
코드에서 멀리 떨어져 있어 같이 고쳐질 계기가 없다.

## 어떻게 고쳤나

- 설치 절차 → **"손으로 복사하지 마라. 서버가 자동으로 깐다"** + 전역에 걸면 이중이 된다는 경고
- v2 항목 → **이미 되어 있다**고 정정(어디서 하는지 함수명까지)
- 재시작 안내 → **해당 멤버**

**배경 서술은 그대로 뒀다.** 특정 팀원이 그룹 전체 메시지를 직접 받는다는 설명은 **사실이고,
게이트가 왜 있는지를 설명한다.** 규칙을 이름으로 설명하는 것과 사실을 적는 것은 다르다.

## 검증 결과

주석만이라 동작 검증은 없다. 훅 테스트 통과, 타입 변화 없음.

## 롤백

주석만 되돌린다.

Submitted-by: steve