### PR TITLE
feat(tasks): add recoverable hold view

### DIFF
--- a/rules/TEAM-OS.task-mgmt.md
+++ b/rules/TEAM-OS.task-mgmt.md
@@ -15,6 +15,8 @@ A card has four fields:
 
 Blocked work stays in plan/doing with a blocked marker in the description or badge. Do not create a separate blocked column.
 
+Held work is different from blocked work. It keeps its original plan/doing lane but is removed from the active board into the recoverable Hold view. Use Hold when the work may still be valuable but has no current commitment or reliable start/resume date. Fourteen days without a card update is a review signal, not an automatic hold or cancellation decision.
+
 ## When To Card
 
 Card the work when any condition is true:

--- a/scripts/task-continuation-guard.test.ts
+++ b/scripts/task-continuation-guard.test.ts
@@ -68,6 +68,12 @@ describe("stall 판정 — 가드가 시킨 표시를 실제로 반영한다", (
   });
 });
 
+test("보류된 doing 카드는 continuation 대상으로 깨우지 않는다", () => {
+  const now = Date.parse("2026-08-03T06:00:00Z");
+  const card = { id: "held", title: "보류", owner: "codex", column: "doing" as const, description: null, updated_at: "2026-08-01 00:00:00", held_at: "2026-08-02 00:00:00" };
+  expect(stalledDoingCards([card], new Set(["codex"]), now, 60_000)).toEqual([]);
+});
+
 describe("안내 문구", () => {
   test("표시하면 무엇이 달라지는지 알려준다 — 안 그러면 유인이 서지 않는다", () => {
     const body = guardBody("someone", [card()], 60);

--- a/scripts/task-continuation-guard.ts
+++ b/scripts/task-continuation-guard.ts
@@ -34,6 +34,7 @@ interface Task {
   column: "plan" | "doing" | "done";
   description: string | null;
   updated_at: string;
+  held_at?: string | null;
 }
 
 interface Agent {
@@ -90,7 +91,7 @@ export function isBlockedCard(t: Task): boolean {
 //   임계 = 일반 stallMs, blocked 표시가 있으면 그 6배.
 export function stalledDoingCards(tasks: Task[], owners: Set<string>, nowMs: number, stallMs: number): Task[] {
   return tasks.filter((t) => {
-    if (t.column !== "doing" || t.owner == null || !owners.has(t.owner)) return false;
+    if (t.held_at || t.column !== "doing" || t.owner == null || !owners.has(t.owner)) return false;
     const threshold = isBlockedCard(t) ? stallMs * BLOCKED_STALL_MULTIPLIER : stallMs;
     return nowMs - parseUtc(t.updated_at, nowMs) >= threshold;
   });

--- a/scripts/task-review-ping.ts
+++ b/scripts/task-review-ping.ts
@@ -25,6 +25,7 @@ interface Task {
   owner: string | null;
   column: "plan" | "doing" | "done";
   description: string | null;
+  held_at?: string | null;
 }
 
 interface Agent {
@@ -36,7 +37,7 @@ export function activeReviewOwners(tasks: Task[], reviewOwners: string[]): strin
   const allowed = new Set(reviewOwners);
   return [...new Set(
     tasks
-      .filter((t) => t.column !== "done" && t.owner && allowed.has(t.owner))
+      .filter((t) => !t.held_at && t.column !== "done" && t.owner && allowed.has(t.owner))
       .map((t) => t.owner!),
   )];
 }
@@ -107,7 +108,7 @@ async function main(): Promise<void> {
   // owner별 active(doing/plan) 과제 모으기
   const byOwner = new Map<string, { doing: Task[]; plan: Task[] }>();
   for (const t of tasks) {
-    if (t.column === "done") continue;
+    if (t.held_at || t.column === "done") continue;
     if (!t.owner || !reviewOwnerSet.has(t.owner)) continue;
     const g = byOwner.get(t.owner) ?? { doing: [], plan: [] };
     (t.column === "doing" ? g.doing : g.plan).push(t);

--- a/scripts/task-review-summary.ts
+++ b/scripts/task-review-summary.ts
@@ -20,6 +20,7 @@ interface Task {
   description: string | null;
   column: "plan" | "doing" | "done";
   updated_at?: string;
+  held_at?: string | null;
 }
 
 interface Message {
@@ -126,7 +127,7 @@ function isReviewPing(m: Message): boolean {
 }
 
 function reviewOwnersFromRegistry(agents: AgentRecord[], tasks: Task[]): string[] {
-  const activeOwnerSet = new Set(tasks.filter((t) => t.owner && t.column !== "done").map((t) => t.owner!));
+  const activeOwnerSet = new Set(tasks.filter((t) => !t.held_at && t.owner && t.column !== "done").map((t) => t.owner!));
   const configured = configuredOwners();
   if (configured.length) return configured.filter((owner) => activeOwnerSet.has(owner));
 
@@ -432,10 +433,10 @@ async function main(): Promise<void> {
   const activeByOwner = new Map<string, Task[]>();
   const updatedByOwner = new Map<string, Task[]>();
   for (const owner of reviewOwners) {
-    activeByOwner.set(owner, tasks.filter((t) => t.owner === owner && t.column !== "done"));
+    activeByOwner.set(owner, tasks.filter((t) => !t.held_at && t.owner === owner && t.column !== "done"));
     updatedByOwner.set(
       owner,
-      tasks.filter((t) => t.owner === owner && (t.updated_at ?? "") >= reviewStartUtc),
+      tasks.filter((t) => !t.held_at && t.owner === owner && (t.updated_at ?? "") >= reviewStartUtc),
     );
   }
 

--- a/src/server/db/migrate.hold.test.ts
+++ b/src/server/db/migrate.hold.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { migrate } from "./migrate";
+
+describe("task hold additive migration", () => {
+  test("기존 task 행을 보존하며 두 번 실행해도 멱등이다", () => {
+    const db = new Database(":memory:");
+    db.exec(`CREATE TABLE task (
+      id TEXT PRIMARY KEY, title TEXT NOT NULL,
+      lane TEXT NOT NULL DEFAULT 'plan' CHECK(lane IN ('plan','doing','done')),
+      owner TEXT, description TEXT, sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    ); INSERT INTO task (id,title,lane) VALUES ('legacy','기존 계획','plan');`);
+    migrate(db);
+    migrate(db);
+    const cols = db.query(`SELECT name FROM pragma_table_info('task') WHERE name IN ('held_at','hold_reason','review_at') ORDER BY name`).all() as { name: string }[];
+    expect(cols.map((x) => x.name)).toEqual(["held_at", "hold_reason", "review_at"]);
+    expect(db.query(`SELECT id,title,lane,held_at FROM task WHERE id='legacy'`).get()).toEqual({ id: "legacy", title: "기존 계획", lane: "plan", held_at: null });
+  });
+});

--- a/src/server/db/migrate.ts
+++ b/src/server/db/migrate.ts
@@ -815,6 +815,10 @@ export function runBusMigration(db: Database): void {
     "ALTER TABLE message ADD COLUMN sync TEXT NOT NULL DEFAULT 'none'",
     // Tasks kanban: owner-maintained free-form description (목표·범위·계획·완료기준·메모)
     "ALTER TABLE task ADD COLUMN description TEXT",
+    // Tasks 보류함: 실행 칼럼과 분리된 commitment 전 저장소. lane은 plan/doing/done 호환 유지.
+    "ALTER TABLE task ADD COLUMN held_at TEXT",
+    "ALTER TABLE task ADD COLUMN hold_reason TEXT",
+    "ALTER TABLE task ADD COLUMN review_at TEXT",
     // 결과물 포털: report 분류(보고서/교육자료/리서치) — /research 통합 후 category 로 구분 (2026-06-07)
     "ALTER TABLE report ADD COLUMN category TEXT",
     // 결과물 포털: GD 중요표시 별표 필터 (2026-07-02)

--- a/src/server/db/schema.sql
+++ b/src/server/db/schema.sql
@@ -243,6 +243,9 @@ CREATE TABLE IF NOT EXISTS task (
   lane TEXT NOT NULL DEFAULT 'plan' CHECK(lane IN ('plan','doing','done')),
   owner TEXT,
   description TEXT,
+  held_at TEXT,
+  hold_reason TEXT,
+  review_at TEXT,
   sort_order INTEGER NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))

--- a/src/server/db/taskQueries.ts
+++ b/src/server/db/taskQueries.ts
@@ -15,6 +15,9 @@ export interface Task {
   column: TaskLane; // kanban column — stored as `lane` in the DB
   owner: string | null;
   description: string | null;
+  held_at: string | null;
+  hold_reason: string | null;
+  review_at: string | null;
   sort_order: number;
   created_at: string;
   updated_at: string;
@@ -26,6 +29,9 @@ interface TaskRow {
   lane: TaskLane;
   owner: string | null;
   description: string | null;
+  held_at: string | null;
+  hold_reason: string | null;
+  review_at: string | null;
   sort_order: number;
   created_at: string;
   updated_at: string;
@@ -38,6 +44,9 @@ function toTask(row: TaskRow): Task {
     column: row.lane,
     owner: row.owner,
     description: row.description ?? null,
+    held_at: row.held_at ?? null,
+    hold_reason: row.hold_reason ?? null,
+    review_at: row.review_at ?? null,
     sort_order: row.sort_order,
     created_at: row.created_at,
     updated_at: row.updated_at,
@@ -46,7 +55,7 @@ function toTask(row: TaskRow): Task {
 
 const LANE_RANK: Record<TaskLane, number> = { plan: 0, doing: 1, done: 2 };
 
-const SELECT_COLS = `id, title, lane, owner, description, sort_order, created_at, updated_at`;
+const SELECT_COLS = `id, title, lane, owner, description, held_at, hold_reason, review_at, sort_order, created_at, updated_at`;
 
 /** All tasks, ordered plan→doing→done then by sort_order within each lane. */
 export function listTasks(db: Database): Task[] {
@@ -97,6 +106,9 @@ export interface UpdateTaskInput {
   owner?: string | null;
   description?: string | null;
   sort_order?: number;
+  held?: boolean;
+  hold_reason?: string | null;
+  review_at?: string | null;
 }
 
 /** Partial update. Returns the updated task, or null if the id does not exist. */
@@ -136,6 +148,20 @@ export function updateTask(
   if (input.sort_order !== undefined) {
     sets.push("sort_order = ?");
     args.push(input.sort_order);
+  }
+  if (input.held !== undefined) {
+    sets.push(input.held ? "held_at = datetime('now')" : "held_at = NULL");
+    if (!input.held) {
+      sets.push("hold_reason = NULL", "review_at = NULL");
+    }
+  }
+  if (input.hold_reason !== undefined) {
+    sets.push("hold_reason = ?");
+    args.push(input.hold_reason);
+  }
+  if (input.review_at !== undefined) {
+    sets.push("review_at = ?");
+    args.push(input.review_at);
   }
   sets.push("updated_at = datetime('now')");
 

--- a/src/server/mcp/b3osMcpServer.ts
+++ b/src/server/mcp/b3osMcpServer.ts
@@ -165,7 +165,7 @@ export function buildMcpServer(db: Database): McpServer {
     },
     async (args: unknown) => {
       const { lane } = args as { lane?: "plan" | "doing" | "done" };
-      const all = listTasks(db);
+      const all = listTasks(db).filter((t) => !t.held_at);
       const tasks = lane ? all.filter((t) => t.column === lane) : all;
       const lines = tasks.map((t) => `- [${t.column}] ${t.title}${t.owner ? ` (${t.owner})` : ""}`);
       const text = `칸반 카드 ${tasks.length}건${lane ? ` (lane=${lane})` : ""}\n` + lines.join("\n");

--- a/src/server/routes/proposalAutomation.test.ts
+++ b/src/server/routes/proposalAutomation.test.ts
@@ -328,6 +328,27 @@ describe("후보를 다 돌아도 리뷰가 없을 때", () => {
     expect(a?.description).toContain("다음 행동");
   });
 
+  test("보류된 후속 카드는 peer review 미확보 자동화가 수정하지 않는다", async () => {
+    const { app, db } = setup();
+    const agents = agentsWithCoordinator("demis");
+    const { id } = (await (await create(app)).json()) as { id: string };
+    const before = db.prepare(
+      `SELECT t.id, t.owner, t.description
+         FROM proposal_followup_task pft JOIN task t ON t.id = pft.task_id
+        WHERE pft.proposal_id = ? AND pft.closed_at IS NULL`,
+    ).get(id) as { id: string; owner: string; description: string };
+    db.prepare(`UPDATE task SET held_at=datetime('now'), hold_reason='대기', review_at='2026-08-17' WHERE id=?`).run(before.id);
+
+    let blocked = false;
+    for (let i = 0; i < 12 && !blocked; i += 1) {
+      ageProposal(db, id, 40);
+      blocked = sweepStaleProposals(db, agents).blocked.includes(id);
+    }
+    expect(blocked).toBe(true);
+    const after = db.prepare(`SELECT owner, description FROM task WHERE id=?`).get(before.id);
+    expect(after).toEqual({ owner: before.owner, description: before.description });
+  });
+
   test("카드가 없어진 채로 넘기면 기록을 남긴다", async () => {
     const { app, db } = setup();
     const agents = agentsWithCoordinator("demis");

--- a/src/server/routes/proposals.ts
+++ b/src/server/routes/proposals.ts
@@ -305,7 +305,7 @@ function createLinkedFollowup(
     `SELECT t.id
        FROM proposal_followup_task pft
        JOIN task t ON t.id = pft.task_id
-      WHERE pft.proposal_id = ? AND pft.status = ? AND pft.closed_at IS NULL AND t.lane != 'done'
+      WHERE pft.proposal_id = ? AND pft.status = ? AND pft.closed_at IS NULL AND t.lane != 'done' AND t.held_at IS NULL
       ORDER BY pft.created_at DESC
       LIMIT 1`,
   ).get(p.id, statusKey) as { id: string } | undefined;
@@ -539,6 +539,7 @@ function closeProposalFollowups(db: Database, proposalId: string, status: string
     `UPDATE task
        SET lane = 'done', updated_at = datetime('now')
       WHERE lane != 'done'
+        AND held_at IS NULL
         AND id IN (
           SELECT task_id
             FROM proposal_followup_task
@@ -548,7 +549,8 @@ function closeProposalFollowups(db: Database, proposalId: string, status: string
   db.prepare(
     `UPDATE proposal_followup_task
         SET closed_at = datetime('now')
-      WHERE proposal_id = ? AND (${clauses}) AND closed_at IS NULL`,
+      WHERE proposal_id = ? AND (${clauses}) AND closed_at IS NULL
+        AND task_id IN (SELECT id FROM task WHERE lane = 'done')`,
   ).run(proposalId, ...args);
 }
 
@@ -557,6 +559,7 @@ function closeAllProposalFollowups(db: Database, proposalId: string): void {
     `UPDATE task
        SET lane = 'done', updated_at = datetime('now')
       WHERE lane != 'done'
+        AND held_at IS NULL
         AND id IN (
           SELECT task_id
             FROM proposal_followup_task
@@ -566,7 +569,8 @@ function closeAllProposalFollowups(db: Database, proposalId: string): void {
   db.prepare(
     `UPDATE proposal_followup_task
         SET closed_at = datetime('now')
-      WHERE proposal_id = ? AND closed_at IS NULL`,
+      WHERE proposal_id = ? AND closed_at IS NULL
+        AND task_id IN (SELECT id FROM task WHERE lane = 'done')`,
   ).run(proposalId);
 }
 

--- a/src/server/routes/proposals.ts
+++ b/src/server/routes/proposals.ts
@@ -783,7 +783,8 @@ export function sweepStaleProposals(
               WHERE id IN (
                 SELECT task_id FROM proposal_followup_task
                  WHERE proposal_id = ? AND status LIKE ? AND closed_at IS NULL
-              )`,
+              )
+                AND held_at IS NULL`,
           );
           // 조율자도 제안자도 DB 에 없어 담당이 그대로면(명부와 DB 어긋남), 다음 행동이 아니라
           // 그 사실을 적어야 사람이 고칠 수 있다. 조율자가 마침 그 담당인 정상 경우와 구분된다.

--- a/src/server/routes/tasks.test.ts
+++ b/src/server/routes/tasks.test.ts
@@ -170,6 +170,29 @@ describe("tasks HOLD — 복원 가능한 보류", () => {
     });
     expect(orphan.status).toBe(400);
   });
+
+  test("이미 보류된 카드의 사유와 재검토일은 갱신하되 보류 시각과 audit은 보존한다", async () => {
+    const { app, db } = setup();
+    const card = await createCard(app, { title: "메타 수정", column: "plan" });
+    await app.request(`/tasks/${card.id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ held: true, hold_reason: "초기", review_at: "2026-08-17" }),
+    });
+    const first = db.query(`SELECT held_at FROM task WHERE id=?`).get(card.id) as { held_at: string };
+
+    const updated = await app.request(`/tasks/${card.id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ held: true, hold_reason: "변경", review_at: "2026-08-24" }),
+    });
+    expect(updated.status).toBe(200);
+    const task = (await updated.json()).task;
+    expect(task.hold_reason).toBe("변경");
+    expect(task.review_at).toBe("2026-08-24");
+    expect(task.held_at).toBe(first.held_at);
+    expect(db.query(`SELECT count(*) c FROM audit_event WHERE action='task_held' AND target=?`).get(card.id)).toEqual({ c: 1 });
+  });
 });
 
 describe("tasks — 카드변경 담당자 알림", () => {

--- a/src/server/routes/tasks.test.ts
+++ b/src/server/routes/tasks.test.ts
@@ -102,6 +102,76 @@ describe("tasks DELETE — audit 계측", () => {
   });
 });
 
+describe("tasks HOLD — 복원 가능한 보류", () => {
+  test("보류는 행과 lane을 보존하고 audit을 남긴 뒤 원래 lane으로 복귀한다", async () => {
+    const { app, db } = setup();
+    const card = await createCard(app, { title: "잠시 멈춘 실행", column: "doing", owner: "dbak" });
+
+    const held = await app.request(`/tasks/${card.id}?actor=codex`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ held: true, hold_reason: "우선순위", review_at: "2026-08-17" }),
+    });
+    expect(held.status).toBe(200);
+    const heldTask = (await held.json()).task;
+    expect(heldTask.column).toBe("doing");
+    expect(heldTask.held_at).not.toBeNull();
+    expect(heldTask.hold_reason).toBe("우선순위");
+    expect(db.query(`SELECT count(*) c FROM task WHERE id=?`).get(card.id)).toEqual({ c: 1 });
+    expect(db.query(`SELECT count(*) c FROM audit_event WHERE action='task_held' AND target=?`).get(card.id)).toEqual({ c: 1 });
+    expect(db.query(`SELECT count(*) c FROM audit_event WHERE action='task_deleted' AND target=?`).get(card.id)).toEqual({ c: 0 });
+
+    const resumed = await app.request(`/tasks/${card.id}?actor=codex`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ held: false }),
+    });
+    const resumedTask = (await resumed.json()).task;
+    expect(resumedTask.column).toBe("doing");
+    expect(resumedTask.held_at).toBeNull();
+    expect(resumedTask.hold_reason).toBeNull();
+    expect(resumedTask.review_at).toBeNull();
+    expect(db.query(`SELECT count(*) c FROM audit_event WHERE action='task_resumed' AND target=?`).get(card.id)).toEqual({ c: 1 });
+  });
+
+  test("잘못된 보류 payload는 400이고 카드가 바뀌지 않는다", async () => {
+    const { app, db } = setup();
+    const card = await createCard(app, { title: "검증", column: "plan" });
+    const r = await app.request(`/tasks/${card.id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ held: "yes" }),
+    });
+    expect(r.status).toBe(400);
+    expect(db.query(`SELECT held_at FROM task WHERE id=?`).get(card.id)).toEqual({ held_at: null });
+
+    const missingMeta = await app.request(`/tasks/${card.id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ held: true }),
+    });
+    expect(missingMeta.status).toBe(400);
+    expect(db.query(`SELECT held_at FROM task WHERE id=?`).get(card.id)).toEqual({ held_at: null });
+  });
+
+  test("보류 전이는 멱등이고 활성 카드에 보류 메타만 남길 수 없다", async () => {
+    const { app, db } = setup();
+    const card = await createCard(app, { title: "멱등", column: "plan" });
+    const payload = JSON.stringify({ held: true, hold_reason: "대기", review_at: "2026-08-17" });
+    await app.request(`/tasks/${card.id}`, { method: "PATCH", headers: { "content-type": "application/json" }, body: payload });
+    const first = db.query(`SELECT held_at FROM task WHERE id=?`).get(card.id) as { held_at: string };
+    await app.request(`/tasks/${card.id}`, { method: "PATCH", headers: { "content-type": "application/json" }, body: payload });
+    const second = db.query(`SELECT held_at FROM task WHERE id=?`).get(card.id) as { held_at: string };
+    expect(second.held_at).toBe(first.held_at);
+    expect(db.query(`SELECT count(*) c FROM audit_event WHERE action='task_held' AND target=?`).get(card.id)).toEqual({ c: 1 });
+
+    const orphan = await app.request(`/tasks/${card.id}`, {
+      method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ held: false, hold_reason: "남으면 안 됨" }),
+    });
+    expect(orphan.status).toBe(400);
+  });
+});
+
 describe("tasks — 카드변경 담당자 알림", () => {
   test("삭제 시 담당자에게 버스 알림이 가고 깨움 대기(pending)다", async () => {
     const { app, db } = setup();

--- a/src/server/routes/tasks.ts
+++ b/src/server/routes/tasks.ts
@@ -119,6 +119,9 @@ export function createTaskRoutes(deps: TaskRouteDeps): Hono {
       owner?: unknown;
       description?: unknown;
       sort_order?: unknown;
+      held?: unknown;
+      hold_reason?: unknown;
+      review_at?: unknown;
     };
     try {
       body = await c.req.json();
@@ -134,7 +137,34 @@ export function createTaskRoutes(deps: TaskRouteDeps): Hono {
     if (body.sort_order !== undefined && typeof body.sort_order !== "number") {
       return c.json({ ok: false, error: "invalid sort_order" }, 400);
     }
-    const before = getTask(deps.db, id); // capture owner BEFORE update to detect reassignment
+    if (body.held !== undefined && typeof body.held !== "boolean") {
+      return c.json({ ok: false, error: "invalid held" }, 400);
+    }
+    if (body.hold_reason !== undefined && body.hold_reason !== null && typeof body.hold_reason !== "string") {
+      return c.json({ ok: false, error: "invalid hold_reason" }, 400);
+    }
+    if (body.review_at !== undefined && body.review_at !== null && typeof body.review_at !== "string") {
+      return c.json({ ok: false, error: "invalid review_at" }, 400);
+    }
+    if (body.held === true) {
+      if (typeof body.hold_reason !== "string" || body.hold_reason.trim() === "") {
+        return c.json({ ok: false, error: "hold_reason required" }, 400);
+      }
+      if (typeof body.review_at !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(body.review_at)) {
+        return c.json({ ok: false, error: "review_at required (YYYY-MM-DD)" }, 400);
+      }
+    }
+    if (body.held === false && (body.hold_reason !== undefined || body.review_at !== undefined)) {
+      return c.json({ ok: false, error: "hold metadata not allowed when resuming" }, 400);
+    }
+    if (body.held === undefined && (body.hold_reason !== undefined || body.review_at !== undefined)) {
+      return c.json({ ok: false, error: "held required with hold metadata" }, 400);
+    }
+    const before = getTask(deps.db, id); // capture owner/state BEFORE update
+    if (!before) return c.json({ ok: false, error: "not found" }, 404);
+    if (body.held === true && before.held_at) {
+      return c.json({ ok: true, task: before }); // idempotent hold retry; timestamp/audit unchanged
+    }
     const task = updateTask(deps.db, id, {
       title: typeof body.title === "string" ? body.title.trim() : undefined,
       column: body.column as TaskLane | undefined,
@@ -151,8 +181,30 @@ export function createTaskRoutes(deps: TaskRouteDeps): Hono {
             ? body.description
             : null,
       sort_order: typeof body.sort_order === "number" ? body.sort_order : undefined,
+      held: typeof body.held === "boolean" ? body.held : undefined,
+      hold_reason:
+        body.hold_reason === undefined ? undefined : typeof body.hold_reason === "string" ? body.hold_reason.trim() || null : null,
+      review_at:
+        body.review_at === undefined ? undefined : typeof body.review_at === "string" ? body.review_at.trim() || null : null,
     });
     if (!task) return c.json({ ok: false, error: "not found" }, 404);
+
+    if (before && before.held_at !== task.held_at) {
+      const actor = c.req.query("actor") || c.req.header("x-actor") || "unknown";
+      const action = task.held_at ? "task_held" : "task_resumed";
+      const detail = {
+        title: task.title,
+        lane: task.column,
+        hold_reason: task.hold_reason,
+        review_at: task.review_at,
+      };
+      try {
+        appendAudit(deps.db, actor, action, id, detail);
+        appendAuditFile(actor, action, id, detail);
+      } catch (e) {
+        console.error("[tasks] hold audit failed:", e);
+      }
+    }
 
     // Reassignment notify (scope per GD = delete + reassign only): when owner changes, audit
     // it and wake BOTH the previous owner ("removed from you") and the new owner ("assigned").

--- a/src/server/routes/tasks.ts
+++ b/src/server/routes/tasks.ts
@@ -162,9 +162,11 @@ export function createTaskRoutes(deps: TaskRouteDeps): Hono {
     }
     const before = getTask(deps.db, id); // capture owner/state BEFORE update
     if (!before) return c.json({ ok: false, error: "not found" }, 404);
-    if (body.held === true && before.held_at) {
-      return c.json({ ok: true, task: before }); // idempotent hold retry; timestamp/audit unchanged
-    }
+    // Repeating hold on an already-held task updates its metadata/other requested fields,
+    // but must not reset held_at or emit a second hold audit event.
+    const held = body.held === true && before.held_at
+      ? undefined
+      : typeof body.held === "boolean" ? body.held : undefined;
     const task = updateTask(deps.db, id, {
       title: typeof body.title === "string" ? body.title.trim() : undefined,
       column: body.column as TaskLane | undefined,
@@ -181,7 +183,7 @@ export function createTaskRoutes(deps: TaskRouteDeps): Hono {
             ? body.description
             : null,
       sort_order: typeof body.sort_order === "number" ? body.sort_order : undefined,
-      held: typeof body.held === "boolean" ? body.held : undefined,
+      held,
       hold_reason:
         body.hold_reason === undefined ? undefined : typeof body.hold_reason === "string" ? body.hold_reason.trim() || null : null,
       review_at:

--- a/src/server/runtimes/b3osNative/tools.ts
+++ b/src/server/runtimes/b3osNative/tools.ts
@@ -195,7 +195,7 @@ export function runTool(db: Database, agentId: string, tool: ToolName, args: Rec
       const lane = args.lane as TaskLane | undefined;
       const limit = (args.limit as number | undefined) ?? DEFAULT_TASK_LIMIT;
       argsPreview = `lane=${lane ?? "*"} limit=${limit}`;
-      const all = listTasks(db);
+      const all = listTasks(db).filter((t) => !t.held_at);
       const filtered = (lane ? all.filter((t) => t.column === lane) : all).slice(0, limit);
       body = filtered.length
         ? filtered.map((t) => `- [${t.column}] ${t.title}${t.owner ? ` (owner: ${t.owner})` : ""}`).join("\n")

--- a/src/server/workers/telegramCapture.test.ts
+++ b/src/server/workers/telegramCapture.test.ts
@@ -319,6 +319,15 @@ describe("slash command formatters (fmt*)", () => {
     expect(out).not.toContain("✅ 완료");
     expect(out).not.toContain("완료 작업C");
   });
+  test("fmtBoard excludes held plan/doing cards", () => {
+    const db = dbWithTasks();
+    db.prepare(`UPDATE task SET held_at=datetime('now'), hold_reason='대기', review_at='2026-08-17' WHERE id IN ('t1','t2')`).run();
+    const out = fmtBoard(db);
+    expect(out).toContain("📝 계획 (0)");
+    expect(out).toContain("🔧 실행 중 (0)");
+    expect(out).not.toContain("플랜 작업A");
+    expect(out).not.toContain("실행 작업B");
+  });
   test("fmtReview lists doing; empty message when none", () => {
     expect(fmtReview(dbWithTasks())).toContain("실행 작업B — @bill");
     const empty = new Database(":memory:"); migrate(empty);

--- a/src/server/workers/telegramCapture.ts
+++ b/src/server/workers/telegramCapture.ts
@@ -336,7 +336,7 @@ export function applyTelegramBotActivityAutoAck(
 type TaskRow = { lane: string; title: string; owner: string | null };
 export function allTasks(db: Database): TaskRow[] {
   return db
-    .prepare("SELECT lane, title, owner FROM task ORDER BY lane, sort_order")
+    .prepare("SELECT lane, title, owner FROM task WHERE held_at IS NULL ORDER BY lane, sort_order")
     .all() as TaskRow[];
 }
 function byLane(rows: TaskRow[], lane: string): TaskRow[] {

--- a/src/web/components/TasksKanban.test.ts
+++ b/src/web/components/TasksKanban.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { isTaskStale, localDateKey } from "./TasksKanban";
+
+const now = Date.parse("2026-08-03T06:00:00Z");
+const task = (updated_at: string, extra: Record<string, unknown> = {}) => ({
+  id: "t1",
+  title: "검토",
+  owner: null,
+  description: null,
+  column: "plan" as const,
+  updated_at,
+  ...extra,
+});
+
+test("재검토일은 런타임의 로컬 달력 날짜를 사용한다", () => {
+  expect(localDateKey(new Date(2026, 7, 17, 0, 30))).toBe("2026-08-17");
+});
+
+describe("TasksKanban stale 후보", () => {
+  test("SQLite UTC 문자열 기준 정확히 14일부터 stale이다", () => {
+    expect(isTaskStale(task("2026-07-20 06:00:01"), now)).toBe(false);
+    expect(isTaskStale(task("2026-07-20 06:00:00"), now)).toBe(true);
+  });
+
+  test("완료와 보류 카드는 stale 후보가 아니다", () => {
+    expect(isTaskStale({ ...task("2026-07-01 00:00:00"), column: "done" }, now)).toBe(false);
+    expect(isTaskStale(task("2026-07-01 00:00:00", { held_at: "2026-08-01 00:00:00" }), now)).toBe(false);
+  });
+
+  test("잘못된 날짜는 오래됐다고 단정하지 않는다", () => {
+    expect(isTaskStale(task("not-a-date"), now)).toBe(false);
+  });
+});

--- a/src/web/components/TasksKanban.ts
+++ b/src/web/components/TasksKanban.ts
@@ -7,6 +7,7 @@
 import { apiBase } from "../ws";
 import { pick } from "../i18n";
 import { parseSqliteDate } from "../lib/datetime";
+import { showConfirm } from "./dialogs";
 
 type ColKey = "plan" | "doing" | "done";
 
@@ -165,7 +166,10 @@ export function renderTasksKanban(root: HTMLElement): void {
   }
 
   async function delTask(id: string) {
-    if (!window.confirm(pick("이 카드를 영구 삭제할까요? 보류하려면 보류 버튼을 사용하세요.", "Permanently delete this card? Use Hold if you may need it later."))) return;
+    if (!await showConfirm({
+      message: pick("이 카드를 영구 삭제할까요? 보류하려면 보류 버튼을 사용하세요.", "Permanently delete this card? Use Hold if you may need it later."),
+      danger: true,
+    })) return;
     tasks = tasks.filter((x) => x.id !== id);
     render();
     try {

--- a/src/web/components/TasksKanban.ts
+++ b/src/web/components/TasksKanban.ts
@@ -19,7 +19,12 @@ interface KanbanTask {
   sort_order?: number;
   created_at?: string;
   updated_at?: string;
+  held_at?: string | null;
+  hold_reason?: string | null;
+  review_at?: string | null;
 }
+
+type BoardView = "board" | "hold";
 
 // dot 의미(승인 프로토) = 계획:중립회색 · 실행중:accent green · 완료:blue. 시맨틱 토큰으로 라이트/다크 적응.
 const COLUMNS: { key: ColKey; label: string; accent: string }[] = [
@@ -62,6 +67,21 @@ function taskTimeMs(value?: string): number {
   return d ? d.getTime() : 0;
 }
 
+const STALE_AFTER_MS = 14 * 24 * 60 * 60 * 1000;
+
+export function localDateKey(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export function isTaskStale(t: KanbanTask, nowMs = Date.now()): boolean {
+  if (t.held_at || t.column === "done") return false;
+  const d = parseSqliteDate(t.updated_at ?? t.created_at ?? null);
+  return d ? nowMs - d.getTime() >= STALE_AFTER_MS : false;
+}
+
 function trashIcon(cls = "h-3.5 w-3.5"): string {
   return `<svg class="${cls}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v5"/><path d="M14 11v5"/></svg>`;
 }
@@ -80,6 +100,8 @@ export function renderTasksKanban(root: HTMLElement): void {
   let expandedId: string | null = null; // description 펼침/편집
   let filterOwner: string | null = null; // 담당자 필터 (null=전체)
   let visibleCount = initialVisible(); // 칼럼별 표시 개수(더보기로 증가)
+  let view: BoardView = "board";
+  let holdVisibleCount = LANE_PAGE_SIZE;
 
   const base = () => `${apiBase()}/api/tasks`;
 
@@ -102,6 +124,7 @@ export function renderTasksKanban(root: HTMLElement): void {
       const body = (await res.json()) as { tasks: KanbanTask[] };
       tasks = body.tasks ?? [];
       visibleCount = initialVisible();
+      holdVisibleCount = LANE_PAGE_SIZE;
       loadError = false;
     } catch (e) {
       console.error("[loadTasks]", e);
@@ -142,6 +165,7 @@ export function renderTasksKanban(root: HTMLElement): void {
   }
 
   async function delTask(id: string) {
+    if (!window.confirm(pick("이 카드를 영구 삭제할까요? 보류하려면 보류 버튼을 사용하세요.", "Permanently delete this card? Use Hold if you may need it later."))) return;
     tasks = tasks.filter((x) => x.id !== id);
     render();
     try {
@@ -149,6 +173,29 @@ export function renderTasksKanban(root: HTMLElement): void {
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
     } catch (e) {
       console.error("[delTask]", e);
+      await loadTasks();
+    }
+  }
+
+  async function setHeld(id: string, held: boolean) {
+    const task = tasks.find((x) => x.id === id);
+    if (!task) return;
+    const reviewAt = localDateKey(new Date(Date.now() + STALE_AFTER_MS));
+    const holdReason = isTaskStale(task) ? pick("14일+ 미갱신 검토", "Inactive 14+ days review") : pick("수동 보류", "Manually held");
+    task.held_at = held ? new Date().toISOString() : null;
+    task.hold_reason = held ? holdReason : null;
+    task.review_at = held ? reviewAt : null;
+    task.updated_at = new Date().toISOString();
+    render();
+    try {
+      const res = await fetch(`${base()}/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(held ? { held, hold_reason: holdReason, review_at: reviewAt } : { held }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    } catch (e) {
+      console.error("[setHeld]", e);
       await loadTasks();
     }
   }
@@ -211,11 +258,12 @@ export function renderTasksKanban(root: HTMLElement): void {
   }
 
   function cardHtml(t: KanbanTask): string {
+    const held = !!t.held_at;
     const idx = COL_ORDER.indexOf(t.column);
-    const left = idx > 0
+    const left = !held && idx > 0
       ? `<button data-move="-1" data-id="${t.id}" class="text-slate-500 hover:text-slate-200 px-1" title="${pick("왼쪽 컬럼으로", "To left column")}">◀</button>`
       : `<span class="px-1 opacity-0">◀</span>`;
-    const right = idx < COL_ORDER.length - 1
+    const right = !held && idx < COL_ORDER.length - 1
       ? `<button data-move="1" data-id="${t.id}" class="text-slate-500 hover:text-slate-200 px-1" title="${pick("오른쪽 컬럼으로", "To right column")}">▶</button>`
       : `<span class="px-1 opacity-0">▶</span>`;
     const titleHtml = editingId === t.id
@@ -230,14 +278,26 @@ export function renderTasksKanban(root: HTMLElement): void {
            class="w-full mt-2 bg-surface-0 border border-surface-3 rounded px-2 py-1 text-[11px] text-slate-200 placeholder:text-slate-600 focus:outline-none focus:border-accent-green resize-y">${escape(t.description ?? "")}</textarea>
          <div class="text-[9px] text-slate-600 mt-0.5">${pick("상세는 자동 저장 (포커스 벗어날 때)", "Details auto-save (on blur)")}</div>`
       : "";
+    const staleBadge = isTaskStale(t)
+      ? `<span class="inline-flex items-center rounded-full bg-amber-400/10 px-2 py-0.5 text-[10px] font-semibold text-amber-300">${pick("14일+ 미갱신", "Inactive 14+ days")}</span>`
+      : "";
+    const holdAction = held
+      ? `<button data-unhold="${t.id}" class="rounded-md border border-accent-green/30 px-2 py-1 text-[11px] font-semibold text-accent-green hover:bg-accent-green/10">${pick("보드로 복귀", "Return to board")}</button>`
+      : `<button data-hold="${t.id}" class="rounded-md border border-amber-400/20 px-2 py-1 text-[11px] font-semibold text-amber-300 hover:bg-amber-400/10">${pick("보류", "Hold")}</button>`;
+    const holdMeta = held
+      ? `<div class="mt-2 text-[10px] text-slate-500">${escape(t.hold_reason ?? pick("사유 없음", "No reason"))}${t.review_at ? ` · ${pick("재검토", "Review")} ${escape(t.review_at)}` : ""}</div>`
+      : "";
     return `
       <div class="relative rounded-[14px] bg-surface-3 border border-surface-3 p-4 shadow-[0_1px_2px_rgba(0,0,0,.05)] hover:shadow-[0_4px_16px_rgba(0,0,0,.08)] transition-shadow group">
         ${detailLink}
         <div class="min-w-0">${titleHtml}</div>
         ${descBlock}
-        <div class="mt-4 flex flex-wrap items-center gap-2">
+        ${holdMeta}
+        <div class="mt-3 flex min-h-5 items-center gap-2">${staleBadge}</div>
+        <div class="mt-2 flex flex-wrap items-center gap-2">
           <div class="min-w-[7rem] flex-1">${ownerSelectHtml(t.owner, `data-owner="${t.id}"`)}</div>
           <div class="ml-auto flex shrink-0 items-center gap-1.5">
+            ${holdAction}
             <button data-del="${t.id}" class="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-transparent text-slate-500 transition-colors hover:border-red-400/30 hover:bg-red-400/10 hover:text-status-blocked" title="${pick("삭제", "Delete")}" aria-label="${pick("삭제", "Delete")}">${trashIcon()}</button>
             <div class="flex items-center">${left}${right}</div>
           </div>
@@ -245,9 +305,27 @@ export function renderTasksKanban(root: HTMLElement): void {
       </div>`;
   }
 
+  function viewTabsHtml(): string {
+    const heldCount = tasks.filter((t) => !!t.held_at).length;
+    const tab = (key: BoardView, label: string) => `<button data-view="${key}" class="rounded-full border px-3 py-1 text-[12px] font-semibold ${view === key ? "border-slate-100 bg-slate-100 text-surface-0" : "border-surface-3 bg-surface-3 text-slate-400 hover:text-slate-200"}">${label}</button>`;
+    return `<div class="flex items-center gap-2 px-1 pb-3">${tab("board", pick("업무 보드", "Work board"))}${tab("hold", `${pick("보류함", "Hold")} (${heldCount})`)}</div>`;
+  }
+
+  function holdHtml(): string {
+    const items = tasks
+      .filter((t) => !!t.held_at)
+      .filter((t) => filterOwner === null || t.owner === filterOwner)
+      .sort((a, b) => taskTimeMs(b.held_at ?? b.updated_at) - taskTimeMs(a.held_at ?? a.updated_at));
+    const visible = items.slice(0, holdVisibleCount);
+    const cards = visible.map(cardHtml).join("") || `<div class="rounded-[14px] border border-surface-3 px-4 py-10 text-center text-[12px] text-slate-500">${pick("보류한 계획이 없습니다.", "No held plans.")}</div>`;
+    const remaining = items.length - visible.length;
+    const more = remaining > 0 ? `<button data-hold-more class="mt-3 w-full rounded-[10px] border border-surface-3 bg-surface-2 px-3 py-2 text-[12px] font-semibold text-slate-300">${pick(`더보기 ${Math.min(LANE_PAGE_SIZE, remaining)}`, `Show ${Math.min(LANE_PAGE_SIZE, remaining)} more`)}</button>` : "";
+    return `${filterBarHtml()}<div class="mx-auto flex max-w-3xl flex-col gap-3">${cards}${more}</div>`;
+  }
+
   function columnHtml(col: { key: ColKey; label: string; accent: string }): string {
     const items = tasks
-      .filter((t) => t.column === col.key)
+      .filter((t) => !t.held_at && t.column === col.key)
       .filter((t) => filterOwner === null || t.owner === filterOwner)
       .sort(byNewestFirst);
     const visibleItems = items.slice(0, visibleCount[col.key]);
@@ -285,7 +363,7 @@ export function renderTasksKanban(root: HTMLElement): void {
         <button data-retry class="px-3 py-1 rounded bg-surface-3 hover:bg-surface-0 text-[12px] text-slate-200">${pick("다시 시도", "Retry")}</button>
       </div>`;
     }
-    return `${filterBarHtml()}<div class="flex gap-5 min-h-full items-stretch flex-col md:flex-row">${COLUMNS.map(columnHtml).join("")}</div>`;
+    return `${viewTabsHtml()}${view === "hold" ? holdHtml() : `${filterBarHtml()}<div class="flex gap-5 min-h-full items-stretch flex-col md:flex-row">${COLUMNS.map(columnHtml).join("")}</div>`}`;
   }
 
   function render() {
@@ -312,12 +390,19 @@ export function renderTasksKanban(root: HTMLElement): void {
     root.querySelector<HTMLButtonElement>("[data-retry]")?.addEventListener("click", () => void loadTasks());
     root.querySelectorAll<HTMLButtonElement>("[data-del]").forEach((b) =>
       b.addEventListener("click", () => void delTask(b.dataset.del!)));
+    root.querySelectorAll<HTMLButtonElement>("[data-hold]").forEach((b) =>
+      b.addEventListener("click", () => void setHeld(b.dataset.hold!, true)));
+    root.querySelectorAll<HTMLButtonElement>("[data-unhold]").forEach((b) =>
+      b.addEventListener("click", () => void setHeld(b.dataset.unhold!, false)));
+    root.querySelectorAll<HTMLButtonElement>("[data-view]").forEach((b) =>
+      b.addEventListener("click", () => { view = b.dataset.view as BoardView; editingId = null; expandedId = null; render(); }));
+    root.querySelector<HTMLButtonElement>("[data-hold-more]")?.addEventListener("click", () => { holdVisibleCount += LANE_PAGE_SIZE; render(); });
     root.querySelectorAll<HTMLButtonElement>("[data-move]").forEach((b) =>
       b.addEventListener("click", () => void moveTask(b.dataset.id!, Number(b.dataset.move) as -1 | 1)));
 
     // 담당자 필터
     root.querySelectorAll<HTMLButtonElement>("[data-filter]").forEach((b) =>
-      b.addEventListener("click", () => { filterOwner = b.dataset.filter || null; visibleCount = initialVisible(); render(); }));
+      b.addEventListener("click", () => { filterOwner = b.dataset.filter || null; visibleCount = initialVisible(); holdVisibleCount = LANE_PAGE_SIZE; render(); }));
 
     root.querySelectorAll<HTMLButtonElement>("[data-show-more]").forEach((b) =>
       b.addEventListener("click", () => {


### PR DESCRIPTION
## 핵심 3줄
1. 오래된 계획을 정리할 때 현재 삭제는 DB 행을 실제 제거해 복원 UI가 없습니다.
2. 활성 plan/doing과 분리된 복원 가능한 보류함, 14일+ 미갱신 신호, 영구삭제 확인을 추가합니다.
3. 18개 파일 변경이며 기존 3-lane 계약은 유지하고 additive DB migration을 사용합니다.

## 무엇을 바꿨나
- 업무 보드와 별도 보류함 탭
- 14일+ 미갱신 배지와 수동 보류/복귀
- 보류 사유·재검토일·감사 이벤트
- review/continuation/MCP/Telegram/proposal 자동화에서 보류 카드 제외
- 영구삭제 확인창

## 검증
- 관련 테스트 135개 통과
- TypeScript typecheck 통과
- Vite production build 통과
- 라이브 DB 복제본 migration 2회: task 473→473, 신규 컬럼 3개 확인
- harness UX·DB/API·적대검증 수행, P1 지적 반영

## 배포 주의
- additive migration 전 라이브 team.db와 agents.json 백업 필요
- merge preflight에서 main branch protection이 읽히지 않거나 미설정으로 경고됨; merge 전 확인 필요
- 배포 후 /team, /team/api/agents, 보류/복귀 대표 케이스 실측 필요

## 미검증
- 라이브 서버 재시작 및 실제 브라우저 보류/복귀는 배포 후 확인 예정

Submitted-by: Codex