### PR TITLE
fix(registry): b3os_native 팀원의 두뇌 선택이 로드에서 사라지던 것

### DIFF
--- a/src/server/lib/registry.ts
+++ b/src/server/lib/registry.ts
@@ -54,6 +54,16 @@ export function loadRegistry(path: string): AgentRecord[] {
     state_db_path: a.state_db_path ?? null,
     hermes_alias: a.hermes_alias ?? null,
     gateway_service: a.gateway_service ?? null,
+    // ★b3os_native 두뇌 선택 — 이 두 줄이 없으면 팀원이 무조건 Claude 로 돈다.★
+    // loadRegistry 는 필드 화이트리스트로 레코드를 ★재구성★ 하므로, 목록에 없는 필드는
+    // agents.json 에 써도 로드에서 조용히 사라진다. 그러면 adapter 의 pickModel 이 둘 다
+    // undefined 를 받아 기본값(anthropic / claude-sonnet-4-6)으로 떨어진다 — 즉 "설정했는데
+    // 안 먹는다". runner 쪽 화이트리스트(OPENAI_COMPAT_PROVIDERS)는 이미 openai_compatible·
+    // ollama 를 받고 있었으니, 막고 있던 건 그 화이트리스트가 아니라 ★이 매핑★ 이었다.
+    // 빈 문자열·공백은 null 로 접는다(runtime_cwd 선례) — pickModel 의 `||` 기본값 폴백이
+    // 공백 문자열은 참으로 보기 때문에, 여기서 접지 않으면 provider="  " 로 호출이 나간다.
+    model_provider: typeof a.model_provider === "string" && a.model_provider.trim() ? String(a.model_provider) : null,
+    model_id: typeof a.model_id === "string" && a.model_id.trim() ? String(a.model_id) : null,
     codex_sandbox: isAgentCodexSandbox(a.codex_sandbox) ? a.codex_sandbox : null,
     codex_network_access: typeof a.codex_network_access === "boolean" ? a.codex_network_access : null,
     };

