### PR TITLE
채팅 말풍선 인라인 마크다운: **볼드**·`코드`·[링크] 를 원문 대신 스타일로

### DIFF
--- a/src/web/components/Chat.ts
+++ b/src/web/components/Chat.ts
@@ -7,6 +7,7 @@ import { agentIconName, renderIcon } from "../icons";
 import { renderAgentIcon } from "../agentColors";
 import { pick } from "../i18n";
 import { captureScrollStick, applyScrollStick, stickToBottom } from "../lib/scrollStick";
+import { mdInlineToHtml } from "../lib/mdInline";
 
 function api(path: string): string { return `${apiBase()}/api${path}`; }
 function escape(s: unknown): string {
@@ -113,7 +114,7 @@ export function renderChat(root: HTMLElement): void {
       return `
         <div class="flex flex-col ${align} gap-0.5">
           <div class="text-[10px] text-slate-500 px-1">${meta} · ${hhmm(m.created_at)}</div>
-          <div class="max-w-[78%] rounded-2xl px-3.5 py-2 text-sm leading-relaxed whitespace-pre-wrap ${bubble}">${escape(m.body)}</div>
+          <div class="max-w-[78%] rounded-2xl px-3.5 py-2 text-sm leading-relaxed whitespace-pre-wrap [&_a]:underline [&_a]:underline-offset-2 ${bubble}">${mdInlineToHtml(m.body)}</div>
         </div>`;
     }).join("");
     applyScrollStick(wrap, stick);

--- a/src/web/components/Reports.ts
+++ b/src/web/components/Reports.ts
@@ -11,6 +11,7 @@
 
 import { pick } from "../i18n";
 import { parseSqliteDate } from "../lib/datetime";
+import { mdInlineToHtml } from "../lib/mdInline";
 import { humanizeApiError } from "../lib/apiErrorMessage";
 import { showAlert, showConfirm, showForm, showPrompt } from "./dialogs";
 
@@ -155,14 +156,9 @@ function mdToHtml(src: string): string {
   const lines = String(src).replace(/\r\n/g, "\n").split("\n");
   const out: string[] = [];
   let i = 0;
-  const inline = (t: string): string => {
-    let s = escape(t);
-    s = s.replace(/`([^`]+)`/g, (_m, c) => `<code>${c}</code>`);
-    s = s.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
-    s = s.replace(/(^|[^*])\*([^*]+)\*/g, "$1<em>$2</em>");
-    s = s.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (_m, txt, href) => `<a href="${escape(href)}" target="_blank" rel="noopener">${txt}</a>`);
-    return s;
-  };
+  // 인라인 처리 = lib/mdInline 공유 헬퍼 (Chat/ThreadView 와 단일 출처, GD 2026-08-01).
+  // 원본 대비 강화 2건이 여기에도 적용된다: javascript: 링크 차단(http/https 만), 공백 경계 이탤릭 오변환 방지.
+  const inline = (t: string): string => mdInlineToHtml(t);
   while (i < lines.length) {
     const ln = lines[i]!;
     if (/^\s*$/.test(ln)) { i++; continue; }

--- a/src/web/components/ThreadView.ts
+++ b/src/web/components/ThreadView.ts
@@ -8,6 +8,7 @@ import { agentIconName, renderIcon } from "../icons";
 import { pick, getLocale } from "../i18n";
 import { parseSqliteDate } from "../lib/datetime";
 import { captureScrollStick, applyScrollStick, stickToBottom } from "../lib/scrollStick";
+import { mdInlineToHtml } from "../lib/mdInline";
 import { showAlert } from "./dialogs";
 
 function safeRelative(s: string | null): string {
@@ -145,7 +146,7 @@ export function renderThreadView(root: HTMLElement): void {
                 <span class="text-[10px] text-slate-500">${time}</span>
                 ${hopBadge}${expiredBadge}
               </div>
-              <div class="text-sm text-slate-200 whitespace-pre-wrap">${escape(m.body)}</div>
+              <div class="text-sm text-slate-200 whitespace-pre-wrap [&_a]:underline [&_a]:underline-offset-2">${mdInlineToHtml(m.body)}</div>
             </div>
           </div>`;
       })

