### PR TITLE
fix(router): 라우터 LLM 을 OpenAI 호환 /v1/chat/completions 로 전환 (vLLM)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,14 @@ GD_CHAT_ID=
 CAPTURE_BOT_TOKEN=
 # 라우터 ON 이어야 agent 를 실제로 깨워 응답시킴(OFF=shadow: 결정만 로그·응답 안 함). 기본 false.
 ROUTER_ENABLED=false
+# 라우터 owner-inference 에 쓰는 LLM. ★OpenAI 호환 /v1/chat/completions★ 를 기대한다
+#   (vLLM·Ollama·OpenAI 등 호환 서버면 무엇이든. Ollama 는 네이티브 /api/chat 말고 /v1 경로를 써야 한다).
+#   원격 박스를 가리켜도 된다. 미설정이면 아래 기본값. 호출이 실패하면 조용히 regex 폴백으로 내려간다.
+#   ★키 이름이 TEAM_ROUTER_OLLAMA_URL 에서 바뀌었다★ — 경로가 /api/chat → /v1/chat/completions 로
+#   달라져서, 옛 키를 그대로 두면 "설정은 있는데 경로가 틀린" 상태로 조용히 폴백만 계속된다.
+# TEAM_ROUTER_LLM_URL=http://127.0.0.1:8000/v1/chat/completions
+#   서버가 서빙하는 모델 이름과 정확히 같아야 한다(vLLM 은 --served-model-name 값).
+# TEAM_ROUTER_MODEL=Qwen3-Next-80B-A3B
 # ─── 스케줄러 (칸반 과제리뷰·주간 잡 자동 실행) ───────────────
 # 서버 내장 스케줄러 — 켜면 매일 과제리뷰(06:00 팀원 핑 / 06:20 팀장 요약 DM)와 주간 잡을 자동 발화한다.
 #   ★공개(개인 장비)는 기본 ON★: 라이브는 이 잡들을 launchd(macOS)로 돌리는데 공개 빌드엔 launchd 가 없어,

--- a/.env.example
+++ b/.env.example
@@ -39,12 +39,23 @@ CAPTURE_BOT_TOKEN=
 ROUTER_ENABLED=false
 # 라우터 owner-inference 에 쓰는 LLM. ★OpenAI 호환 /v1/chat/completions★ 를 기대한다
 #   (vLLM·Ollama·OpenAI 등 호환 서버면 무엇이든. Ollama 는 네이티브 /api/chat 말고 /v1 경로를 써야 한다).
-#   원격 박스를 가리켜도 된다. 미설정이면 아래 기본값. 호출이 실패하면 조용히 regex 폴백으로 내려간다.
-#   ★키 이름이 TEAM_ROUTER_OLLAMA_URL 에서 바뀌었다★ — 경로가 /api/chat → /v1/chat/completions 로
-#   달라져서, 옛 키를 그대로 두면 "설정은 있는데 경로가 틀린" 상태로 조용히 폴백만 계속된다.
+#   원격 박스를 가리켜도 된다. 미설정이면 아래 기본값.
+#   ★호출이 실패하면 조용히 regex 폴백으로 내려간다★ — 팀 라우팅은 계속 되지만 LLM 판정은 안 쓰인다.
+#   실패는 서버 로그의 `[router] ... → regex 폴백` 한 줄로만 보인다. 오설정을 눈치채려면 거길 봐라.
+#
+#   ★★키 이름이 둘 다 바뀌었다 — 업그레이드하면 반드시 .env 를 손봐야 한다★★
+#     (구) TEAM_ROUTER_OLLAMA_URL / TEAM_ROUTER_MODEL
+#     (신) TEAM_ROUTER_LLM_URL    / TEAM_ROUTER_LLM_MODEL
+#   옛 줄을 남겨두면 사문(死文)이 되고, 특히 옛 TEAM_ROUTER_MODEL 을 그대로 두면 새 엔드포인트에
+#   옛 Ollama 태그(name:tag)를 보내 404 가 난다 → 위의 조용한 폴백으로 묻힌다. ★옛 줄은 지워라.★
 # TEAM_ROUTER_LLM_URL=http://127.0.0.1:8000/v1/chat/completions
 #   서버가 서빙하는 모델 이름과 정확히 같아야 한다(vLLM 은 --served-model-name 값).
-# TEAM_ROUTER_MODEL=Qwen3-Next-80B-A3B
+# TEAM_ROUTER_LLM_MODEL=Qwen3-Next-80B-A3B
+#   인증이 필요한 서버(OpenAI, --api-key 로 띄운 vLLM)만 설정. 로컬 키-불요 서버면 비워 둔다.
+# TEAM_ROUTER_LLM_API_KEY=
+#   ※ Ollama 의 /v1 경로를 쓸 경우: 이 코드에는 모델 상주(warmup)가 없다. Ollama 는 유휴 시 모델을
+#     내리므로 첫 판정이 콜드스타트를 물 수 있다(예전 실측 ~9초). 상한(2.5초)을 넘기면 regex 폴백이다.
+#     상시 상주가 필요하면 Ollama 쪽에서 OLLAMA_KEEP_ALIVE 로 잡아라.
 # ─── 스케줄러 (칸반 과제리뷰·주간 잡 자동 실행) ───────────────
 # 서버 내장 스케줄러 — 켜면 매일 과제리뷰(06:00 팀원 핑 / 06:20 팀장 요약 DM)와 주간 잡을 자동 발화한다.
 #   ★공개(개인 장비)는 기본 ON★: 라이브는 이 잡들을 launchd(macOS)로 돌리는데 공개 빌드엔 launchd 가 없어,

--- a/src/server/lib/teamRouter.llm.test.ts
+++ b/src/server/lib/teamRouter.llm.test.ts
@@ -1,5 +1,8 @@
-// LLM 라우터(EXAONE/Ollama) 통합 테스트 — 논의(multi) vs 구현(single) intent + GD 시나리오.
-// Ollama 가 떠 있어야 함. (없으면 regex 폴백 → intent='other' 라 intent 단정은 skip 처리)
+// LLM 라우터 통합 테스트 — 논의(multi) vs 구현(single) intent + GD 시나리오.
+// ★실행 조건: TEAM_ROUTER_LLM_URL(기본 http://127.0.0.1:8000/v1/chat/completions)에 OpenAI 호환
+//   서버가 떠 있어야 하고, TEAM_ROUTER_LLM_MODEL 이 그 서버의 서빙 모델명과 같아야 한다.★
+//   (Ollama 를 쓸 거면 네이티브 /api/chat 이 아니라 /v1 경로를 가리켜야 한다.)
+//   없으면 regex 폴백 → intent='other' 라 intent 단정은 skip 처리
 import { describe, expect, test } from "bun:test";
 import type { AgentRecord } from "../types";
 import { routeTeamMessageHybrid, routeTeamMessageLLM } from "./teamRouter";

