### PR TITLE
chore(release): 0.6.0 → 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team-collab",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/src/web/components/LiveBadge.ts
+++ b/src/web/components/LiveBadge.ts
@@ -5,7 +5,7 @@
 
 const LIVE_HOSTS = new Set(["dev.b3rys.com"]);
 // b3os 제품 버전. package.json version과 맞춰 관리.
-export const APP_VERSION = "0.6.0";
+export const APP_VERSION = "0.6.1";
 
 export function shouldShowLiveBadge(hostname: string): boolean {
   return LIVE_HOSTS.has(hostname);


### PR DESCRIPTION
0.6.0 이후 머지된 7건을 묶는다.

- #212 스레드/1:1 대화 스크롤 — 위에서 읽는 중엔 위치 보존, 바닥일 때만 따라가기 (외부 기여)
- #239 react 훅 배선을 멤버 스코프로 — 전역 래퍼의 손으로 관리하던 봇 목록에서 팀원이 빠졌다
- #240 화면이 팀원 id 를 이름으로 박고 있던 두 곳 — 그 이름이 없는 설치에서 깨진다
- #241 recovery 능력을 coordinator 로 통합 — 신규 설치 팀은 코디네이터가 보호받지 못했다
- #242 정지·재시작 규칙을 팀원 이름이 아니라 코디네이터로 설명
- #243 owner-gate 머리말의 설치 절차 — 그대로 따라 하면 훅이 두 번 걸린다
- #244 1:1 스레드 출처 라벨이 방향에 따라 갈리던 것

patch 로 올린다. #241 이 능력 하나를 제거하지만 `recovery` 는 공개 문서에 없었고
설치 경로가 부여한 적도 없다(`LEAD_CAPABILITIES` 는 coordinator·full_context 만 준다).
따라서 이 능력에 의존하던 공개 설치가 없다.

MAC_APP_DOWNLOAD_TAG 는 v0.6.0 그대로 둔다. 이 값은 현재 버전이 아니라
b3os.app.zip 자산이 실제로 붙어 있는 태그를 가리킨다.
