### PR TITLE
fix(bus): 마감 알림이 어느 수집인지 말한다 + 단정을 없앤다

### DIFF
--- a/src/server/bus/collectionDeadline.test.ts
+++ b/src/server/bus/collectionDeadline.test.ts
@@ -644,3 +644,37 @@ it("★자른 자리의 말줄임이 겹치지 않는다★", () => {
   expect(t).toContain("…(잘림)");
   expect(t).not.toContain("……");
 });
+
+// ★식별이 ack 을 집으면 안 된다★ (steve 리뷰 2026-08-04 · P1)
+//   collector 는 팬아웃 전에 요청자에게 ack 을 보낸다 — burst[0] 이 그 ack 이면
+//   알림 첫 줄이 「접수. 확인하고 회신하겠습니다.」 로 나간다. ★틀린 식별은 없느니만 못하다.★
+it("★팬아웃 전 ack 이 있어도 제목·id 는 진짜 질문에서 뽑는다★", () => {
+  const d = new Database(":memory:");
+  migrate(d);
+  d.run(`INSERT INTO thread (id,title,kind,participants_json,opened_by) VALUES ('tg-ack','t','dm','[]','bill')`);
+  const M = (f: string, to: string, mins: number, body: string, id: string) =>
+    d.run(`INSERT INTO message (id,thread_id,from_agent_id,to_agent_id,type,body,source,created_at)
+           VALUES (?,'tg-ack',?,?,'dm',?,'agent',datetime('now','-'||?||' minutes'))`,
+      [id, f, to, body, String(mins)]);
+  M("bill", "steve", 30, "[위임] 마감 알림 리뷰 좀 봐줘", "REQ-1");
+  M("steve", "bill", 29, "접수. 확인하고 회신하겠습니다.", "ACK-1");   // ★요청자에게 보낸 ack★
+  M("steve", "lui", 28, "[요청] bot-liveness 승격 — 판단근거 교체", "ASK-1");
+  M("steve", "demis", 28, "[요청] bot-liveness 승격 — 판단근거 교체", "ASK-2");
+  const c = findStalledCollections(d, AGENTS).find((x) => x.collector === "steve")!;
+  expect(c.askId).toBe("ASK-1");                       // ★ack 이 아니라 첫 질문★
+  expect(c.askTitle).toContain("bot-liveness 승격");
+  expect(c.askTitle).not.toContain("접수");
+  expect(c.missing.sort()).toEqual(["demis", "lui"]);  // 판정은 종전대로
+});
+
+// ★서로게이트를 쪼개지 않는다★ (steve 리뷰 · P2)
+it("★44자 경계에 이모지가 걸려도 반쪽 문자가 안 남는다★", () => {
+  const t = askTitleOf("가".repeat(43) + "😀" + "뒤에 더 있다");
+  expect(t).toContain("…(잘림)");
+  // ★"서로게이트가 있나" 가 아니라 "짝 없는 서로게이트가 있나" 다★ —
+  //   정상 이모지도 서로게이트 ★쌍★ 이라 /[\uD800-\uDFFF]/ 에 걸린다(내가 처음 이걸로 틀렸다).
+  //   spread 는 코드포인트 단위라, 짝이 없을 때만 그 범위 문자가 낱개로 나온다.
+  const lone = [...t].filter((ch) => { const c = ch.codePointAt(0)!; return c >= 0xd800 && c <= 0xdfff; });
+  expect(lone).toHaveLength(0);
+  expect(t).toContain("😀");                           // 이모지는 통째로 살아남는다
+});

--- a/src/server/bus/collectionDeadline.test.ts
+++ b/src/server/bus/collectionDeadline.test.ts
@@ -21,7 +21,7 @@
  */
 import { describe, expect, it, beforeEach } from "bun:test";
 import { Database } from "bun:sqlite";
-import { findStalledCollections, sweepCollectionDeadlines } from "./collectionDeadline";
+import { findStalledCollections, sweepCollectionDeadlines, askTitleOf } from "./collectionDeadline";
 import { migrate } from "../db/migrate";
 
 const AGENTS = ["steve", "hermes", "codex", "demis", "bill", "dbak", "devon"].map((id) => ({ id })) as never;
