### PR TITLE
fix(router): owner-inference LLM 타임아웃을 env 로 빼고 기본 8초로

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,14 @@ GD_CHAT_ID=
 CAPTURE_BOT_TOKEN=
 # 라우터 ON 이어야 agent 를 실제로 깨워 응답시킴(OFF=shadow: 결정만 로그·응답 안 함). 기본 false.
 ROUTER_ENABLED=false
+# 라우터 owner-inference LLM (@멘션·답장·sticky 가 모두 없을 때 담당을 추론하는 경로).
+#   셋 다 선택 — 미설정이면 아래 기본값으로 돌고, 호출이 실패하면 조용히 regex 폴백으로 내려간다.
+#   원격 박스의 Ollama 를 볼 수도 있어(예: 사내 GPU 머신) URL·모델·상한을 환경마다 따로 준다.
+# TEAM_ROUTER_OLLAMA_URL=http://127.0.0.1:11434/api/chat
+# TEAM_ROUTER_MODEL=exaone3.5:2.4b
+#   호출 상한(ms). 기본 8000. 원격 + 7.8b 급 모델이면 응답이 1~3.5초로 흩어져 3000 은 짧다.
+#   숫자로 못 읽히거나 0 이하면 기본값을 쓴다.
+# TEAM_ROUTER_TIMEOUT_MS=8000
 # ─── 스케줄러 (칸반 과제리뷰·주간 잡 자동 실행) ───────────────
 # 서버 내장 스케줄러 — 켜면 매일 과제리뷰(06:00 팀원 핑 / 06:20 팀장 요약 DM)와 주간 잡을 자동 발화한다.
 #   ★공개(개인 장비)는 기본 ON★: 라이브는 이 잡들을 launchd(macOS)로 돌리는데 공개 빌드엔 launchd 가 없어,

