### PR TITLE
fix(liveness): 설치 환경을 코드에 고정하지 않는다

### DIFF
--- a/scripts/bot-liveness-monitor.sh
+++ b/scripts/bot-liveness-monitor.sh
@@ -3,7 +3,7 @@
 # 배경: weekly-healthcheck 는 주 1회 + 세션 "존재"만 봐서, 주중 freeze 를 못 잡았다.
 #   2026-06-03 스티브가 1:1 리액션만 되고 응답 없던 건(설문 프롬프트 점거 + reply 도구 미호출)을
 #   미리 잡기 위해 10분 주기 경량 liveness 체크를 추가한다. 순수 shell — LLM 미호출(토큰 0).
-# Fired by ~/Library/LaunchAgents/com.gdmini.bot-liveness-monitor.plist (StartInterval=600s=10분)
+# Fired by ~/Library/LaunchAgents/<TEAMOS_LAUNCHD_PREFIX>.bot-liveness-monitor.plist (StartInterval=600s=10분)
 #
 # 검사 항목 (claude_channel 봇: bill steve demis dbak):
 #   1) tmux 세션 존재 (claude-<bot>)
@@ -48,6 +48,11 @@ mkdir -p "$LIVENESS_STATE_DIR" 2>/dev/null || true
 : "${BOT_LIVENESS_LOG:=$B3OS_ROOT/var/bot-liveness-monitor.log}"
 mkdir -p "$(dirname "$BOT_LIVENESS_LOG")" 2>/dev/null || true
 LOG="$BOT_LIVENESS_LOG"