@@ -568,4 +568,79 @@ describe("보고 인정 — 팀장 1:1 DM(dm_message)은 근거로 쓰지 않는
     expect(findStalledCollections(bare, AGENTS)).toHaveLength(1);   // 수정 이전과 동일
   });
 
+});
+
+// ═══ ★알림 첫 줄이 "어느 수집인지" 를 말한다★ (GD 2026-08-03) ═══
+//   thread_id 는 원래도 실려 나갔지만 `tg--1003947108339` 처럼 ★사람이 못 읽는다.★
+//   실측: bill 이 하루에 이 알림을 4번 받고 매번 어느 건인지 되짚었다.
+describe("★알림 식별 — 제목 + msg id★", () => {
+  function dbReal(threads: string[]): Database {
+    const d = new Database(":memory:");
+    migrate(d);
+    for (const t of threads) {
+      d.run(`INSERT INTO thread (id, title, kind, participants_json, opened_by) VALUES (?, 't', 'dm', '[]', 'bill')`, [t]);
+    }
+    return d;
+  }
+  /** msg 와 달리 ★본문을 지정★ 한다 — 제목은 본문 첫 줄에서 나오므로 여기서만 검증 가능하다. */
+  function msgBody(d: Database, thread: string, from: string, to: string, minsAgo: number, body: string, id?: string) {
+    d.run(
+      `INSERT INTO message (id, thread_id, from_agent_id, to_agent_id, type, body, source, created_at)
+       VALUES (?, ?, ?, ?, 'dm', ?, 'agent', datetime('now','-' || ? || ' minutes'))`,
+      [id ?? `b${Math.random().toString(36).slice(2, 10)}`, thread, from, to, body, String(minsAgo)],
+    );
+  }
+  function sentBody(d: Database, collector: string): string | null {
+    const r = d.prepare(
+      `SELECT body FROM message WHERE from_agent_id='system' AND to_agent_id=? ORDER BY created_at DESC LIMIT 1`,
+    ).get(collector) as { body: string } | undefined;
+    return r?.body ?? null;
+  }
+
+  it("★첫 줄에 제목과 msg id 가 실린다★ — 이게 없으면 어느 수집인지 알 수 없다", () => {
+    const d = dbReal(["tg-id1"]);
+    msgBody(d, "tg-id1", "steve", "lui", 20, "[요청] bot-liveness 승격 — 판단근거 교체", "ASK-1");
+    msgBody(d, "tg-id1", "steve", "ames", 20, "[요청] bot-liveness 승격 — 판단근거 교체", "ASK-2");
+    expect(sweepCollectionDeadlines(d, AGENTS)).toBe(1);
+    const body = sentBody(d, "steve")!;
+    const head = body.split("\n")[0]!;
+    expect(head).toContain("[요청] bot-liveness 승격 — 판단근거 교체");   // 제목
+    expect(head).toContain("ASK-1");                                      // ★첫 팬아웃의 id★
+    expect(body.indexOf("ASK-1")).toBeLessThan(body.indexOf("분 지났습니다")); // 식별이 ★맨 앞★
+  });
+
+  it("★긴 첫 줄은 잘리고 (잘림) 이 붙는다★ — … 만으로는 원문 말줄임과 구분이 안 된다", () => {
+    const d = dbReal(["tg-id2"]);
+    const long = "이상한 경우 같은 거 테스트 하지말라니깐. 혹시 그런거 더 없는 지 봐. 일반적인 것만 보자";
+    msgBody(d, "tg-id2", "steve", "lui", 20, long);
+    msgBody(d, "tg-id2", "steve", "ames", 20, long);
+    expect(sweepCollectionDeadlines(d, AGENTS)).toBe(1);
+    const head = sentBody(d, "steve")!.split("\n")[0]!;
+    expect(head).toContain("…(잘림)");
+    expect(head).not.toContain("일반적인 것만 보자");     // 뒤가 실제로 잘렸다
+  });
+
+  it("★짧은 첫 줄에는 (잘림) 이 안 붙는다★ — 안 잘렸는데 잘렸다고 하면 그게 오보다", () => {
+    const d = dbReal(["tg-id3"]);
+    msgBody(d, "tg-id3", "steve", "lui", 20, "[확인] 짧은 요청");
+    msgBody(d, "tg-id3", "steve", "ames", 20, "[확인] 짧은 요청");
+    expect(sweepCollectionDeadlines(d, AGENTS)).toBe(1);
+    const head = sentBody(d, "steve")!.split("\n")[0]!;
+    expect(head).toContain("[확인] 짧은 요청");
+    expect(head).not.toContain("잘림");
+  });
+
+  it("★제목은 아무것도 벗기지 않는다★ — 벗기려다 대괄호 짝이 깨졌다 (GD '심플하게')", () => {
+    expect(askTitleOf("[6am 과제 리뷰] bill님 active 과제입니다.")).toBe("[6am 과제 리뷰] bill님 active 과제입니다.");
+    expect(askTitleOf("✦ ★강조★ 남는다")).toBe("✦ ★강조★ 남는다");        // 기호 보존
+    expect(askTitleOf("  \n\n  둘째 줄이 첫 줄\n뒷줄")).toBe("둘째 줄이 첫 줄"); // 빈 줄은 건너뛴다
+    expect(askTitleOf("")).toBe("");                                          // 빈 본문도 안 던진다
+  });
+});
+
+// ★말줄임이 겹치지 않는다★ — 원문이 …로 끝나는데 자르면 ……(잘림) 이 된다
+it("★자른 자리의 말줄임이 겹치지 않는다★", () => {
+  const t = askTitleOf("[요청] bot-liveness 승격 — ① 판단근거 교체 (카드 eoLxrg…) 추가 내용");
+  expect(t).toContain("…(잘림)");
+  expect(t).not.toContain("……");
 });

