### PR TITLE
Promote bot liveness monitor paths

### DIFF
--- a/skills/b3os/references/system-jobs.md
+++ b/skills/b3os/references/system-jobs.md
@@ -42,6 +42,19 @@
 
 그룹/DM 에서 물으면 그때 답하는 명령(팀방 협업 셋업 시): `/status`(팀 상태) · `/board`(칸반) · `/digest`(요약) · `/approve`(민감 실행 승인) · `/onoff`(라우터/기능 토글).
 
+## bot-liveness-monitor 승격 기준
+
+`bot-liveness-monitor` 는 10분 주기 `launchd` 잡이다. 서버와 스크립트의 기본 경로는 한 곳에서 맞춰야 한다.
+
+- 로그 기본값: `<b3os repo>/var/bot-liveness-monitor.log` (`BOT_LIVENESS_LOG` 로 override 가능). `/tmp` 는 재부팅에 지워지므로 기본값으로 쓰지 않는다.
+- 상태 디렉터리 기본값: `<b3os repo>/var/bot-liveness-monitor` (`LIVENESS_STATE_DIR` 로 override 가능).
+- LaunchAgent 라벨: `<TEAMOS_LAUNCHD_PREFIX 또는 com.$USER>.bot-liveness-monitor`. `com.gdmini.*` 같은 개인 라벨은 설치 시점 로컬 값이지 공개 기본값이 아니다.
+- plist 템플릿은 `src/server/lib/livenessMonitor.ts` 의 `renderBotLivenessMonitorPlist()` 가 정본이다. `StartInterval=600`, `scripts/bot-liveness-monitor.sh`, 위 로그/상태 env를 같은 값으로 넘긴다.
+- 감시 대상 bot 목록은 `agents.json` 의 `runtime=claude_channel` 이 정본이다. 고정 팀원 목록으로 조용히 폴백하면 새 팀원이 빠져 잘못된 모니터링이 된다.
+- 알림 bot/chat, 토큰, heal/restart 명령 경로는 환경·설정 또는 repo-local 경로로 분리한다. 특정 팀장 chat id, `@gd452_team_op_bot`, `~/Development/<member>` 경로는 공개 템플릿 기본값에 넣지 않는다.
+
+원칙: 신뢰할 수 없는 입력이면 `unknown`/로그-only 로 닫고, 잘못된 모니터링으로 잘못된 복구를 실행하지 않는다.
+
 ## 관리 방법 (권장)
 
 시스템 잡이 늘수록 "뭐가 도는지" 관리가 어려워진다. 세 축으로 관리한다:

--- a/src/server/lib/agentControl.ts
+++ b/src/server/lib/agentControl.ts
@@ -33,6 +33,10 @@ export function claudeTelegramLaunchdLabel(id: string): string {
   return `${teamosLaunchdPrefix()}.claude-telegram-${id}`;
 }
 
+export function botLivenessLaunchdLabel(): string {
+  return `${teamosLaunchdPrefix()}.bot-liveness-monitor`;
+}
+
 export interface ControlResult { ok: boolean; detail: string }
 
 // ── 의도적 off 명단 (auto-heal 조율) ──────────────────────────────────────

--- a/src/server/lib/livenessMonitor.test.ts
+++ b/src/server/lib/livenessMonitor.test.ts
@@ -76,6 +76,51 @@ describe("bot liveness monitor shared defaults", () => {
     expect(status.healthy).toBe(true);
   });
 