+
+# LaunchAgent 라벨 접두. plist 렌더러(src/server/lib/livenessMonitor.ts)가 이미 이 값을 넘긴다.
+#   설치마다 다르므로 개인 라벨을 코드에 고정하지 않는다 — 접두가 어긋나면 모든 팀원이
+#   "LaunchAgent 미로드"로 판정돼 그 아래 tmux·폴러 검사에 도달하지 못한다(=감시 0).
+: "${TEAMOS_LAUNCHD_PREFIX:=com.${USER:-$(id -un)}}"
 [ "$DRY_RUN" = "0" ] && [ "$RESET" = "0" ] && exec >> "$LOG" 2>&1
 
 finish_status() { printf '%s bot-liveness DONE status=%s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1"; }
@@ -58,8 +63,8 @@ finish_status() { printf '%s bot-liveness DONE status=%s\n' "$(date '+%Y-%m-%d %
 #   죽었을 때 이 감시기가 lui 를 아예 보지 않았고, 자가치유 대상에서도 제외돼 그물이 0이었다(수동 복구함).
 #   새 멤버를 영입할 때마다 이 줄을 고쳐야 하는 구조 자체가 누락의 원인이므로 정본을 읽는다.
 #   읽기 실패 시에만 옛 하드코딩으로 폴백(감시가 통째로 죽는 것보다 낫다) + 경고.
-: "${TEAM_AGENT_REGISTRY:=$HOME/Development/b3rys-team-os/agents.json}"
-: "${TEAMOS_AGENT_OFF_FILE:=$HOME/Development/b3rys-team-collab/var/agent-off.txt}"
+: "${TEAM_AGENT_REGISTRY:=$B3OS_ROOT/agents.json}"
+: "${TEAMOS_AGENT_OFF_FILE:=$B3OS_ROOT/var/agent-off.txt}"
 : "${LIVENESS_LA_AUTOHEAL:=0}"
 _AGENTS_JSON="$TEAM_AGENT_REGISTRY"
 _BOTS_STR="$(python3 -c "
@@ -126,15 +131,15 @@ PY
 
 launchagent_member() {
   case "$1" in
-    com.gdmini.claude-telegram-*) printf '%s\n' "${1#com.gdmini.claude-telegram-}" ;;
+    ${TEAMOS_LAUNCHD_PREFIX}.claude-telegram-*) printf '%s\n' "${1#${TEAMOS_LAUNCHD_PREFIX}.claude-telegram-}" ;;
     *) return 1 ;;
   esac
 }
 
 ensure_launchagents_registered() {
   local fixed="" p lbl member
-  for p in "$HOME"/Library/LaunchAgents/com.gdmini.claude-telegram-*.plist \
-           "$HOME/Library/LaunchAgents/com.gdmini.team-collab.plist"; do
+  for p in "$HOME"/Library/LaunchAgents/"$TEAMOS_LAUNCHD_PREFIX".claude-telegram-*.plist \
+           "$HOME/Library/LaunchAgents/$TEAMOS_LAUNCHD_PREFIX.team-collab.plist"; do
     [ -f "$p" ] || continue
     lbl="$(basename "$p" .plist)"
     launchctl print "gui/$(id -u)/$lbl" >/dev/null 2>&1 && continue   # 이미 로드됨
@@ -186,15 +191,28 @@ UPTIME_STALE_DAYS=7   # 매주 일요일 weekly-restart 기준 — 7일 초과 =
 RECENT_SECS=1200      # #4 DM 무응답: react 가 최근 이 시간(20분) 이내일 때만 — stale/재시작 로그 false positive 제외
 STATE_FILE="$LIVENESS_STATE_DIR/bot-liveness-monitor.state"      # 직전 이상치 signature (중복알림 방지)
 PENDING_FILE="$LIVENESS_STATE_DIR/bot-liveness-monitor.pending"  # #4 지속성: 직전 run 의 pending DM msgid
-ENV_FILE="$HOME/Development/b3rys-team-collab/.env"   # 알림은 team op 봇(@gd452_team_op_bot)으로 발신 — 운영성 시스템 메시지 (GD 2220, TEAM-OS §8 허용)
+: "${ENV_FILE:=$B3OS_ROOT/.env}"   # 알림 봇 토큰을 읽는 곳. 설치 위치 기준이라야 다른 기기에서도 찾는다
 TOKEN_VAR="CAPTURE_BOT_TOKEN"
-TEAM_OS="$HOME/Development/b3rys-team-collab/scripts/team-os.sh"   # 게이트웨이·서비스 복구용 (idempotent)
+: "${TEAM_OS:=$B3OS_ROOT/bin/team-os}"   # 게이트웨이·서비스 복구용 (idempotent)
 # ★봇 복구는 team-os.sh 를 거치지 않고 restart-agent 를 직접 부른다 (codex·steve 교차검증 2026-08-03)★
 #   team-os.sh:26 은 CLAUDE_BOTS="bill steve demis dbak" ★하드코딩이라 lui 가 없다.★ 그래서 감시 목록만
 #   agents.json 으로 동적화해도 ★lui 는 감지만 되고 복구는 조용히 실패★ 했다(`team-os up lui` 가 no-op).
 #   restart-agent.sh:35 는 agents.json 을 읽어 lui 를 포함하므로 이쪽이 정본에 붙어 있다.
-RESTART_AGENT="$HOME/Development/b3rys-team-collab/scripts/restart-agent.sh"
-OPENCLAW_INGRESS_CHECK="$HOME/Development/b3rys-team-collab/scripts/openclaw-telegram-ingress-check.sh"  # OpenClaw Telegram ingress silence + provider stuck detector (read-only)
+#   이 두 경로는 설치마다 다르므로 env 로 덮을 수 있어야 한다. 기본값은 설치 위치 기준이며,
+#   저장소가 이 스크립트를 제공하지 않는 설치도 있다 — 그 경우 아래 HEAL_READY 가 0 이 된다.
+: "${RESTART_AGENT:=$B3OS_ROOT/scripts/restart-agent.sh}"
+: "${OPENCLAW_INGRESS_CHECK:=$B3OS_ROOT/scripts/openclaw-telegram-ingress-check.sh}"  # OpenClaw Telegram ingress silence + provider stuck detector (read-only)
+
+# ★복구 수단이 없으면 파괴적 조치를 하지 않는다 (fail-closed)★
+#   폴러 사망 분기는 ★tmux 세션을 먼저 죽이고★ RESTART_AGENT 를 부른다. RESTART_AGENT 가 없으면
+#   그 호출은 조용히 실패하고(2>&1 로 버려짐, set -e 도 없음) ★세션만 죽은 채 남는다.★
+#   즉 "복구하려다 봇을 완전히 내리는" 결과가 된다. 그래서 복구 수단 유무를 먼저 확인하고,
+#   없으면 감지·알림만 한다. 감시를 잃는 것보다 낫지만, 봇을 잃는 것보다는 훨씬 낫다.
+HEAL_READY=1
+if [ ! -x "$RESTART_AGENT" ]; then
+  HEAL_READY=0
+  HEAL_UNAVAILABLE_REASON="복구 스크립트를 실행할 수 없습니다: $RESTART_AGENT (RESTART_AGENT 로 지정하세요)"
+fi
 # onoff 서킷브레이커 조율(2026-06-11 forin 인시던트): GD가 /onoff 로 의도적 정지한 팀원은 auto-heal 이
 # 되살리지 않는다. agentControl 이 이 파일에 off 명단을 기록 → 아래 복구 지점들이 존중(skip).
 OFF_FILE="$TEAMOS_AGENT_OFF_FILE"
@@ -214,7 +232,7 @@ echo "$(date '+%Y-%m-%d %H:%M:%S') bot-liveness START (dry_run=$DRY_RUN)"
 # 정기 유지보수: 노후(48h+) terminal-bad(dead_letter + blocked 가드기록) 자동 아카이브 →
 # 모니터링이 '최근 실제 문제'만 보이게. 옛 주차 레코드가 영구 카운트로 남아 "이게 뭐지?" 노이즈
 # 되는 것 방지(GD 2026-06-07, blocked 포함 승인). 상세=scripts/bus-autoclean.sh
-BUS_AUTOCLEAN="$HOME/Development/b3rys-team-collab/scripts/bus-autoclean.sh"
+: "${BUS_AUTOCLEAN:=$B3OS_ROOT/scripts/bus-autoclean.sh}"
 AUTOCLEAN_STAMP="$LIVENESS_STATE_DIR/bus-autoclean.lastrun"
 if [ "$DRY_RUN" = "0" ] && [ -x "$BUS_AUTOCLEAN" ] && \
    [ "$(cat "$AUTOCLEAN_STAMP" 2>/dev/null)" != "$(date +%Y-%m-%d)" ]; then
@@ -377,7 +395,7 @@ for bot in "${BOTS[@]}"; do
 
   # 로그인 항목에 현재 로드된 팀원만 복구한다. plist/등록부만으로 운영자의 제외 의도를 추정하지 않는다.
   # 부팅 유예 검사는 이 루프보다 앞에서 끝났으므로, 부팅 중 미로드를 의도적 제외로 오판하지 않는다.
-  launchagent_label="com.gdmini.claude-telegram-$bot"
+  launchagent_label="$TEAMOS_LAUNCHD_PREFIX.claude-telegram-$bot"
   if ! launchctl print "gui/$(id -u)/$launchagent_label" >/dev/null 2>&1; then
     ISSUES="${ISSUES}· [$bot] LaunchAgent 미로드 — alert-only (로그인 항목 제외 가능성, 자동복구 안 함)
 "
@@ -390,6 +408,9 @@ for bot in "${BOTS[@]}"; do
   if ! tmux has-session -t "$session" 2>/dev/null; then
     if [ "$DRY_RUN" = "1" ]; then
       HEALED="${HEALED}· [$bot] tmux 세션 없음 → team-os up $bot (dry-run)
+"
+    elif [ "$HEAL_READY" = "0" ]; then
+      ISSUES="${ISSUES}· [$bot] tmux 세션 없음 — 자동복구 불가, 알림만. $HEAL_UNAVAILABLE_REASON
 "
     elif ! restart_budget_left; then
       ISSUES="${ISSUES}· [$bot] tmux 세션 없음 — 이번 점검의 재시작 예산($RESTART_BUDGET)을 이미 썼다. 다음 점검에서 복구 시도(여러 봇 동시 재시작 방지)
@@ -448,6 +469,10 @@ for bot in "${BOTS[@]}"; do
 "
     elif [ "$DRY_RUN" = "1" ]; then
       HEALED="${HEALED}· [$bot] 폴러 사망(세션 up) → tmux kill + team-os up (dry-run)
+"
+    elif [ "$HEAL_READY" = "0" ]; then
+      # ★세션을 죽이기 전에 확인한다★ — 복구 수단이 없는데 죽이면 봇이 완전히 내려간다.
+      ISSUES="${ISSUES}· [$bot] 폴러 미가동 — 자동복구 불가, 세션 유지하고 알림만. $HEAL_UNAVAILABLE_REASON
 "
     elif ! restart_budget_left; then
       ISSUES="${ISSUES}· [$bot] 폴러 미가동 — 이번 점검의 재시작 예산($RESTART_BUDGET)을 이미 썼다. 다음 점검에서 복구 시도(여러 봇 동시 재시작 방지)
@@ -611,10 +636,10 @@ check_gateway() {  # $1=LaunchAgent label, $2=표시이름, $3=team-os svc alias
 #   대시보드 무응답 · 팀버스 정지였는데 ★아무 알림도 없었다★(사람이 수동으로 발견해 bootstrap 함).
 #   서버 안에 health 워커(팀원 감시)가 들어 있어서, 서버가 없으면 팀원이 죽어도 볼 주체가 사라진다 = ★그물 0★.
 #   재시작 예산이 주기당 1건이라 ★순서가 곧 우선순위★ 다. 그래서 다른 게이트웨이보다 앞에 둔다.
-check_gateway "com.gdmini.team-collab" "b3os 서버" "collab" "http://127.0.0.1:7878/health" "-"
+check_gateway "$TEAMOS_LAUNCHD_PREFIX.team-collab" "b3os 서버" "collab" "http://127.0.0.1:7878/health" "-"
 check_gateway "ai.openclaw.gateway" "codex/openclaw" "openclaw" "http://127.0.0.1:18789/health" "-"
 check_gateway "ai.hermes.gateway-b3ryshermes" "hermes" "hermes" "-" "hermes"
-check_gateway "com.gdmini.b3rys-dev" "b3rys-dev" "b3rys-dev" "http://127.0.0.1:3000/" "-"
+check_gateway "$TEAMOS_LAUNCHD_PREFIX.b3rys-dev" "b3rys-dev" "b3rys-dev" "http://127.0.0.1:3000/" "-"
 
 # OpenClaw Telegram provider stuck detector (Phase A, 2026-06-16 outage):
 # alert only when last inbound is stale AND provider state is stopped/disconnected.
@@ -641,7 +666,7 @@ fi
 #   봇 생존 체크(#1~5)·게이트웨이 체크로는 못 잡던 갭 = "GD 메시지가 실제 도달 가능한가".
 # router-off 는 봇 문제가 아니라 설정 킬스위치 → 재시작/자가치유 대상 아님(전용 조치 안내).
 # 의도적 off 일 수 있으니 SIG dedup 으로 1회만 알림(off 유지 중 도배 안 함).
-TEAM_DB="${TEAM_DB_OVERRIDE:-$HOME/Development/b3rys-team-collab/team.db}"
+TEAM_DB="${TEAM_DB_OVERRIDE:-$B3OS_ROOT/team.db}"
 if command -v sqlite3 >/dev/null 2>&1 && [ -f "$TEAM_DB" ]; then
   router_val=$(sqlite3 "$TEAM_DB" "SELECT value FROM setting WHERE key='router_enabled';" 2>/dev/null || echo "")
   # store 비면 env ROUTER_ENABLED fallback (captureConfig 와 동일 규약, 기본 on).
@@ -704,7 +729,7 @@ ${ISSUES}"
     #   ★WORKDIR 를 반드시 붙인다★ — tmux 안에서 실행하면 tmux 전역에 박힌 첫 기동자의 WORKDIR(예: lui)을
     #   정본 스크립트가 검증 없이 물려받아 ★그 팀원이 남의 폴더에서 뜬다★(2026-08-03 dbak 실측).
     MSG="${MSG}조치: 해당 봇 재시작 (라이브 정본 스크립트 · 컨텍스트 유지)
-  WORKDIR=~/Development/<bot> ~/Development/b3rys-team-os/src/server/runtimes/claude/start-telegram-channel.sh <bot> --resume --force
+  WORKDIR=<그 팀원의 작업 폴더> $B3OS_ROOT/src/server/runtimes/claude/start-telegram-channel.sh <bot> --resume --force
   ※ WORKDIR 를 빼면 남의 폴더에서 뜰 수 있습니다(자기 CLAUDE.md/TEAM-OS 미로드)."
   elif printf "%s" "$NON_ROUTER_ISSUES" | grep -q "Telegram reply 플러그인 인증 만료"; then
     MSG="${MSG}조치: 해당 Claude 세션에서 /login 재인증 필요. 자동 로그인/토큰 조작은 하지 않음. 재인증 후에도 실패하면 채널 재시작."

--- a/scripts/bot-liveness-monitor.sh
+++ b/scripts/bot-liveness-monitor.sh
@@ -193,7 +193,11 @@ STATE_FILE="$LIVENESS_STATE_DIR/bot-liveness-monitor.state"      # 직전 이상
 PENDING_FILE="$LIVENESS_STATE_DIR/bot-liveness-monitor.pending"  # #4 지속성: 직전 run 의 pending DM msgid
 : "${ENV_FILE:=$B3OS_ROOT/.env}"   # 알림 봇 토큰을 읽는 곳. 설치 위치 기준이라야 다른 기기에서도 찾는다
 TOKEN_VAR="CAPTURE_BOT_TOKEN"
-: "${TEAM_OS:=$B3OS_ROOT/bin/team-os}"   # 게이트웨이·서비스 복구용 (idempotent)
+#   ★bin/team-os 를 기본값으로 삼지 않는다★ — 호출 계약이 다르다. 여기서는 `up <alias>` 와
+#   `restart <alias>` 를 기대하는데, bin/team-os 의 up 은 두 번째 인자를 무시하고 설치의 모든
+#   상주 서비스를 순회하며 restart 서브커맨드는 없다. 그대로 두면 게이트웨이 하나를 살리려다
+#   전체를 올리고, restart 폴백은 확정 실패한다. 무엇을 쓸지는 설치가 지정한다.
+: "${TEAM_OS:=$B3OS_ROOT/scripts/team-os.sh}"   # 게이트웨이·서비스 복구용 (idempotent)
 # ★봇 복구는 team-os.sh 를 거치지 않고 restart-agent 를 직접 부른다 (codex·steve 교차검증 2026-08-03)★
 #   team-os.sh:26 은 CLAUDE_BOTS="bill steve demis dbak" ★하드코딩이라 lui 가 없다.★ 그래서 감시 목록만
 #   agents.json 으로 동적화해도 ★lui 는 감지만 되고 복구는 조용히 실패★ 했다(`team-os up lui` 가 no-op).
@@ -601,6 +605,13 @@ check_gateway() {  # $1=LaunchAgent label, $2=표시이름, $3=team-os svc alias
   fi
   if [ "$DRY_RUN" = "1" ]; then
     HEALED="${HEALED}· [$2] $down → team-os up $3 (dry-run)
+"
+    return 0
+  fi
+  # ★예산을 쓰기 전에 복구 수단을 확인한다★ — 없으면 성공할 수 없는 호출에 그 사이클의
+  #   재시작 예산을 태우고, 정작 복구 가능한 다른 대상이 예산 부족으로 밀린다.
+  if [ ! -x "$TEAM_OS" ]; then
+    ISSUES="${ISSUES}· [$2] $down — 자동복구 불가, 알림만. 서비스 복구 명령을 실행할 수 없습니다: $TEAM_OS (TEAM_OS 로 지정하세요)
 "
     return 0
   fi

--- a/scripts/bot-liveness-monitor.test.sh
+++ b/scripts/bot-liveness-monitor.test.sh
@@ -54,7 +54,12 @@ cat > "$T/bin/launchctl" <<'SH'
 # ★기대 라벨은 리터럴로 박는다★ — 스크립트와 같은 변수에서 만들면 스크립트가 그 값을 덮어써도
 #   export 속성이 유지돼 이 mock 에 그대로 전달된다. 그러면 mock 이 ★스크립트가 정한 라벨에
 #   무조건 동의하게 되어★ 접두를 개인 라벨로 되돌린 회귀를 잡지 못한다(실측: 그 뮤턴트가 생존했다).
-[ "$1" = print ] && { case "$2" in *"com.b3ostest.claude-telegram-${LOADED_AGENT:-__none__}") exit 0 ;; *) exit 1 ;; esac; }
+[ "$1" = print ] && { case "$2" in
+  *"com.b3ostest.claude-telegram-${LOADED_AGENT:-__none__}") exit 0 ;;
+  *"${LOADED_GATEWAY:-__none__}") exit 0 ;;      # 게이트웨이 시나리오에서만 켠다
+  *) exit 1 ;; esac; }
+# 로드됐지만 프로세스는 없는 상태(pid 자리에 '-')를 흉내낸다 → check_gateway 가 '미가동' 으로 본다
+[ "$1" = list ] && { [ -n "${LOADED_GATEWAY:-}" ] && printf -- '-\t0\t%s\n' "$LOADED_GATEWAY"; exit 0; }
 [ "$1" = bootstrap ] && { printf '%s\n' "$3" >> "$LAUNCHCTL_CALLS"; exit 0; }
 exit 2
 SH
