### PR TITLE
fix(snapshot): 멤버 워크스페이스의 .git 도 담는다 — 반쪽 스냅샷이었다

### DIFF
--- a/scripts/snapshot-excludes.test.sh
+++ b/scripts/snapshot-excludes.test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# snapshot-team.sh 의 제외 목록이 ★구획별로 다른지★ 실제 rsync 를 돌려서 잰다.
+#
+# 왜 rsync 를 실제로 돌리나: 배열을 눈으로 비교하면 "--exclude 가 있다/없다"만 보이고,
+#   그게 ★실제로 무엇을 걸러내는지★는 안 보인다. rsync 의 패턴 해석(디렉토리 vs 파일,
+#   앵커링)까지 포함해서 결과물을 봐야 검사와 변경이 같은 축에 선다.
+#
+# 정의는 snapshot-team.sh 에서 ★그대로 뽑아 쓴다★ — 여기에 복사해두면 원본이 바뀔 때 조용히 어긋난다.
+#
+# 사용: bash scripts/snapshot-excludes.test.sh
+set -uo pipefail
+cd "$(dirname "$0")/.."
+SRC="${SNAPSHOT_SRC:-scripts/snapshot-team.sh}"   # 옛 버전 대조용으로 바꿔 끼울 수 있다
+[ -f "$SRC" ] || { echo "✗ $SRC 없음"; exit 1; }
+
+# 제외 배열 정의 블록만 뽑아서 평가 (원본과 단일 출처 유지)
+# ★첫 EX_ 배열부터 EX_HERMES 끝까지★ — 시작 이름을 EX_BASE 로 못박으면 구조가 다른 옛 버전에서
+#   "블록 없음"으로 끝나버려서, 정작 재려던 .git 축을 못 재고 통과/실패가 뒤집힌다.
+BLOCK="$(awk "/^EX_(BASE|COMMON)=\(/{p=1} p{print} /--exclude='skills'\)/{if(p)exit}" "$SRC")"
+[ -n "$BLOCK" ] || { echo "✗ 제외 배열 블록을 못 찾았다 — snapshot-team.sh 구조가 바뀌었나"; exit 1; }
+eval "$BLOCK"
+
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+FAIL=0
+ok(){   printf '  ✓ %s\n' "$1"; }
+bad(){  printf '  ✗ %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+# 가짜 워크스페이스 — 팀원 폴더가 실제로 갖는 것들
+mk_ws(){
+  local w="$1"; rm -rf "$w"; mkdir -p "$w"
+  mkdir -p "$w/.git/objects" "$w/node_modules/x" "$w/backups/old" "$w/reports" "$w/decks"
+  echo commit    > "$w/.git/HEAD"
+  echo obj       > "$w/.git/objects/deadbeef"
+  echo dep       > "$w/node_modules/x/index.js"
+  echo stale     > "$w/backups/old/a.txt"
+  echo 작업물    > "$w/MEMORY.md"
+  echo 보고서    > "$w/reports/r.md"
+  echo 덱        > "$w/decks/d.html"
+  echo 로그      > "$w/run.log"
+}
+
+run_rsync(){  # $1=dest $2...=excludes
+  local dest="$1"; shift
+  rm -rf "$dest"; mkdir -p "$dest"
+  rsync -a "$@" "$T/ws" "$dest/" 2>/dev/null
+}
+
+has(){ [ -e "$T/$1/ws/$2" ]; }
+
+echo "■ snapshot-team.sh 제외 목록 — 구획별 동작"
+
+mk_ws "$T/ws"
+
+# ① 멤버 워크스페이스: .git 은 담고, 재생성물은 뺀다
+run_rsync "$T/out-member" "${EX_MEMBER[@]}"
+has out-member .git/objects/deadbeef && ok "멤버: .git 담긴다 (커밋 히스토리 보존)" \
+                                     || bad "멤버: .git 이 빠졌다 — 파일만 복구되고 이력은 사라진다"
+has out-member MEMORY.md      && ok "멤버: 작업물 MEMORY.md 담긴다"      || bad "멤버: MEMORY.md 가 빠졌다"
+has out-member reports/r.md   && ok "멤버: reports 담긴다(작업물)"        || bad "멤버: reports 가 빠졌다"
+has out-member decks/d.html   && ok "멤버: decks 담긴다(작업물)"          || bad "멤버: decks 가 빠졌다"
+has out-member node_modules/x/index.js && bad "멤버: node_modules 가 담겼다(재생성물)" \
+                                       || ok "멤버: node_modules 제외된다"
+has out-member backups/old/a.txt       && bad "멤버: backups 가 담겼다(중복)" \
+                                       || ok "멤버: backups 제외된다"
+has out-member run.log                 && bad "멤버: *.log 가 담겼다" || ok "멤버: *.log 제외된다"
+
+# ② 트리·hermes 구획: .git 은 계속 뺀다 (원격에 있고, 크다)
+run_rsync "$T/out-tree" "${EX_TREE[@]}"
+has out-tree .git/objects/deadbeef && bad "트리: .git 이 담겼다 — 원격에 있는 것을 중복 백업한다" \
+                                  || ok "트리: .git 제외 유지"
+run_rsync "$T/out-hermes" "${EX_HERMES[@]}"
+has out-hermes .git/objects/deadbeef && bad "hermes: .git 이 담겼다" || ok "hermes: .git 제외 유지"
+has out-hermes reports/r.md          && bad "hermes: reports 가 담겼다(재생성물)" || ok "hermes: reports 제외 유지"
+
+# ③ ★뮤턴트★ — EX_MEMBER 에 .git 제외가 되돌아오면 ①이 반드시 깨져야 한다.
+#    이게 안 깨지면 위 검사는 아무것도 안 재고 있는 것이다.
+MUT=("${EX_MEMBER[@]}" --exclude='.git')
+run_rsync "$T/out-mutant" "${MUT[@]}"
+has out-mutant .git/objects/deadbeef && bad "뮤턴트: .git 제외를 되살렸는데도 담겼다 — 검사가 무력하다" \
+                                     || ok "뮤턴트: .git 제외 복구 시 ①이 깨진다(검사 유효)"
+
+echo
+if [ "$FAIL" -eq 0 ]; then echo "✅ 통과"; else echo "❌ 실패 ${FAIL}건"; fi
+exit "$FAIL"

--- a/scripts/snapshot-team.sh
+++ b/scripts/snapshot-team.sh
@@ -20,17 +20,22 @@ mkdir -p "$DEST" "$STAGE"/{tree,home/Development,home/.claude,home/.hermes,launc
 #   지우려던 패턴이 ★멤버 워크스페이스의 reports·decks(작업물)까지★ 걸어 백업에서 빼고 있었다.
 #   백업 도구가 조용히 작업물을 버리는 형태라, 구획별로 나눈다.
 
-# 어디서나 안전한 것 — 재생성물·임시물
-EX_COMMON=(--exclude='.git' --exclude='node_modules' --exclude='backups' --exclude='migration-backups-*'
+# 어디서나 안전한 것 — 재생성물·임시물 (.git 제외는 여기 넣지 않는다 — 아래 EX_MEMBER 주석 참조)
+EX_BASE=(--exclude='node_modules' --exclude='backups' --exclude='migration-backups-*'
     --exclude='*.pre-*' --exclude='*.bak' --exclude='*.bak-*' --exclude='*.log' --exclude='.DS_Store'
     --exclude='dist' --exclude='.cache' --exclude='scratchpad' --exclude='outbox'
     --exclude='team.db.pre-*' --exclude='*.wal' --exclude='*.sqlite-*')
 
+EX_COMMON=("${EX_BASE[@]}" --exclude='.git')
+
 # 트리(var) 대용량 재생성물 — 모델·검색eval·벡터인덱스
 EX_TREE=("${EX_COMMON[@]}" --exclude='models' --exclude='team-search-eval' --exclude='*.lancedb')
 
-# 멤버 워크스페이스 — ★작업물을 지우지 않는다.★ 공통 제외만 건다.
-EX_MEMBER=("${EX_COMMON[@]}")
+# 멤버 워크스페이스 — ★작업물을 지우지 않는다.★
+#   ★.git 도 담는다★ (GD 2026-08-03). 팀원 워크스페이스는 원격이 없을 수 있어서, .git 을 빼면
+#   "파일은 복구되는데 언제 왜 바꿨는지는 사라지는" 반쪽 스냅샷이 된다. 스냅샷은 그야말로 스냅샷이다.
+#   비용: 실측 4MB (등록 12명 중 git repo 는 bill·lui 둘뿐) — 405MB 묶음의 1%.
+EX_MEMBER=("${EX_BASE[@]}")
 
 # hermes 프로필 — 대화state·홈·캐시·bin·모델·세션·미디어·스킬(repo서 옴)은 재생성 가능
 EX_HERMES=("${EX_COMMON[@]}" --exclude='state.db' --exclude='state.db-*' --exclude='state-snapshots'


### PR DESCRIPTION
## 무엇이 문제였나

`EX_COMMON` 의 `--exclude='.git'` 이 멤버 워크스페이스에도 걸려 있었다. 스냅샷이 **파일 내용은 복구해도 "언제 왜 바꿨는지"는 복구하지 못한다.**

팀원 워크스페이스는 원격이 없을 수 있다 — bill 은 원격 repo 가 접근 불가 상태로 **2개월간 push 0회**였고, 그동안의 67커밋이 그 기계 디스크에만 있었다. `.git` 이 유일본인 상황에서 백업이 그걸 빼고 있었다.

## 어떻게 고쳤나

`EX_BASE`(`.git` 제외 없음)를 새로 두고 `EX_COMMON = EX_BASE + .git 제외`로 재구성. `EX_MEMBER` 만 `EX_BASE` 를 쓴다.

트리·hermes 구획은 **종전대로 `.git` 제외** — b3os 는 원격(공개 repo)에 있고 83MB 라 중복 백업할 이유가 없다.

## 비용 (실측)

| | |
|---|---|
| git repo 인 워크스페이스 | 등록 12명 중 **2명** (bill 3MB · lui 0.5MB) |
| 묶음 크기 | 405M → **409M (+1%)** |
| GFS 로테이션 14개 기준 | +56MB |

## 검증

`scripts/snapshot-excludes.test.sh` 신규. **실제 rsync 를 돌려 구획별 결과물을 본다** — 배열을 눈으로 비교하면 "exclude 가 있다/없다"만 보이고 그게 실제로 무엇을 걸러내는지는 안 보인다. 배열 정의는 `snapshot-team.sh` 에서 뽑아 쓴다(복사본 drift 방지).

- **변경 전 스크립트로 돌리면 `✗ 멤버: .git 이 빠졌다` 로 실패**, 변경 후 통과 — 재려는 축에서 정확히 갈린다
- **뮤턴트**: `EX_MEMBER` 에 `.git` 제외를 되살리면 검사가 깨지는 것까지 확인 (검사가 무력하지 않다는 증거)
- 트리·hermes 의 `.git` 제외가 유지되는지, 멤버의 `reports`·`decks`(작업물)가 계속 담기는지도 함께 고정

전체 스크립트 실행 (bash 3.2 + 격리 DEST, 라이브 `~/.b3os-backups` 미접촉 확인):
- 멤버 워크스페이스 12/12, 묶음 안 `bill/.git` 159개 · `lui/.git` 47개 항목
- **묶음에서 꺼내 복원 → 67커밋 = 라이브와 동일, `git fsck` 손상 없음**

## 롤백

`scripts/snapshot-team.sh` 한 파일. revert 하면 즉시 이전 동작. 이미 만들어진 묶음에는 영향 없다.