--- a/src/web/components/chatScroll.dom.test.ts
+++ b/src/web/components/chatScroll.dom.test.ts
@@ -17,7 +17,7 @@ const savedGlobals: Record<string, unknown> = {};
 let prevFetch: typeof fetch;
 
 const MSGS = [
-  { id: "c1", thread_id: "dm-user-lisa", from_agent_id: "lisa", to_agent_id: "user", type: "dm", body: "보고 1", source: "agent", hop_count: 0, in_reply_to: null, read_at: null, delivery_status: "delivered", retry_count: 0, expires_at: null, priority: "normal", dedupe_key: null, created_at: "2026-08-01 04:00:00" },
+  { id: "c1", thread_id: "dm-user-lisa", from_agent_id: "lisa", to_agent_id: "user", type: "dm", body: "**보고** 1 <b>x</b>", source: "agent", hop_count: 0, in_reply_to: null, read_at: null, delivery_status: "delivered", retry_count: 0, expires_at: null, priority: "normal", dedupe_key: null, created_at: "2026-08-01 04:00:00" },
   { id: "c2", thread_id: "dm-user-lisa", from_agent_id: "lisa", to_agent_id: "user", type: "dm", body: "보고 2", source: "agent", hop_count: 0, in_reply_to: null, read_at: null, delivery_status: "delivered", retry_count: 0, expires_at: null, priority: "normal", dedupe_key: null, created_at: "2026-08-01 04:01:00" },
 ];
 