@@ -194,4 +199,35 @@ grep -q "세션 유지하고 알림만" "$BOT_LIVENESS_LOG" || {
   RC=1
 }
 pass_if_clean "폴러가 죽어도 복구 수단이 없으면 세션을 죽이지 않는다"
+
+# 같은 폴러 사망 상태에서 ★복구 수단이 있으면 실제로 복구한다★ (양성 경로).
+#   위 시나리오만 있으면 "항상 alert-only" 로 바꾸는 회귀를 잡지 못한다 — 감시기가 아무것도
+#   고치지 않게 되어도 테스트는 통과한다(실측: elif true 뮤턴트가 exit 0 이었다).
+: > "$TMUX_KILLS"; : > "$RESTART_CALLS"; : > "$BOT_LIVENESS_LOG"
+rm -f "$T/b3os/var/bot-liveness-monitor"/bot-liveness-poller-heal-*.ts   # 40분 thrash 마커 초기화
+printf '999999\n' > "$HOME/.claude/channels/telegram-bill/bot.pid"
+bash "$SCRIPT" >"$T/heal-out.txt" 2>"$T/heal-err.txt"       # RESTART_AGENT 기본값 = 존재하는 mock
+grep -q 'kill-session' "$TMUX_KILLS" || {
+  echo "FAIL: 복구 수단이 있는데 폴러 사망 세션을 정리하지 않았다" >&2
+  RC=1
+}
+[ "$(cat "$RESTART_CALLS")" = bill ] || {
+  echo "FAIL: 폴러 사망 복구에서 restart-agent 가 안 불렸다: $(cat "$RESTART_CALLS" || true)" >&2
+  RC=1
+}
+pass_if_clean "복구 수단이 있으면 폴러 사망을 실제로 복구한다"
+
+# 게이트웨이도 같다 — 복구 명령을 실행할 수 없으면 ★예산을 쓰기 전에★ 알림만 한다.
+#   가드가 없으면 성공할 수 없는 호출에 그 사이클의 재시작 예산을 태우고, 정작 복구 가능한
+#   다른 대상이 예산 부족으로 밀린다.
+: > "$TMUX_KILLS"; : > "$RESTART_CALLS"; : > "$BOT_LIVENESS_LOG"
+printf '%s\n' "$$" > "$HOME/.claude/channels/telegram-bill/bot.pid"   # 봇은 정상 — 예산을 안 쓰게
+LOADED_GATEWAY=ai.openclaw.gateway \
+  TEAM_OS="$T/b3os/scripts/no-such-team-os.sh" \
+  bash "$SCRIPT" >"$T/gw-out.txt" 2>"$T/gw-err.txt"
+grep -q "서비스 복구 명령을 실행할 수 없습니다" "$BOT_LIVENESS_LOG" || {
+  echo "FAIL: 게이트웨이 복구 수단 부재를 알리지 않았다" >&2
+  RC=1
+}
+pass_if_clean "게이트웨이도 복구 명령이 없으면 예산을 쓰지 않고 알림만 한다"
 exit "$RC"

