### PR TITLE
fix(bus): 1:1 방에서 내 답만 팀버스로 찍히던 것 — 한 방은 한 이름이어야 한다

### DIFF
--- a/src/server/bus/contextLineOrigin.test.ts
+++ b/src/server/bus/contextLineOrigin.test.ts
@@ -104,3 +104,44 @@ describe("주입 문맥은 줄마다 출처를 밝힌다", () => {
     expect(teamContextLabel("en")).not.toContain("Group-room");
   });
 });
+
+describe("한 방은 한 이름으로만 보인다", () => {
+  const DM = "task-1"; // 그룹이 아닌 스레드
+
+  /** 그 본문 줄의 출처 라벨만 뽑는다. */
+  const labelOf = (ctx: string, needle: string): string =>
+    lineFor(ctx, needle).match(/\[([^\s·]+) ·/)?.[1] ?? "(없음)";
+
+  test("★1:1 방에서는 내 답도 1:1 이다★ — 예전엔 내 답만 팀버스로 찍혔다", () => {
+    const db = setup();
+    put(db, DM, "user", "steve", "팀장님이 물었다", "user");
+    put(db, DM, "steve", "user", "내가 답했다", "agent");
+
+    const ctx = buildTeamContext(db, DM, "steve");
+    expect(labelOf(ctx, "팀장님이 물었다")).toBe("1:1");
+    expect(labelOf(ctx, "내가 답했다")).toBe("1:1");
+  });
+
+  test("★같은 스레드에서 두 이름이 나오면 안 된다★ — 방이 둘로 보인다", () => {
+    const db = setup();
+    put(db, DM, "user", "steve", "질문", "user");
+    put(db, DM, "steve", "user", "답", "agent");
+    put(db, DM, "user", "steve", "추가 질문", "user");
+
+    const ctx = buildTeamContext(db, DM, "steve");
+    const labels = new Set(["질문", "답", "추가 질문"].map((n) => labelOf(ctx, n)));
+    expect([...labels]).toEqual(["1:1"]);
+  });
+
+  test("팀원끼리의 비그룹 스레드는 그대로 팀버스", () => {
+    const db = setup();
+    put(db, DM, "bill", "steve", "버스 위임", "agent");
+    expect(labelOf(buildTeamContext(db, DM, "steve"), "버스 위임")).toBe("팀버스");
+  });
+
+  test("단톡방으로 온 개인 수신 DM 은 여전히 팀버스", () => {
+    const db = setup();
+    put(db, GROUP, "bill", "steve", "방으로 온 버스 DM", "agent");
+    expect(labelOf(buildTeamContext(db, GROUP, "steve"), "방으로 온 버스 DM")).toBe("팀버스");
+  });
+});

--- a/src/server/channels/registry.ts
+++ b/src/server/channels/registry.ts
@@ -62,8 +62,17 @@ export function lineOrigin(
 ): LineOrigin {
   if (m.source === "system") return "시스템";
   const inRoom = m.to_agent_id === "broadcast" || m.type === "broadcast";
-  if (m.source === "user") return isGroupThread ? "단체" : "1:1";
-  return isGroupThread && inRoom ? "단체" : "팀버스";
+  if (isGroupThread) {
+    // 방 안에서는 팀장님 글도, 방에 올린 글도 전부 "방에 떠 있는 말" 이다.
+    // 방 스레드로 들어온 개인 수신 DM 만 팀버스다.
+    if (m.source === "user" || inRoom) return "단체";
+    return "팀버스";
+  }
+  // ★그룹이 아닌 방 — 상대가 팀장님이면 양방향 다 1:1 이다.★
+  //   예전에는 발신 축만 봐서 ★같은 1:1 방인데 내 답만 '팀버스' 로 찍혔다.★
+  //   한 방이 두 이름으로 보이면 읽는 쪽은 다른 경로라고 읽는다 — ★이 표시가 없애려던 바로 그 오독이다.★
+  if (m.source === "user" || m.to_agent_id === "user") return "1:1";
+  return "팀버스";
 }
 
 /**


### PR DESCRIPTION
같은 1:1 스레드인데 방향에 따라 라벨이 갈렸다. **한 방이 두 이름으로 보였다.**

바뀌는 것: 그룹이 아닌 방에서 상대가 팀장님이면 **양방향 다 `1:1`**.
영향: 1:1(대시보드·DM) 스레드로 깨어나는 팀원 전원.
규모: 판정 함수 1곳, 신규 테스트 4건.

## 무엇이 문제인가

라이브 1:1 스레드에서 실제로 이렇게 찍혔다:

```
[1:1  · user → 너]   팀장님 메시지
[팀버스 · 너 → user]  내 답        ← 같은 방인데 다른 이름
```

**한 방이 두 이름으로 보이면 읽는 쪽은 다른 경로라고 읽는다.**
그게 `#229` 가 없애려던 오독 그 자체다 — 이 기능이 자기 출력에서 그 오독을 만들고 있었다.

## 왜 그렇게 되나

`lineOrigin` 이 **발신 축만** 봤다.

```ts
if (m.source === "user") return isGroupThread ? "단체" : "1:1";
return isGroupThread && inRoom ? "단체" : "팀버스";   // ← agent 는 무조건 팀버스
```

`source === "agent"` 인 줄은 **어느 방이든 팀버스**로 떨어진다.
1:1 방에서 내가 보낸 답이 정확히 그 경우다.

**출처는 "누가 보냈나" 가 아니라 "어느 방을 거쳤나" 다.** 축을 하나만 봐서 갈렸다.

## 어떻게 고쳤나

그룹 여부로 먼저 갈라 놓고, **비그룹 방에서는 상대가 팀장님이면 양방향 다 `1:1`** 로 본다.

| 방 | 줄 | 결과 |
|---|---|---|
| 비그룹 | 팀장님 ↔ 나 (양방향) | **1:1** |
| 비그룹 | 팀원 → 팀원 | 팀버스 |
| 그룹 | 팀장님 글 · 방에 올린 글 | 단체 |
| 그룹 | 개인 수신 DM | 팀버스 |

## 검증 결과

**라이브 스레드로 확인했다.** 고치기 전에는 위 표처럼 섞여 있었고, 고친 뒤:

```
 (4분 전)[1:1 · user → 너] 대시보드 메시지 테스트
★(3분 전)[1:1 · 너 → user] ✦ 스티브 — 대시보드 메시지 받았습니다…
 (3분 전)[1:1 · user → 너] 다시 테스트
★(2분 전)[1:1 · 너 → user] ✦ 스티브 — 두 번째도…
```

**뮤턴트** — 옛 규칙(발신 축만)으로 되돌리면 **2건이 죽는다.**

새 테스트에는 **"같은 스레드에서 두 이름이 나오면 실패"** 를 직접 넣었다. 라벨 하나씩만 재면
**다시 갈라져도 각 줄은 통과한다** — 갈라짐 자체를 재야 한다.

전체 2321 pass · **신규 실패 0** · 타입 신규 오류 0.

## 롤백

되돌리면 1:1 방에서 팀원 발신 줄이 다시 `팀버스` 로 찍힌다. 데이터 변경 없음.

Submitted-by: steve