### PR TITLE
fix(router): 멘션·답장·sticky 가 없으면 coordinator 가 받는다 (LLM 추론 제거)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,10 +37,11 @@ GD_CHAT_ID=
 CAPTURE_BOT_TOKEN=
 # 라우터 ON 이어야 agent 를 실제로 깨워 응답시킴(OFF=shadow: 결정만 로그·응답 안 함). 기본 false.
 ROUTER_ENABLED=false
-# 라우터가 쓰는 로컬 LLM(Ollama). 둘 다 선택 — 미설정이면 아래 기본값으로 돈다.
+# 라우터 LLM 함수가 쓰는 로컬 Ollama. 둘 다 선택 — 미설정이면 아래 기본값으로 돈다.
 #   원격 박스의 Ollama 를 가리켜도 된다(예: 사내 GPU 머신).
-#   ★owner 판정에는 안 쓰인다★ — 담당자 결정은 [@멘션 > 답장 > sticky > coordinator] 결정론 규칙이다.
-#   현재 실사용처는 기동 시 모델 상주(warmup)와 standalone 라우터 함수뿐이다.
+#   ★지금 라이브 경로에는 이 값을 읽는 곳이 없다.★ 담당자 결정은
+#   [@멘션 > 답장 > sticky > coordinator] 결정론 규칙이라 LLM 을 부르지 않는다.
+#   routeDefaultIntakeLLM / routeTeamMessageLLM 을 라이브에 다시 붙일 때 쓰는 값이다.
 # TEAM_ROUTER_OLLAMA_URL=http://127.0.0.1:11434/api/chat
 # TEAM_ROUTER_MODEL=exaone3.5:2.4b
 # ─── 스케줄러 (칸반 과제리뷰·주간 잡 자동 실행) ───────────────

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,12 @@ GD_CHAT_ID=
 CAPTURE_BOT_TOKEN=
 # 라우터 ON 이어야 agent 를 실제로 깨워 응답시킴(OFF=shadow: 결정만 로그·응답 안 함). 기본 false.
 ROUTER_ENABLED=false
+# 라우터가 쓰는 로컬 LLM(Ollama). 둘 다 선택 — 미설정이면 아래 기본값으로 돈다.
+#   원격 박스의 Ollama 를 가리켜도 된다(예: 사내 GPU 머신).
+#   ★owner 판정에는 안 쓰인다★ — 담당자 결정은 [@멘션 > 답장 > sticky > coordinator] 결정론 규칙이다.
+#   현재 실사용처는 기동 시 모델 상주(warmup)와 standalone 라우터 함수뿐이다.
+# TEAM_ROUTER_OLLAMA_URL=http://127.0.0.1:11434/api/chat
+# TEAM_ROUTER_MODEL=exaone3.5:2.4b
 # ─── 스케줄러 (칸반 과제리뷰·주간 잡 자동 실행) ───────────────
 # 서버 내장 스케줄러 — 켜면 매일 과제리뷰(06:00 팀원 핑 / 06:20 팀장 요약 DM)와 주간 잡을 자동 발화한다.
 #   ★공개(개인 장비)는 기본 ON★: 라이브는 이 잡들을 launchd(macOS)로 돌리는데 공개 빌드엔 launchd 가 없어,

--- a/src/server/lib/teamRouter.test.ts
+++ b/src/server/lib/teamRouter.test.ts
@@ -184,130 +184,111 @@ describe("team router", () => {
   });
 });
 