--- a/scripts/bot-liveness-monitor.test.sh
+++ b/scripts/bot-liveness-monitor.test.sh
@@ -51,7 +51,10 @@ SH
 # mock: launchctl — bootstrap 호출을 기록
 cat > "$T/bin/launchctl" <<'SH'
 #!/usr/bin/env bash
-[ "$1" = print ] && { case "$2" in *"${TEAMOS_LAUNCHD_PREFIX}.claude-telegram-${LOADED_AGENT:-__none__}") exit 0 ;; *) exit 1 ;; esac; }
+# ★기대 라벨은 리터럴로 박는다★ — 스크립트와 같은 변수에서 만들면 스크립트가 그 값을 덮어써도
+#   export 속성이 유지돼 이 mock 에 그대로 전달된다. 그러면 mock 이 ★스크립트가 정한 라벨에
+#   무조건 동의하게 되어★ 접두를 개인 라벨로 되돌린 회귀를 잡지 못한다(실측: 그 뮤턴트가 생존했다).
+[ "$1" = print ] && { case "$2" in *"com.b3ostest.claude-telegram-${LOADED_AGENT:-__none__}") exit 0 ;; *) exit 1 ;; esac; }
 [ "$1" = bootstrap ] && { printf '%s\n' "$3" >> "$LAUNCHCTL_CALLS"; exit 0; }
 exit 2
 SH