--- a/src/server/lib/teamRouter/_shared.ts
+++ b/src/server/lib/teamRouter/_shared.ts
@@ -28,6 +28,20 @@ export interface RouteDecision {
 export const OLLAMA_URL = process.env.TEAM_ROUTER_OLLAMA_URL ?? "http://127.0.0.1:11434/api/chat";
 export const ROUTER_MODEL = process.env.TEAM_ROUTER_MODEL ?? "exaone3.5:2.4b";
 
+/**
+ * owner-inference LLM 호출 상한(ms). 라우터가 원격 박스의 Ollama 를 볼 수 있어 환경마다 적정값이
+ * 다르다 — URL·모델과 같은 자리에서 조절한다.
+ *
+ * 기본 8000: 원격(DGX Spark, exaone3.5:7.8b) 실측 응답이 1.2~3.4초로 흩어져, 기존 3000 이면 매
+ * 회차 1건이 3.00초에 잘려 regex 폴백으로 샜다. 폴백 누수만 막는 값이고 판정 정확도는 안 오른다.
+ *
+ * ★잘못 쓴 값은 무시하고 기본값을 쓴다★ — 0 이 들어가면 라우터 LLM 이 통째로 죽는데(전부 regex
+ * 폴백) 에러가 안 나서 아무도 모른다.
+ */
+const parsedTimeout = Number(process.env.TEAM_ROUTER_TIMEOUT_MS);
+export const ROUTER_TIMEOUT_MS =
+  Number.isFinite(parsedTimeout) && parsedTimeout > 0 ? parsedTimeout : 8_000;
+
 export type RouteIntent = "discussion" | "execution" | "other";
 
 export interface LlmRouteDecision extends RouteDecision {

--- a/src/server/lib/teamRouter/defaultIntake.ts
+++ b/src/server/lib/teamRouter/defaultIntake.ts
@@ -3,6 +3,7 @@ import {
   type LlmRouteDecision,
   OLLAMA_URL,
   ROUTER_MODEL,
+  ROUTER_TIMEOUT_MS,
   buildRosterText,
   classifyIntent,
 } from "./_shared";
@@ -53,7 +54,7 @@ export async function routeDefaultIntakeLLM(
   // 오너가 애매/무-확신일 때의 default 담당 = ambiguous_owner(GD 2026-07-10: 빌). 미설정 시 coordinator 폴백.
   const ambiguousOwner = ambiguousOwnerId(agents);
   const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? 3_000);
+  const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? ROUTER_TIMEOUT_MS);
   try {
     const res = await fetch(OLLAMA_URL, {
       method: "POST",


### PR DESCRIPTION
## 왜

라우터의 owner-inference LLM(`routeDefaultIntakeLLM`) 호출 상한이 `3_000` 으로 하드코딩돼 있었다. 이 LLM 이 항상 로컬 Ollama 를 보는 건 아니다 — 원격 박스(DGX Spark)의 Ollama 에 붙여보니 3초가 짧았다.

`exaone3.5:7.8b` 기준 4케이스 × 3회 실측:

| 질의 | 지연 | 3000ms 에서 |
|---|---|---|
| 인프라(디스크·로그로테이션) | 1.18~1.52s | 완주 |
| 일정·우선순위 | 1.21~1.32s | 완주 |
| 개발(리팩터링·테스트) | 2.73~2.83s | 완주 |
| 리서치(경쟁사 조사) | 3.27~3.37s | **3.00초에 잘림 → regex 폴백** |

모델이 짧게 답하면 1.2초대, `reason` 을 길게 쓰면 3초를 넘긴다. 매 회차 1건이 상한에 걸려 샜다.

## 무엇을

상한을 `_shared.ts` 의 `ROUTER_TIMEOUT_MS` 로 빼고 `TEAM_ROUTER_TIMEOUT_MS` 로 조절하게 했다. 같은 파일의 `OLLAMA_URL`/`ROUTER_MODEL` 과 같은 패턴이다.

- 기본 `8000` — `.env` 설정이 없어도 기존과 동작이 같아야 하는 게 아니라, **기존보다 관대해진다**. 3초 하드코딩으로 돌아가려면 `TEAM_ROUTER_TIMEOUT_MS=3000`.
- 숫자로 못 읽히거나 0 이하면 기본값을 쓴다. `0` 이 들어가면 라우터 LLM 이 통째로 죽는데(전부 regex 폴백) 에러가 안 나서 아무도 모른다.
- `.env.example` 에 `TEAM_ROUTER_*` 3종을 적었다 — URL·모델도 그동안 어디에도 문서화돼 있지 않았다.

## 효과 범위 — 과장하지 않기 위해

**이 변경은 폴백 누수만 막는다. 판정 정확도는 올리지 않는다.**

| | 3000ms | 8000ms |
|---|---|---|
| LLM 경로 완주 | 3/4 | **4/4** |
| 담당 판정 정확 | 2/4 | **2/4** (동일) |

3초를 넘기던 케이스도 8초를 주면 LLM 이 답은 하되 똑같이 coordinator 를 고른다. 남은 오답(개발·리서치 질의가 coordinator 로 감)은 타임아웃이 아니라 프롬프트의 보수적 편향("역할이 명확할 때만 specialist 를 고르라") 쪽 문제로 보이며, 별도 과제다.

그래도 넣을 값어치는 있다고 본다 — 결정이 매번 LLM 으로 완주해 재현 가능해지고, 3초 절벽에서 무작위로 폴백하던 게 사라진다.

### 검토했다가 버린 대안

모델 축소(`exaone3.5:2.4b`): 타임아웃은 0건이 되지만 4개 도메인을 **전부 coordinator 로 뭉갠다**(정확 1/4). regex 폴백과 사실상 동급이라 대안이 아니었다.

## 검증

- `tsc --noEmit` 통과
- 전체 테스트 `bun test`: **2317 pass / 8 fail / 1 error** — `origin/main`(2990f67) 기준선과 **완전히 동일**(각 2회 실행, 실패 테스트 목록도 일치). 8건은 이 PR 과 무관한 기존 실패다.
- env 배선 6케이스 — 상수값만이 아니라 실제 abort 까지 확인

  | `TEAM_ROUTER_TIMEOUT_MS` | `ROUTER_TIMEOUT_MS` | 실호출 |
  |---|---|---|
  | (미설정) | 8000 | 3437ms `via=llm` 완주 |
  | `1500` | 1500 | 1504ms 에 abort → `regex_fallback` |
  | `abc` / `0` / `-5` | 8000 | — |
  | `20000` | 20000 | — |

- `release-preflight --mode merge`: origin 확인 · worktree clean · 브랜치 확인 · 커밋 email 전부 noreply 통과. `main` 브랜치 보호 설정 읽기만 404(계정 권한 문제로 보이며 이 PR 과 무관).

## 미검증

실제 그룹방 트래픽에서의 판정 품질, 장시간 운영에서의 지연 분포. 위 수치는 4케이스 스냅샷이다.

## 롤백

`ROUTER_TIMEOUT_MS` 한 줄 되돌리거나, 배포 환경에서 `TEAM_ROUTER_TIMEOUT_MS=3000`.
