### PR TITLE
fix(dashboard): 다른 화면에서 Tasks 로 돌아오면 현황이 stale 로 남던 것

### DIFF
--- a/src/web/components/TasksKanban.ts
+++ b/src/web/components/TasksKanban.ts
@@ -10,6 +10,24 @@ import { parseSqliteDate } from "../lib/datetime";
 
 type ColKey = "plan" | "doing" | "done";
 
+// ★Tasks 뷰 재진입 시 재조회용 훅★
+// renderTasksKanban 은 main.ts 에서 ★1회만★ 호출된다(tasksRendered 가드). 그 뒤 뷰 전환은
+// display 토글이라, 다른 화면(1:1 대화 등)에 있는 동안 팀원들이 카드를 바꿔도 Tasks 로
+// 돌아오면 ★첫 렌더 때의 데이터가 그대로 보였다★ — 새로고침(F5)해야 최신이 됐다(팀장 리포트).
+// 컴포넌트 상태(담당자 필터·펼친 카드·더보기 개수)는 클로저에 있으므로 재렌더로 갈아치우지
+// 않고, 인스턴스의 loadTasks 만 꺼내 쓴다 → 사용자가 보던 화면 상태를 유지한 채 데이터만 갱신.
+// (Settings 뷰의 refreshSettingsSlack/Members 와 같은 관례 — 매 store update 마다는 X, 전환 순간만.)
+let _reload: (() => Promise<void>) | null = null;
+
+/**
+ * Tasks 뷰로 다시 들어온 순간의 가벼운 재조회. 아직 한 번도 렌더되지 않았으면
+ * `renderTasksKanban` 이 초기 로드를 하므로 아무 것도 하지 않는다(호출은 안전).
+ */
+export async function refreshTasksKanban(): Promise<void> {
+  if (!_reload) return;
+  await _reload();
+}
+
 interface KanbanTask {
   id: string;
   title: string;
@@ -366,5 +384,8 @@ export function renderTasksKanban(root: HTMLElement): void {
   }
 
   render();
+  // 재진입 재조회용으로 이 인스턴스의 loadTasks 를 노출한다(위 _reload 주석 참조).
+  // owners 는 여기서 다시 안 받는다 — 로스터는 자주 안 바뀌고, 재진입마다 2번 왕복할 이유가 없다.
+  _reload = loadTasks;
   void loadOwners().then(loadTasks);
 }

--- a/src/web/components/tasksRefresh.test.ts
+++ b/src/web/components/tasksRefresh.test.ts
@@ -1,0 +1,35 @@
+/**
+ * TasksKanban 재진입 재조회 — 렌더 없이 검증 가능한 계약.
+ *
+ * ★왜 DOM 테스트가 여기 없는지★
+ * 이 저장소의 happy-dom 하네스에서는 `querySelector` 가 ★동작하지 않는다.★ 실측(2026-08-03,
+ * happy-dom 20.9.0 + bun 1.3.14): `div`·`.c`·`#i`·`[attr]` 전부 예외를 던진다(`window.SyntaxError`
+ * 가 없어서 에러 생성 자체가 깨진다). shim 을 넣으면 예외는 사라지지만 매칭이 안 돼 null 이 온다.
+ * 통과 중인 다른 DOM 테스트들은 그 경로를 밟지 않아서 그린인 것이다.
+ * `TasksKanban.render()` 는 스크롤 위치 보존을 위해 `querySelector` 를 쓰므로 ★마운트 자체가
+ * 불가능★ 하다. 그래서 렌더가 필요한 검증은 ★실제 Chrome(playwright)★ 하네스로 했다:
+ *   `~/b3os/members/devon/verify/tasks-refresh-browser.mjs`  (7건 전부 통과)
+ *   — 초기 표시 · ★재조회 전 stale(버그 재현)★ · refresh 후 갱신 · 삭제 반영 ·
+ *     /api/tasks 만 1회 추가 · /api/agents 재호출 없음 · 칼럼 카운트 이동
+ * 이 갭 자체는 별도 카드로 등록해뒀다(happy-dom 커버리지 과대평가).
+ */
+import { describe, expect, test } from "bun:test";
+import { refreshTasksKanban } from "./TasksKanban";
+
+describe("refreshTasksKanban — 렌더 전 계약", () => {
+  test("한 번도 렌더되지 않았으면 아무 것도 하지 않는다(호출이 안전하다)", async () => {
+    // main.ts 는 `tasksRendered` 가드로 초기 렌더를 하고, 재진입일 때만 이 함수를 부른다.
+    // 그래도 순서가 뒤집히는 경로(뷰 복원·라우팅 변경)가 생길 수 있어서, 렌더 전 호출이
+    // throw 하지 않고 조용히 빠지는 것을 계약으로 고정한다 — Settings 의
+    // refreshSettingsSlack/Members 가 `if (!_root) return` 으로 같은 계약을 갖는다.
+    await refreshTasksKanban();
+    // fetch 를 건드리지 않았는데도 여기까지 왔다 = 네트워크 호출을 시도하지 않았다.
+    expect(true).toBe(true);
+  });
+
+  test("여러 번 불러도 안전하다", async () => {
+    await refreshTasksKanban();
+    await refreshTasksKanban();
+    expect(true).toBe(true);
+  });
+});

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -11,7 +11,7 @@ import { renderAgentSetup } from "./components/AgentSetup";
 import { renderBusFlow } from "./components/BusFlow";
 import { renderTeamOs } from "./components/TeamOS";
 import { renderTopology } from "./components/TopologyView";