--- a/scripts/bot-liveness-monitor.test.sh
+++ b/scripts/bot-liveness-monitor.test.sh
@@ -13,6 +13,14 @@
 set -uo pipefail
 SCRIPT="${1:-$(cd "$(dirname "$0")" && pwd)/bot-liveness-monitor.sh}"
 
+# PASS 문구는 ★그 시나리오에서 실패가 없었을 때만★ 낸다.
+#   무조건 출력하면 FAIL 바로 뒤에 PASS 가 찍혀 로그만 보고는 통과로 읽힌다(RC 로만 판정됐다).
+_LAST_RC=0
+pass_if_clean() {
+  if [ "$RC" = "$_LAST_RC" ]; then echo "PASS: $1"; else echo "SKIP(위 FAIL 때문): $1"; fi
+  _LAST_RC="$RC"
+}
+
 T="$(mktemp -d "${TMPDIR:-/tmp}/probe-restart.XXXXXX")"
 export HOME="$T/home"
 if [ "${KEEP_TMP:-0}" != "1" ]; then trap 'rm -rf "$T"' EXIT; fi
@@ -115,7 +123,7 @@ tail -1 "$BOT_LIVENESS_LOG" | grep -q 'bot-liveness DONE status=issues$' || {
   tail -3 "$BOT_LIVENESS_LOG" >&2
   RC=1
 }
-echo "PASS: 전체 진입점이 alert-only에서 bootstrap/restart를 호출하지 않음"
+pass_if_clean "전체 진입점이 alert-only에서 bootstrap/restart를 호출하지 않음"
 
 # 같은 등록부/off 조건에서 LaunchAgent가 로드돼 있으면 세션 부재는 실제 장애이므로 복구한다.
 : > "$LAUNCHCTL_CALLS"