+  test("server parser treats machine-readable DONE status=issues as unhealthy", () => {
+    const log = `${DEFAULT_BOT_LIVENESS_STATE_DIR}/issues-status.log`;
+    mkdirSync(dirname(log), { recursive: true });
+    writeFileSync(
+      log,
+      [
+        "2026-08-03 15:20:00 bot-liveness START (dry_run=0)",
+        "이상 발견 — 알림 전송 성공",
+        "2026-08-03 15:20:03 bot-liveness DONE status=issues",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const status = readLivenessStatus(log);
+    expect(status.available).toBe(true);
+    expect(status.lastRun).toBe("2026-08-03 15:20:00");
+    expect(status.lastResult).toBe("2026-08-03 15:20:03 bot-liveness DONE status=issues");
+    expect(status.healthy).toBe(false);
+  });
+
+  test("server parser falls back past an unclassified DONE line for legacy logs", () => {
+    const log = `${DEFAULT_BOT_LIVENESS_STATE_DIR}/legacy-done.log`;
+    mkdirSync(dirname(log), { recursive: true });
+    writeFileSync(
+      log,
+      [
+        "2026-08-03 15:30:00 bot-liveness START (dry_run=0)",
+        "--- 메시지 미리보기 ---",
+        "⚠️ [steve] tmux 세션 없음 — 수동 확인 필요",
+        "--- 끝 --- (sig=abc123, last=)",
+        "Telegram API: HTTP 200",
+        "DM 전송 완료",
+        "2026-08-03 15:30:03 bot-liveness DONE",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const status = readLivenessStatus(log);
+    expect(status.available).toBe(true);
+    expect(status.lastResult).toBe("2026-08-03 15:30:03 bot-liveness DONE");
+    expect(status.healthy).toBe(false);
+  });
+
   test("server parser default follows BOT_LIVENESS_LOG at call time", () => {
     const override = `${DEFAULT_BOT_LIVENESS_STATE_DIR}/override.log`;
     mkdirSync(dirname(override), { recursive: true });

--- a/src/server/lib/livenessMonitor.test.ts
+++ b/src/server/lib/livenessMonitor.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import {
+  DEFAULT_BOT_LIVENESS_LOG,
+  DEFAULT_BOT_LIVENESS_STATE_DIR,
+  botLivenessLogPath,
+  botLivenessMonitorPaths,
+  renderBotLivenessMonitorPlist,
+} from "./livenessMonitor";
+import { botLivenessLaunchdLabel } from "./agentControl";
+import { readLivenessStatus } from "./monitoringStatus";
+
+const savedLog = process.env.BOT_LIVENESS_LOG;
+const savedState = process.env.LIVENESS_STATE_DIR;
+const savedPrefix = process.env.TEAMOS_LAUNCHD_PREFIX;
+const savedUser = process.env.USER;
+
+afterEach(() => {
+  if (savedLog === undefined) delete process.env.BOT_LIVENESS_LOG;
+  else process.env.BOT_LIVENESS_LOG = savedLog;
+  if (savedState === undefined) delete process.env.LIVENESS_STATE_DIR;
+  else process.env.LIVENESS_STATE_DIR = savedState;
+  if (savedPrefix === undefined) delete process.env.TEAMOS_LAUNCHD_PREFIX;
+  else process.env.TEAMOS_LAUNCHD_PREFIX = savedPrefix;
+  if (savedUser === undefined) delete process.env.USER;
+  else process.env.USER = savedUser;
+});
+
+describe("bot liveness monitor shared defaults", () => {
+  test("default log is repo-local durable var path, not /tmp", () => {
+    delete process.env.BOT_LIVENESS_LOG;
+    expect(botLivenessLogPath()).toBe(DEFAULT_BOT_LIVENESS_LOG);
+    expect(botLivenessLogPath()).toContain("/var/bot-liveness-monitor.log");
+    expect(botLivenessLogPath()).not.toStartWith("/tmp/");
+  });
+
+  test("env override is still honored for isolated tests or deployments", () => {
+    process.env.BOT_LIVENESS_LOG = "/custom/bot-liveness-monitor.log";
+    expect(botLivenessLogPath()).toBe("/custom/bot-liveness-monitor.log");
+  });
+
+  test("launchd label uses the same generic prefix rule as b3os services", () => {
+    process.env.TEAMOS_LAUNCHD_PREFIX = "com.example";
+    expect(botLivenessLaunchdLabel()).toBe("com.example.bot-liveness-monitor");
+  });
+
+  test("plist template passes the same durable log and state defaults to the script", () => {
+    process.env.TEAMOS_LAUNCHD_PREFIX = "com.example";
+    delete process.env.BOT_LIVENESS_LOG;
+    delete process.env.LIVENESS_STATE_DIR;
+    const xml = renderBotLivenessMonitorPlist();
+    expect(xml).toContain("<key>StartInterval</key><integer>600</integer>");
+    expect(xml).toContain("<key>BOT_LIVENESS_LOG</key>");
+    expect(xml).toContain(DEFAULT_BOT_LIVENESS_LOG);
+    expect(xml).toContain("<key>LIVENESS_STATE_DIR</key>");
+    expect(xml).toContain(DEFAULT_BOT_LIVENESS_STATE_DIR);
+    expect(xml).toContain("scripts/bot-liveness-monitor.sh");
+    expect(xml).not.toContain("com.gdmini.bot-liveness-monitor");
+    expect(xml).not.toContain("/tmp/bot-liveness-monitor.log");
+  });
+
+  test("server parser can read an actual log written at the durable default path", () => {
+    delete process.env.BOT_LIVENESS_LOG;
+    mkdirSync(dirname(DEFAULT_BOT_LIVENESS_LOG), { recursive: true });
+    writeFileSync(
+      DEFAULT_BOT_LIVENESS_LOG,
+      "2026-08-03 15:00:00 bot-liveness START (dry_run=0)\n이상 없음\n",
+      "utf-8",
+    );
+
+    const status = readLivenessStatus(DEFAULT_BOT_LIVENESS_LOG);
+    expect(status.available).toBe(true);
+    expect(status.runs).toBeGreaterThanOrEqual(1);
+    expect(status.lastRun).toBe("2026-08-03 15:00:00");
+    expect(status.healthy).toBe(true);
+  });
+
+  test("server parser default follows BOT_LIVENESS_LOG at call time", () => {
+    const override = `${DEFAULT_BOT_LIVENESS_STATE_DIR}/override.log`;
+    mkdirSync(dirname(override), { recursive: true });
+    writeFileSync(override, "2026-08-03 15:10:00 bot-liveness START (dry_run=0)\nOK\n", "utf-8");
+    process.env.BOT_LIVENESS_LOG = override;
+
+    const status = readLivenessStatus();
+    expect(status.available).toBe(true);
+    expect(status.lastRun).toBe("2026-08-03 15:10:00");
+    expect(status.healthy).toBe(true);
+  });
+
+  test("path helper returns plist/script/log from one source", () => {
+    process.env.TEAMOS_LAUNCHD_PREFIX = "com.example";
+    const p = botLivenessMonitorPaths("/Users/alice");
+    expect(p.plist).toBe("/Users/alice/Library/LaunchAgents/com.example.bot-liveness-monitor.plist");
+    expect(p.script).toContain("scripts/bot-liveness-monitor.sh");
+    expect(p.log).toBe(botLivenessLogPath());
+  });
+});

--- a/src/server/lib/livenessMonitor.ts
+++ b/src/server/lib/livenessMonitor.ts
@@ -1,0 +1,68 @@
+import { join } from "node:path";
+import { botLivenessLaunchdLabel, teamosLaunchdPrefix } from "./agentControl";
+import { REPO_ROOT } from "./personaTemplates";
+
+export const DEFAULT_BOT_LIVENESS_LOG = join(REPO_ROOT, "var", "bot-liveness-monitor.log");
+export const DEFAULT_BOT_LIVENESS_STATE_DIR = join(REPO_ROOT, "var", "bot-liveness-monitor");
+
+export function botLivenessLogPath(): string {
+  return process.env.BOT_LIVENESS_LOG?.trim() || DEFAULT_BOT_LIVENESS_LOG;
+}
+
+export interface BotLivenessMonitorPaths {
+  label: string;
+  plist: string;
+  script: string;
+  log: string;
+  stateDir: string;
+}
+
+export function botLivenessMonitorPaths(home: string = process.env.HOME ?? ""): BotLivenessMonitorPaths {
+  const label = botLivenessLaunchdLabel();
+  return {
+    label,
+    plist: join(home, "Library", "LaunchAgents", `${label}.plist`),
+    script: join(REPO_ROOT, "scripts", "bot-liveness-monitor.sh"),
+    log: botLivenessLogPath(),
+    stateDir: process.env.LIVENESS_STATE_DIR?.trim() || DEFAULT_BOT_LIVENESS_STATE_DIR,
+  };
+}
+
+function xmlEscape(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function renderBotLivenessMonitorPlist(): string {
+  const p = botLivenessMonitorPaths();
+  const env: Record<string, string> = {
+    PATH: `${process.env.HOME ?? ""}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`,
+    HOME: process.env.HOME ?? "",
+    TEAMOS_LAUNCHD_PREFIX: teamosLaunchdPrefix(),
+    BOT_LIVENESS_LOG: p.log,
+    LIVENESS_STATE_DIR: p.stateDir,
+  };
+  return [
+    `<?xml version="1.0" encoding="UTF-8"?>`,
+    `<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">`,
+    `<plist version="1.0">`,
+    `<dict>`,
+    `  <key>Label</key><string>${xmlEscape(p.label)}</string>`,
+    `  <key>ProgramArguments</key>`,
+    `  <array>`,
+    `    <string>/bin/bash</string>`,
+    `    <string>${xmlEscape(p.script)}</string>`,
+    `  </array>`,
+    `  <key>WorkingDirectory</key><string>${xmlEscape(REPO_ROOT)}</string>`,
+    `  <key>RunAtLoad</key><true/>`,
+    `  <key>StartInterval</key><integer>600</integer>`,
+    `  <key>StandardOutPath</key><string>${xmlEscape(join(REPO_ROOT, "logs", "bot-liveness-monitor.launchd.out.log"))}</string>`,
+    `  <key>StandardErrorPath</key><string>${xmlEscape(join(REPO_ROOT, "logs", "bot-liveness-monitor.launchd.err.log"))}</string>`,
+    `  <key>EnvironmentVariables</key>`,
+    `  <dict>`,
+    ...Object.entries(env).map(([k, v]) => `    <key>${xmlEscape(k)}</key><string>${xmlEscape(v)}</string>`),
+    `  </dict>`,
+    `</dict>`,
+    `</plist>`,
+    ``,
+  ].join("\n");
+}

--- a/src/server/lib/monitoringStatus.ts
+++ b/src/server/lib/monitoringStatus.ts
@@ -1,13 +1,12 @@
 // 모니터링 탭 데이터소스 (GD 2026-07-10, Bill 핸드오프) — 새 probe 0, 기존 소스만.
-//   ① bot-liveness 상태: /tmp/bot-liveness-monitor.log 파싱(runs·마지막실행·정상여부·결과문구)
+//   ① bot-liveness 상태: durable repo-local log 파싱(runs·마지막실행·정상여부·결과문구)
 //   ② dm_message health: team.db 집계(dm-monitor.sh 로직 이식)
 // ★방어적(Bill 요청): 로그 파일 없거나 형식 바뀌어도 크래시 X — 전부 try/catch + 안전 기본값.★
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Database } from "bun:sqlite";
-
-const LIVENESS_LOG = process.env.BOT_LIVENESS_LOG || "/tmp/bot-liveness-monitor.log";
+import { botLivenessLogPath } from "./livenessMonitor";
 const INGRESS_STATUS_FILE =
   process.env.OPENCLAW_TELEGRAM_STATUS_FILE ||
   join(homedir(), "Development/b3rys-team-os/var/openclaw-telegram-ingress-status.json");
@@ -21,7 +20,7 @@ export interface LivenessStatus {
   logMtime: string | null; // 로그 파일 mtime(ISO)
 }
 
-export function readLivenessStatus(logPath: string = LIVENESS_LOG): LivenessStatus {
+export function readLivenessStatus(logPath: string = botLivenessLogPath()): LivenessStatus {
   const base: LivenessStatus = { available: false, runs: 0, lastRun: null, healthy: null, lastResult: null, logMtime: null };
   try {
     if (!existsSync(logPath)) return base;

--- a/src/server/lib/monitoringStatus.ts
+++ b/src/server/lib/monitoringStatus.ts
@@ -20,6 +20,14 @@ export interface LivenessStatus {
   logMtime: string | null; // 로그 파일 mtime(ISO)
 }
 
+function classifyBotLivenessResult(line: string): boolean | null {
+  const explicitStatus = line.match(/\bstatus=(ok|healthy|healed|issues|failed|error|down|unhealthy)\b/i)?.[1]?.toLowerCase();
+  if (explicitStatus) return /^(ok|healthy|healed)$/.test(explicitStatus);
+  if (/이상 없음|정상|\bOK\b|healthy/i.test(line)) return true;
+  if (/이상|실패|error|재시작|down|무응답|죽|수동 확인 필요|[⚠❌]/i.test(line)) return false;
+  return null;
+}
+
 export function readLivenessStatus(logPath: string = botLivenessLogPath()): LivenessStatus {
   const base: LivenessStatus = { available: false, runs: 0, lastRun: null, healthy: null, lastResult: null, logMtime: null };
   try {
@@ -35,10 +43,13 @@ export function readLivenessStatus(logPath: string = botLivenessLogPath()): Live
       if (/bot-liveness START/.test(lines[i]!)) break;
       if (lines[i]!.trim()) { lastResult = lines[i]!.trim(); break; }
     }
-    let healthy: boolean | null = null;
-    if (lastResult) {
-      if (/이상 없음|정상|\bOK\b|healthy/i.test(lastResult)) healthy = true;
-      else if (/이상|실패|error|재시작|down|무응답|죽|❌/i.test(lastResult)) healthy = false;
+    let healthy = lastResult ? classifyBotLivenessResult(lastResult) : null;
+    if (healthy === null) {
+      for (let i = lines.length - 1; i >= 0; i--) {
+        if (/bot-liveness START/.test(lines[i]!)) break;
+        const classified = classifyBotLivenessResult(lines[i]!.trim());
+        if (classified !== null) { healthy = classified; break; }
+      }
     }
     let logMtime: string | null = null;
     try { logMtime = new Date(statSync(logPath).mtimeMs).toISOString(); } catch { /* noop */ }

--- a/src/server/lib/teamosProbe.ts
+++ b/src/server/lib/teamosProbe.ts
@@ -14,7 +14,7 @@ import type { Database } from "bun:sqlite";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
-import { teamosLaunchdPrefix } from "./agentControl";
+import { botLivenessLaunchdLabel, teamosLaunchdPrefix } from "./agentControl";
 import { captureConfigStatus } from "./captureConfig";
 import { fromSqliteDate } from "../scheduler/core";
 
@@ -71,7 +71,7 @@ function launchdDesc(): Record<string, string> {
     [`${prefix}.claude-telegram-steve`]: "Claude 채널 팀원 텔레그램 봇 (tmux 세션)",
     [`${prefix}.claude-telegram-demis`]: "Claude 채널 팀원 텔레그램 봇 (tmux 세션)",
     [`${prefix}.claude-telegram-dbak`]: "Claude 채널 팀원 텔레그램 봇 (tmux 세션)",
-    [`${prefix}.bot-liveness-monitor`]: "Claude channel bot liveness monitor · auto-heal",
+    [botLivenessLaunchdLabel()]: "Claude channel bot liveness monitor · auto-heal",
     [`${prefix}.bill-context-monitor`]: "Claude 세션 컨텍스트 크기 감시 (커지면 알림)",
     [`${prefix}.bill-weekly-healthcheck`]: "주간 팀 헬스체크 리포트",
     [`${prefix}.claude-bots-weekly-restart`]: "Claude 봇 주간 자동 재시작 (컨텍스트 정리)",


### PR DESCRIPTION
## 핵심 3줄
1. `/tmp/bot-liveness-monitor.log` 기본값을 없애고 서버 기본 로그를 `<repo>/var/bot-liveness-monitor.log` 로 단일화했습니다.
2. 서버 참조 3곳은 같은 source of truth 를 봅니다: parser(`monitoringStatus`), launchd label(`agentControl`), OS 탭 설명(`teamosProbe`).
3. plist 템플릿 source와 퍼블릭 적합 설정 경계를 추가했습니다. 실제 스크립트 로직 승격은 데본 파일 경계와 맞춰야 합니다.

## 무엇을 바꿨나
| 문제 | 고친 방법 |
|---|---|
| 재부팅 시 `/tmp` 로그가 사라져 dashboard monitoring 이 깜깜해짐 | `src/server/lib/livenessMonitor.ts` 에 durable 기본값 `<repo>/var/bot-liveness-monitor.log` 추가 |
| 서버 참조별 기본값이 조용히 갈릴 수 있음 | `monitoringStatus.ts` 는 `botLivenessLogPath()`, `agentControl.ts` 는 `botLivenessLaunchdLabel()`, `teamosProbe.ts` 는 같은 label helper 사용 |
| plist 가 `com.gdmini.*` 로 고정될 위험 | `renderBotLivenessMonitorPlist()` 가 `TEAMOS_LAUNCHD_PREFIX`/`com.$USER` 기반 label, `StartInterval=600`, `BOT_LIVENESS_LOG`, `LIVENESS_STATE_DIR` 를 렌더 |
| 퍼블릭 적합 기준이 코드 밖에 흩어짐 | `skills/b3os/references/system-jobs.md` 에 설정으로 빠질 값/기본값 정리 |

## 검증
검증 범위: `src/server/lib/livenessMonitor.test.ts`, `agentControl.test.ts`, `teamosProbe.test.ts`, full TypeScript typecheck
baseline:   현재 브랜치에서 `bun test src/server/lib/livenessMonitor.test.ts src/server/lib/agentControl.test.ts src/server/lib/teamosProbe.test.ts` → 32 pass, 0 fail; `bun run typecheck` → pass
mutation:   별도 원복 mutation 은 미실행. 대신 새 테스트가 `/tmp` 미사용, durable default 실제 write/read, `BOT_LIVENESS_LOG` call-time override, plist env 일치, label prefix 규칙을 직접 검증합니다.
미검증:     실제 launchd bootstrap 및 라이브 b3os 서버 재시작/적용은 미실행(승인/데본 스크립트 합류 필요). `scripts/bot-liveness-monitor.sh` 본문은 데본 파일 경계라 이 PR에서 만들거나 수정하지 않았습니다.

Submitted-by: Hermes