--- a/src/server/lib/teamRouter.test.ts
+++ b/src/server/lib/teamRouter.test.ts
@@ -707,13 +707,32 @@ describe("라우터 LLM 와이어 포맷 (OpenAI 호환 /v1/chat/completions)", 
     await expect(callRouterLlmJson("sys", "user")).rejects.toThrow();
   });
 
-  test("content 가 아예 없으면 빈 객체", async () => {
+  // ★빈 응답의 세 가지 모양을 모두 throw 로 통일한다.★ 예전엔 content:"" 만 (JSON.parse 실패로 우연히)
+  // throw 되고 content:null·choices:[] 는 {} 로 삼켜져, 같은 실패인데 via 가 regex_fallback / llm 으로
+  // 갈렸다. reasoning 계열 모델은 content:null + reasoning_content 를 실제로 낸다 — 그게 "LLM 이
+  // 판정했다" 로 기록되면 감사 로그가 거짓말을 한다.
+  test.each([
+    ["content 없음", { choices: [{ message: {} }] }],
+    ["content:null (reasoning 모델)", { choices: [{ message: { content: null } }] }],
+    ["choices 비어있음", { choices: [] }],
+    ["choices 없음", {}],
+  ])("빈 응답은 throw 한다 — %s", async (_label, payload) => {
     globalThis.fetch = (async () =>
-      new Response(JSON.stringify({ choices: [{ message: {} }] }), {
+      new Response(JSON.stringify(payload), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       })) as unknown as typeof fetch;
-    expect(await callRouterLlmJson("sys", "user")).toEqual({});
+    await expect(callRouterLlmJson("sys", "user")).rejects.toThrow("empty response");
+  });
+
+  // 모델명 오설정이 가장 흔한 실패다. 상태코드만 남기면 원인을 영영 못 본다.
+  test("비 2xx 는 응답 본문을 에러에 담는다", async () => {
+    globalThis.fetch = (async () =>
+      new Response('{"error":{"message":"The model does not exist."}}', {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof fetch;
+    await expect(callRouterLlmJson("sys", "user")).rejects.toThrow("does not exist");
   });
 
   test("타임아웃이면 abort 되어 throw 한다", async () => {

--- a/src/server/lib/teamRouter.test.ts
+++ b/src/server/lib/teamRouter.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { AgentRecord } from "../types";
-import { routeTeamMessage, routeTeamMessageHybrid, detectExplicitTargets, isConfidentOwner, shouldSuppress, callRouterLlmJson } from "./teamRouter";
+import { readFileSync } from "node:fs";
+import { routeTeamMessage, routeTeamMessageHybrid, detectExplicitTargets, isConfidentOwner, shouldSuppress, callRouterLlmJson, ROUTER_MODEL, ROUTER_LLM_TIMEOUT_MS } from "./teamRouter";
+import { routeDefaultIntakeLLM } from "./teamRouter/defaultIntake";
 
 const agents: AgentRecord[] = [
   {
@@ -659,9 +661,10 @@ describe("라우터 LLM 와이어 포맷 (OpenAI 호환 /v1/chat/completions)", 
   });
 
   function capture(status = 200, content = '{"ok":true}') {
-    const seen: { url?: string; body?: Record<string, unknown> } = {};
+    const seen: { url?: string; body?: Record<string, unknown>; headers?: Record<string, string> } = {};
     globalThis.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
       seen.url = String(url);
+      seen.headers = (init?.headers ?? {}) as Record<string, string>;
       seen.body = JSON.parse(String(init?.body)) as Record<string, unknown>;
       return new Response(JSON.stringify({ choices: [{ message: { content } }] }), {
         status,
@@ -735,11 +738,78 @@ describe("라우터 LLM 와이어 포맷 (OpenAI 호환 /v1/chat/completions)", 
     await expect(callRouterLlmJson("sys", "user")).rejects.toThrow("does not exist");
   });
 
+  // ★자체 안전장치가 있는 이유★: signal 배선이 빠지면 이 mock 은 영원히 pending 이 되고
+  //   테스트가 실패가 아니라 ★hang★ 한다(파일 결과 유실 · CI 정지). 빨간 테스트로 떨어뜨린다.
   test("타임아웃이면 abort 되어 throw 한다", async () => {
     globalThis.fetch = ((_u: RequestInfo | URL, init?: RequestInit) =>
       new Promise((_resolve, reject) => {
         init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+        setTimeout(() => reject(new Error("abort 배선 없음 — signal 이 fetch 로 안 넘어갔다")), 300);
       })) as unknown as typeof fetch;
     await expect(callRouterLlmJson("sys", "user", { timeoutMs: 30 })).rejects.toThrow();
+  });
+
+  test("fetch 자체가 reject 하면(연결 거부) 그대로 전파한다", async () => {
+    globalThis.fetch = (async () => {
+      throw new TypeError("Failed to connect");
+    }) as unknown as typeof fetch;
+    await expect(callRouterLlmJson("sys", "user")).rejects.toThrow("Failed to connect");
+  });
+
+  // ★모델명 오설정이 가장 흔한 실패다★ — 그런데 model 이 실려 나가는지 자체는 무검증이었다
+  //   (하네스 실증: model 을 통째로 빼도 전 테스트 통과). Ollama 태그(name:tag)가 새 키로
+  //   흘러드는 것도 여기서 막는다.
+  test("요청에 model 이 실린다 — Ollama 태그(name:tag) 형식이 아니다", async () => {
+    const seen = capture();
+    await callRouterLlmJson("sys", "user");
+    expect(seen.body?.model).toBe(ROUTER_MODEL);
+    expect(String(seen.body?.model)).not.toContain(":");
+  });
+
+  test("API 키가 없으면 Authorization 을 붙이지 않는다", async () => {
+    const seen = capture();
+    await callRouterLlmJson("sys", "user");
+    expect(Object.keys(seen.headers ?? {})).not.toContain("Authorization");
+  });
+});
+
+// ─── 교차파일 불변식·폴백 계약 ────────────────────────────────────────────────
+describe("라우터 LLM — 교차파일 불변식과 폴백 계약", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  // ★이 결합은 주석으로만 존재하면 반드시 깨진다.★ owner-gate 훅은 서버 응답을 N초까지만 기다리고
+  // 넘으면 fail-open 한다(= 아무도 억제 안 함 = 그룹방 전원 응답). 서버 상한이 훅 예산보다 크면
+  // 우리가 무슨 판정을 내든 훅에는 안 닿는다. 둘 중 하나만 고치는 사고를 여기서 잡는다.
+  test("서버 상한 < owner-gate 훅 예산", async () => {
+    const hook = readFileSync(
+      new URL("../../../hooks/telegram-owner-gate.py", import.meta.url).pathname,
+      "utf-8",
+    );
+    const m = hook.match(/urlopen\([^)]*timeout=(\d+(?:\.\d+)?)/);
+    expect(m).not.toBeNull();
+    const hookBudgetMs = Number(m?.[1]) * 1000;
+    expect(ROUTER_LLM_TIMEOUT_MS).toBeLessThan(hookBudgetMs);
+  });
+
+  // throw 는 고정됐지만 "그 throw 가 무엇이 되는가" 는 안 고정돼 있었다. 신규 블록 주석의 논거가
+  // 'via:"llm" 거짓 기록 방지' 인데, 정작 via 를 단언하는 테스트가 저장소에 하나도 없었다.
+  test("LLM 실패 시 via=regex_fallback 로 떨어진다", async () => {
+    globalThis.fetch = (async () => new Response("boom", { status: 503 })) as unknown as typeof fetch;
+    const d = await routeDefaultIntakeLLM("아무 말이나", agents);
+    expect(d.via).toBe("regex_fallback");
+    expect(d.domain).toBe("owner_inference:llm_unavailable");
+  });
+
+  test("빈 응답도 via=regex_fallback 이다 (llm 으로 위장하지 않는다)", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ choices: [{ message: { content: null } }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof fetch;
+    const d = await routeDefaultIntakeLLM("아무 말이나", agents);
+    expect(d.via).toBe("regex_fallback");
   });
 });

--- a/src/server/lib/teamRouter.test.ts
+++ b/src/server/lib/teamRouter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { AgentRecord } from "../types";
-import { routeTeamMessage, routeTeamMessageHybrid, detectExplicitTargets, isConfidentOwner, shouldSuppress } from "./teamRouter";
+import { routeTeamMessage, routeTeamMessageHybrid, detectExplicitTargets, isConfidentOwner, shouldSuppress, callRouterLlmJson } from "./teamRouter";
 
 const agents: AgentRecord[] = [
   {
@@ -189,7 +189,7 @@ describe("owner inference fallback", () => {
 
   function mockRouter(reply: Record<string, unknown>): void {
     globalThis.fetch = (async () =>
-      new Response(JSON.stringify({ message: { content: JSON.stringify(reply) } }), {
+      new Response(JSON.stringify({ choices: [{ message: { content: JSON.stringify(reply) } }] }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       })) as unknown as typeof fetch;
@@ -233,7 +233,7 @@ describe("owner inference fallback", () => {
       const reply = user.new_message?.includes("team-collab")
         ? { outcome: "route", responder: "steve", domain: "ops_from_role", needs_gd_confirm: false }
         : { outcome: "route", responder: "dbak", domain: "pm_from_role", needs_gd_confirm: false };
-      return new Response(JSON.stringify({ message: { content: JSON.stringify(reply) } }), {
+      return new Response(JSON.stringify({ choices: [{ message: { content: JSON.stringify(reply) } }] }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
@@ -645,5 +645,82 @@ describe("hybrid 라우터도 인용/펜스 멘션 무시 (routeTeamMessageHybri
     const d = await routeTeamMessageHybrid("@빌 확인해줘\n—-\n@코덱스 @스티브 예시 멘션", agents);
     expect(d.targetAgentIds).toEqual(["bill"]);
     expect(d.reason).toBe("explicit_mention");
+  });
+});
+
+// ─── 라우터 LLM 와이어 포맷 (OpenAI 호환) ─────────────────────────────────────
+// 이 블록이 고정하는 것: 요청/응답이 ★OpenAI 호환 모양★ 이라는 것. 예전엔 Ollama 네이티브
+// (/api/chat + format:"json" + options.temperature + body.message.content) 였고, vLLM 은 그 경로가
+// 아예 없다. 모양이 되돌아가면 라우터는 에러 없이 조용히 regex 폴백만 계속한다 — 그게 이 테스트의 이유다.
+describe("라우터 LLM 와이어 포맷 (OpenAI 호환 /v1/chat/completions)", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function capture(status = 200, content = '{"ok":true}') {
+    const seen: { url?: string; body?: Record<string, unknown> } = {};
+    globalThis.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+      seen.url = String(url);
+      seen.body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({ choices: [{ message: { content } }] }), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    return seen;
+  }
+
+  test("요청 바디가 OpenAI 규격이다 — response_format·temperature 있고 Ollama 전용 필드는 없다", async () => {
+    const seen = capture();
+    await callRouterLlmJson("sys", "user");
+    expect(seen.body?.response_format).toEqual({ type: "json_object" });
+    expect(seen.body?.temperature).toBe(0);
+    expect(seen.body?.stream).toBe(false);
+    // ★Ollama 전용 필드가 다시 끼면 vLLM 이 거부하거나 무시한다★
+    expect(seen.body).not.toHaveProperty("format");
+    expect(seen.body).not.toHaveProperty("options");
+    expect(seen.body).not.toHaveProperty("keep_alive");
+  });
+
+  test("엔드포인트가 /v1/chat/completions 다 (/api/chat 아님)", async () => {
+    const seen = capture();
+    await callRouterLlmJson("sys", "user");
+    expect(seen.url).toContain("/v1/chat/completions");
+    expect(seen.url).not.toContain("/api/chat");
+  });
+
+  test("응답을 choices[0].message.content 에서 읽는다", async () => {
+    capture(200, '{"responder":"bill"}');
+    expect(await callRouterLlmJson("sys", "user")).toEqual({ responder: "bill" });
+  });
+
+  test("비 2xx 는 throw — 폴백 판단은 호출부 몫", async () => {
+    capture(500);
+    await expect(callRouterLlmJson("sys", "user")).rejects.toThrow("router llm 500");
+  });
+
+  // 빈 content 는 throw 한다 — 호출부가 regex 폴백으로 내려간다. ★{} 로 삼키면 안 된다★:
+  // 그러면 아무것도 못 받았는데 via:"llm" 로 기록돼 "LLM 이 판정했다" 는 거짓 신호가 남는다.
+  test("content 가 비면 throw (조용히 빈 결정으로 위장하지 않는다)", async () => {
+    capture(200, "");
+    await expect(callRouterLlmJson("sys", "user")).rejects.toThrow();
+  });
+
+  test("content 가 아예 없으면 빈 객체", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ choices: [{ message: {} }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof fetch;
+    expect(await callRouterLlmJson("sys", "user")).toEqual({});
+  });
+
+  test("타임아웃이면 abort 되어 throw 한다", async () => {
+    globalThis.fetch = ((_u: RequestInfo | URL, init?: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+      })) as unknown as typeof fetch;
+    await expect(callRouterLlmJson("sys", "user", { timeoutMs: 30 })).rejects.toThrow();
   });
 });

--- a/src/server/lib/teamRouter.ts
+++ b/src/server/lib/teamRouter.ts
@@ -8,7 +8,7 @@
  *
  * Module map (Devon guidance: keep mention regexes together, isolate legacy):
  *   _shared       — RouterContext, RouteDecision, RouteIntent, LlmRouteDecision,
- *                   OLLAMA_URL/ROUTER_MODEL, buildRosterText, classifyIntent
+ *                   ROUTER_LLM_URL/ROUTER_MODEL/callRouterLlmJson, buildRosterText, classifyIntent
  *                   (default_step owner = coordinator capability via lib/capabilities.coordinatorId)
  *   mention       — aliasesFor, hasTelegramMention, hasRestrictedMention, escapeRegex,
  *                   stripExampleRegions, detectExplicitTargets, detectAddressedNamesLoose

--- a/src/server/lib/teamRouter/_shared.ts
+++ b/src/server/lib/teamRouter/_shared.ts
@@ -52,7 +52,7 @@ const ROUTER_LLM_API_KEY = process.env.TEAM_ROUTER_LLM_API_KEY ?? "";
  * 2.5초면 훅이 포기하기 전에 반드시 답을 받는다 — 늦으면 폴백 판정이라도 제때 준다.
  * 실측(DGX vLLM, Qwen3-Next-80B): 1.5~2.2초. 이 값을 올리려면 훅 쪽 timeout 도 같이 올려야 한다.
  */
-const ROUTER_LLM_TIMEOUT_MS = 2_500;
+export const ROUTER_LLM_TIMEOUT_MS = 2_500;
 
 /**
  * 라우터 LLM 에 JSON 응답을 요청하고 파싱해 돌려준다.

--- a/src/server/lib/teamRouter/_shared.ts
+++ b/src/server/lib/teamRouter/_shared.ts
@@ -25,8 +25,58 @@ export interface RouteDecision {
 // (removed) DEFAULT_STEP_AGENT_ID = "codex" — default_step owner 는 이제 coordinator capability 로
 // 결정한다. lib/capabilities.ts 의 coordinatorId(agents) 사용. 정본 = agents.json.
 
-export const OLLAMA_URL = process.env.TEAM_ROUTER_OLLAMA_URL ?? "http://127.0.0.1:11434/api/chat";
-export const ROUTER_MODEL = process.env.TEAM_ROUTER_MODEL ?? "exaone3.5:2.4b";
+/**
+ * 라우터 판정용 LLM 엔드포인트 — ★OpenAI 호환 /v1/chat/completions★.
+ *
+ * 예전엔 Ollama 네이티브 `/api/chat` 이었다(`TEAM_ROUTER_OLLAMA_URL`). 로컬 LLM 을 vLLM 으로 옮기면서
+ * 바꿨다 — vLLM 은 OpenAI 호환 API 만 제공하고 `/api/chat` 이 없다. Ollama 도 OpenAI 호환 경로
+ * (`/v1/chat/completions`)를 제공하므로 이 클라이언트 하나로 양쪽을 다 붙일 수 있다.
+ *
+ * ★env 키 이름도 바꿨다★ — 값(경로)이 어차피 달라져야 해서, 옛 키를 그대로 두면 "설정은 있는데
+ * 경로가 틀린" 상태로 조용히 폴백만 계속된다. 키를 바꾸면 미설정으로 잡혀 기본값이 쓰인다.
+ */
+export const ROUTER_LLM_URL =
+  process.env.TEAM_ROUTER_LLM_URL ?? "http://127.0.0.1:8000/v1/chat/completions";
+export const ROUTER_MODEL = process.env.TEAM_ROUTER_MODEL ?? "Qwen3-Next-80B-A3B";
+
+/**
+ * 라우터 LLM 에 JSON 응답을 요청하고 파싱해 돌려준다.
+ *
+ * ★와이어 포맷을 아는 곳은 여기 하나다.★ 예전엔 defaultIntake 와 ownerDecision 이 같은 요청을 각자
+ * 만들어 두 벌이었다 — 한쪽만 고치면 같은 질문에 답이 둘이 된다.
+ *
+ * 실패(네트워크·비 2xx·JSON 파싱 실패·타임아웃)는 전부 throw 한다. 폴백 판단은 호출부의 몫이다.
+ */
+export async function callRouterLlmJson(
+  systemPrompt: string,
+  userContent: string,
+  opts: { model?: string; timeoutMs?: number } = {},
+): Promise<Record<string, unknown>> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? 8_000);
+  try {
+    const res = await fetch(ROUTER_LLM_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      signal: ctrl.signal,
+      body: JSON.stringify({
+        model: opts.model ?? ROUTER_MODEL,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userContent },
+        ],
+        stream: false,
+        response_format: { type: "json_object" },
+        temperature: 0,
+      }),
+    });
+    if (!res.ok) throw new Error(`router llm ${res.status}`);
+    const body = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> };
+    return JSON.parse(body.choices?.[0]?.message?.content ?? "{}") as Record<string, unknown>;
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 export type RouteIntent = "discussion" | "execution" | "other";
 

--- a/src/server/lib/teamRouter/_shared.ts
+++ b/src/server/lib/teamRouter/_shared.ts
@@ -32,12 +32,27 @@ export interface RouteDecision {
  * 바꿨다 — vLLM 은 OpenAI 호환 API 만 제공하고 `/api/chat` 이 없다. Ollama 도 OpenAI 호환 경로
  * (`/v1/chat/completions`)를 제공하므로 이 클라이언트 하나로 양쪽을 다 붙일 수 있다.
  *
- * ★env 키 이름도 바꿨다★ — 값(경로)이 어차피 달라져야 해서, 옛 키를 그대로 두면 "설정은 있는데
- * 경로가 틀린" 상태로 조용히 폴백만 계속된다. 키를 바꾸면 미설정으로 잡혀 기본값이 쓰인다.
+ * ★env 키 이름도 둘 다 바꿨다★ — 값(경로·모델명)이 어차피 달라져야 해서, 옛 키를 그대로 두면
+ * "설정은 있는데 값이 틀린" 상태로 조용히 폴백만 계속된다. 키를 바꾸면 미설정으로 잡혀 기본값이 쓰인다.
+ * ★URL 만 바꾸고 MODEL 을 두면 최악이다★ — 새 엔드포인트에 옛 Ollama 태그(`name:tag`)를 보내
+ * 404 가 나고, 그게 조용한 폴백으로 묻힌다. 둘은 같이 움직여야 한다.
  */
 export const ROUTER_LLM_URL =
   process.env.TEAM_ROUTER_LLM_URL ?? "http://127.0.0.1:8000/v1/chat/completions";
-export const ROUTER_MODEL = process.env.TEAM_ROUTER_MODEL ?? "Qwen3-Next-80B-A3B";
+export const ROUTER_MODEL = process.env.TEAM_ROUTER_LLM_MODEL ?? "Qwen3-Next-80B-A3B";
+/** 있으면 Bearer 로 붙인다(OpenAI·`--api-key` 로 띄운 vLLM). 로컬 키-불요 서버면 미설정. */
+const ROUTER_LLM_API_KEY = process.env.TEAM_ROUTER_LLM_API_KEY ?? "";
+
+/**
+ * owner-inference 호출 상한(ms).
+ *
+ * ★owner-gate 훅의 예산보다 반드시 작아야 한다.★ `hooks/telegram-owner-gate.py` 는 서버 응답을
+ * 3초까지만 기다리고, 넘으면 fail-open 해서 아무도 억제하지 않는다(= 전원이 답한다). 서버가 훅보다
+ * 오래 기다리면 훅은 답을 못 받고, 우리가 어떤 판정을 냈든 무의미해진다.
+ * 2.5초면 훅이 포기하기 전에 반드시 답을 받는다 — 늦으면 폴백 판정이라도 제때 준다.
+ * 실측(DGX vLLM, Qwen3-Next-80B): 1.5~2.2초. 이 값을 올리려면 훅 쪽 timeout 도 같이 올려야 한다.
+ */
+const ROUTER_LLM_TIMEOUT_MS = 2_500;
 
 /**
  * 라우터 LLM 에 JSON 응답을 요청하고 파싱해 돌려준다.
@@ -45,7 +60,11 @@ export const ROUTER_MODEL = process.env.TEAM_ROUTER_MODEL ?? "Qwen3-Next-80B-A3B
  * ★와이어 포맷을 아는 곳은 여기 하나다.★ 예전엔 defaultIntake 와 ownerDecision 이 같은 요청을 각자
  * 만들어 두 벌이었다 — 한쪽만 고치면 같은 질문에 답이 둘이 된다.
  *
- * 실패(네트워크·비 2xx·JSON 파싱 실패·타임아웃)는 전부 throw 한다. 폴백 판단은 호출부의 몫이다.
+ * 실패(네트워크·비 2xx·빈 응답·JSON 파싱 실패·타임아웃)는 전부 throw 한다. 폴백 판단은 호출부의 몫이다.
+ *
+ * ★빈 응답을 {} 로 삼키지 않는다.★ 삼키면 아무것도 못 받았는데 via:"llm" 으로 기록돼 "LLM 이 판정했다"
+ * 는 거짓 신호가 남는다. 특히 reasoning 계열 모델은 `content:null` + `reasoning_content` 를 낸다 —
+ * 그게 성공으로 보이면 안 된다. (runtimes/b3osNative/runner.ts 의 openai_compat_empty_response 와 같은 규칙.)
  */
 export async function callRouterLlmJson(
   systemPrompt: string,
@@ -53,11 +72,14 @@ export async function callRouterLlmJson(
   opts: { model?: string; timeoutMs?: number } = {},
 ): Promise<Record<string, unknown>> {
   const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? 8_000);
+  const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? ROUTER_LLM_TIMEOUT_MS);
   try {
     const res = await fetch(ROUTER_LLM_URL, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(ROUTER_LLM_API_KEY ? { Authorization: `Bearer ${ROUTER_LLM_API_KEY}` } : {}),
+      },
       signal: ctrl.signal,
       body: JSON.stringify({
         model: opts.model ?? ROUTER_MODEL,
@@ -70,9 +92,18 @@ export async function callRouterLlmJson(
         temperature: 0,
       }),
     });
-    if (!res.ok) throw new Error(`router llm ${res.status}`);
-    const body = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> };
-    return JSON.parse(body.choices?.[0]?.message?.content ?? "{}") as Record<string, unknown>;
+    if (!res.ok) {
+      // ★본문을 버리지 않는다★ — vLLM 은 "model does not exist" 같은 진단을 본문에 담는다.
+      //   모델명 오설정이 가장 흔한 실패인데, 상태코드만 남기면 그걸 영영 못 본다.
+      const detail = await res.text().catch(() => "");
+      throw new Error(`router llm ${res.status}${detail ? `: ${detail.slice(0, 200)}` : ""}`);
+    }
+    const body = (await res.json()) as { choices?: Array<{ message?: { content?: string | null } }> };
+    const content = body.choices?.[0]?.message?.content;
+    if (typeof content !== "string" || content.trim() === "") {
+      throw new Error("router llm empty response");
+    }
+    return JSON.parse(content) as Record<string, unknown>;
   } finally {
     clearTimeout(timer);
   }

--- a/src/server/lib/teamRouter/defaultIntake.ts
+++ b/src/server/lib/teamRouter/defaultIntake.ts
@@ -55,7 +55,7 @@ export async function routeDefaultIntakeLLM(
     const parsed = (await callRouterLlmJson(
       defaultIntakePrompt(agents),
       JSON.stringify({ new_message: text }),
-      { model: opts.model, timeoutMs: opts.timeoutMs ?? 8_000 },
+      { model: opts.model, timeoutMs: opts.timeoutMs },
     )) as RawDefaultIntake;
     const suggested = (parsed.suggested ?? []).filter((id) => validIds.has(id));
     const responder = parsed.responder && validIds.has(parsed.responder) ? parsed.responder : null;
@@ -87,7 +87,10 @@ export async function routeDefaultIntakeLLM(
       outcome: "route",
       suggested,
     };
-  } catch {
+  } catch (e) {
+    // ★조용히 삼키지 않는다★ — 여기가 무음이면 모델명 오설정·엔드포인트 다운이 몇 주씩 안 보인다.
+    //   (실제로 라우터 LLM 경로는 오늘까지 로그가 한 줄도 없었다.)
+    console.error("[router] owner-inference 실패 → regex 폴백:", (e as Error).message);
     return {
       targetAgentIds: ambiguousOwner ? [ambiguousOwner] : [],
       reason: "default_step",

--- a/src/server/lib/teamRouter/defaultIntake.ts
+++ b/src/server/lib/teamRouter/defaultIntake.ts
@@ -1,9 +1,8 @@
 import type { AgentRecord } from "../../types";
 import {
   type LlmRouteDecision,
-  OLLAMA_URL,
-  ROUTER_MODEL,
   buildRosterText,
+  callRouterLlmJson,
   classifyIntent,
 } from "./_shared";
 import { ambiguousOwnerId } from "../capabilities";
@@ -52,28 +51,12 @@ export async function routeDefaultIntakeLLM(
   const validIds = new Set(agents.map((a) => a.id));
   // 오너가 애매/무-확신일 때의 default 담당 = ambiguous_owner(GD 2026-07-10: 빌). 미설정 시 coordinator 폴백.
   const ambiguousOwner = ambiguousOwnerId(agents);
-  const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? 3_000);
   try {
-    const res = await fetch(OLLAMA_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      signal: ctrl.signal,
-      body: JSON.stringify({
-        model: opts.model ?? ROUTER_MODEL,
-        messages: [
-          { role: "system", content: defaultIntakePrompt(agents) },
-          { role: "user", content: JSON.stringify({ new_message: text }) },
-        ],
-        stream: false,
-        format: "json",
-        options: { temperature: 0 },
-      }),
-    });
-    clearTimeout(timer);
-    if (!res.ok) throw new Error(`ollama ${res.status}`);
-    const body = (await res.json()) as { message?: { content?: string } };
-    const parsed = JSON.parse(body.message?.content ?? "{}") as RawDefaultIntake;
+    const parsed = (await callRouterLlmJson(
+      defaultIntakePrompt(agents),
+      JSON.stringify({ new_message: text }),
+      { model: opts.model, timeoutMs: opts.timeoutMs ?? 8_000 },
+    )) as RawDefaultIntake;
     const suggested = (parsed.suggested ?? []).filter((id) => validIds.has(id));
     const responder = parsed.responder && validIds.has(parsed.responder) ? parsed.responder : null;
     const needsGdConfirm = Boolean(parsed.needs_gd_confirm) || GD_CONFIRM_RE.test(text);
@@ -105,7 +88,6 @@ export async function routeDefaultIntakeLLM(
       suggested,
     };
   } catch {
-    clearTimeout(timer);
     return {
       targetAgentIds: ambiguousOwner ? [ambiguousOwner] : [],
       reason: "default_step",

--- a/src/server/lib/teamRouter/ownerDecision.ts
+++ b/src/server/lib/teamRouter/ownerDecision.ts
@@ -4,9 +4,8 @@ import {
   type RouteDecision,
   type RouteIntent,
   type LlmRouteDecision,
-  OLLAMA_URL,
-  ROUTER_MODEL,
   buildRosterText,
+  callRouterLlmJson,
   classifyIntent,
 } from "./_shared";
 import { coordinatorId } from "../capabilities";
@@ -203,27 +202,10 @@ export async function routeTeamMessageLLM(
       reply_to_agent: context.replyToAgentId ?? null,
       new_message: text,
     });
-    const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? 15_000);
-    const res = await fetch(OLLAMA_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      signal: ctrl.signal,
-      body: JSON.stringify({
-        model: opts.model ?? ROUTER_MODEL,
-        messages: [
-          { role: "system", content: routerSystemPrompt(agents) },
-          { role: "user", content: user },
-        ],
-        stream: false,
-        format: "json",
-        options: { temperature: 0 },
-      }),
-    });
-    clearTimeout(timer);
-    if (!res.ok) throw new Error(`ollama ${res.status}`);
-    const body = (await res.json()) as { message?: { content?: string } };
-    const parsed = JSON.parse(body.message?.content ?? "{}") as RawLlm;
+    const parsed = (await callRouterLlmJson(routerSystemPrompt(agents), user, {
+      model: opts.model,
+      timeoutMs: opts.timeoutMs ?? 15_000,
+    })) as RawLlm;
 
     const coordinator = coordinatorId(agents);
     let responders = (parsed.responders ?? []).filter((id) => validIds.has(id));

--- a/src/server/lib/teamRouter/ownerDecision.ts
+++ b/src/server/lib/teamRouter/ownerDecision.ts
@@ -131,14 +131,15 @@ function validActiveAssignees(context: RouterContext, agents: AgentRecord[]): st
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// LLM router (EXAONE via Ollama) — PRIMARY engine per GD's "all-LLM, no regex"
+// LLM router (OpenAI 호환 엔드포인트) — PRIMARY engine per GD's "all-LLM, no regex"
 // decision (2026-05-23). The regex routeTeamMessage above is kept as a fast,
-// deterministic FALLBACK (used when Ollama is unavailable) + its tests document
+// deterministic FALLBACK (라우터 LLM 호출 실패 시) + its tests document
 // the expected behavior. The LLM engine additionally classifies discussion vs
 // execution intent (논의=multi / 구현=single owner) — GD pattern.
 // ─────────────────────────────────────────────────────────────────────────────
 
-// NOTE (2026-06-20): routerSystemPrompt 는 데이터화(routing_domains) 시도했으나 EXAONE(2.4b, temp=0)이
+// NOTE (2026-06-20, 모델 전제 갱신 2026-08-02): routerSystemPrompt 는 데이터화(routing_domains) 시도했으나
+// 당시 기본 모델 EXAONE(2.4b, temp=0)이
 // 프롬프트 텍스트/순서/예시에 민감해 기존 green 테스트 3개(explicit name·finance·sticky)를 깨뜨려 behavior
 // 보존 실패 → 원문 유지. routeTeamMessageLLM 는 라이브 미연결(standalone) 함수라 영향 범위도 작다. 이 프롬프트
 // 속 실명은 public export pipeline 의 ownerDecision 치환 + SKIN 단계가 처리. (LIVE 경로인 defaultIntakePrompt 는
@@ -185,7 +186,7 @@ interface RawLlm {
 }
 
 /**
- * LLM 라우팅 (EXAONE/Ollama). Ollama 실패 시 regex routeTeamMessage 로 폴백.
+ * LLM 라우팅 (OpenAI 호환 엔드포인트). 호출 실패 시 regex routeTeamMessage 로 폴백.
  * standalone — 아직 라이브 메시지 흐름에 연결 안 됨 (GD 리뷰 후 통합).
  */
 export async function routeTeamMessageLLM(
@@ -204,7 +205,7 @@ export async function routeTeamMessageLLM(
     });
     const parsed = (await callRouterLlmJson(routerSystemPrompt(agents), user, {
       model: opts.model,
-      timeoutMs: opts.timeoutMs ?? 15_000,
+      timeoutMs: opts.timeoutMs,
     })) as RawLlm;
 
     const coordinator = coordinatorId(agents);
@@ -231,8 +232,9 @@ export async function routeTeamMessageLLM(
       domain: parsed.domain ?? "none",
       via: "llm",
     };
-  } catch {
-    // Ollama 불가 → 결정론적 regex 폴백 (Codex 라우터).
+  } catch (e) {
+    console.error("[router] LLM 라우팅 실패 → regex 폴백:", (e as Error).message);
+    // 라우터 LLM 불가 → 결정론적 regex 폴백.
     const d = routeTeamMessage(text, agents, context);
     return { ...d, intent: "other", domain: "none", via: "regex_fallback" };
   }
@@ -240,7 +242,8 @@ export async function routeTeamMessageLLM(
 
 // ─────────────────────────────────────────────────────────────────────────────
 // HYBRID 라우터 (권장) — 결정론 신호는 regex 로 100% 확실하게, 모호한 도메인만 LLM.
-// 이유: 순수 small-LLM(EXAONE 2.4b) 단독은 ~77% + run-to-run 변동(명시멘션·주제전환을
+// 이유(2026-05 당시 기본 모델 기준 — 80B 로 바뀐 뒤 재측정 기록 없음): 순수 small-LLM(EXAONE 2.4b)
+// 단독은 ~77% + run-to-run 변동(명시멘션·주제전환을
 // 가끔 놓침). 명시 @멘션/이름/주제전환 마커는 regex 가 확실하므로 그건 regex 로 고정하고,
 // "이름·도메인 불명확" 인 경우에만 LLM 으로 도메인 분류. → 신뢰도↑ + LLM 호출↓(빠름).
 // (GD 의 "all-LLM" 결정과의 트레이드오프: 신뢰도 위해 명확신호는 결정론. GD 리뷰 후 택1.)

--- a/src/server/workers/telegramCapture.ts
+++ b/src/server/workers/telegramCapture.ts
@@ -434,7 +434,9 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
   //   keep_alive=-1 을 걸던 블록. 라우터 LLM 이 vLLM(OpenAI 호환)으로 바뀌면서 두 가지 이유로 뺀다:
   //   ① keep_alive 는 Ollama 전용 필드고 /v1/chat/completions 에는 없다 — 보내봐야 무의미하다.
   //   ② vLLM 은 기동 시 가중치를 올려 두고 계속 물고 있으므로 데워 둘 cold-start 자체가 없다.
-  //   다시 Ollama 로 돌아가면 이 블록도 같이 되살려야 한다.
+  //   ★단, env 한 줄로도 Ollama 로 되돌아갈 수 있다★ — TEAM_ROUTER_LLM_URL 을 Ollama 의 /v1 경로로
+  //   두면 코드 변경 없이 그 상태가 되고, 그때는 warmup 이 없어 첫 판정이 콜드스타트를 문다.
+  //   그 조합을 쓸 거면 Ollama 쪽 OLLAMA_KEEP_ALIVE 로 잡거나 이 블록을 되살려라(.env.example 에도 적어뒀다).
   let offset = 0;
   let stopped = false;
   // ★in-flight getUpdates 롱폴(timeout=25s)을 stop() 에서 즉시 끊기 위한 abort★ — 이게 없으면 restartCapture 시

--- a/src/server/workers/telegramCapture.ts
+++ b/src/server/workers/telegramCapture.ts
@@ -430,21 +430,11 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
     console.log("[capture] disabled — CAPTURE_BOT_TOKEN 미설정 (inert)");
     return () => {};
   }
-  // 라우터 LLM(exaone) 상주 — cold-start(~9s) 제거. 재부팅/재시작마다 재핀 (GD 결정 2026-05-24).
-  void (async () => {
-    const url = process.env.TEAM_ROUTER_OLLAMA_URL ?? "http://127.0.0.1:11434/api/chat";
-    const model = process.env.TEAM_ROUTER_MODEL ?? "exaone3.5:2.4b";
-    try {
-      await fetch(url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model, messages: [{ role: "user", content: "warmup" }], stream: false, keep_alive: -1 }),
-      });
-      console.log(`[capture] router model ${model} 상주 (keep_alive=-1)`);
-    } catch (e) {
-      console.error("[capture] model warmup failed:", (e as Error).message);
-    }
-  })();
+  // (제거) 라우터 LLM 상주 warmup — GD 2026-05-24 에 cold-start(~9s) 를 없애려고 기동 때 Ollama 에
+  //   keep_alive=-1 을 걸던 블록. 라우터 LLM 이 vLLM(OpenAI 호환)으로 바뀌면서 두 가지 이유로 뺀다:
+  //   ① keep_alive 는 Ollama 전용 필드고 /v1/chat/completions 에는 없다 — 보내봐야 무의미하다.
+  //   ② vLLM 은 기동 시 가중치를 올려 두고 계속 물고 있으므로 데워 둘 cold-start 자체가 없다.
+  //   다시 Ollama 로 돌아가면 이 블록도 같이 되살려야 한다.
   let offset = 0;
   let stopped = false;
   // ★in-flight getUpdates 롱폴(timeout=25s)을 stop() 에서 즉시 끊기 위한 abort★ — 이게 없으면 restartCapture 시

--- a/web/b3os.html
+++ b/web/b3os.html
@@ -313,9 +313,9 @@
         </div>
         <div class="context-card">
           <div class="context-label">LLM ENGINE</div>
-          <div class="context-title">로컬 Ollama exaone3.5:2.4b</div>
-          <div class="context-desc">온디바이스 판단 모델. 외부 전송 없이 역할 라우팅.</div>
-          <div class="context-example"><strong>exact 73% · acceptable 95%</strong> — 평균 0.9s</div>
+          <div class="context-title">자체 호스팅 OpenAI 호환 LLM</div>
+          <div class="context-desc">직접 띄운 모델이 역할을 판단한다. 상용 API 로 나가지 않는다.</div>
+          <div class="context-example">엔드포인트·모델은 <strong>TEAM_ROUTER_LLM_URL</strong> 로 지정</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 왜

로컬 LLM 을 Ollama → vLLM 으로 옮겼다. **vLLM 은 OpenAI 호환 API 만 제공하고 Ollama 네이티브 `/api/chat` 이 없다.** 라우터의 owner-inference 는 그 경로를 쓰고 있었으므로 그대로 두면 전면 폴백이 된다.

Ollama 도 `/v1/chat/completions` 를 제공하므로, 이 클라이언트 하나로 양쪽을 다 붙일 수 있다.

## 무엇을

| | 이전 | 이후 |
|---|---|---|
| 엔드포인트 | `/api/chat` | `/v1/chat/completions` |
| JSON 강제 | `format:"json"` | `response_format:{type:"json_object"}` |
| 온도 | `options.{temperature}` | `temperature` |
| 응답 | `body.message.content` | `choices[0].message.content` |
| env | `TEAM_ROUTER_OLLAMA_URL` / `TEAM_ROUTER_MODEL` | `TEAM_ROUTER_LLM_URL` / `TEAM_ROUTER_LLM_MODEL` |

요청을 만드는 코드를 `_shared.ts` 의 `callRouterLlmJson` **하나로** 합쳤다. 전에는 `defaultIntake` 와 `ownerDecision` 이 같은 요청을 각자 만들어 두 벌이었고, 그런 자리는 한쪽만 고치면 같은 질문에 답이 둘이 된다.

기동 warmup(`telegramCapture`)도 제거했다. `keep_alive` 는 Ollama 전용 필드라 `/v1` 에서 의미가 없고, vLLM 은 가중치를 계속 물고 있어 데워 둘 cold-start 자체가 없다.

## ⚠️ 배포 시 `.env` 를 반드시 고쳐야 한다

**두 키 모두 이름이 바뀌었다.** 옛 줄을 남겨두면 사문(死文)이 되고, 특히 옛 `TEAM_ROUTER_MODEL` 을 그대로 두면 새 엔드포인트에 옛 Ollama 태그(`name:tag`)가 나가 404 → **조용한 regex 폴백**이 된다.

```diff
- TEAM_ROUTER_OLLAMA_URL=http://.../api/chat
- TEAM_ROUTER_MODEL=exaone3.5:7.8b
+ TEAM_ROUTER_LLM_URL=http://<host>:8000/v1/chat/completions
+ TEAM_ROUTER_LLM_MODEL=<vLLM 의 --served-model-name 값>
```

상수는 모듈 최상위에서 1회 평가되므로 **서버 재시작**이 필요하다. 신규/공개 설치는 회귀 없음 — 기본값이 로컬이라 즉시 실패 후 regex 폴백이고, 이는 옛 기본값과 같은 동작이다.

## 리뷰에서 잡혀 고친 것

세 명의 리뷰어를 붙였고 둘이 **독립적으로 같은 blocker** 를 짚었다. 초기 커밋(`ab1ce91`)에는 아래가 있었다:

1. **`TEAM_ROUTER_MODEL` 을 안 바꿔서** 업그레이드한 배포가 조용히 깨졌다. URL 리네임의 근거가 MODEL 에도 그대로 적용되는데 적용을 안 했다. → 리네임 + `.env.example` 에 구/신 대조 명시
2. **상한 8초가 owner-gate 훅의 3초 fail-open 예산을 넘겼다.** `hooks/telegram-owner-gate.py:175` 는 3초까지만 기다리고 넘으면 아무도 억제하지 않는다(= 전원 응답). → **2.5초**로 낮추고 결합을 테스트로 고정
3. **빈 응답을 `{}` 로 삼켜 `via:"llm"` 로 기록**했다. `content:null`/`choices:[]` 는 삼켜지고 `content:""` 만 (파싱 실패로 우연히) throw — 같은 실패에 정반대 감사 라벨. reasoning 계열 모델은 `content:null` 을 실제로 낸다. → 전부 throw 로 통일(`runner.ts` 와 같은 규칙)
4. **라우터 LLM 실패에 로그가 한 줄도 없었다.** warmup 제거가 마지막 관측 지점까지 없앴다. → 비 2xx 응답 본문을 에러에 담고(vLLM 은 `model does not exist` 를 본문에 준다) 두 호출부에 `console.error` 추가
5. 옵셔널 `TEAM_ROUTER_LLM_API_KEY` Bearer — `.env.example` 이 "OpenAI 등 호환 서버면 무엇이든" 이라 적었는데 헤더가 없었다

## 검증

**실측 (DGX Spark vLLM, Qwen3-Next-80B-A3B-Instruct-FP8, 4케이스 × 3회)**

| | 완주 | 판정 정확 | 지연 |
|---|---|---|---|
| 이전 (Ollama exaone3.5:7.8b, 상한 3초) | 3/4 | 2/4 | 최대 3.3초(잘림) |
| 이후 (vLLM 80B, 상한 2.5초) | **12/12** | 9/12 | 1.5~2.2초 (최대 2156ms, 여유 344ms) |

`needsGdConfirm`(위험 신호) 유지 확인. 서버 다운·500 응답 모두 `regex_fallback` 로 안전하게 내려감.

**테스트** — 새 블록이 실제로 가드인지 mutation 으로 확인했다:

| 일부러 깨뜨린 것 | 결과 |
|---|---|
| 상한 2.5s → 10s | 교차파일 불변식 1건 fail |
| 요청에서 `model` 제거 | 1건 fail |
| 빈 응답 다시 삼키기 | 5건 fail |
| 응답 파싱을 Ollama 로 되돌리기 | 9건 fail |
| URL 을 `/api/chat` 으로 되돌리기 | 1건 fail |

**회귀** — 스위트에 실행마다 도는 flaky 가 있어 1회 비교는 신뢰할 수 없다. 기준선(`2990f67`)과 브랜치를 **각각 3회** 돌려 실패 **합집합**으로 비교했다:

- 기준선 union **8건** · 브랜치 union **7건** · **신규 0건**
- 기준선에만 있고 브랜치엔 없는 1건: `owner-gate ... 라우터가 깨진 응답을 줘도 통과한다`

`tsc --noEmit` 통과. 2334 pass.

## 후속 (이 PR 범위 밖 — 별도로 봐야 함)

- **대시보드의 `Ollama ●/○` 칩이 더 이상 라우터 LLM 헬스가 아니다.** `metricsProbe.ts:43` 이 `pgrep -x ollama` 로 판정하는데, vLLM 이 정상이어도 ○ 로 뜬다. 제품에 남은 유일한 라우터-LLM 신호가 거짓말을 한다
- `teamRouter.llm.test.ts` 의 4건은 실제 LLM 서버가 필요해 기준선에서도 상시 실패다. `describe.skipIf` 로 정리할지 결정 필요
- `.env.example` 의 키와 코드가 읽는 키가 어긋나도 CI 가 침묵한다 — 계약 테스트 후보
- `ownerDecision` 의 hybrid 설계 근거가 2.4b 실측이다. 80B 기준 재평가 기록이 없다
