### PR TITLE
fix(preflight): '못 읽음' 과 '없음' 을 가른다 — 게이트가 상시 빨간불이었다

### DIFF
--- a/skills/b3os-release-ops/scripts/preflight-protection.test.sh
+++ b/skills/b3os-release-ops/scripts/preflight-protection.test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# release-preflight.sh 의 ★브랜치 보호 판정★ 만 잰다.
+#
+# 왜: 이 검사는 admin 전용 API 를 쓴다. admin 이 아니면 ★설정이 멀쩡해도 404★ 라,
+#   404 를 전부 "없음" 으로 보면 ★작업 계정으로는 영원히 통과 못 한다★ (2026-08-03 실측: bill·codex 둘 다 정지).
+#   그래서 "권한 없어 못 읽음(warn)" 과 "admin 인데 없음(fail)" 이 갈리는지를 본다.
+#
+# gh 를 PATH mock 으로 갈아끼워 세 경우를 만든다. 실 GitHub·실 계정 미접촉.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="${PREFLIGHT_SRC:-$HERE/release-preflight.sh}"   # 옛 버전 대조용으로 바꿔 끼울 수 있다
+[ -f "$SCRIPT" ] || { echo "✗ release-preflight.sh 없음"; exit 1; }
+
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+FAIL=0
+ok(){ printf '  ✓ %s\n' "$1"; }
+bad(){ printf '  ✗ %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+# 검사 대상 repo — noreply 이메일 커밋 1개, clean, main 아님
+R="$T/repo"; mkdir -p "$R"; cd "$R"
+git init -q -b main .
+git remote add origin https://github.com/b3rys/b3rys-team-os.git
+git -c user.name=t -c user.email='1+t@users.noreply.github.com' commit -q --allow-empty -m base
+git branch -q -f origin/main HEAD          # BASE=origin/main 로 비교되게 로컬 ref 를 만든다
+git checkout -q -b work
+git -c user.name=t -c user.email='1+t@users.noreply.github.com' commit -q --allow-empty -m work
+
+mk_gh(){ # $1=protection(ok|404) $2=admin(true|false)
+  cat > "$T/bin/gh" <<SH
+#!/usr/bin/env bash
+case "\$*" in
+  *branches/main/protection*) [ "$1" = ok ] && exit 0 || exit 1 ;;
+  *repos/*--jq*permissions.admin*) printf '%s\n' "$2"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$T/bin/gh"
+}
+mkdir -p "$T/bin"; export PATH="$T/bin:$PATH"
+
+run(){ bash "$SCRIPT" --mode merge --base origin/main --skip-approver-check "test harness" 2>&1; }
+
+echo "■ release-preflight 브랜치 보호 판정"
+
+mk_gh ok true
+out="$(run)"; rc=$?
+[ $rc -eq 0 ] && printf '%s' "$out" | grep -q '✓ main branch protection exists' \
+  && ok "보호 있음 → 통과" || bad "보호 있음인데 통과 못 함 (rc=$rc)"
+
+mk_gh 404 false
+out="$(run)"; rc=$?
+[ $rc -eq 0 ] && printf '%s' "$out" | grep -q 'not verifiable' \
+  && ok "★admin 아님 + 404 → 판정불가로 경고하고 통과★" \
+  || bad "admin 없는 계정이 막힌다 — 게이트가 상시 빨간불이 된다 (rc=$rc)"
+
+mk_gh 404 true
+out="$(run)"; rc=$?
+[ $rc -ne 0 ] && printf '%s' "$out" | grep -q 'protection missing' \
+  && ok "★admin 인데 404 → 진짜 없음이므로 실패★" \
+  || bad "보호가 진짜 없는데 통과시켰다 (rc=$rc)"
+
+echo
+[ "$FAIL" -eq 0 ] && echo "✅ 통과" || echo "❌ 실패 ${FAIL}건"
+exit "$FAIL"

--- a/skills/b3os-release-ops/scripts/release-preflight.sh
+++ b/skills/b3os-release-ops/scripts/release-preflight.sh
@@ -164,10 +164,18 @@ if [ "$CHECK_BRANCH_PROTECTION" -eq 1 ]; then
   fi
   SLUG="$(printf '%s\n' "$REMOTE_URL" | sed -E 's#^git@github.com:##; s#^https://github.com/##; s#\.git$##')"
   [ -n "$SLUG" ] || fail "could not parse GitHub owner/repo from origin"
+  # ★"못 읽음" 과 "없음" 은 다른 얘기다★ (bill 2026-08-03 실측)
+  #   branches/main/protection 은 ★admin 권한이 있어야★ 읽힌다. admin 이 아니면 설정이 멀쩡해도 404 다.
+  #   이 팀의 작업 계정(작성·승인 둘 다)은 pull/push/triage 뿐이라 ★항상 404★ 였고, 그래서 이 게이트는
+  #   ★설정이 걸려 있는데도 아무도 통과 못 하는 상태★ 였다(2026-08-03 bill·codex 둘 다 여기서 멈춤).
+  #   상시 빨간불인 게이트는 사람이 --skip 을 습관으로 쓰게 만든다 — 그게 검사 없는 것보다 나쁘다.
+  #   그래서 ★권한을 먼저 확인하고★ 판정한다: admin 인데 404 = 진짜 없음(fail) / admin 아님 = 판정불가(warn).
   if gh api "repos/$SLUG/branches/main/protection" >/dev/null 2>&1; then
     ok "main branch protection exists: $SLUG"
+  elif [ "$(gh api "repos/$SLUG" --jq '.permissions.admin' 2>/dev/null)" = "true" ]; then
+    fail "main branch protection missing: $SLUG (admin 권한으로 조회했는데 없다)"
   else
-    fail "main branch protection not readable or missing: $SLUG"
+    warn "main branch protection not verifiable: $SLUG — this account has no admin, so 'missing' and 'unreadable' cannot be told apart. Verify with the owner account."
   fi
 else
   warn "branch protection check skipped"


### PR DESCRIPTION
## 무엇이 문제였나

브랜치 보호 조회(`repos/{slug}/branches/main/protection`)는 **admin 권한 전용**이다. admin이 아니면 **설정이 멀쩡해도 404**가 온다.

이 팀의 작업 계정은 작성(`github_team_account`)·승인(`github_approver_account`) 둘 다 `pull,push,triage` 뿐이다. 그래서 이 게이트는 **설정이 걸려 있는데도 아무도 통과할 수 없는 상태**였다.

2026-08-03 실측: bill과 codex가 각각 이 지점에서 멈췄다. 소유 계정으로 조회하니 보호 설정은 멀쩡했다 — 필수승인 1 · `enforce_admins` true · force push 금지 · 브랜치 삭제 금지.

## 왜 고쳐야 하나

상시 빨간불인 게이트는 사람이 `--skip-branch-protection`을 **습관으로** 쓰게 만든다. 그러면 검사가 있는데 아무도 안 보는 상태가 된다 — **검사가 없는 것보다 나쁘다.**

## 어떻게 고쳤나

권한을 먼저 확인하고 판정한다.

| 상황 | 판정 |
|---|---|
| 보호 읽힘 | ✓ 통과 (종전대로) |
| **admin 인데 404** | ✗ **fail** — 진짜 없음 |
| **admin 아님 + 404** | ⚠ **warn 후 통과** — 판정 불가, 소유 계정 확인 안내 |

보호가 실제로 없을 때 통과시키는 구멍은 만들지 않았다.

## 검증

`skills/b3os-release-ops/scripts/preflight-protection.test.sh` 신규. `gh`를 PATH mock으로 갈아끼워 세 경우를 만든다 — 실 GitHub·실 계정 미접촉.

- 보호 있음 → 통과
- admin 아님 + 404 → 경고 후 통과
- admin + 404 → 실패

**변경 전 스크립트로 돌리면 뒤 두 케이스가 실패한다** — 재려는 축에서 정확히 갈린다.

## 롤백

`release-preflight.sh` 한 파일. revert 하면 즉시 이전 동작.