--- a/src/server/bus/collectionDeadline.ts
+++ b/src/server/bus/collectionDeadline.ts
@@ -59,8 +59,11 @@ export function askTitleOf(body: string, max = 44): string {
   const first = (body ?? "").split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
   // ★잘렸다는 걸 반드시 보이게★ — `…` 만으로는 원문에 있던 말줄임과 구분이 안 된다.
   // 자른 자리에 이미 말줄임이 있으면 ★……(잘림) 처럼 두 번 겹친다★ — 그 자리만 정리하고 붙인다.
-  if (first.length <= max) return first;
-  return `${first.slice(0, max).trimEnd().replace(/[…]+$/, "").trimEnd()}…(잘림)`;
+  if ([...first].length <= max) return first;
+  // ★코드유닛이 아니라 코드포인트로 자른다★ (steve 리뷰) — slice 는 경계에 astral 문자(😀 등)가
+  //   걸리면 ★반쪽 서로게이트★ 를 남긴다. 실측: "가"×43 + "😀" → "…가가\ud83d…(잘림)".
+  const cut = [...first].slice(0, max).join("");
+  return `${cut.trimEnd().replace(/[…]+$/, "").trimEnd()}…(잘림)`;
 }
 
 /**
@@ -331,7 +334,14 @@ export function findStalledCollections(db: Database, agents: AgentRecord[]): Sta
       //   요청자 행은 없을 수 있다(팀장이 단톡방에서 시키면 message 테이블에 안 남는다 — 위 ② 참조).
       //   반면 팬아웃 첫 건은 ★수집의 정의상 반드시 있다.★ 그리고 collector 가 직접 쓴 문장이라
       //   본인이 가장 빨리 알아본다.
-      const ask = burst[0]!;
+      // ★burst[0] 은 팬아웃 첫 건이 아닐 수 있다★ (steve 리뷰 2026-08-04, 재현 확인).
+      //   collector 는 팬아웃 ★전에★ 요청자에게 ack 을 보낸다(:202 주석이 이미 경고한 그 패턴).
+      //   그러면 burst[0] = 그 ack → 알림 첫 줄이 「접수. 확인하고 회신하겠습니다.」 로 나간다.
+      //   ★틀린 식별은 못 읽는 thread_id 보다 나쁘다★ — 사람이 딴 수집을 되짚는다.
+      //   targets 는 위(:230)에서 requester 를 빼지만 ★burst 배열 자체는 안 걸러진다.★
+      //   폴백을 남기는 이유: 팀장 단톡방 지시처럼 ★requester 행이 아예 없는★ 경우
+      //   requester 가 undefined 라 find 가 첫 건을 그대로 준다 — 그 경로는 지금도 옳다.
+      const ask = burst.find((b) => b.peer !== requester) ?? burst[0]!;
       out.push({
         threadId: thread_id, collector: C, missing, answered, key: `${thread_id}:${C}:${lastAsk}`,
         askId: ask.id, askTitle: askTitleOf(ask.body),
@@ -409,7 +419,7 @@ export function sweepCollectionDeadlines(db: Database, agents: AgentRecord[]): n
           `. ★지금까지 온 답으로 보고하세요★ — 안 온 사람은 '미응답' 이라고 명시하면 됩니다.\n` +
           // ★두 탈출구도 줄을 바꿔 아래로.★ 순서는 그대로 — 기본 동작(위) 다음에 예외(아래).
           `· 각자 GD께 직접 보고하도록 시킨 건이면 종합할 게 없으니 이 알림은 무시하세요\n` +
-          `· 늦게 답이 오면 그때 다시 깨워드립니다`);
+          `· 늦게 답이 오면 그때 다시 깨워드립니다 — 그때 상황에 맞게 응답하시면 됩니다`);
 
       const msg = insertMessage(db, {
         thread_id: c.threadId,

--- a/src/server/bus/collectionDeadline.ts
+++ b/src/server/bus/collectionDeadline.ts
@@ -45,6 +45,22 @@ interface StalledCollection {
   missing: string[];    // 아직 답 안 한 기여자
   answered: string[];   // 답한 기여자
   key: string;          // 중복 재촉 방지 키 (thread:collector:마지막팬아웃시각)
+  // ★어느 수집인지 알려주는 두 값★ (GD 2026-08-03) — 알림 첫 줄에 실린다.
+  //   thread_id 는 이미 실려 나가지만 `tg--1003947108339`·`XZD-y5Fs` 처럼 ★사람이 못 읽는다.★
+  //   (실측 2026-08-03: bill 이 하루에 이 알림을 4번 받고 매번 "어느 수집이지" 를 되짚었다)
+  askId: string;        // collector 가 던진 첫 질문의 message id — 제목이 무의미해도 이건 항상 식별된다
+  askTitle: string;     // 그 질문의 첫 줄 (자르면 …(잘림))
+}
+
+/** 첫 줄을 제목으로 쓴다. ★아무것도 벗기지 않는다★ (GD 2026-08-03 "심플하게").
+ *  벗기려다 `[아침 브리핑 …]` 의 여는 대괄호만 지워 ★닫는 짝이 혼자 남는★ 일이 있었다.
+ *  안 벗기면 `[6am 과제 리뷰]`·`[workloop: …]` 같은 말머리가 살아 종류가 한눈에 보인다. */
+export function askTitleOf(body: string, max = 44): string {
+  const first = (body ?? "").split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
+  // ★잘렸다는 걸 반드시 보이게★ — `…` 만으로는 원문에 있던 말줄임과 구분이 안 된다.
+  // 자른 자리에 이미 말줄임이 있으면 ★……(잘림) 처럼 두 번 겹친다★ — 그 자리만 정리하고 붙인다.
+  if (first.length <= max) return first;
+  return `${first.slice(0, max).trimEnd().replace(/[…]+$/, "").trimEnd()}…(잘림)`;
 }
 
 /**
@@ -143,7 +159,7 @@ export function findStalledCollections(db: Database, agents: AgentRecord[]): Sta
       // C 가 보낸 directed 메시지 (질문일 수도, 보고일 수도)
       const sends = db
         .prepare(
-          `SELECT to_agent_id AS peer, created_at,
+          `SELECT id, body, to_agent_id AS peer, created_at,
                   json_extract(meta_json,'$.individual') AS individual
              FROM message
             WHERE thread_id = ? AND from_agent_id = ? AND source='agent'
@@ -151,7 +167,7 @@ export function findStalledCollections(db: Database, agents: AgentRecord[]): Sta
               AND to_agent_id <> ? AND created_at > datetime('now','-90 minutes')
             ORDER BY created_at`,
         )
-        .all(thread_id, C, C) as { peer: string; created_at: string; individual: number | null }[];
+        .all(thread_id, C, C) as { id: string; body: string; peer: string; created_at: string; individual: number | null }[];
       if (sends.length < 2) continue;
 
       // C 에게 들어온 메시지 (답·지시)
@@ -176,12 +192,12 @@ export function findStalledCollections(db: Database, agents: AgentRecord[]): Sta
       //   ② 위임 행을 anchor → ★팀장의 단톡방 지시는 message 테이블에 없다★ (캡처로 직접 주입)
       //   ③ "요청자는 먼저 말 건 사람" → 장수 그룹방에선 기여자도 예전에 말한 적이 있다 → ★0건★
       //   → ★버스트 = 답이 하나라도 들어오기 전에 연달아 나간 발신★. 보고는 답 뒤에 나온다.
-      let burst: { peer: string; at: string; individual: number | null }[] = [];
+      let burst: { peer: string; at: string; individual: number | null; id: string; body: string }[] = [];
       for (const s of sends) {
         const answeredBetween = burst.length > 0 &&
           inbound.some((i) => i.created_at > burst[0]!.at && i.created_at < s.created_at);
         if (answeredBetween) break;          // 답이 끼어들었다 → 여기부터는 보고다
-        burst.push({ peer: s.peer, at: s.created_at, individual: s.individual });  // ★손에 있는 걸 버리지 않는다★ (dbak)
+        burst.push({ peer: s.peer, at: s.created_at, individual: s.individual, id: s.id, body: s.body });  // ★손에 있는 걸 버리지 않는다★ (dbak)
       }
       // ★요청자에게 보낸 ack 은 질문이 아니다★ — codex 는 팬아웃 ★전에★ 요청자에게 "확인했습니다" 를 보낸다.
       //   그러면 그 ack 이 버스트에 섞여 ★요청자가 '미응답 기여자'★ 로 잡힌다 (실측: 미응답=[bill]).
@@ -311,7 +327,15 @@ export function findStalledCollections(db: Database, agents: AgentRecord[]): Sta
         if (answeredToCollector.length !== targets.length) continue;
       }
 
-      out.push({ threadId: thread_id, collector: C, missing, answered, key: `${thread_id}:${C}:${lastAsk}` });
+      // ★식별은 collector 가 던진 첫 질문에서 뽑는다★ — 요청자 메시지가 아니다.
+      //   요청자 행은 없을 수 있다(팀장이 단톡방에서 시키면 message 테이블에 안 남는다 — 위 ② 참조).
+      //   반면 팬아웃 첫 건은 ★수집의 정의상 반드시 있다.★ 그리고 collector 가 직접 쓴 문장이라
+      //   본인이 가장 빨리 알아본다.
+      const ask = burst[0]!;
+      out.push({
+        threadId: thread_id, collector: C, missing, answered, key: `${thread_id}:${C}:${lastAsk}`,
+        askId: ask.id, askTitle: askTitleOf(ask.body),
+      });
     }
   }
   return out;
@@ -339,10 +363,16 @@ export function sweepCollectionDeadlines(db: Database, agents: AgentRecord[]): n
         .get(key) as { n: number }).n;
       if (already > 0) continue;   // ★수집 하나당 한 번만 — 예외 없다★
 
+      // ★첫 줄 = 어느 수집인지.★ (GD 2026-08-03) 나머지를 읽기 전에 이것부터 걸린다.
+      //   서버가 1:1 DM 을 못 보는 건 그대로 둔다 — 대신 ★오탐일 때 사람이 1초에 판단하게★ 만든다.
+      const head = `[확인] 「${c.askTitle}」 (${c.askId})\n`;
+
       // ★두 상황은 다르다 — 다르게 말해줘야 팀원이 옳게 판단한다.★
-      const body = c.missing.length === 0
+      const body = head + (c.missing.length === 0
         // ★전원 답했는데 종합이 안 나갔다★ (실측: collector 가 ack 으로 마지막 턴을 써버렸다)
-        ? `[마감] ${COLLECTION_DEADLINE_MIN}분이 지났는데 아직 보고가 없습니다. ` +
+        //   ★"보고가 없습니다" 라고 단정하지 않는다★ (GD 2026-08-03) — 서버는 1:1 DM 을 못 보므로
+        //   ★못 본 것과 없는 것을 구분할 수 없다.★ 그러니 확인 가능한 사실("N분 지났다")만 말한다.
+        ? `${COLLECTION_DEADLINE_MIN}분 지났습니다. ` +
           `★${c.answered.join(", ")} 전원이 이미 답했습니다.★ ` +
           // ★훈계는 뺀다★ (GD: "이건 빼도 되지 않아?") — 서버는 ★"시간이 됐다 + 지금 상황"★ 만 말한다.
           //   "ack 은 보고가 아니다" 는 ★이미 룰에 있다.★ 시스템 알림이 룰을 다시 읊을 이유가 없다.
@@ -352,9 +382,10 @@ export function sweepCollectionDeadlines(db: Database, agents: AgentRecord[]): n
           //   실측: steve 가 보고 83초 뒤에 이 독촉을 받았다. 따르면 중복 보고가 되어 팀 룰을 어긴다.
           //   ★기본 동작이 먼저, 탈출구는 조건과 함께 뒤에★ (순서 원칙은 아래 미응답 분기와 같다).
           //   이 탈출구는 "아직 안 한 사람" 에게는 해당되지 않으므로 진짜 수집을 무시하게 만들지 않는다.
-          `★아직 종합 보고를 안 하셨으면 지금 보내세요.★ ` +
-          `(이미 팀장님께 1:1 로 보고하셨다면 이 알림은 무시하세요 — 서버는 1:1 DM 을 보지 못합니다.)`
-        : `[마감] ${COLLECTION_DEADLINE_MIN}분이 지났는데 아직 보고가 없습니다. ` +
+          `★아직 종합 보고를 안 하셨으면 지금 보내세요.★\n` +
+          // ★탈출구는 줄을 바꿔 아래로.★ 첫 줄만 봐도 판단되게 — 길이는 그대로인데 훨씬 빨리 읽힌다.
+          `· 이미 팀장님께 1:1 로 보고하셨다면 이 알림은 무시하세요 (서버는 1:1 DM 을 보지 못합니다)`
+        : `${COLLECTION_DEADLINE_MIN}분 지났습니다. ` +
           `미응답: ${c.missing.join(", ")}` +
           (c.answered.length ? ` / 답함: ${c.answered.join(", ")}` : "") +
           // ★개별보고면 이 알림 자체가 틀린 것이다 — 그런데 서버는 아직 그걸 알 수가 없다.★ (GD 2026-07-17)
@@ -375,9 +406,10 @@ export function sweepCollectionDeadlines(db: Database, agents: AgentRecord[]): n
           //     첫 버전은 '무시하세요' 를 앞에 둬서 ★무조건 명령을 조건문으로★ 바꿨다 — collector 가 처음
           //     읽는 지시가 탈출구가 되면, 애매한 상태의 팀원이 진짜 수집을 무시할 확률이 올라간다.
           //     → 기본 동작은 ★무조건★ 으로 두고, 탈출구는 ★괄호 예외★ 로 내린다.
-          `. ★지금까지 온 답으로 보고하세요★ — 안 온 사람은 '미응답' 이라고 명시하면 됩니다. ` +
-          `(각자 GD께 직접 보고하도록 시킨 건이면 종합할 게 없으니 이 알림은 무시하세요.) ` +
-          `(늦게 답이 오면 그때 다시 깨워드립니다. 그때 상황에 맞게 응답하시면 됩니다)`;
+          `. ★지금까지 온 답으로 보고하세요★ — 안 온 사람은 '미응답' 이라고 명시하면 됩니다.\n` +
+          // ★두 탈출구도 줄을 바꿔 아래로.★ 순서는 그대로 — 기본 동작(위) 다음에 예외(아래).
+          `· 각자 GD께 직접 보고하도록 시킨 건이면 종합할 게 없으니 이 알림은 무시하세요\n` +
+          `· 늦게 답이 오면 그때 다시 깨워드립니다`);
 
       const msg = insertMessage(db, {
         thread_id: c.threadId,


### PR DESCRIPTION
## 무엇이 문제였나

마감 알림에 `thread_id` 는 원래도 실려 나갔다. 그런데 그 값이 `tg--1003947108339`·`XZD-y5Fs` 같은 **사람이 못 읽는 문자열**이라 실제 식별에는 쓸모가 없었다.

**실측 2026-08-03**: bill 이 하루에 이 알림을 4번 받고 **매번 "어느 수집이지"를 되짚었다.** 스레드명을 본인이 지어서 겨우 알아본 것이고, 남이 만든 스레드였으면 `thread.sh` 를 떠야 했다.

## 어떻게 고쳤나

**① 첫 줄에 제목 + msg id**

```
[확인] 「[요청] bot-liveness 승격 — ① 판단근거 교체」 (RDqDfVMJHY9-)
10분 지났습니다. ★lui, ames 전원이 이미 답했습니다.★ ★아직 종합 보고를 안 하셨으면 지금 보내세요.★
· 이미 팀장님께 1:1 로 보고하셨다면 이 알림은 무시하세요 (서버는 1:1 DM 을 보지 못합니다)
```

제목 = collector 가 던진 첫 질문의 **첫 줄**. **아무것도 벗기지 않는다.**
벗기려다 `[아침 브리핑 …]` 의 여는 대괄호만 지워 **닫는 짝이 혼자 남는** 일이 있었다. 안 벗기면 `[6am 과제 리뷰]`·`[workloop: …]` 말머리가 살아 종류가 한눈에 보인다.

식별을 **요청자 메시지가 아니라 collector 의 첫 팬아웃**에서 뽑는다 — 요청자 행은 없을 수 있지만(팀장 단톡방 지시는 message 테이블에 없다) 팬아웃은 **수집의 정의상 반드시 있다.**

**② 44자 초과면 `…(잘림)`**

`…` 만으로는 원문에 있던 말줄임과 구분이 안 된다. 자른 자리에 이미 `…` 가 있으면 겹치지 않게 정리한다.

**③ `[마감]` → `[확인]`, 단정 제거**

`"보고가 없습니다"` → `"N분 지났습니다"`. 서버는 1:1 DM 을 못 보므로 **못 본 것과 없는 것을 구분할 수 없다.** 확인 가능한 사실만 말한다. (#262 와 같은 원칙)

**④ 탈출구를 줄바꿔 아래로** — 길이는 그대로인데 첫 줄만 봐도 판단된다.

## 건드리지 않은 것

이 경로는 **과거 회귀가 두 번 났다.** 주석에 기록된 보호 항목을 전부 유지했다.

- 순서 원칙 — 기본 동작이 먼저, 탈출구는 뒤 (dbak 리뷰 2026-07-17)
- 탈출구 문구 `"이 알림은 무시하세요"` **그대로**. 처음에 '이 알림은' 을 뺐다가 기존 테스트 2건이 깨졌고, **테스트를 고치지 않고 문구를 되살렸다**
- `--individual` 탈출구 · 조건부 탈출구 · 수집당 1회 dedupe
- 판정 로직(누가 미응답인지) 미변경 — 문구·식별만

## 검증

신규 5건 — 첫 줄에 제목+id · 긴 것 `(잘림)` · 짧은 것 안 붙음 · 아무것도 안 벗김 · 말줄임 안 겹침

**뮤턴트**: 식별줄을 빈 문자열로 바꾸면 신규 3건이 **정확히** 깨진다 → 검사가 유효하다.

`collectionDeadline` 43 pass / `src/server/bus` 전체 **324 pass** / typecheck 통과.

## 롤백

`collectionDeadline.ts` 한 파일. revert 하면 즉시 이전 문구.