-import { renderTasksKanban } from "./components/TasksKanban";
+import { renderTasksKanban, refreshTasksKanban } from "./components/TasksKanban";
 import { renderJobsView } from "./components/JobsView";
 import { renderTeamSearch } from "./components/TeamSearch";
 import { renderReports } from "./components/Reports";
@@ -292,10 +292,15 @@ function renderMainContent(root: HTMLElement) {
   let auditRendered = false;
   let proposalsRendered = false;
 
-  let prevMainView: MainView | null = null; // 뷰 전환 감지용 — settings 재진입 때만 새로고침(매 store update마다 X)
+  let prevMainView: MainView | null = null; // 뷰 전환 감지용 — settings·tasks 재진입 때만 새로고침(매 store update마다 X)
   const update = () => {
     const { mainView } = store.getState();
     const enteredSettings = mainView === "settings" && prevMainView !== "settings"; // 다른 뷰→settings 전환 순간만 true
+    // ★어느 화면에서 오든★ Tasks 로 "들어오는 순간" 이면 true — 조건이 `prevMainView !== "tasks"`
+    // 이므로 1:1 대화·Jobs·Settings·모니터링 등 출처를 가리지 않는다(특정 뷰로 좁혀져 있지 않다).
+    // 첫 진입(prevMainView === null)도 true 지만, 그때는 아래에서 초기 렌더 분기가 잡으므로
+    // 재조회가 중복되지 않는다. Tasks 안에서 도는 store update 는 false(스크롤·입력 깜빡임 방지).
+    const enteredTasks = mainView === "tasks" && prevMainView !== "tasks";
     prevMainView = mainView;
     if (!logEl) {
       logEl = document.createElement("div");
@@ -423,9 +428,9 @@ function renderMainContent(root: HTMLElement) {
     } else if (mainView === "topology" && !topoRendered) {
       renderTopology(topoEl);
       topoRendered = true;
-    } else if (mainView === "tasks" && !tasksRendered) {
-      renderTasksKanban(tasksEl);
-      tasksRendered = true;
+    } else if (mainView === "tasks") {
+      if (!tasksRendered) { renderTasksKanban(tasksEl); tasksRendered = true; }
+      else if (enteredTasks) { void refreshTasksKanban(); } // 들어오는 순간에만 재조회 — ★출처 화면과 무관하다★. 다른 화면에 있는 동안 팀원이 바꾼 카드가 stale 로 남던 것 방지(팀장 2026-08-02) · 매 update마다 X(입력 중 깜빡임·스크롤 jank 방지)
     } else if (mainView === "jobs" && !jobsRendered) {
       renderJobsView(jobsEl);
       jobsRendered = true;


### PR DESCRIPTION
## 배경 — Tasks 는 첫 렌더 이후 다시 조회되지 않았다

대시보드에서 다른 화면(1:1 대화 등)에 있는 동안 팀원이 카드를 옮기거나 추가해도, **Tasks 로 돌아오면 처음 열었을 때의 데이터가 그대로** 보였습니다. 새로고침(F5)을 눌러야 최신이 됐습니다.

원인은 `src/web/main.ts` 의 렌더 래치입니다:

```ts
} else if (mainView === "tasks" && !tasksRendered) {
  renderTasksKanban(tasksEl);
  tasksRendered = true;
}
```

`renderTasksKanban` 은 호출될 때마다 `/api/tasks` 를 다시 받습니다. 문제는 **그 호출이 딱 한 번만 일어난다**는 것입니다 — 이후 뷰 전환은 `tasksEl.style.display` 토글이라 DOM 이 그대로 살아있고, 재조회 시점이 없습니다. 즉 컴포넌트의 버그가 아니라 **호출 시점의 누락**입니다.

같은 문제를 `settings` 뷰는 이미 해결해 두었습니다 — 재진입 순간을 감지해 가벼운 재조회 함수를 부르고, 매 store update 마다는 하지 않습니다(스크롤 jank 방지). 이 PR 은 **그 선례를 그대로 따릅니다.**

## 변경 내용

**`src/web/components/TasksKanban.ts`** — 재진입 재조회 진입점 `refreshTasksKanban()` 추가

컴포넌트를 다시 렌더하지 않고 **데이터만 갈아끼웁니다.** 이유가 있습니다: 담당자 필터·펼친 카드·"더보기" 개수 같은 화면 상태가 `renderTasksKanban` 의 클로저에 있어서, 재렌더하면 **사용자가 보던 화면이 초기화**됩니다. 그래서 인스턴스의 `loadTasks` 만 모듈 레벨로 노출해 호출합니다. 아직 한 번도 렌더되지 않았으면 아무 것도 하지 않습니다(`Settings` 의 `if (!_root) return` 과 같은 계약).

담당자 목록(`/api/agents`)은 **재진입마다 다시 받지 않습니다** — 로스터는 자주 바뀌지 않고, 들어올 때마다 2왕복 할 이유가 없습니다.

**`src/web/main.ts`** — 들어오는 순간에만 재조회

```ts
const enteredTasks = mainView === "tasks" && prevMainView !== "tasks";
...
} else if (mainView === "tasks") {
  if (!tasksRendered) { renderTasksKanban(tasksEl); tasksRendered = true; }
  else if (enteredTasks) { void refreshTasksKanban(); }
}
```

조건이 `prevMainView !== "tasks"` 이므로 **출처 화면을 가리지 않습니다** — 1:1 대화·Jobs·Settings·모니터링·Inbox 어디서 오든 재조회합니다. 첫 진입(`prevMainView === null`)도 참이지만 그때는 초기 렌더 분기가 잡으므로 조회가 중복되지 않습니다. Tasks 안에 머무는 동안 도는 store update 는 거짓이라, 카드 편집 중 깜빡임이나 스크롤 점프가 생기지 않습니다.

**`src/web/components/tasksRefresh.test.ts`** — 렌더 전 호출이 안전한지 고정하는 계약 테스트 2건

## 검증

- `bun test` **2162 pass / 4 fail** — 실패 4건은 이 브랜치 이전과 동일합니다(`LLM team router (EXAONE)`; 로컬 Ollama 부재로 인한 환경의존 실패로, #255 에서 별도로 다룹니다). `tsc --noEmit` 클린.
- **렌더가 필요한 검증은 실제 Chrome(playwright)으로 했습니다.** 이 저장소의 happy-dom 하네스에서는 `querySelector` 가 동작하지 않아(`div`·`.c`·`#i`·`[attr]` 전부 예외) `TasksKanban.render()` 가 스크롤 위치 보존을 위해 쓰는 `querySelector` 에서 **마운트 자체가 불가능**합니다. 통과 중인 다른 DOM 테스트들은 그 경로를 밟지 않아 초록불인 것입니다(이 갭 자체는 별도 카드로 등록했습니다).

  브라우저 하네스 7건 전부 통과:

  | 확인 | 결과 |
  |---|---|
  | 초기 렌더에 카드 표시 | ✅ |
  | **재조회 전에는 stale (버그 재현)** | ✅ |
  | refresh 후 새 카드 표시 / 옛 카드 사라짐 | ✅ |
  | 삭제 반영 | ✅ |
  | `/api/tasks` 만 1회 추가 호출 | ✅ (1→2) |
  | `/api/agents` 재호출 없음 | ✅ (1→1) |
  | 칼럼 이동 반영 | ✅ (완료 칼럼 카운트 1) |

  두 번째 항목이 중요합니다 — **버그를 재현하는 단정**이 있어야 이 수정이 실제로 무언가를 고쳤다는 증거가 됩니다.

## 알려진 한계

- **`main.ts` 배선 자체에는 테스트가 없습니다.** `main.ts` 는 자기 초기화 진입점이라 이 저장소에 테스트 하네스가 없습니다(`icons.test.ts` 뿐). 컴포넌트 계약 테스트 + 브라우저 검증 + `settings` 선례 대조로 커버했습니다.
- **같은 stale 문제가 다른 뷰에도 남아 있습니다** — `jobs`·`busflow`·`monitoring`·`inbox`·`audit`·`proposals`·`topology` 등이 모두 같은 1회-렌더 래치입니다. 리포트 범위가 Tasks 였고 뷰마다 재조회 비용이 달라 **이번에 넓히지 않았습니다**(`settings` 도 뷰별 opt-in 입니다). 별도 카드로 등록했고 **Jobs 가 우선 후보**입니다 — Tasks 와 같은 탭 그룹이라 사용자가 바로 옆에서 오갑니다.
- 재조회는 **들어오는 순간 1회**입니다. Tasks 를 열어둔 채 오래 머무는 동안의 갱신(폴링)은 이 PR 에 없습니다 — 카드 편집 중 깜빡임 위험이 있어 별도 판단이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
