### PR TITLE
채팅 말풍선: 인라인 마크다운 렌더 + 스크롤 위치 보존

### DIFF
--- a/src/web/components/Chat.ts
+++ b/src/web/components/Chat.ts
@@ -7,6 +7,7 @@ import { agentIconName, renderIcon } from "../icons";
 import { renderAgentIcon } from "../agentColors";
 import { pick } from "../i18n";
 import { captureScrollStick, applyScrollStick, stickToBottom } from "../lib/scrollStick";
+import { mdInlineToHtml } from "../lib/mdInline";
 
 function api(path: string): string { return `${apiBase()}/api${path}`; }
 function escape(s: unknown): string {
@@ -113,7 +114,7 @@ export function renderChat(root: HTMLElement): void {
       return `
         <div class="flex flex-col ${align} gap-0.5">
           <div class="text-[10px] text-slate-500 px-1">${meta} · ${hhmm(m.created_at)}</div>
-          <div class="max-w-[78%] rounded-2xl px-3.5 py-2 text-sm leading-relaxed whitespace-pre-wrap ${bubble}">${escape(m.body)}</div>
+          <div class="max-w-[78%] rounded-2xl px-3.5 py-2 text-sm leading-relaxed whitespace-pre-wrap [&_a]:underline [&_a]:underline-offset-2 ${bubble}">${mdInlineToHtml(m.body)}</div>
         </div>`;
     }).join("");
     applyScrollStick(wrap, stick);

--- a/src/web/components/Chat.ts
+++ b/src/web/components/Chat.ts
@@ -6,6 +6,7 @@ import { apiBase } from "../ws";
 import { agentIconName, renderIcon } from "../icons";
 import { renderAgentIcon } from "../agentColors";
 import { pick } from "../i18n";