@@ -131,7 +139,7 @@ loaded_calls="$(cat "$RESTART_CALLS")"
   echo "FAIL: loaded LaunchAgent must not be bootstrapped" >&2
   RC=1
 }
-echo "PASS: 로드된 LaunchAgent의 세션 부재는 restart-agent로 복구함"
+pass_if_clean "로드된 LaunchAgent의 세션 부재는 restart-agent로 복구함"
 
 # 복구 수단이 없으면 파괴적 조치를 하지 않는다.
 #   폴러 사망 분기는 세션을 ★먼저 죽이고★ 복구를 부른다. 복구 스크립트가 없는 설치에서 그대로 두면
@@ -149,5 +157,38 @@ grep -q "자동복구 불가" "$BOT_LIVENESS_LOG" || {
   echo "FAIL: 복구 수단 부재를 알리지 않았다" >&2
   RC=1
 }
-echo "PASS: 복구 수단이 없으면 재시작하지 않고 알림만 한다"
+pass_if_clean "복구 수단이 없으면 재시작하지 않고 알림만 한다"
+
+# ★폴러 사망★ + 복구 수단 없음 → 세션을 죽이지 않는다.
+#   세션은 살아 있고 폴러만 죽은 상태. 이 분기는 tmux kill-session 을 ★먼저★ 하므로,
+#   복구 수단이 없으면 세션만 죽고 봇이 완전히 내려간다. 위 시나리오들은 세션 부재라
+#   세션 체크에서 continue 되어 이 경로에 도달하지 못한다 — 그래서 따로 만든다.
+cat > "$T/bin/tmux" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+  has-session)   exit 0 ;;                       # ★세션은 살아 있다★
+  kill-session)  printf '%s\n' "$*" >> "$TMUX_KILLS"; exit 0 ;;
+  capture-pane)  printf 'idle\n'; exit 0 ;;
+  display-message) printf '%s\n' "$(date +%s)"; exit 0 ;;
+  list-sessions) printf 'claude-bill\n'; exit 0 ;;
+  send-keys|load-buffer|paste-buffer|delete-buffer) exit 0 ;;
+esac
+exit 0
+SH
+chmod +x "$T/bin/tmux"
+export TMUX_KILLS="$T/tmux.kills"; : > "$TMUX_KILLS"
+printf 'CHANNEL_BOT_TOKEN=x\n' > "$HOME/.claude/channels/telegram-bill/.env"   # .env 가드로 빠지지 않게
+printf '999999\n' > "$HOME/.claude/channels/telegram-bill/bot.pid"             # ★죽은 pid★
+: > "$RESTART_CALLS"; : > "$BOT_LIVENESS_LOG"
+RESTART_AGENT="$T/b3os/scripts/does-not-exist.sh" \
+  bash "$SCRIPT" >"$T/poller-out.txt" 2>"$T/poller-err.txt"
+[ ! -s "$TMUX_KILLS" ] || {
+  echo "FAIL: 복구 수단이 없는데 세션을 죽였다: $(cat "$TMUX_KILLS")" >&2
+  RC=1
+}
+grep -q "세션 유지하고 알림만" "$BOT_LIVENESS_LOG" || {
+  echo "FAIL: 폴러 사망 + 복구불가에서 세션 유지 알림이 없다" >&2
+  RC=1
+}
+pass_if_clean "폴러가 죽어도 복구 수단이 없으면 세션을 죽이지 않는다"
 exit "$RC"

--- a/scripts/bot-liveness-monitor.test.sh
+++ b/scripts/bot-liveness-monitor.test.sh
@@ -16,10 +16,12 @@ SCRIPT="${1:-$(cd "$(dirname "$0")" && pwd)/bot-liveness-monitor.sh}"
 T="$(mktemp -d "${TMPDIR:-/tmp}/probe-restart.XXXXXX")"
 export HOME="$T/home"
 if [ "${KEEP_TMP:-0}" != "1" ]; then trap 'rm -rf "$T"' EXIT; fi
+# ★일부러 개인 라벨이 아닌 접두를 쓴다★ — 라벨을 다시 코드에 고정하면 이 테스트가 실패한다.
+export TEAMOS_LAUNCHD_PREFIX="com.b3ostest"
 mkdir -p "$HOME/Library/LaunchAgents" "$T/bin" \
-         "$HOME/Development/b3rys-team-collab/scripts" \
+         "$T/b3os/scripts" \
          "$HOME/.claude/channels/telegram-bill" "$T/b3os"
-: > "$HOME/Library/LaunchAgents/com.gdmini.claude-telegram-bill.plist"
+: > "$HOME/Library/LaunchAgents/$TEAMOS_LAUNCHD_PREFIX.claude-telegram-bill.plist"
 
 # 등록부: bill 은 ★활성 팀원★ (GD 가 지운 건 로그인 항목뿐)
 cat > "$T/agents.json" <<'JSON'
@@ -41,13 +43,13 @@ SH
 # mock: launchctl — bootstrap 호출을 기록
 cat > "$T/bin/launchctl" <<'SH'
 #!/usr/bin/env bash
-[ "$1" = print ] && { case "$2" in *"com.gdmini.claude-telegram-${LOADED_AGENT:-__none__}") exit 0 ;; *) exit 1 ;; esac; }
+[ "$1" = print ] && { case "$2" in *"${TEAMOS_LAUNCHD_PREFIX}.claude-telegram-${LOADED_AGENT:-__none__}") exit 0 ;; *) exit 1 ;; esac; }
 [ "$1" = bootstrap ] && { printf '%s\n' "$3" >> "$LAUNCHCTL_CALLS"; exit 0; }
 exit 2
 SH
 
 # mock: restart-agent.sh — ★이게 불리면 팀원이 되살아난 것★
