### PR TITLE
fix(tasks): tailor delete confirmation by view

### DIFF
--- a/src/web/components/TasksKanban.test.ts
+++ b/src/web/components/TasksKanban.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isTaskStale, localDateKey } from "./TasksKanban";
+import { deletePrompt, isTaskStale, localDateKey } from "./TasksKanban";
 
 const now = Date.parse("2026-08-03T06:00:00Z");
 const task = (updated_at: string, extra: Record<string, unknown> = {}) => ({
@@ -14,6 +14,11 @@ const task = (updated_at: string, extra: Record<string, unknown> = {}) => ({
 
 test("재검토일은 런타임의 로컬 달력 날짜를 사용한다", () => {
   expect(localDateKey(new Date(2026, 7, 17, 0, 30))).toBe("2026-08-17");
+});
+
+test("활성 카드와 보류 카드의 삭제 안내를 구분한다", () => {
+  expect(deletePrompt(task("2026-08-03 00:00:00"))).toContain("보류하려면");
+  expect(deletePrompt(task("2026-08-03 00:00:00", { held_at: "2026-08-03 01:00:00" }))).not.toContain("보류하려면");
 });
 
 describe("TasksKanban stale 후보", () => {

--- a/src/web/components/TasksKanban.ts
+++ b/src/web/components/TasksKanban.ts
@@ -83,6 +83,12 @@ export function isTaskStale(t: KanbanTask, nowMs = Date.now()): boolean {
   return d ? nowMs - d.getTime() >= STALE_AFTER_MS : false;
 }
 
+export function deletePrompt(t: KanbanTask | undefined): string {
+  return t?.held_at
+    ? pick("이 보류 카드를 영구 삭제할까요?", "Permanently delete this held card?")
+    : pick("이 카드를 영구 삭제할까요? 보류하려면 보류 버튼을 사용하세요.", "Permanently delete this card? Use Hold if you may need it later.");
+}
+
 function trashIcon(cls = "h-3.5 w-3.5"): string {
   return `<svg class="${cls}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v5"/><path d="M14 11v5"/></svg>`;
 }
@@ -170,8 +176,9 @@ export function renderTasksKanban(root: HTMLElement): void {
   }
 
   async function delTask(id: string) {
+    const task = tasks.find((x) => x.id === id);
     if (!await showConfirm({
-      message: pick("이 카드를 영구 삭제할까요? 보류하려면 보류 버튼을 사용하세요.", "Permanently delete this card? Use Hold if you may need it later."),
+      message: deletePrompt(task),
       danger: true,
     })) return;
     tasks = tasks.filter((x) => x.id !== id);


### PR DESCRIPTION
## 핵심 3줄
1. 활성 보드와 보류함의 삭제 확인 문구가 같아 보류함에서도 불필요한 보류 안내가 표시됐습니다.
2. 활성 카드는 기존 안내를 유지하고, 보류 카드는 영구삭제 확인만 표시합니다.
3. 2개 파일, 14줄 변경입니다.

## 검증
- TasksKanban 테스트 5개 통과
- TypeScript typecheck 통과
- Vite production build 통과

## 미검증
- 라이브 브라우저 팝업은 배포 후 확인 예정

Submitted-by: Codex