--- a/src/server/lib/registryModelFields.test.ts
+++ b/src/server/lib/registryModelFields.test.ts
@@ -1,0 +1,129 @@
+// ★b3os_native 두뇌 선택(model_provider·model_id)의 ★로드 경로★ 회귀가드★
+//
+// 왜 이 파일이 따로 있나 — 이 버그는 ★유닛테스트를 통과하면서★ 실환경에서만 터지는 계열이다.
+// `loadRegistry` 는 agents.json 을 필드 ★화이트리스트로 재구성★ 한다. 목록에 없는 필드는 로드에서
+// 조용히 사라진다. 그런데 agent 객체를 ★손으로 만들어★ 넣는 테스트는 이 정규화 단계를 지나지
+// 않으므로 사각지대가 된다 — 실제로 `no_bot` 때 유닛테스트 100+ 개가 전부 통과했는데 실환경에서
+// 안 먹었다(2026-08-02). 그래서 여기서는 ★임시 agents.json 파일을 실제로 써서★ 로드 결과를 본다.
+//
+// 그리고 로드만 보는 것으로도 부족하다 — 이 필드의 의미는 "그래서 어떤 두뇌로 호출되나" 다.
+// 그래서 마지막에 `pickModel` 까지 ★체인으로★ 확인한다(버그가 눈에 보이던 유일한 지점).
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, test } from "bun:test";
+import { loadRegistry } from "./registry";
+import { pickModel, DEFAULT_PROVIDER, DEFAULT_MODEL } from "../runtimes/b3osNative/runner";
+
+const dirs: string[] = [];
+afterAll(() => {
+  for (const d of dirs) {
+    try { rmSync(d, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
+});
+
+/** 임시 agents.json 을 써서 첫 레코드를 로드한다 — ★정규화 경로를 반드시 통과시킨다.★ */
+function loadOne(extra: Record<string, unknown>): any {
+  const dir = mkdtempSync(join(tmpdir(), "registry-model-"));
+  dirs.push(dir);
+  const path = join(dir, "agents.json");
+  writeFileSync(
+    path,
+    JSON.stringify([
+      {
+        id: "qwenling",
+        display_name: "Qwenling",
+        role: "local-model teammate",
+        runtime: "b3os_native",
+        status_provider: "b3os_native_runner",
+        tmux_session: null,
+        telegram_bot_username: null,
+        workspace_path: "/tmp/qwenling",
+        persona_file: "/tmp/qwenling/SOUL.md",
+        moderator_eligible: false,
+        avatar_emoji: "Q",
+        ...extra,
+      },
+    ]),
+  );
+  return loadRegistry(path)[0];
+}
+
+describe("loadRegistry — b3os_native 두뇌 필드", () => {
+  test("★핵심★ model_provider·model_id 가 로드에서 살아남는다", () => {
+    const a = loadOne({ model_provider: "openai_compatible", model_id: "Qwen/Qwen3-32B" });
+    expect(a.model_provider).toBe("openai_compatible");
+    expect(a.model_id).toBe("Qwen/Qwen3-32B");
+  });
+
+  test("★버그 재현 가드★ 로드된 레코드가 pickModel 까지 가면 그 모델로 호출된다", () => {
+    // 고치기 전엔 여기서 {anthropic, claude-sonnet-4-6} 이 나왔다 — 즉 agents.json 에 뭘 써도
+    // 무조건 Claude 로 돌았다. 이 단정이 그 회귀를 잡는다.
+    const a = loadOne({ model_provider: "openai_compatible", model_id: "Qwen/Qwen3-32B" });
+    expect(pickModel(a.model_provider, a.model_id)).toEqual({
+      provider: "openai_compatible",
+      model: "Qwen/Qwen3-32B",
+    });
+  });
+
+  test("ollama provider 도 그대로 전달된다(runner 화이트리스트의 다른 한 값)", () => {
+    const a = loadOne({ model_provider: "ollama", model_id: "qwen3-coder-next:latest" });
+    expect(pickModel(a.model_provider, a.model_id).provider).toBe("ollama");
+  });
+
+  test("★하위호환★ 필드가 없으면 null — 기존 팀원은 기본 두뇌(Claude)로 그대로 돈다", () => {
+    const a = loadOne({});
+    expect(a.model_provider).toBeNull();
+    expect(a.model_id).toBeNull();
+    expect(pickModel(a.model_provider, a.model_id)).toEqual({
+      provider: DEFAULT_PROVIDER,
+      model: DEFAULT_MODEL,
+    });
+  });
+
+  test("빈 문자열·공백은 null 로 접는다 — provider=\"  \" 로 호출이 나가지 않게", () => {
+    // pickModel 은 `provider || DEFAULT` 라서 ""는 스스로 폴백하지만 "  "(공백)은 ★참★ 이다.
+    // 여기서 접지 않으면 공백 provider 로 resolveCaller 가 불려 조용히 엉뚱한 곳으로 간다.
+    expect(loadOne({ model_provider: "", model_id: "" }).model_provider).toBeNull();
+    const ws = loadOne({ model_provider: "   ", model_id: "  " });
+    expect(ws.model_provider).toBeNull();
+    expect(ws.model_id).toBeNull();
+    expect(pickModel(ws.model_provider, ws.model_id).provider).toBe(DEFAULT_PROVIDER);
+  });
+
+  test("문자열이 아닌 값(숫자·객체·배열·true)은 null 로 떨어뜨린다", () => {
+    // 손으로 편집하는 파일이라 오타가 들어온다. 숫자 3을 provider 로 들고 가면 fetch 단계에서
+    // 죽으므로, 경계에서 막고 기본 두뇌로 돈다.
+    for (const bad of [3, { a: 1 }, ["x"], true]) {
+      const a = loadOne({ model_provider: bad as unknown, model_id: bad as unknown });
+      expect(a.model_provider).toBeNull();
+      expect(a.model_id).toBeNull();
+    }
+  });
+
+  test("한쪽만 있어도 각각 독립으로 살아남는다", () => {
+    // provider 만 지정하고 모델은 runner 기본값을 쓰는 조합이 실제로 쓰인다.
+    const onlyProvider = loadOne({ model_provider: "openai_compatible" });
+    expect(onlyProvider.model_provider).toBe("openai_compatible");
+    expect(onlyProvider.model_id).toBeNull();
+    expect(pickModel(onlyProvider.model_provider, onlyProvider.model_id)).toEqual({
+      provider: "openai_compatible",
+      model: DEFAULT_MODEL,
+    });
+
+    const onlyModel = loadOne({ model_id: "Qwen/Qwen3-32B" });
+    expect(onlyModel.model_provider).toBeNull();
+    expect(onlyModel.model_id).toBe("Qwen/Qwen3-32B");
+  });
+
+  test("★하위호환★ 두 키를 뺀 나머지 레코드는 필드가 하나도 안 바뀐다", () => {
+    // 이 매핑은 모든 팀원의 부팅 경로라, 조용한 변화가 곧 전원 장애다.
+    const before = loadOne({});
+    const after = loadOne({ model_provider: "openai_compatible", model_id: "Qwen/Qwen3-32B" });
+    const strip = (r: any) => {
+      const { model_provider: _p, model_id: _m, ...rest } = r;
+      return rest;
+    };
+    expect(strip(after)).toEqual(strip(before));
+  });
+});


### PR DESCRIPTION
## 무엇이 잘못돼 있었나

`agents.json` 에 `model_provider`·`model_id` 를 지정해도 **`b3os_native` 팀원이 무조건 Claude(`anthropic` / `claude-sonnet-4-6`)로 돌았습니다.**

원인은 화이트리스트가 아니라 **로드 경로**입니다. `loadRegistry` 는 `agents.json` 을 **필드 화이트리스트로 레코드를 재구성**하는데, 그 목록에 이 두 필드가 없어서 로드 시점에 조용히 사라졌습니다. 그래서 `adapter` 의 `pickModel` 이 둘 다 `undefined` 를 받아 기본값으로 떨어집니다.

runner 쪽 `OPENAI_COMPAT_PROVIDERS` 는 **이미** `openai_compatible`·`ollama` 를 받고 있었습니다 — 즉 막고 있던 것은 그 화이트리스트가 아니라 이 매핑이었습니다.

```
# 수정 전: 임시 agents.json 에 model_provider="openai_compatible" 을 넣고 loadRegistry
model_provider = undefined
model_id       = undefined
→ pickModel  = {"provider":"anthropic","model":"claude-sonnet-4-6"}
```

## 무엇을 고쳤나

`loadRegistry` 매핑에 두 필드를 추가했습니다. 값 정규화는 `runtime_cwd` 선례를 따릅니다:

- 빈 문자열·공백 → `null`. **공백 접기가 실질적으로 필요합니다** — `pickModel` 은 `provider || DEFAULT` 라서 `""` 는 스스로 폴백하지만 `"  "` 는 참이므로, 접지 않으면 `provider="  "` 로 호출이 나갑니다.
- 문자열이 아닌 값(숫자·객체·배열·`true`) → `null`. 손으로 편집하는 파일이라 오타가 들어옵니다.
- 필드가 없으면 `null` → 기존 팀원은 기본 두뇌로 **그대로** 돕니다.

## 테스트

`src/server/lib/registryModelFields.test.ts` (8건). **임시 `agents.json` 을 실제로 써서 로드 경로를 직접 지나고**, `pickModel` 까지 체인으로 확인합니다 — agent 객체를 손으로 만드는 테스트로는 이 계열 버그가 잡히지 않기 때문입니다.

가드가 실제로 동작하는지도 확인했습니다: **매핑 2줄을 다시 빼면 8건 중 7건이 red** 입니다.

하위호환도 잠갔습니다 — 두 키를 제외한 나머지 레코드가 필드 하나도 달라지지 않는지 단정합니다(이 매핑은 모든 팀원의 부팅 경로라 조용한 변화가 곧 전원 장애입니다).

## 검증

- `bun test` → **2168 pass / 4 fail**. 실패 4건은 **baseline 과 완전히 동일**(`LLM team router (EXAONE)` — 로컬 모델 부재로 인한 기존 실패). baseline 은 착수 전 `main` 에서 따로 측정했습니다(2160 pass / 4 fail → +8 은 이 PR 의 신규 테스트).
- `tsc --noEmit` 클린.

## 이 PR 범위 밖(알려진 한계)

- DB `agent` 테이블에는 이 두 컬럼이 없습니다(스키마 변경은 별건). `agents.json` 이 정본이라 평시 동작엔 무관하지만, **registry 파일 유실 후 DB 스냅샷으로 복구하는 경로**에서는 두 값이 빠집니다 — `nicknames`·`capabilities` 와 같은 성격입니다.
- **멤버마다 다른 엔드포인트**는 아직 안 됩니다. `B3OS_NATIVE_OPENAI_BASE_URL` 이 프로세스 전역 env 하나입니다. 이 PR 이 살린 것은 "멤버마다 다른 **모델/provider**" 까지입니다.
- `preflight` 는 키 없는 **원격** OpenAI 호환 엔드포인트를 `isLocal`(`localhost`·`127.0.0.1`·빈값)로 인정하지 않아 `openai_api_key_missing_for_remote` 로 blocking 판정합니다. 무인증 vLLM 을 원격에 두는 구성이 여기 걸립니다. 키 게이트 완화는 별도 판단이 필요해 이 PR 에서 손대지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