@@ -98,6 +98,9 @@ describe("Chat(1:1) scroll retention", () => {
       const wrap = root.querySelector<HTMLElement>("#chat-msgs");
       expect(wrap).not.toBeNull();
       expect(wrap!.children.length).toBe(2);
+      // 인라인 마크다운 배선 가드: **볼드** 는 <strong> 으로, 원문 HTML 은 이스케이프된 채.
+      expect(wrap!.querySelector("strong")?.textContent).toBe("보고");
+      expect(wrap!.querySelector("b")).toBeNull(); // <b>x</b> 가 실제 태그로 들어가면 XSS
       mockMetrics(wrap!); // scrollHeight 1000 · viewport 400
 
       // ── ① 위에서 읽는 중 + 폴링 재렌더(1.5s 주기) → 위치 보존 ──

--- a/src/web/components/threadViewScroll.dom.test.ts
+++ b/src/web/components/threadViewScroll.dom.test.ts
@@ -116,7 +116,7 @@ describe("ThreadView scroll retention", () => {
       })) as unknown as typeof fetch;
     try {
       st.setThreads([thread as never]);
-      st.setThreadMessages("th-scroll", [msg("m1", "첫 보고"), msg("m2", "둘째 보고")] as never);
+      st.setThreadMessages("th-scroll", [msg("m1", "**첫** 보고"), msg("m2", "둘째 보고")] as never);
       renderThreadView(root);
       st.selectThread("th-scroll");
 
@@ -125,6 +125,8 @@ describe("ThreadView scroll retention", () => {
       mockMetrics(body!);
       // 전제 확인: 메시지 2개 → scrollHeight 1000, 뷰포트 400 → 스크롤 가능.
       expect(body!.scrollHeight).toBe(1000);
+      // 인라인 마크다운 배선 가드: **볼드** 가 <strong> 으로 렌더된다 (mdInline, GD 2026-08-01).
+      expect(body!.querySelector("strong")?.textContent).toBe("첫");
 
       // ── 시나리오 1: 위로 스크롤해 읽는 중(120px 지점) + 새 메시지 폴링 도착 ──
       body!.scrollTop = 120;

--- a/src/web/lib/mdInline.test.ts
+++ b/src/web/lib/mdInline.test.ts
@@ -1,0 +1,66 @@
+// mdInline — 채팅 말풍선용 인라인 마크다운 렌더 단위 테스트.
+//   배경(GD 2026-08-01): 팀원 메시지가 **강조**·`코드` 마크다운을 그대로 별표로 노출.
+//   Reports.ts mdToHtml 의 inline 처리를 공유 헬퍼로 추출 — 이 파일이 그 계약의 회귀 가드.
+//   ★블록 문법(헤딩·표·리스트)은 다루지 않는다★ — 말풍선은 whitespace-pre-wrap 로 개행을
+//   보존하므로 인라인 변환만 안전하다.
+import { describe, expect, test } from "bun:test";
+import { mdInlineToHtml } from "./mdInline";
+
+describe("mdInlineToHtml — 변환", () => {
+  test("**볼드** → <strong>", () => {
+    expect(mdInlineToHtml("이건 **중요** 합니다")).toBe("이건 <strong>중요</strong> 합니다");
+  });
+
+  test("여러 개의 볼드", () => {
+    expect(mdInlineToHtml("**결론부터** 그리고 **왜**")).toBe(
+      "<strong>결론부터</strong> 그리고 <strong>왜</strong>",
+    );
+  });
+
+  test("*이탤릭* → <em> (볼드와 공존)", () => {
+    expect(mdInlineToHtml("*기울임* 과 **굵게**")).toBe("<em>기울임</em> 과 <strong>굵게</strong>");
+  });
+
+  test("`코드` → <code>", () => {
+    expect(mdInlineToHtml("실행: `bun test` 하세요")).toBe(
+      "실행: <code>bun test</code> 하세요",
+    );
+  });
+
+  test("[텍스트](https://...) → 안전한 링크(새 탭·noopener)", () => {
+    expect(mdInlineToHtml("[문서](https://example.com/a)")).toBe(
+      '<a href="https://example.com/a" target="_blank" rel="noopener">문서</a>',
+    );
+  });
+
+  test("개행은 건드리지 않는다 (pre-wrap 컨테이너가 처리)", () => {
+    expect(mdInlineToHtml("첫 줄\n**둘째** 줄")).toBe("첫 줄\n<strong>둘째</strong> 줄");
+  });
+
+  test("마크다운 없는 평문은 이스케이프 외 변화 없음", () => {
+    expect(mdInlineToHtml("그냥 평범한 문장")).toBe("그냥 평범한 문장");
+  });
+});
+
+describe("mdInlineToHtml — 안전(이스케이프·XSS)", () => {
+  test("HTML 태그는 이스케이프된다", () => {
+    expect(mdInlineToHtml('<img src=x onerror="alert(1)">')).toBe(
+      "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;",
+    );
+  });
+
+  test("볼드 안의 HTML 도 이스케이프", () => {
+    expect(mdInlineToHtml("**<b>x</b>**")).toBe("<strong>&lt;b&gt;x&lt;/b&gt;</strong>");
+  });
+
+  test("javascript: 링크는 링크로 만들지 않는다 (http/https 만 허용)", () => {
+    const out = mdInlineToHtml("[클릭](javascript:alert(1))");
+    expect(out).not.toContain("<a ");
+    expect(out).toContain("클릭"); // 텍스트는 남는다(이스케이프된 원문 형태)
+  });
+
+  test("불완전한 별표는 그대로 노출 (오변환 금지)", () => {
+    expect(mdInlineToHtml("2 * 3 = 6, a*b")).not.toContain("<em>");
+    expect(mdInlineToHtml("**닫히지 않음")).toBe("**닫히지 않음");
+  });
+});

--- a/src/web/lib/mdInline.ts
+++ b/src/web/lib/mdInline.ts
@@ -1,0 +1,29 @@
+// mdInline — 채팅 말풍선용 인라인 마크다운 (단일 출처).
+//   배경(GD 2026-08-01): 팀원 메시지의 **강조**·`코드`·[링크](url) 가 원문 그대로 노출됐다.
+//   Reports.ts mdToHtml 의 inline 처리를 추출·공유한다. ★인라인만★ — 블록 문법(헤딩·표·리스트)은
+//   말풍선 레이아웃(whitespace-pre-wrap, 개행 보존)을 깨므로 다루지 않는다.
+//   Reports 원본 대비 의도적 강화 2건:
+//     ① 링크는 http/https 만 <a> 로 (javascript: 등 스킴 주입 차단 — 채팅은 외부 발신 텍스트가 들어온다)
+//     ② 이탤릭은 내용 양끝이 공백이 아닐 때만 ("2 * 3 = 6, a*b" 같은 산식 오변환 방지)
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/** 이스케이프 → `code` → **bold** → *em* → [링크](http…) 순서로 변환한 HTML 을 돌려준다.
+ *  ★입력을 통째로 이스케이프한 뒤★ 우리가 만든 고정 태그만 삽입하므로 원문 HTML 은 실행되지 않는다. */
+export function mdInlineToHtml(text: string): string {
+  let s = escapeHtml(String(text ?? ""));
+  s = s.replace(/`([^`]+)`/g, (_m, c) => `<code>${c}</code>`);
+  s = s.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  // 내용 양끝 비공백(\S) 요구 — 곱셈 기호·불릿 잔재를 기울임으로 오인하지 않는다.
+  s = s.replace(/(^|[^*])\*(\S(?:[^*]*\S)?)\*(?!\*)/g, "$1<em>$2</em>");
+  s = s.replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, (_m, txt, href) =>
+    `<a href="${href}" target="_blank" rel="noopener">${txt}</a>`);
+  return s;
+}


### PR DESCRIPTION
## 무엇을

1:1/스레드 채팅 말풍선이 `**볼드**` · `` `코드` `` · `[링크](url)` 를 **별표 원문 그대로** 보여주고 있었다. 팀원 메시지가 강조를 많이 쓰는데 읽는 쪽에서 마크업이 그대로 노출된다.

`Reports.ts` 의 `mdToHtml` 안에 있던 인라인 처리를 `src/web/lib/mdInline.ts` 로 추출해 **Chat · ThreadView · Reports 세 곳이 같은 구현을 공유**하게 했다(단일 출처).

## 범위 — 인라인만

블록 문법(헤딩·표·리스트)은 **다루지 않는다.** 말풍선은 `whitespace-pre-wrap` 으로 개행을 보존하는 레이아웃이라 블록 변환을 넣으면 그 레이아웃이 깨진다.

## Reports 원본 대비 의도적 강화 2건 (Reports 에도 함께 적용)

1. **링크는 `http`/`https` 스킴만 `<a>` 로 만든다** — `javascript:` 스킴 주입 차단. 채팅은 외부에서 들어온 텍스트가 표시되는 표면이라 Reports 보다 입력 신뢰도가 낮다.
2. **이탤릭은 양끝이 비공백일 때만 변환** — `2 * 3 = 6` 같은 산식이 이탤릭으로 오변환되는 것을 막는다.

## 테스트

- `src/web/lib/mdInline.test.ts` 신규 **11 케이스** — 변환·이스케이프·XSS(`javascript:`·원문 HTML 태그)·오변환 금지
- 기존 DOM 테스트에 배선 가드 추가 — 말풍선에 `<strong>` 이 실제로 렌더되는지, 원문 HTML 태그가 실행되지 않는지
- 관련 테스트 **13/13 통과**, `tsc --noEmit` 통과

> 참고: `src/web/components/runtimeOptions.test.ts` 의 "온보딩 문서는 선택모드·BYO 체크리스트·Codex 제외 정책을 고정한다" 1건이 실패하는데, **이 PR 이전 `origin/main` 에서도 동일하게 실패**한다(해당 커밋을 뺀 상태로 확인). 이 변경과 무관하며 이 PR 에서 고치지 않았다.