-cat > "$HOME/Development/b3rys-team-collab/scripts/restart-agent.sh" <<'SH'
+cat > "$T/b3os/scripts/restart-agent.sh" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$1" >> "$RESTART_CALLS"
 SH
@@ -60,7 +62,7 @@ printf '200'
 exit 0
 SH
 
-chmod +x "$T/bin/"* "$HOME/Development/b3rys-team-collab/scripts/restart-agent.sh"
+chmod +x "$T/bin/"* "$T/b3os/scripts/restart-agent.sh"
 export PATH="$T/bin:$PATH"
 export LAUNCHCTL_CALLS="$T/launchctl.calls"; : > "$LAUNCHCTL_CALLS"
 export RESTART_CALLS="$T/restart.calls";     : > "$RESTART_CALLS"
@@ -72,7 +74,7 @@ export B3OS_ROOT="$T/b3os"
 export BOT_LIVENESS_LOG="$T/b3os/var/bot-liveness-monitor.log"
 export LIVENESS_LA_AUTOHEAL=0
 export GD_CHAT_ID=test
-printf 'CAPTURE_BOT_TOKEN=test\n' > "$HOME/Development/b3rys-team-collab/.env"
+printf 'CAPTURE_BOT_TOKEN=test\n' > "$T/b3os/.env"
 
 echo "■ 시나리오: bill 은 등록부에 있고 off 목록엔 없다. 세션은 안 떠 있다."
 echo "  (= GD 가 로그인 항목에서만 뺀 상태)"
@@ -130,4 +132,22 @@ loaded_calls="$(cat "$RESTART_CALLS")"
   RC=1
 }
 echo "PASS: 로드된 LaunchAgent의 세션 부재는 restart-agent로 복구함"
+
+# 복구 수단이 없으면 파괴적 조치를 하지 않는다.
+#   폴러 사망 분기는 세션을 ★먼저 죽이고★ 복구를 부른다. 복구 스크립트가 없는 설치에서 그대로 두면
+#   세션만 죽고 복구는 실패해 봇이 완전히 내려간다. 그래서 감지·알림만 하고 손대지 않아야 한다.
+: > "$LAUNCHCTL_CALLS"
+: > "$RESTART_CALLS"
+: > "$BOT_LIVENESS_LOG"          # 이 시나리오의 출력만 보도록 — 평상 실행은 stdout 을 로그로 보낸다
+RESTART_AGENT="$T/b3os/scripts/does-not-exist.sh" \
+  bash "$SCRIPT" >"$T/noheal-out.txt" 2>"$T/noheal-err.txt"
+[ ! -s "$RESTART_CALLS" ] || {
+  echo "FAIL: 복구 수단이 없는데 재시작을 시도했다: $(cat "$RESTART_CALLS")" >&2
+  RC=1
+}
+grep -q "자동복구 불가" "$BOT_LIVENESS_LOG" || {
+  echo "FAIL: 복구 수단 부재를 알리지 않았다" >&2
+  RC=1
+}
+echo "PASS: 복구 수단이 없으면 재시작하지 않고 알림만 한다"
 exit "$RC"


### PR DESCRIPTION
## 핵심 3줄

1. `bot-liveness-monitor.sh` 가 launchd 라벨 접두와 의존 경로를 특정 기기 값(`com.gdmini.*`, `~/Development/b3rys-team-collab/*`)으로 고정한다.
2. 그 값이 아닌 설치에서는 **모든 팀원이 "LaunchAgent 미로드"로 판정돼 tmux·폴러 검사에 도달하지 못한다 — 감시기는 10분마다 도는데 감시는 0이다.** 알림 경로도 `.env` 를 못 찾아 `exit 1` 하므로 그 사실조차 알려지지 않는다. 라벨이 다른 모든 설치에 해당한다.
3. 접두·경로를 env 기본값으로 바꾸고, 복구 수단이 없을 때 파괴적 조치를 막는 가드를 넣었다. 코드 39줄 추가·14줄 삭제, 테스트 24줄 추가·8줄 삭제.

## 무엇을 바꿨나

| 문제 | 고친 방법 |
|---|---|
| 라벨 접두가 `com.gdmini.*` 로 고정 (6곳) | `TEAMOS_LAUNCHD_PREFIX` 에서 읽는다. plist 렌더러(`livenessMonitor.ts:62`)가 **이미 이 값을 넘기고 있었는데 셸이 읽지 않았다.** 기본값 `com.$USER` |
| `.env`·registry·off 파일·`team.db`·복구 스크립트 경로가 `~/Development/b3rys-team-collab/*` 로 고정 | `B3OS_ROOT` 기준 기본값 + env 오버라이드. `B3OS_ROOT` 는 이 파일이 이미 자기 위치에서 계산하고 있었다(로그·상태 경로에만 쓰이던 값) |
| `ENV_FILE`·`RESTART_AGENT`·`BUS_AUTOCLEAN` 등은 **오버라이드 수단 자체가 없었다** (평문 대입) | `: "${VAR:=기본값}"` 으로 바꿔 설치가 지정할 수 있게 했다 |
| 복구 스크립트가 없어도 파괴적 조치를 진행 | `HEAL_READY` 가드. 실행 가능한 복구 수단이 없으면 감지·알림만 한다 |

### 왜 마지막 항목이 이 PR 에 같이 들어가나