+import { captureScrollStick, applyScrollStick, stickToBottom } from "../lib/scrollStick";
 
 function api(path: string): string { return `${apiBase()}/api${path}`; }
 function escape(s: unknown): string {
@@ -90,13 +91,16 @@ export function renderChat(root: HTMLElement): void {
     void fetchMsgs(); startPoll();
   }
 
-  function paintMessages(): void {
+  // forceStick: 내가 보낸 직후엔 위에서 읽던 중이어도 바닥으로(내 말풍선 확인) — 그 외 재렌더는
+  // 바닥 근처일 때만 stick, 위로 스크롤해 읽는 중이면 위치 보존(scrollStick, GD 2026-08-01).
+  function paintMessages(forceStick = false): void {
     const wrap = root.querySelector<HTMLElement>("#chat-msgs");
     if (!wrap) return;
     if (!msgs.length) {
       wrap.innerHTML = `<div class="h-full flex items-center justify-center text-slate-500 text-sm">${pick("아직 대화가 없습니다. 첫 메시지를 보내보세요.", "No messages yet. Send the first one.")}</div>`;
       return;
     }
+    const stick = forceStick ? stickToBottom() : captureScrollStick(wrap);
     const agents = store.getState().agents;
     const nameOf = (id: string) => agents.find((a) => a.id === id)?.display_name ?? id;
     wrap.innerHTML = msgs.map((m) => {
@@ -112,7 +116,7 @@ export function renderChat(root: HTMLElement): void {
           <div class="max-w-[78%] rounded-2xl px-3.5 py-2 text-sm leading-relaxed whitespace-pre-wrap ${bubble}">${escape(m.body)}</div>
         </div>`;
     }).join("");
-    wrap.scrollTop = wrap.scrollHeight;
+    applyScrollStick(wrap, stick);
   }
 
   function paintShell(): void {
@@ -157,7 +161,7 @@ export function renderChat(root: HTMLElement): void {
         delivery_status: "pending", retry_count: 0, expires_at: null, priority: "normal",
         dedupe_key: null, created_at: new Date().toISOString(),
       }]);
-      paintMessages();
+      paintMessages(true); // 내 전송 직후는 항상 바닥으로 — 내 말풍선이 보여야 한다
       void send(v);
     });
     input?.focus();

--- a/src/web/components/Reports.ts
+++ b/src/web/components/Reports.ts
@@ -11,6 +11,7 @@
 
 import { pick } from "../i18n";
 import { parseSqliteDate } from "../lib/datetime";
+import { mdInlineToHtml } from "../lib/mdInline";
 import { humanizeApiError } from "../lib/apiErrorMessage";
 import { showAlert, showConfirm, showForm, showPrompt } from "./dialogs";
 
@@ -155,14 +156,9 @@ function mdToHtml(src: string): string {
   const lines = String(src).replace(/\r\n/g, "\n").split("\n");
   const out: string[] = [];
   let i = 0;
-  const inline = (t: string): string => {
-    let s = escape(t);
-    s = s.replace(/`([^`]+)`/g, (_m, c) => `<code>${c}</code>`);
-    s = s.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
-    s = s.replace(/(^|[^*])\*([^*]+)\*/g, "$1<em>$2</em>");
-    s = s.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (_m, txt, href) => `<a href="${escape(href)}" target="_blank" rel="noopener">${txt}</a>`);
-    return s;
-  };
+  // 인라인 처리 = lib/mdInline 공유 헬퍼 (Chat/ThreadView 와 단일 출처, GD 2026-08-01).
+  // 원본 대비 강화 2건이 여기에도 적용된다: javascript: 링크 차단(http/https 만), 공백 경계 이탤릭 오변환 방지.
+  const inline = (t: string): string => mdInlineToHtml(t);
   while (i < lines.length) {
     const ln = lines[i]!;
     if (/^\s*$/.test(ln)) { i++; continue; }

--- a/src/web/components/ThreadView.ts
+++ b/src/web/components/ThreadView.ts
@@ -6,6 +6,7 @@ import { enUS } from "date-fns/locale/en-US";
 import { agentIconName, renderIcon } from "../icons";
 import { pick, getLocale } from "../i18n";
 import { parseSqliteDate } from "../lib/datetime";
+import { captureScrollStick, applyScrollStick, stickToBottom } from "../lib/scrollStick";
 import { showAlert } from "./dialogs";
 
 function safeRelative(s: string | null): string {
@@ -82,6 +83,10 @@ export function renderThreadView(root: HTMLElement): void {
         if (!input || !input.value.trim()) return;
         const body = input.value.trim();
         input.value = "";
+        // 전송 즉시 바닥으로 — 내 메시지가 뜰 자리를 보여줘야 "전송됨"을 안다(리뷰 #1).
+        // 바닥에 있으면 도착 재렌더도 일반 캡처 로직으로 자연히 stick 하므로 별도 플래그는 불필요.
+        // (도착 전에 사용자가 다시 위로 올라가면 보존 — Chat 과 동일한 의도 해석.)
+        applyScrollStick(root.querySelector<HTMLElement>("#thread-msgs"), stickToBottom());
         const recipients = (t?.participants ?? []).filter((p) => p !== "user");
         const to = recipients[0] ?? "bill";
         const result = await sendMessage({
@@ -100,6 +105,9 @@ export function renderThreadView(root: HTMLElement): void {
     const body = root.querySelector<HTMLElement>("#thread-msgs");
     if (!body) return;
 
+    // 위로 스크롤해 읽는 중이면 폴링 재렌더가 위치를 뺏지 않는다 — 바닥 근처일 때만 stick.
+    // (무조건 scrollTop=scrollHeight 로 끌어내리던 문제 수정, GD 2026-08-01. scrollStick 참조.)
+    const stick = captureScrollStick(body);
     body.innerHTML = msgs
       .map((m: Message) => {
         const borderClass = SOURCE_BORDER[m.source] ?? "border-l-status-offline";
@@ -134,7 +142,7 @@ export function renderThreadView(root: HTMLElement): void {
           </div>`;
       })
       .join("");
-    body.scrollTop = body.scrollHeight;
+    applyScrollStick(body, stick);
   };
 
   update();

--- a/src/web/components/ThreadView.ts
+++ b/src/web/components/ThreadView.ts
@@ -7,6 +7,7 @@ import { agentIconName, renderIcon } from "../icons";
 import { pick, getLocale } from "../i18n";
 import { parseSqliteDate } from "../lib/datetime";
 import { captureScrollStick, applyScrollStick, stickToBottom } from "../lib/scrollStick";
+import { mdInlineToHtml } from "../lib/mdInline";
 import { showAlert } from "./dialogs";
 
 function safeRelative(s: string | null): string {
@@ -137,7 +138,7 @@ export function renderThreadView(root: HTMLElement): void {
                 <span class="text-[10px] text-slate-500">${time}</span>
                 ${hopBadge}${expiredBadge}
               </div>
-              <div class="text-sm text-slate-200 whitespace-pre-wrap">${escape(m.body)}</div>
+              <div class="text-sm text-slate-200 whitespace-pre-wrap [&_a]:underline [&_a]:underline-offset-2">${mdInlineToHtml(m.body)}</div>
             </div>
           </div>`;
       })

--- a/src/web/components/TmuxPane.ts
+++ b/src/web/components/TmuxPane.ts
@@ -103,6 +103,9 @@ export function renderTmuxPane(root: HTMLElement): void {
       lastLineCount = lines.length;
     }
 
+    // ★의도적으로 scrollStick(바닥 근처일 때만 stick) 미적용★ — 이 pane 은 tail -f 성격의 라이브 로그라
+    // "따라가기 기본 + 명시적 일시정지(pauseAutoScroll)" 가 계약이다. 채팅형(ThreadView/Chat)과 달리
+    // 스크롤 위치로 독자 의도를 추정하지 않는다. 바꾸려면 pause 버튼과의 상호작용을 함께 설계할 것. (2026-08-01)
     if (!pauseAutoScroll) {
       body.scrollTop = body.scrollHeight;
     }

--- a/src/web/components/chatScroll.dom.test.ts
+++ b/src/web/components/chatScroll.dom.test.ts
@@ -17,7 +17,7 @@ const savedGlobals: Record<string, unknown> = {};
 let prevFetch: typeof fetch;
 
 const MSGS = [
-  { id: "c1", thread_id: "dm-user-lisa", from_agent_id: "lisa", to_agent_id: "user", type: "dm", body: "보고 1", source: "agent", hop_count: 0, in_reply_to: null, read_at: null, delivery_status: "delivered", retry_count: 0, expires_at: null, priority: "normal", dedupe_key: null, created_at: "2026-08-01 04:00:00" },
+  { id: "c1", thread_id: "dm-user-lisa", from_agent_id: "lisa", to_agent_id: "user", type: "dm", body: "**보고** 1 <b>x</b>", source: "agent", hop_count: 0, in_reply_to: null, read_at: null, delivery_status: "delivered", retry_count: 0, expires_at: null, priority: "normal", dedupe_key: null, created_at: "2026-08-01 04:00:00" },
   { id: "c2", thread_id: "dm-user-lisa", from_agent_id: "lisa", to_agent_id: "user", type: "dm", body: "보고 2", source: "agent", hop_count: 0, in_reply_to: null, read_at: null, delivery_status: "delivered", retry_count: 0, expires_at: null, priority: "normal", dedupe_key: null, created_at: "2026-08-01 04:01:00" },
 ];
 
@@ -98,6 +98,9 @@ describe("Chat(1:1) scroll retention", () => {
       const wrap = root.querySelector<HTMLElement>("#chat-msgs");
       expect(wrap).not.toBeNull();
       expect(wrap!.children.length).toBe(2);
+      // 인라인 마크다운 배선 가드: **볼드** 는 <strong> 으로, 원문 HTML 은 이스케이프된 채.
+      expect(wrap!.querySelector("strong")?.textContent).toBe("보고");
+      expect(wrap!.querySelector("b")).toBeNull(); // <b>x</b> 가 실제 태그로 들어가면 XSS
       mockMetrics(wrap!); // scrollHeight 1000 · viewport 400
 
       // ── ① 위에서 읽는 중 + 폴링 재렌더(1.5s 주기) → 위치 보존 ──

--- a/src/web/components/chatScroll.dom.test.ts
+++ b/src/web/components/chatScroll.dom.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Chat(1:1 대화창) 스크롤 유지 — DOM 회귀 테스트 (threadViewScroll.dom.test.ts 의 Chat 판).
+ *   Chat 은 자체 1.5s 폴링(fetchMsgs→paintMessages)으로 재렌더한다. 가드하는 계약:
+ *   ① 위에서 읽는 중 폴링 재렌더 → 위치 보존   ② 내 전송(낙관적 렌더) → 무조건 바닥(forceStick)
+ *   fetch 는 전부 목킹 — 실서버(localhost:7878)로 나가면 안 된다.
+ */
+import { describe, expect, test, beforeAll, afterAll, afterEach } from "bun:test";
+import { Window } from "happy-dom";
+
+afterEach(() => {
+  const b = (globalThis as { document?: Document }).document?.body;
+  if (b) b.innerHTML = "";
+});
+
+const installedGlobals: string[] = [];
+const savedGlobals: Record<string, unknown> = {};
+let prevFetch: typeof fetch;
+
+const MSGS = [
+  { id: "c1", thread_id: "dm-user-lisa", from_agent_id: "lisa", to_agent_id: "user", type: "dm", body: "보고 1", source: "agent", hop_count: 0, in_reply_to: null, read_at: null, delivery_status: "delivered", retry_count: 0, expires_at: null, priority: "normal", dedupe_key: null, created_at: "2026-08-01 04:00:00" },
+  { id: "c2", thread_id: "dm-user-lisa", from_agent_id: "lisa", to_agent_id: "user", type: "dm", body: "보고 2", source: "agent", hop_count: 0, in_reply_to: null, read_at: null, delivery_status: "delivered", retry_count: 0, expires_at: null, priority: "normal", dedupe_key: null, created_at: "2026-08-01 04:01:00" },
+];
+
+beforeAll(() => {
+  const g = globalThis as Record<string, unknown>;
+  const win = (g.window as Window | undefined) ?? new Window();
+  for (const [k, v] of [
+    ["window", win],
+    ["document", win.document],
+    ["MutationObserver", win.MutationObserver],
+  ] as const) {
+    if (!g[k]) {
+      savedGlobals[k] = g[k];
+      installedGlobals.push(k);
+      g[k] = v;
+    }
+  }
+  // happy-dom 20.9 워크어라운드 (inboxAudit.dom.test.ts 참조): querySelector 가 window.SyntaxError 요구.
+  (win as unknown as { SyntaxError: typeof SyntaxError }).SyntaxError = SyntaxError;
+
+  // fetch 전면 목킹: threads 조회 = 고정 메시지, inbox 전송 = 성공. (Bun 전역 Response 사용 —
+  // happy-dom Response 를 심으면 뒤에 도는 서버 테스트가 오염된다, inboxRefined 교훈.)
+  prevFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: RequestInfo | URL) => {
+    const u = String(url);
+    if (u.includes("/threads/")) {
+      return new Response(JSON.stringify({ messages: MSGS }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (u.includes("/inbox")) {
+      return new Response(JSON.stringify({ ok: true, message: { thread_id: "dm-user-lisa" } }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+  }) as unknown as typeof fetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = prevFetch;
+  const g = globalThis as Record<string, unknown>;
+  for (const k of installedGlobals) g[k] = savedGlobals[k];
+});
+
+const MSG_PX = 500;
+const VIEWPORT_PX = 400;
+
+function mockMetrics(el: HTMLElement): void {
+  Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => el.children.length * MSG_PX });
+  Object.defineProperty(el, "clientHeight", { configurable: true, get: () => VIEWPORT_PX });
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("Chat(1:1) scroll retention", () => {
+  test("위에서 읽는 중 폴링 재렌더 → 위치 보존 · 내 전송 → 바닥(forceStick)", async () => {
+    const { store } = await import("../store");
+    const { renderChat } = await import("./Chat");
+
+    const st = store.getState();
+    const prevMainView = store.getState().mainView;
+    const prevAgents = store.getState().agents;
+    const prevAgent = store.getState().selectedAgentId;
+
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+
+    try {
+      st.setAgents([
+        {
+          id: "lisa", display_name: "Lisa", role: "PM", runtime: "claude_channel",
+          status_provider: "claude_tmux", tmux_session: null, telegram_bot_username: null,
+          workspace_path: "/tmp/x", persona_file: "SOUL.md", moderator_eligible: false, avatar_emoji: "🤖",
+        } as never,
+      ]);
+      st.setMainView("chat" as never);
+      st.selectAgent("lisa");
+      renderChat(root);
+      await sleep(80); // reinit → fetchMsgs(목킹) 반영 대기
+
+      const wrap = root.querySelector<HTMLElement>("#chat-msgs");
+      expect(wrap).not.toBeNull();
+      expect(wrap!.children.length).toBe(2);
+      mockMetrics(wrap!); // scrollHeight 1000 · viewport 400
+
+      // ── ① 위에서 읽는 중 + 폴링 재렌더(1.5s 주기) → 위치 보존 ──
+      wrap!.scrollTop = 100;
+      // 첫 자식에 마커를 심어, 폴링 후 마커가 사라졌는지로 "innerHTML 재작성이 실제 일어났음"을 증명
+      // (재렌더 없이 통과하는 공허한 테스트 방지).
+      wrap!.children[0]!.setAttribute("data-marker", "pre-poll");
+      await sleep(1700); // 폴링 1틱 이상 경과(fetchMsgs→paintMessages)
+      expect(wrap!.querySelector("[data-marker]")).toBeNull(); // 재렌더가 실제로 일어났고
+      expect(wrap!.children.length).toBe(2); // 내용은 동일한데
+      expect(wrap!.scrollTop).toBe(100); // ★위치가 보존되어야 한다★
+
+      // ── ② 위에서 읽는 중이어도 ★내 전송★(낙관적 렌더)은 바닥으로 ──
+      const input = root.querySelector<HTMLInputElement>("#chat-input")!;
+      const form = root.querySelector<HTMLFormElement>("#chat-form")!;
+      input.value = "지시 하나";
+      const EventCtor = (globalThis.window as unknown as { Event: typeof Event }).Event;
+      form.dispatchEvent(new EventCtor("submit", { bubbles: true, cancelable: true }));
+      // submit 핸들러 동기 구간: 낙관적 메시지 추가(3개) + paintMessages(true) → 바닥
+      expect(wrap!.children.length).toBe(3);
+      expect(wrap!.scrollTop).toBe(1500); // scrollHeight(3×500) — happy-dom 은 클램프 없음
+    } finally {
+      // 폴링 정지: mainView 를 chat 밖으로 돌리면 update() 가 stopPoll 한다. 이후 원상 복원.
+      st.setMainView(prevMainView as never);
+      st.selectAgent(prevAgent);
+      st.setAgents(prevAgents as never);
+      root.remove();
+    }
+  });
+});

--- a/src/web/components/threadViewScroll.dom.test.ts
+++ b/src/web/components/threadViewScroll.dom.test.ts
@@ -116,7 +116,7 @@ describe("ThreadView scroll retention", () => {
       })) as unknown as typeof fetch;
     try {
       st.setThreads([thread as never]);
-      st.setThreadMessages("th-scroll", [msg("m1", "첫 보고"), msg("m2", "둘째 보고")] as never);
+      st.setThreadMessages("th-scroll", [msg("m1", "**첫** 보고"), msg("m2", "둘째 보고")] as never);
       renderThreadView(root);
       st.selectThread("th-scroll");
 
@@ -125,6 +125,8 @@ describe("ThreadView scroll retention", () => {
       mockMetrics(body!);
       // 전제 확인: 메시지 2개 → scrollHeight 1000, 뷰포트 400 → 스크롤 가능.
       expect(body!.scrollHeight).toBe(1000);
+      // 인라인 마크다운 배선 가드: **볼드** 가 <strong> 으로 렌더된다 (mdInline, GD 2026-08-01).
+      expect(body!.querySelector("strong")?.textContent).toBe("첫");
 
       // ── 시나리오 1: 위로 스크롤해 읽는 중(120px 지점) + 새 메시지 폴링 도착 ──
       body!.scrollTop = 120;

--- a/src/web/components/threadViewScroll.dom.test.ts
+++ b/src/web/components/threadViewScroll.dom.test.ts
@@ -1,0 +1,202 @@
+/**
+ * ThreadView 스크롤 유지 — DOM 회귀 테스트.
+ *   증상(2026-08-01, GD 리포트): 1:1 스레드에서 위로 스크롤해 이전 보고를 읽는 중에도
+ *   폴링 재렌더마다 무조건 바닥으로 끌려 내려감 (구현이 재렌더 후 scrollTop=scrollHeight 고정).
+ *   기대: 바닥 근처일 때만 stick, 위에서 읽는 중이면 위치 보존.
+ *
+ *   happy-dom 은 레이아웃이 없어 scrollHeight 를 "메시지 노드 수 × 500px" getter 로 주입한다 —
+ *   innerHTML 재작성 순간에 scrollHeight 가 변하는 실제 브라우저 타이밍(캡처는 옛 높이,
+ *   적용은 새 높이)을 그대로 재현하기 위해서다.
+ */
+import { describe, expect, test, beforeAll, afterAll, afterEach } from "bun:test";
+import { Window } from "happy-dom";
+
+afterEach(() => {
+  const b = (globalThis as { document?: Document }).document?.body;
+  if (b) b.innerHTML = "";
+});
+
+// ★여기서 심은 전역은 여기서 걷는다★ (inboxRefined.dom.test.ts 와 동일 규약 — bun test 는
+//   파일들을 한 프로세스에서 돌리므로 되돌리지 않으면 뒤에 도는 서버 테스트가 오염된다.)
+const installedGlobals: string[] = [];
+const savedGlobals: Record<string, unknown> = {};
+
+beforeAll(() => {
+  const g = globalThis as Record<string, unknown>;
+  // 다른 DOM 테스트 파일이 먼저 window 를 심었을 수 있다 — 있으면 재사용, 없는 global 만 보강.
+  const win = (g.window as Window | undefined) ?? new Window();
+  for (const [k, v] of [
+    ["window", win],
+    ["document", win.document],
+    ["MutationObserver", win.MutationObserver],
+  ] as const) {
+    if (!g[k]) {
+      savedGlobals[k] = g[k];
+      installedGlobals.push(k);
+      g[k] = v;
+    }
+  }
+  // happy-dom 20.9 워크어라운드(inboxAudit.dom.test.ts 와 동일): SelectorParser 가 querySelector
+  // 마다 `new this.window.SyntaxError(...)` 를 즉시 생성하는데 Window 에 SyntaxError 가 없어
+  // "undefined is not a constructor" 로 터진다 → 표준 SyntaxError 를 심는다.
+  (win as unknown as { SyntaxError: typeof SyntaxError }).SyntaxError = SyntaxError;
+});
+
+afterAll(() => {
+  const g = globalThis as Record<string, unknown>;
+  for (const k of installedGlobals) g[k] = savedGlobals[k];
+});
+
+const MSG_PX = 500; // 메시지 1개당 가상 높이
+const VIEWPORT_PX = 400;
+
+/** happy-dom 레이아웃 부재 보완: scrollHeight = 자식 수 × MSG_PX (innerHTML 재작성 시 자동 반영). */
+function mockMetrics(el: HTMLElement): void {
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    get: () => el.children.length * MSG_PX,
+  });
+  Object.defineProperty(el, "clientHeight", { configurable: true, get: () => VIEWPORT_PX });
+}
+
+function msg(id: string, body: string) {
+  return {
+    id,
+    thread_id: "th-scroll",
+    from_agent_id: "lisa",
+    to_agent_id: "user",
+    type: "dm",
+    body,
+    source: "agent" as const,
+    hop_count: 0,
+    in_reply_to: null,
+    read_at: null,
+    delivery_status: "delivered" as const,
+    retry_count: 0,
+    expires_at: null,
+    priority: "normal" as const,
+    dedupe_key: null,
+    created_at: "2026-08-01 04:00:00",
+  };
+}
+
+const thread = {
+  id: "th-scroll",
+  title: "scroll test",
+  kind: "dm" as const,
+  participants: ["user", "lisa"],
+  moderator_agent_id: null,
+  status: "open" as const,
+  state: "active",
+  round_no: 0,
+  last_message_at: null,
+  opened_by: "user",
+  opened_at: "2026-08-01 04:00:00",
+  closed_at: null,
+};
+
+describe("ThreadView scroll retention", () => {
+  test("위에서 읽는 중 재렌더 → 위치 보존 · 바닥 근처 재렌더 → 바닥 stick · 내 전송 → 바닥", async () => {
+    const { store } = await import("../store");
+    const { renderThreadView } = await import("./ThreadView");
+
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+
+    const st = store.getState();
+    const prevSelected = store.getState().selectedThreadId;
+    const prevThreads = store.getState().threads;
+    const prevThreadMessages = store.getState().threadMessages;
+    // 전송(sendMessage→fetch)이 실서버로 나가지 않게 성공 응답으로 목킹.
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+    try {
+      st.setThreads([thread as never]);
+      st.setThreadMessages("th-scroll", [msg("m1", "첫 보고"), msg("m2", "둘째 보고")] as never);
+      renderThreadView(root);
+      st.selectThread("th-scroll");
+
+      const body = root.querySelector<HTMLElement>("#thread-msgs");
+      expect(body).not.toBeNull();
+      mockMetrics(body!);
+      // 전제 확인: 메시지 2개 → scrollHeight 1000, 뷰포트 400 → 스크롤 가능.
+      expect(body!.scrollHeight).toBe(1000);
+
+      // ── 시나리오 1: 위로 스크롤해 읽는 중(120px 지점) + 새 메시지 폴링 도착 ──
+      body!.scrollTop = 120;
+      st.setThreadMessages("th-scroll", [
+        msg("m1", "첫 보고"),
+        msg("m2", "둘째 보고"),
+        msg("m3", "새 보고"),
+      ] as never);
+      // 같은 스레드 재렌더 — 컨테이너 요소는 유지된다(#thread-msgs 재사용).
+      const bodyAfter = root.querySelector<HTMLElement>("#thread-msgs");
+      expect(bodyAfter).toBe(body); // 같은 요소여야 위치 보존이 의미 있다
+      expect(body!.scrollHeight).toBe(1500); // 재렌더로 내용이 자람
+      expect(body!.scrollTop).toBe(120); // ★핵심: 바닥으로 끌려가면 회귀★
+
+      // ── 시나리오 2: 정확히 바닥(1500-400=1100)에서 새 메시지 → 새 바닥 따라감 ──
+      body!.scrollTop = 1100;
+      st.setThreadMessages("th-scroll", [
+        msg("m1", "첫 보고"),
+        msg("m2", "둘째 보고"),
+        msg("m3", "새 보고"),
+        msg("m4", "더 새 보고"),
+      ] as never);
+      expect(body!.scrollHeight).toBe(2000);
+      expect(body!.scrollTop).toBe(2000); // stick: scrollTop=scrollHeight (브라우저가 최대로 클램프)
+
+      // ── 시나리오 3: 내용 변화 없는 폴링 틱에서도 읽던 위치 보존 ──
+      body!.scrollTop = 300;
+      st.setThreadMessages("th-scroll", [
+        msg("m1", "첫 보고"),
+        msg("m2", "둘째 보고"),
+        msg("m3", "새 보고"),
+        msg("m4", "더 새 보고"),
+      ] as never);
+      expect(body!.scrollTop).toBe(300);
+
+      // ── 시나리오 4(리뷰 #1 회귀 가드): 위에서 읽는 중이어도 ★내 전송★은 즉시 바닥으로 ──
+      // 없으면 내 메시지가 뜰 자리가 안 보여 "전송이 조용히 실패한 것"처럼 보인다.
+      body!.scrollTop = 300; // 위에서 읽는 중
+      const input = root.querySelector<HTMLInputElement>("#thread-input")!;
+      const form = root.querySelector<HTMLFormElement>("#thread-form")!;
+      input.value = "내 답장";
+      const EventCtor = (globalThis.window as unknown as { Event: typeof Event }).Event;
+      form.dispatchEvent(new EventCtor("submit", { bubbles: true, cancelable: true }));
+      // 핸들러 동기 구간에서 즉시 바닥으로 (4개 메시지 = scrollHeight 2000)
+      expect(body!.scrollTop).toBe(2000);
+      // 바닥에 머무는 동안 내 메시지 도착 → 별도 플래그 없이 일반 캡처 로직으로 자연히 stick
+      st.setThreadMessages("th-scroll", [
+        msg("m1", "첫 보고"),
+        msg("m2", "둘째 보고"),
+        msg("m3", "새 보고"),
+        msg("m4", "더 새 보고"),
+        msg("m5", "내 답장"),
+      ] as never);
+      expect(body!.scrollTop).toBe(2500);
+      // 전송 후라도 사용자가 다시 위로 올라갔으면 보존 — Chat 과 동일한 의도 해석(스크롤 = 의도 신호)
+      body!.scrollTop = 200;
+      st.setThreadMessages("th-scroll", [
+        msg("m1", "첫 보고"),
+        msg("m2", "둘째 보고"),
+        msg("m3", "새 보고"),
+        msg("m4", "더 새 보고"),
+        msg("m5", "내 답장"),
+      ] as never);
+      expect(body!.scrollTop).toBe(200);
+    } finally {
+      // 전역 store 오염 정리 — 뒤에 도는 테스트 파일 보호. ★저장해둔 원값을 그대로 복원★(대칭).
+      // ★selectThread 를 먼저★: 선택 해제 후의 상태 복원 갱신은 update() 의 early-return(빈 화면)
+      // 경로만 타서, 정리 중 재렌더가 본 테스트 대상 DOM 을 다시 만지지 않는다.
+      st.selectThread(prevSelected);
+      store.setState({ threads: prevThreads, threadMessages: prevThreadMessages });
+      globalThis.fetch = prevFetch;
+      root.remove();
+    }
+  });
+});

--- a/src/web/lib/mdInline.test.ts
+++ b/src/web/lib/mdInline.test.ts
@@ -1,0 +1,66 @@
+// mdInline — 채팅 말풍선용 인라인 마크다운 렌더 단위 테스트.
+//   배경(GD 2026-08-01): 팀원 메시지가 **강조**·`코드` 마크다운을 그대로 별표로 노출.
+//   Reports.ts mdToHtml 의 inline 처리를 공유 헬퍼로 추출 — 이 파일이 그 계약의 회귀 가드.
+//   ★블록 문법(헤딩·표·리스트)은 다루지 않는다★ — 말풍선은 whitespace-pre-wrap 로 개행을
+//   보존하므로 인라인 변환만 안전하다.
+import { describe, expect, test } from "bun:test";
+import { mdInlineToHtml } from "./mdInline";
+
+describe("mdInlineToHtml — 변환", () => {
+  test("**볼드** → <strong>", () => {
+    expect(mdInlineToHtml("이건 **중요** 합니다")).toBe("이건 <strong>중요</strong> 합니다");
+  });
+
+  test("여러 개의 볼드", () => {
+    expect(mdInlineToHtml("**결론부터** 그리고 **왜**")).toBe(
+      "<strong>결론부터</strong> 그리고 <strong>왜</strong>",
+    );
+  });
+
+  test("*이탤릭* → <em> (볼드와 공존)", () => {
+    expect(mdInlineToHtml("*기울임* 과 **굵게**")).toBe("<em>기울임</em> 과 <strong>굵게</strong>");
+  });
+
+  test("`코드` → <code>", () => {
+    expect(mdInlineToHtml("실행: `bun test` 하세요")).toBe(
+      "실행: <code>bun test</code> 하세요",
+    );
+  });
+
+  test("[텍스트](https://...) → 안전한 링크(새 탭·noopener)", () => {
+    expect(mdInlineToHtml("[문서](https://example.com/a)")).toBe(
+      '<a href="https://example.com/a" target="_blank" rel="noopener">문서</a>',
+    );
+  });
+
+  test("개행은 건드리지 않는다 (pre-wrap 컨테이너가 처리)", () => {
+    expect(mdInlineToHtml("첫 줄\n**둘째** 줄")).toBe("첫 줄\n<strong>둘째</strong> 줄");
+  });
+
+  test("마크다운 없는 평문은 이스케이프 외 변화 없음", () => {
+    expect(mdInlineToHtml("그냥 평범한 문장")).toBe("그냥 평범한 문장");
+  });
+});
+
+describe("mdInlineToHtml — 안전(이스케이프·XSS)", () => {
+  test("HTML 태그는 이스케이프된다", () => {
+    expect(mdInlineToHtml('<img src=x onerror="alert(1)">')).toBe(
+      "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;",
+    );
+  });
+
+  test("볼드 안의 HTML 도 이스케이프", () => {
+    expect(mdInlineToHtml("**<b>x</b>**")).toBe("<strong>&lt;b&gt;x&lt;/b&gt;</strong>");
+  });
+
+  test("javascript: 링크는 링크로 만들지 않는다 (http/https 만 허용)", () => {
+    const out = mdInlineToHtml("[클릭](javascript:alert(1))");
+    expect(out).not.toContain("<a ");
+    expect(out).toContain("클릭"); // 텍스트는 남는다(이스케이프된 원문 형태)
+  });
+
+  test("불완전한 별표는 그대로 노출 (오변환 금지)", () => {
+    expect(mdInlineToHtml("2 * 3 = 6, a*b")).not.toContain("<em>");
+    expect(mdInlineToHtml("**닫히지 않음")).toBe("**닫히지 않음");
+  });
+});

--- a/src/web/lib/mdInline.ts
+++ b/src/web/lib/mdInline.ts
@@ -1,0 +1,29 @@
+// mdInline — 채팅 말풍선용 인라인 마크다운 (단일 출처).
+//   배경(GD 2026-08-01): 팀원 메시지의 **강조**·`코드`·[링크](url) 가 원문 그대로 노출됐다.
+//   Reports.ts mdToHtml 의 inline 처리를 추출·공유한다. ★인라인만★ — 블록 문법(헤딩·표·리스트)은
+//   말풍선 레이아웃(whitespace-pre-wrap, 개행 보존)을 깨므로 다루지 않는다.
+//   Reports 원본 대비 의도적 강화 2건:
+//     ① 링크는 http/https 만 <a> 로 (javascript: 등 스킴 주입 차단 — 채팅은 외부 발신 텍스트가 들어온다)
+//     ② 이탤릭은 내용 양끝이 공백이 아닐 때만 ("2 * 3 = 6, a*b" 같은 산식 오변환 방지)
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/** 이스케이프 → `code` → **bold** → *em* → [링크](http…) 순서로 변환한 HTML 을 돌려준다.
+ *  ★입력을 통째로 이스케이프한 뒤★ 우리가 만든 고정 태그만 삽입하므로 원문 HTML 은 실행되지 않는다. */
+export function mdInlineToHtml(text: string): string {
+  let s = escapeHtml(String(text ?? ""));
+  s = s.replace(/`([^`]+)`/g, (_m, c) => `<code>${c}</code>`);
+  s = s.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  // 내용 양끝 비공백(\S) 요구 — 곱셈 기호·불릿 잔재를 기울임으로 오인하지 않는다.
+  s = s.replace(/(^|[^*])\*(\S(?:[^*]*\S)?)\*(?!\*)/g, "$1<em>$2</em>");
+  s = s.replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, (_m, txt, href) =>
+    `<a href="${href}" target="_blank" rel="noopener">${txt}</a>`);
+  return s;
+}

--- a/src/web/lib/scrollStick.test.ts
+++ b/src/web/lib/scrollStick.test.ts
@@ -1,0 +1,96 @@
+// scrollStick — 채팅형 스크롤 유지 규칙 단위 테스트.
+//   규칙: 독자가 바닥 근처에 있을 때만 재렌더 후 바닥으로 따라가고(stick),
+//   위로 스크롤해 읽는 중이면 읽던 위치를 그대로 보존한다.
+//   (ThreadView/Chat 이 폴링 재렌더마다 무조건 바닥으로 끌어내리던 문제의 회귀 가드.)
+import { describe, expect, test } from "bun:test";
+import {
+  NEAR_BOTTOM_SLACK_PX,
+  isNearBottom,
+  captureScrollStick,
+  applyScrollStick,
+} from "./scrollStick";
+
+// happy-dom 은 레이아웃이 없어 scrollHeight/clientHeight 가 늘 0 이다 — 헬퍼는
+// 순수 메트릭 인터페이스({scrollTop, scrollHeight, clientHeight})만 받게 설계해
+// 레이아웃 없이도 실측 시나리오를 그대로 검증한다.
+function el(scrollTop: number, scrollHeight: number, clientHeight: number) {
+  return { scrollTop, scrollHeight, clientHeight };
+}
+
+describe("isNearBottom", () => {
+  test("정확히 바닥 = near", () => {
+    expect(isNearBottom(el(600, 1000, 400))).toBe(true);
+  });
+
+  test("slack 이내로 살짝 위 = near", () => {
+    expect(isNearBottom(el(600 - NEAR_BOTTOM_SLACK_PX, 1000, 400))).toBe(true);
+  });
+
+  test("slack 보다 위로 올라가 있으면 not near", () => {
+    expect(isNearBottom(el(600 - NEAR_BOTTOM_SLACK_PX - 1, 1000, 400))).toBe(false);
+  });
+
+  test("맨 위에서 읽는 중이면 not near", () => {
+    expect(isNearBottom(el(0, 1000, 400))).toBe(false);
+  });
+
+  test("내용이 컨테이너보다 짧으면(스크롤 불가) near", () => {
+    expect(isNearBottom(el(0, 300, 400))).toBe(true);
+  });
+
+  test("빈/미레이아웃 컨테이너(0/0/0)는 near — 첫 렌더가 바닥 스크롤을 유지하게", () => {
+    expect(isNearBottom(el(0, 0, 0))).toBe(true);
+  });
+
+  test("커스텀 slack 적용", () => {
+    expect(isNearBottom(el(500, 1000, 400), 100)).toBe(true);
+    expect(isNearBottom(el(499, 1000, 400), 100)).toBe(false);
+  });
+});
+
+describe("captureScrollStick / applyScrollStick", () => {
+  test("바닥 근처에서 캡처 → 내용이 자라도 새 바닥으로 stick", () => {
+    const before = el(600, 1000, 400); // 정확히 바닥
+    const saved = captureScrollStick(before);
+    expect(saved.stick).toBe(true);
+
+    const after = el(600, 1500, 400); // 재렌더로 내용이 자람
+    applyScrollStick(after, saved);
+    expect(after.scrollTop).toBe(1500); // scrollTop=scrollHeight (브라우저가 최대치로 클램프)
+  });
+
+  test("위로 스크롤해 읽는 중 캡처 → 내용이 자라도 읽던 위치 보존", () => {
+    const before = el(120, 1000, 400); // 한참 위에서 읽는 중
+    const saved = captureScrollStick(before);
+    expect(saved.stick).toBe(false);
+    expect(saved.scrollTop).toBe(120);
+
+    const after = el(0, 1500, 400); // innerHTML 재작성 직후 scrollTop 리셋 상태
+    applyScrollStick(after, saved);
+    expect(after.scrollTop).toBe(120); // ★핵심 회귀 가드: 바닥으로 끌려가지 않는다★
+  });
+
+  test("내용 변화가 없어도(폴링 틱) 읽던 위치 보존", () => {
+    const before = el(120, 1000, 400);
+    const saved = captureScrollStick(before);
+    const after = el(0, 1000, 400);
+    applyScrollStick(after, saved);
+    expect(after.scrollTop).toBe(120);
+  });
+
+  test("null/undefined 컨테이너는 캡처=stick 기본, 적용=no-op (throw 금지)", () => {
+    const saved = captureScrollStick(null);
+    expect(saved.stick).toBe(true);
+    expect(() => applyScrollStick(null, saved)).not.toThrow();
+    expect(() => applyScrollStick(undefined, { stick: false, scrollTop: 10 })).not.toThrow();
+  });
+
+  test("새로 만들어진 컨테이너(0/0/0)에서 캡처 → stick (스레드 전환 시 바닥 스크롤 유지)", () => {
+    const fresh = el(0, 0, 0);
+    const saved = captureScrollStick(fresh);
+    expect(saved.stick).toBe(true);
+    const after = el(0, 900, 400);
+    applyScrollStick(after, saved);
+    expect(after.scrollTop).toBe(900);
+  });
+});

--- a/src/web/lib/scrollStick.ts
+++ b/src/web/lib/scrollStick.ts
@@ -1,0 +1,51 @@
+// scrollStick — 채팅형 컨테이너의 스크롤 유지 규칙 (단일 출처).
+//   문제: ThreadView/Chat 이 폴링 재렌더마다 무조건 scrollTop=scrollHeight 로 끌어내려,
+//   위로 스크롤해 이전 보고를 읽는 중에도 바닥으로 튕겼다 (GD 리포트 2026-08-01).
+//   규칙(채팅 UX 관례): ★독자가 바닥 근처일 때만 재렌더 후 바닥으로 따라가고(stick),
+//   위에서 읽는 중이면 읽던 위치를 그대로 보존한다.★
+//   사용법: innerHTML 재작성 ★직전에★ captureScrollStick(el) → 재작성 ★직후에★ applyScrollStick(el, saved).
+//   레이아웃에 의존하지 않도록 메트릭 인터페이스만 받는다(happy-dom 테스트 가능).
+
+/** "바닥 근처" 판정 여유(px). 마지막 줄 일부가 걸쳐 보이는 정도는 바닥으로 취급한다. */
+export const NEAR_BOTTOM_SLACK_PX = 48;
+
+export interface ScrollMetrics {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+export interface ScrollStick {
+  /** true = 재렌더 후 바닥으로 따라감, false = 읽던 scrollTop 복원 */
+  stick: boolean;
+  scrollTop: number;
+}
+
+/** 바닥에서 slackPx 이내면 true. 빈/미레이아웃 컨테이너(0/0/0)와 스크롤 불가 컨테이너는
+ *  true — 첫 렌더·스레드 전환이 기존처럼 바닥에서 시작하게 하기 위해서다. */
+export function isNearBottom(el: ScrollMetrics, slackPx: number = NEAR_BOTTOM_SLACK_PX): boolean {
+  return el.scrollHeight - el.scrollTop - el.clientHeight <= slackPx;
+}
+
+/** innerHTML 재작성 ★직전★ 호출 — 옛 높이 기준으로 독자의 위치를 캡처한다.
+ *  컨테이너가 아직 없으면 stick 기본(첫 렌더 = 바닥). */
+export function captureScrollStick(
+  el: ScrollMetrics | null | undefined,
+  slackPx: number = NEAR_BOTTOM_SLACK_PX,
+): ScrollStick {
+  if (!el) return { stick: true, scrollTop: 0 };
+  return { stick: isNearBottom(el, slackPx), scrollTop: el.scrollTop };
+}
+
+/** innerHTML 재작성 ★직후★ 호출 — stick 이면 새 바닥으로, 아니면 읽던 위치로 복원.
+ *  (scrollTop=scrollHeight 는 브라우저가 최대 스크롤로 클램프한다.) */
+export function applyScrollStick(el: ScrollMetrics | null | undefined, saved: ScrollStick): void {
+  if (!el) return;
+  el.scrollTop = saved.stick ? el.scrollHeight : saved.scrollTop;
+}
+
+/** "무조건 바닥" ScrollStick — 내가 방금 보낸 메시지는 위에서 읽던 중이어도 바닥에서 확인해야 한다.
+ *  (호출부가 {stick:true,...} 리터럴을 복제해 구조가 드리프트하는 것 방지 — 이 모듈이 단일 출처.) */
+export function stickToBottom(): ScrollStick {
+  return { stick: true, scrollTop: 0 };
+}


### PR DESCRIPTION
채팅 말풍선(1:1·스레드)의 읽기 경험 두 가지를 고칩니다. 커밋 2개, 서로 독립입니다.

## 1. 인라인 마크다운 렌더 (`c706df0`)

팀원 메시지가 `**강조**` 를 많이 쓰는데 말풍선이 **별표 원문을 그대로 노출**했습니다. `Reports.ts` 의 `mdToHtml` 인라인 처리를 `src/web/lib/mdInline.ts` 로 추출해 **Chat·ThreadView·Reports 세 곳이 같은 구현을 공유**합니다(단일 출처).

- **인라인만** 적용합니다 — 블록 문법(헤딩·표·리스트)은 말풍선의 `whitespace-pre-wrap` 개행 보존 레이아웃을 깨므로 다루지 않습니다.
- Reports 원본 대비 **의도적 강화 2건**(Reports 에도 함께 적용):
  - 링크는 `http/https` 만 `<a>` 로 만듭니다 — `javascript:` 스킴 주입 차단(채팅은 외부에서 들어온 텍스트가 표시되는 표면입니다)
  - 이탤릭은 내용 양끝이 비공백일 때만 — `2 * 3 = 6` 같은 산식 오변환 방지

## 2. 스크롤 위치 보존 (`2bce122`)

ThreadView·Chat 이 폴링 재렌더마다 무조건 `scrollTop = scrollHeight` 로 끌어내려, **위로 스크롤해 이전 보고를 읽는 중에도 몇 초마다 바닥으로 튕겼습니다**(내용이 안 변한 틱에도).

채팅 UX 관례대로 스크롤 위치를 의도 신호로 읽습니다:

| 상태 | 재렌더 후 |
|---|---|
| 바닥 근처(48px 이내) = 따라가는 중 | 새 바닥으로 stick |
| 그보다 위 = 과거를 읽는 중 | 읽던 위치 그대로 보존 |
| 내 전송 직후 | 예외 — 항상 바닥(내 메시지가 뜰 자리 확인) |

구현은 `src/web/lib/scrollStick.ts` 한 곳에 모았습니다(`innerHTML` 재작성 직전 capture → 직후 apply).

## 검증

- `bunx tsc --noEmit` — 출력 없음(통과)
- `bun test` — **2185 pass / 6 skip / 4 fail**. 실패 4건은 모두 `LLM team router (EXAONE)` 로, 로컬 LLM 모델이 있어야 도는 테스트입니다. `origin/main` 기준에서도 동일하게 실패하는 항목이라 이 변경과 무관합니다.
- `release-preflight.sh --mode merge` — clean worktree / non-main branch / **커밋 2개 모두 GitHub noreply email** 통과.
  - 남은 항목 하나: `main branch protection` 조회. 이 PR 을 올리는 계정은 upstream 에 대해 `admin:false` 라 GitHub 이 보호 설정을 404 로 감춥니다(비관리자에게는 조회 자체가 불가). **머지 수행 측에서 확인이 필요한 항목**이며, fork 기반 PR 이라 보호 설정을 우회할 수 없습니다.

## 미검증

- 실제 브라우저에서의 시각 확인은 이 PR 범위에서 하지 않았습니다(DOM 테스트로 배선·동작만 확인).
- 배포 환경(라이브 `main` 반영 후)의 동작은 머지 후 확인 대상입니다.