-describe("owner inference fallback", () => {
+// 멘션·답장·sticky 가 모두 없을 때 = coordinator 가 받는다 (팀장 지시 2026-08-02).
+// 이전엔 로컬 LLM owner-inference 를 태웠는데 실측 정확도가 4케이스 중 2건이라 걷어냈다.
+// 정본 근거 = TEAM-OS §2 "애매하거나 조율성이면 coordinator capability 보유자가 받는다".
+describe("default owner (멘션·답장·sticky 없음 → coordinator)", () => {
   const originalFetch = globalThis.fetch;
-
-  function mockRouter(reply: Record<string, unknown>): void {
-    globalThis.fetch = (async () =>
-      new Response(JSON.stringify({ message: { content: JSON.stringify(reply) } }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      })) as unknown as typeof fetch;
-  }
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
   });
 
-  test("routes infra/team-collab operations to Bill without explicit mention", async () => {
-    mockRouter({ outcome: "route", responder: "bill", domain: "infra_ops", needs_gd_confirm: false });
-    const d = await routeTeamMessageHybrid("team-collab 라우터 상태 좀 봐야겠네", agents);
-    expect(d.outcome).toBe("route");
-    expect(d.reason).toBe("default_intake");
-    expect(d.targetAgentIds).toEqual(["bill"]);
-    expect(d.domain).toBe("owner_inference:infra_ops");
-  });
-
-  test("routes general PM/coordination messages to Codex without explicit mention", async () => {
-    mockRouter({ outcome: "route", responder: "codex", domain: "general_pm", needs_gd_confirm: false });
-    const d = await routeTeamMessageHybrid("팀원 영입 절차를 정리하고 다음 진행 계획 잡자", agents, {}, { timeoutMs: 10 });
-    expect(d.outcome).toBe("route");
-    expect(d.reason).toBe("default_step");
-    expect(d.targetAgentIds).toEqual(["codex"]);
-    expect(d.domain).toBe("owner_inference:general_pm");
-  });
-
-  test("delegates unowned owner inference to local LLM using roles instead of default-intake fields", async () => {
-    const scoped = agents.map((a) =>
-      a.id === "steve"
-        ? { ...a, role: "Infra operations and team-collab runtime" }
-        : a.id === "dbak"
-          ? { ...a, role: "Team PM and coordination" }
-          : { ...a },
-    );
-    const calls: string[] = [];
-    globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
-      const body = JSON.parse(String(init?.body)) as { messages: Array<{ role: string; content: string }> };
-      calls.push(body.messages[0]?.content ?? "");
-      const user = JSON.parse(body.messages[1]?.content ?? "{}") as { new_message?: string };
-      const reply = user.new_message?.includes("team-collab")
-        ? { outcome: "route", responder: "steve", domain: "ops_from_role", needs_gd_confirm: false }
-        : { outcome: "route", responder: "dbak", domain: "pm_from_role", needs_gd_confirm: false };
-      return new Response(JSON.stringify({ message: { content: JSON.stringify(reply) } }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
+  /** fetch 가 한 번이라도 불리면 기록 — LLM 을 안 거치는지 확인하는 용도. */
+  function watchFetch(): { calls: number } {
+    const seen = { calls: 0 };
+    globalThis.fetch = (async () => {
+      seen.calls += 1;
+      throw new Error("이 경로에서는 LLM 을 호출하면 안 된다");
     }) as unknown as typeof fetch;
+    return seen;
+  }
 
-    const infra = await routeTeamMessageHybrid("team-collab 라우터 상태 좀 봐야겠네", scoped, {}, { timeoutMs: 10 });
-    expect(infra.targetAgentIds).toEqual(["steve"]);
-    expect(infra.domain).toBe("owner_inference:ops_from_role");
-
-    const pm = await routeTeamMessageHybrid("팀원 영입 절차를 정리하고 다음 진행 계획 잡자", scoped, {}, { timeoutMs: 10 });
-    expect(pm.targetAgentIds).toEqual(["dbak"]);
-    expect(pm.domain).toBe("owner_inference:pm_from_role");
-    expect(calls.join("\n")).not.toContain("default_intake_scope=");
-    expect(calls.join("\n")).toContain("Infra operations and team-collab runtime");
-    expect(calls.join("\n")).toContain("Team PM and coordination");
-  });
-
-  test("routes pure decision/approval messages to Codex default owner", async () => {
-    mockRouter({ outcome: "ask_gd", suggested: [], domain: "decision", needs_gd_confirm: false });
-    const d = await routeTeamMessageHybrid("이건 최종 결정이 필요하겠네", agents, {}, { timeoutMs: 10 });
+  test("★LLM 을 호출하지 않는다★ — 판단 없이 곧바로 coordinator", async () => {
+    const seen = watchFetch();
+    const d = await routeTeamMessageHybrid("음 이건 좀 애매하네", agents);
+    expect(seen.calls).toBe(0);
     expect(d.outcome).toBe("route");
-    expect(d.reason).toBe("default_step");
+    expect(d.reason).toBe("default_coordinator");
     expect(d.targetAgentIds).toEqual(["codex"]);
   });
 
-  test("marks risky owner-inferred work as needing GD confirmation", async () => {
-    mockRouter({ outcome: "route", responder: "bill", domain: "ops", needs_gd_confirm: true });
+  test("도메인이 명확해 보여도 coordinator 가 받는다 (특정 담당 자동배정 안 함)", async () => {
+    watchFetch();
+    const d = await routeTeamMessageHybrid("team-collab 라우터 상태 좀 봐야겠네", agents);
+    expect(d.targetAgentIds).toEqual(["codex"]);
+    expect(d.reason).toBe("default_coordinator");
+  });
+
+  test("해석되지 않는 @멘션은 일반 텍스트 취급 → coordinator", async () => {
+    watchFetch();
+    const d = await routeTeamMessageHybrid("@클로드테스트 상태 확인", agents);
+    expect(d.targetAgentIds).toEqual(["codex"]);
+    expect(d.reason).toBe("default_coordinator");
+  });
+
+  test("confident owner 다 — 다른 봇은 억제된다", async () => {
+    watchFetch();
+    const d = await routeTeamMessageHybrid("음 이건 좀 애매하네", agents);
+    expect(isConfidentOwner(d.reason)).toBe(true);
+    expect(shouldSuppress(d.reason, d.targetAgentIds, "bill")).toBe(true);
+    expect(shouldSuppress(d.reason, d.targetAgentIds, "codex")).toBe(false);
+  });
+
+  // ★위험 신호 플래그는 LLM 경로에만 있었다 — 결정론 경로로 바꾸면서 같이 없애면 조용한 안전 후퇴다.★
+  test("위험 신호(배포·재시작 등)는 needsGdConfirm 을 유지한다", async () => {
+    watchFetch();
     const d = await routeTeamMessageHybrid("team-collab 배포하고 서비스 재시작해야겠네", agents);
-    expect(d.outcome).toBe("route");
-    expect(d.targetAgentIds).toEqual(["bill"]);
+    expect(d.targetAgentIds).toEqual(["codex"]);
     expect(d.needsGdConfirm).toBe(true);
   });
 
-  test("routes ambiguous casual messages to Codex default owner", async () => {
-    mockRouter({ outcome: "ask_gd", suggested: [], domain: "ambiguous", needs_gd_confirm: false });
-    const d = await routeTeamMessageHybrid("음 이건 좀 애매하네", agents, {}, { timeoutMs: 10 });
-    expect(d.outcome).toBe("route");
-    expect(d.reason).toBe("default_step");
-    expect(d.targetAgentIds).toEqual(["codex"]);
+  test("평범한 메시지는 needsGdConfirm 이 서지 않는다", async () => {
+    watchFetch();
+    const d = await routeTeamMessageHybrid("오늘 날씨 좋네요", agents);
+    expect(d.needsGdConfirm).toBe(false);
   });
 
-  test("routes unknown @mentions through owner inference when there is no reply or sticky owner", async () => {
-    mockRouter({ outcome: "route", responder: "bill", domain: "infra_ops", needs_gd_confirm: false });
-    const d = await routeTeamMessageHybrid("@클로드테스트 상태 확인", agents, {}, { timeoutMs: 10 });
-    expect(d.outcome).toBe("route");
-    expect(d.reason).toBe("default_intake");
+  test("ambiguous_owner capability 가 있으면 coordinator 보다 우선 (GD 2026-07-10 순서 보존)", async () => {
+    watchFetch();
+    const withIntake = agents.map((a) =>
+      a.id === "bill" ? { ...a, capabilities: [...(a.capabilities ?? []), "ambiguous_owner"] } : a,
+    );
+    const d = await routeTeamMessageHybrid("음 이건 좀 애매하네", withIntake);
     expect(d.targetAgentIds).toEqual(["bill"]);
-    expect(d.domain).toBe("owner_inference:infra_ops");
+    expect(d.reason).toBe("default_coordinator");
   });
 
-  test("allows role-clear owner inference to mention-only agents", async () => {
-    const withTemp: AgentRecord[] = [
-      ...agents,
-      {
-        id: "testclaude",
-        display_name: "Claude Temp",
-        nicknames: ["testclaude", "클로드테스트"],
-        role: "Temporary Claude Channel lifecycle rehearsal member",
-        response_mode: "mention-only",
-        runtime: "claude_channel",
-        status_provider: "claude_tmux",
-        tmux_session: "claude-testclaude",
-        telegram_bot_username: null,
-        workspace_path: "/Users/you/Development/testclaude",
-        persona_file: "/Users/you/Development/testclaude/CLAUDE.md",
-        moderator_eligible: false,
-        avatar_emoji: "T",
-      },
-    ];
-    mockRouter({ outcome: "route", responder: "testclaude", domain: "temp_member", needs_gd_confirm: false });
-    const d = await routeTeamMessageHybrid("클로드테스트 상태 확인", withTemp, {}, { timeoutMs: 10 });
-    expect(d.outcome).toBe("route");
-    expect(d.targetAgentIds).toEqual(["testclaude"]);
-    expect(d.domain).toBe("owner_inference:temp_member");
+  // coordinatorId 는 capability 미지정 시 agents[0] 로 폴백한다(silent-drop 방지). 그 폴백을 confident
+  // 자동배정에 쓰면 "엉뚱한 첫 에이전트가 다 받는" 2026-06-05 의 그 문제로 돌아간다 — 여기선 안 쓴다.
+  test("capability 미지정 레지스트리는 자동배정하지 않고 GD 에게 묻는다", async () => {
+    watchFetch();
+    const noCoord = agents.map((a) => ({ ...a, capabilities: [] as string[] }));
+    const d = await routeTeamMessageHybrid("음 이건 좀 애매하네", noCoord);
+    expect(d.outcome).toBe("ask_gd");
+    expect(d.targetAgentIds).toEqual([]);
+  });
+
+  // ─── 기존 동작 보존 (이 변경이 건드리면 안 되는 것들) ───
+  test("보존: @멘션이 있으면 그대로 그 사람", async () => {
+    watchFetch();
+    const d = await routeTeamMessageHybrid("@빌 라우터 좀 봐줘", agents);
+    expect(d.reason).toBe("explicit_mention");
+    expect(d.targetAgentIds).toEqual(["bill"]);
+  });
+
+  test("보존: 답장이면 원문 작성자", async () => {
+    watchFetch();
+    const d = await routeTeamMessageHybrid("이거 어떻게 됐어", agents, { replyToAgentId: "bill" });
+    expect(d.reason).toBe("reply_author");
+    expect(d.targetAgentIds).toEqual(["bill"]);
+  });
+
+  test("보존: sticky 담당이 있으면 유지된다 (멀티턴 위임이 끊기면 안 된다)", async () => {
+    watchFetch();
+    const d = await routeTeamMessageHybrid("그거 진행상황 어때", agents, { activeAssigneeIds: ["bill"] });
+    expect(d.reason).toBe("active_assignee_followup");
+    expect(d.targetAgentIds).toEqual(["bill"]);
   });
 });
 
@@ -613,7 +594,6 @@ describe("owner-gate suppress 규칙 — shouldSuppress 단일 출처 (커뮤니
       '명시적인 @은 붙는거 확인.. 그런데 그 다음 메시지인 "이번엔 sticky 테스트야. 누가 대답할까?" 는 리액션 뿐만 아니라 응답도 안한거임. 처리가 필요함.',
       agents,
       { activeAssigneeId: "codex" },
-      { timeoutMs: 10 },
     );
     expect(d.targetAgentIds).toEqual(["codex"]);
     expect(d.reason).toBe("active_assignee_followup");

--- a/src/server/lib/teamRouter/_shared.ts
+++ b/src/server/lib/teamRouter/_shared.ts
@@ -17,6 +17,8 @@ export interface RouteDecision {
     | "topic_shift_default"
     | "default_intake"
     | "default_step"
+    /** 멘션·답장·sticky 가 모두 없어 coordinator 가 기본으로 받음 (결정론, LLM 안 거침). */
+    | "default_coordinator"
     | "ask_gd"
     | "broadcast_marker";
   shouldResetThread: boolean;
@@ -24,6 +26,14 @@ export interface RouteDecision {
 
 // (removed) DEFAULT_STEP_AGENT_ID = "codex" — default_step owner 는 이제 coordinator capability 로
 // 결정한다. lib/capabilities.ts 의 coordinatorId(agents) 사용. 정본 = agents.json.
+
+/**
+ * GD 확인이 필요한 위험 신호 — 토큰·삭제·배포·재시작·비용·외부발신 등.
+ * 이 플래그(needsGdConfirm)는 받는 agent 가 "바로 실행하지 말고 GD 께 먼저 확인" 하라는 신호다.
+ * owner-inference 안에만 있었는데, 결정론 라우팅(default_coordinator)에서도 똑같이 필요해서 여기로 옮겼다.
+ */
+export const GD_CONFIRM_RE =
+  /(삭제|지워|제거|revoke|폐기|토큰|token|credential|시크릿|secret|보안|security|권한|permission|결제|비용|paid|외부\s*(공개|발신|전송)|public|배포|deploy|재시작|restart|launchctl|마이그레이션|migration|DB|데이터베이스|database)/i;
 
 export const OLLAMA_URL = process.env.TEAM_ROUTER_OLLAMA_URL ?? "http://127.0.0.1:11434/api/chat";
 export const ROUTER_MODEL = process.env.TEAM_ROUTER_MODEL ?? "exaone3.5:2.4b";

--- a/src/server/lib/teamRouter/defaultIntake.ts
+++ b/src/server/lib/teamRouter/defaultIntake.ts
@@ -1,5 +1,6 @@
 import type { AgentRecord } from "../../types";
 import {
+  GD_CONFIRM_RE,
   type LlmRouteDecision,
   OLLAMA_URL,
   ROUTER_MODEL,
@@ -7,9 +8,6 @@ import {
   classifyIntent,
 } from "./_shared";
 import { ambiguousOwnerId } from "../capabilities";
-
-const GD_CONFIRM_RE =
-  /(삭제|지워|제거|revoke|폐기|토큰|token|credential|시크릿|secret|보안|security|권한|permission|결제|비용|paid|외부\s*(공개|발신|전송)|public|배포|deploy|재시작|restart|launchctl|마이그레이션|migration|DB|데이터베이스|database)/i;
 
 interface RawDefaultIntake {
   outcome?: "route" | "ask_gd";

--- a/src/server/lib/teamRouter/gate.ts
+++ b/src/server/lib/teamRouter/gate.ts
@@ -4,7 +4,14 @@ import { hasCapability } from "../capabilities";
 
 // ─── owner-gate suppress 판단: owner 로직의 단일 출처 (GD 2098 — 판단은 서버 한 곳) ───
 // gate/react 훅은 thin-client로 이 결정만 따른다(자체 로직 없음). 룰 변경은 여기서만 → 서버 재시작으로 배포.
-const CONFIDENT_OWNER_REASONS = new Set(["explicit_mention", "reply_author", "active_assignee_followup"]);
+// default_coordinator 는 추측이 아니라 룰이라 confident 다 — 멘션·답장·sticky 가 모두 없으면
+//   coordinator 가 받는다(TEAM-OS §2). 억제가 안 걸리면 주인 없는 메시지에 전원이 달려든다.
+const CONFIDENT_OWNER_REASONS = new Set([
+  "explicit_mention",
+  "reply_author",
+  "active_assignee_followup",
+  "default_coordinator",
+]);
 
 /** "확실 owner" reason 인가 (default_intake/default_step/broadcast/ask_gd 등 추측·전체는 아님). */
 export function isConfidentOwner(reason: string): boolean {

--- a/src/server/lib/teamRouter/ownerDecision.ts
+++ b/src/server/lib/teamRouter/ownerDecision.ts
@@ -1,5 +1,6 @@
 import type { AgentRecord } from "../../types";
 import {
+  GD_CONFIRM_RE,
   type RouterContext,
   type RouteDecision,
   type RouteIntent,
@@ -9,10 +10,9 @@ import {
   buildRosterText,
   classifyIntent,
 } from "./_shared";
-import { coordinatorId } from "../capabilities";
+import { ambiguousOwnerId, coordinatorId, hasCapability } from "../capabilities";
 import { broadcastRecipientIds } from "../agentMembership";
 import { detectExplicitTargets, stripQuotedForRouting } from "./mention";
-import { routeDefaultIntakeLLM } from "./defaultIntake";
 
 // @all/@b3rys/@group — broadcast-all marker. Checked before explicit_mention.
 const BROADCAST_MARKER_RE = /@(all|b3rys|group)\b/i;
@@ -264,11 +264,12 @@ export async function routeTeamMessageLLM(
 // (GD 의 "all-LLM" 결정과의 트레이드오프: 신뢰도 위해 명확신호는 결정론. GD 리뷰 후 택1.)
 // ─────────────────────────────────────────────────────────────────────────────
 
+// opts(model/timeoutMs)는 뺐다 — LLM 을 안 부르니 아무 효과가 없다. 남겨두면
+// "설정해도 아무 일 안 일어나는 노브" 가 되어 없느니만 못하다.
 export async function routeTeamMessageHybrid(
   text: string,
   agents: AgentRecord[],
   context: RouterContext = {},
-  opts: { model?: string; timeoutMs?: number } = {},
 ): Promise<LlmRouteDecision> {
   const intent = classifyIntent(text);
   const activeAssigneeIds = validActiveAssignees(context, agents);
@@ -339,24 +340,45 @@ export async function routeTeamMessageHybrid(
     };
   }
 
-  // 3) 명시 없음 + sticky 없음 → b3rys 전용 owner inference.
-  //    해석되지 않은 @텍스트도 여기서는 일반 텍스트로 취급한다.
-  //    담당 범주를 코드 regex 로 고정하지 않고, agents.json 의 role 을 로컬 LLM 프롬프트에 넣어 판단한다.
-  //    애매하거나 LLM 실패 시 coordinator capability 보유자가 default owner 로 받는다.
-  const intake = await routeDefaultIntakeLLM(text, agents, opts).catch(() => null);
-  if (intake?.outcome === "route") return { ...intake, shouldResetThread: false };
+  // 3) 명시 없음 + 답장 아님 + sticky 없음 → coordinator 가 받는다 (결정론, LLM 안 거침).
+  //    근거 = TEAM-OS §2 "애매하거나 조율성이면 coordinator capability 보유자가 받는다".
+  //    ★GD 룰 2026-06-05(애매하면 자동배정 말고 ask_gd)를 되돌리는 변경이다★ (팀장 지시 2026-08-02).
+  //    그때 걷어낸 이유는 "sticky 가 비면 ★특정 agent★ 가 엉뚱한 메시지를 잡는다" 였는데, 받는 쪽이
+  //    분류가 일인 coordinator 면 잘못 받아도 손실이 없다.
+  //    LLM 추론을 뺀 이유: 실측 정확도가 4케이스 중 2건이라(2026-08-02, exaone3.5:7.8b) 규칙보다 나을 게
+  //    없었다. 틀리면 엉뚱한 사람을 깨우고, 맞아도 대개 coordinator 였다.
+  //    수신자는 ambiguousOwnerId — 자체적으로 ambiguous_owner → coordinator 순 폴백이다(GD 2026-07-10).
+  //    needsGdConfirm 은 유지한다 — 위험 신호는 owner 를 어떻게 정했든 "실행 전 GD 확인" 이어야 하고,
+  //    LLM 경로에만 있던 걸 놓치면 조용한 안전 후퇴다.
+  //    ★capability 가 실제로 지정된 팀에서만 자동으로 깨운다★ — coordinatorId 는 미지정 시 agents[0] 로
+  //    폴백하는데(silent-drop 방지용), 그 폴백을 confident 자동배정에 쓰면 위의 2026-06-05 문제 그대로다.
+  const hasIntakeOwner = agents.some(
+    (a) => hasCapability(a, "ambiguous_owner") || hasCapability(a, "coordinator"),
+  );
+  const intakeOwner = hasIntakeOwner ? ambiguousOwnerId(agents) : undefined;
+  if (intakeOwner) {
+    return {
+      targetAgentIds: [intakeOwner],
+      reason: "default_coordinator",
+      shouldResetThread: false,
+      intent,
+      domain: "none",
+      via: "llm",
+      needsGdConfirm: GD_CONFIRM_RE.test(text),
+      outcome: "route",
+    };
+  }
 
-  // 4) (GD 룰 2026-06-05) 오너가 애매하면(멘션·답장·sticky 모두 없음) codex 로 자동 배정하지 않는다.
-  //    룰 = @멘션 > 답장 > sticky > **오너 애매하면 GD 문의**. → ask_gd(아무도 안 깨움 + GD 에게 누가 볼지 질문).
-  //    이전엔 하드코딩 default_step 으로 보내, 재시작으로 sticky 가 비면 특정 agent 가 엉뚱한 메시지를 잡던 문제 fix.
+  // 4) coordinator capability 보유자가 아예 없는 팀 → 예전대로 GD 에게 묻는다(아무도 안 깨움).
+  //    임의의 agent 를 골라 깨우지 않는다 — 그게 2026-06-05 에 걷어낸 바로 그 동작이다.
   return {
     targetAgentIds: [],
     reason: "ask_gd",
     shouldResetThread: false,
     intent,
-    domain: intake?.domain ?? "none",
+    domain: "none",
     via: "llm",
     outcome: "ask_gd",
-    suggested: intake?.suggested ?? [],
+    suggested: [],
   };
 }

--- a/src/server/workers/telegramCapture.ts
+++ b/src/server/workers/telegramCapture.ts
@@ -430,21 +430,11 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
     console.log("[capture] disabled — CAPTURE_BOT_TOKEN 미설정 (inert)");
     return () => {};
   }
-  // 라우터 LLM(exaone) 상주 — cold-start(~9s) 제거. 재부팅/재시작마다 재핀 (GD 결정 2026-05-24).
-  void (async () => {
-    const url = process.env.TEAM_ROUTER_OLLAMA_URL ?? "http://127.0.0.1:11434/api/chat";
-    const model = process.env.TEAM_ROUTER_MODEL ?? "exaone3.5:2.4b";
-    try {
-      await fetch(url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model, messages: [{ role: "user", content: "warmup" }], stream: false, keep_alive: -1 }),
-      });
-      console.log(`[capture] router model ${model} 상주 (keep_alive=-1)`);
-    } catch (e) {
-      console.error("[capture] model warmup failed:", (e as Error).message);
-    }
-  })();
+  // (제거) 라우터 LLM 상주 warmup — GD 2026-05-24 에 cold-start(~9s)를 없애려고 넣었던 것.
+  //   owner 판정이 결정론 규칙으로 바뀌면서(같은 PR) 라이브에서 그 모델을 부르는 곳이 없어졌다.
+  //   그런데 warmup 은 keep_alive=-1 로 ★무기한 상주★ 를 걸어서, 아무도 안 쓰는 모델이 GPU 를
+  //   계속 붙잡고 있었다(실측: exaone3.5:7.8b = 11GB). 없앨 cold-start 자체가 없으니 warmup 도 뺀다.
+  //   라우터 LLM 을 라이브로 되살리면 이 블록도 같이 되살려야 한다.
   let offset = 0;
   let stopped = false;
   // ★in-flight getUpdates 롱폴(timeout=25s)을 stop() 에서 즉시 끊기 위한 abort★ — 이게 없으면 restartCapture 시


### PR DESCRIPTION
## 왜

그룹방에서 팀장이 매번 `@coordinator` 를 붙여야 했다. 멘션·답장·sticky 가 모두 없는 메시지는 로컬 LLM owner-inference(`routeDefaultIntakeLLM`)로 갔는데, 실측 정확도가 낮다.

`exaone3.5:7.8b`, 4케이스:

| 질의 | 기대 | LLM 결과 |
|---|---|---|
| 디스크·로그로테이션 | infra 담당 | ✅ |
| 일정·우선순위 | coordinator | ✅ |
| 함수 리팩터링·테스트 | 개발 담당 | ❌ coordinator |
| 경쟁사 조사 | 리서처 | ❌ coordinator |

틀리면 엉뚱한 사람을 깨우고, 맞아도 대개 coordinator 였다. **판단을 안 하는 쪽이 예측 가능하고 빠르다.**

## 무엇을

그 자리를 결정론적 분기로 바꾼다. 정본 근거는 TEAM-OS §2 — "애매하거나 조율성이면 coordinator capability 보유자가 받는다". 이제 코드가 문서를 그대로 따른다.

```
[broadcast > @멘션 > 답장 > sticky] → (신규) coordinator
```

- **앞의 4단계는 그대로다.** 특히 sticky 를 건너뛰지 않았다 — 건너뛰면 멘션 없는 후속이 전부 coordinator 로 가서 멀티턴 위임이 끊긴다.
- LLM 은 이 경로에서 **호출하지 않는다**. `fetch` 감시 테스트로 고정했다.
- `reason` 은 새 값 `default_coordinator`, **confident 로 분류**한다. 억제(`shouldSuppress`)가 안 걸리면 주인 없는 메시지에 전원이 달려든다.

### 같이 챙긴 것 — 안 챙기면 조용히 후퇴하는 것들

1. **`needsGdConfirm` 유지.** 위험 신호(토큰·삭제·배포·재시작…) 판정이 LLM 경로에만 있었다. LLM 호출을 걷어내면 이 플래그가 **아무 데서도 안 서게 된다** — `telegramCapture` 와 `/api/route` 가 소비하는 값이다. `GD_CONFIRM_RE` 를 `_shared.ts` 로 옮겨 두 경로가 같이 쓴다.

2. **capability 가 실제로 지정된 팀에서만 자동으로 깨운다.** `coordinatorId` 는 아무도 capability 를 안 가지면 `agents[0]` 으로 폴백한다(silent-drop 방지용). 그 폴백을 confident 자동배정에 쓰면 *"sticky 가 비면 특정 agent 가 엉뚱한 메시지를 다 받는다"* 는 2026-06-05 에 걷어낸 바로 그 문제로 돌아간다. 미지정 레지스트리는 기존대로 `ask_gd`.

3. **`routeTeamMessageHybrid` 의 `opts`(model/timeoutMs) 제거.** LLM 을 안 부르니 효과가 없다. 남겨두면 "설정해도 아무 일 안 일어나는 노브" 가 되어 없느니만 못하다.

## ⚠️ 되돌리는 결정이 있다

이 변경은 **GD 룰 2026-06-05**(= 오너 애매하면 자동배정하지 말고 `ask_gd`)를 되돌리는 성격이다. 팀장 지시(2026-08-02)로 진행했고, 숨기지 않고 적는다.

그때 하드코딩을 걷어낸 이유는 *"재시작으로 sticky 가 비면 특정 agent(codex)가 엉뚱한 메시지를 잡는다"* 였다. 지금은 받는 쪽이 **분류해서 넘기는 게 일인 coordinator** 라 잘못 받아도 손실이 없다는 판단이다. 위 2번 가드가 "capability 미지정 팀에서 아무나 받는" 옛 실패 모드는 계속 막는다.

정본 기준으로는 이 방향이 맞다 — TEAM-OS §2 가 이미 coordinator 를 지정하고 있고, 동기 폴백 `routeTeamMessage` 도 원래 coordinator 로 보내고 있었다. hybrid 경로만 갈라져 있던 셈이다.

## PR #249 는 닫았다

[#249](https://github.com/b3rys/b3rys-team-os/pull/249)(owner-inference 타임아웃 env 화)는 이 PR 이 그 LLM 경로를 걷어내면서 라이브에서 죽은 코드가 되므로 닫았다(팀장 결정 2026-08-02). 거기서 얻은 실측치는 #249 코멘트에 남겨뒀다. `.env.example` 문서화 중 이 브랜치에도 유효한 부분만 가져왔다 — `TEAM_ROUTER_TIMEOUT_MS` 는 이 브랜치에 존재하지 않는 값이라 제외했다.

## 딸려 나온 정리 2건 (커밋 분리)

**`15d1fdf` — `.env.example` 에 `TEAM_ROUTER_OLLAMA_URL`·`TEAM_ROUTER_MODEL` 문서화.** 둘 다 그동안 어디에도 적혀 있지 않았다.

**`b2f8725` — 기동 시 라우터 모델 상주(warmup) 제거.** GD 2026-05-24 에 cold-start(~9s)를 없애려고 넣은 것인데, 이 PR 로 라이브에서 그 모델을 부르는 곳이 없어졌다. warmup 은 `keep_alive=-1` 이라 **아무도 안 쓰는 모델이 GPU 를 무기한 붙잡는다** — 실측으로 원격 DGX 에서 `exaone3.5:7.8b` = 11GB. 없앨 cold-start 가 없으니 warmup 도 뺐다. 라우터 LLM 을 라이브로 되살리면 이 블록도 같이 되살려야 하고, 그 취지를 코드 주석에 남겼다.

이 정리를 별도 PR 로 빼지 않은 이유: warmup 이 죽는 것은 **이 PR 때문**이다. 따로 내보내면 이 PR 이 머지되지 않았을 때 warmup 만 사라진다. 같이 들어가거나 같이 빠져야 하는 변경이다.

## 검증

- `tsc --noEmit` 통과
- 전체 `bun test`: **2320 pass / 8 fail / 1 error** — 실패 **집합**이 `origin/main`(2990f67) 기준선과 **동일**(`comm` 대조, 신규 0건). 8건은 이 PR 과 무관한 기존 실패.
- 라우터 테스트 파일 단독: 68 pass / 0 fail
- 테스트 전후 라이브 상태파일(`agents.json`·`.env`) 체크섬 대조 — 무변경

### 새로 고정한 테스트 (12건)

동작 변경 4 + 안전장치 4 + **기존 동작 보존 3** + LLM 미호출 1

- LLM 을 호출하지 않는다 (`fetch` 호출 0회)
- 도메인이 명확해 보여도 coordinator 가 받는다
- 해석되지 않는 `@멘션` 은 일반 텍스트 → coordinator
- confident 라서 다른 봇이 억제된다
- 위험 신호는 `needsGdConfirm` 유지 / 평범한 메시지는 안 섬
- `ambiguous_owner` 가 coordinator 보다 우선 (GD 2026-07-10 순서 보존)
- capability 미지정 레지스트리는 자동배정하지 않고 `ask_gd`
- **보존**: @멘션 / 답장 / sticky 각각 그대로

## 미검증

실제 그룹방 트래픽에서의 체감. 위 정확도 수치는 4케이스 스냅샷이다.

## 롤백

`ownerDecision.ts` 의 3번 분기를 되돌리면 끝. 다른 파일 변경(`GD_CONFIRM_RE` 이동, `default_coordinator` reason)은 그것만으로 무해하다.