폴러 사망 분기는 **`tmux kill-session` 을 먼저 하고** `$RESTART_AGENT` 를 부른다. 그 호출은 `>/dev/null 2>&1` 로 오류가 묻히고 `set -e` 도 걸려 있지 않으므로, 복구 스크립트가 없으면 **세션만 죽고 복구는 조용히 실패해 봇이 완전히 내려간다.**

지금은 라벨 불일치가 이 경로를 우연히 막고 있다. **이 PR 이 라벨을 고치면 그 경로가 도달 가능해진다.** 그래서 접두 수정과 가드를 분리하지 않았다 — 접두만 고치는 것이 가장 위험한 조합이다.

## 검증

```
검증 범위:  scripts/bot-liveness-monitor.test.sh (전체) · bash -n 문법검사 ·
            실제 설치 1곳에서 --dry-run (상태 디렉터리 격리)
baseline:   수정 전 원본 = 0 실패 (2 케이스)
            수정본 = 0 실패 (4 케이스, 신규 2건 포함)
mutation:   라벨을 com.gdmini 로 원복    → exit 1 (테스트가 잡음)
            HEAL_READY 가드 무력화        → exit 1 (테스트가 잡음)
            폴러 사망 분기 가드 제거      → exit 1 (테스트가 잡음)
실측:       라벨이 다른 설치에서 이슈 6건·실제 검사 0건 → 이슈 2건·검사 도달.
            사라진 4건은 팀원 2명 오탐 + 서버 오탐 + registry 폴백 경고.
            남은 2건은 그 설치에 실제로 없는 서비스(정상 동작).
미검증:     복구가 실제로 실행되는 경로(RESTART_AGENT 가 있는 설치에서의 재시작)는
            mock 으로만 확인했고 실기기에서 재시작을 유발해보지 않았다.
            LIVENESS_LA_AUTOHEAL=1 경로 미검증(기본 0).
            hermes 게이트웨이 라벨(ai.hermes.gateway-*)은 접두 규약 밖이라 손대지 않았다.
```

## 남은 것 — 이 PR 에 넣지 않은 것

- `scripts/restart-agent.sh` · `scripts/team-os.sh` · `scripts/openclaw-telegram-ingress-check.sh` · `scripts/bus-autoclean.sh` 는 **이 저장소에 없다.** 경로를 오버라이드 가능하게만 만들었고, 무엇을 기본 복구 수단으로 삼을지는 정하지 않았다. `bin/team-os` 에 `member_restart()` 가 있으나 CLI 진입점으로 노출돼 있지 않다. 이 결정은 유지보수자 몫이라 판단했다.
- `check_gateway "$TEAMOS_LAUNCHD_PREFIX.b3rys-dev"` 는 특정 팀 전용 서비스로 보인다. 접두만 맞췄고 목록을 설정화하지는 않았다.

---

## 추가 (리뷰 반영, 2차 커밋)

### 이 저장소에서 받아가면 auto-heal 은 기본 꺼진 채로 시작한다

`restart-agent.sh` 가 이 저장소에 없으므로 기본 설치는 **`HEAL_READY=0`** 으로 출발한다. 즉 **감지·알림은 동작하고 자동복구는 하지 않는다.** 안전한 기본값이지만, 모르면 "자동복구가 도는 줄" 알게 되므로 명시한다. 자동복구를 쓰려면 `RESTART_AGENT` 를 실행 가능한 경로로 지정해야 한다.

### 폴러 사망 분기가 테스트에서 실행되지 않고 있었다

리뷰에서 지적받아 고쳤다. 기존 tmux mock 은 `has-session` 이 항상 실패라 **모든 시나리오가 '세션 부재' 분기만 탔다.** 폴러 사망 분기는 세션 체크에서 `continue` 되어 한 번도 실행되지 않았고, **그 분기의 가드를 통째로 지워도 테스트가 통과했다**(실측 `exit 0`).

세션은 살아 있고 폴러만 죽은 시나리오를 추가했다. 판정은 `kill-session` 호출 여부다.

```
mutation:   폴러 사망 분기 가드 제거 → exit 1   (추가 전 exit 0)
            라벨을 com.gdmini 로 원복        → exit 1
            HEAL_READY 가드 무력화           → exit 1
baseline:   수정본 4 케이스 exit 0
```

또한 PASS 문구가 무조건 출력돼 **FAIL 뒤에 PASS 가 찍히고 있었다.** 실패가 없을 때만 내도록 바꿨다.

### 이 PR 이 덮지 않는 것 (오해 방지)

`HEAL_READY` 는 `RESTART_AGENT` 하나만 본다. 아래는 **가드 밖**이며 이 PR 의 범위가 아니다.

- `attempt_heal` / `attempt_feedback_heal` — pane 문자열이 맞으면 살아있는 세션에 키를 주입한다. 재시작 예산도 타지 않는다
- `nudge_heal` — 작업 중인 세션에 지시문을 붙여넣는다
- `check_gateway` — `restart_budget_spend` 를 먼저 하고 `TEAM_OS` 를 부른다. `TEAM_OS` 가 없는 설치에서는 성공할 수 없는 호출에 그 사이클 예산을 쓴다 (파괴적이지 않음)
- `escalate_to_bill` — 세션 이름이 고정값이다. 이 PR 의 주제와 같은 종류지만 남겨뒀다

`--dry-run` 은 두 분기 모두 `HEAL_READY` 보다 먼저 걸려 "→ team-os up (dry-run)" 을 출력한다. 즉 **dry-run 출력이 실제 능력보다 크게 보인다.** 별도로 다루는 게 맞다고 본다.

발견 = jane(리뷰) · herm(코드 검토)

Submitted-by: lisa
