### PR TITLE
fix(monitoring): status 허용목록을 스크립트와 테스트로 묶는다

### DIFF
--- a/src/server/lib/monitoringStatus.livenessStatus.test.ts
+++ b/src/server/lib/monitoringStatus.livenessStatus.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BOT_LIVENESS_KNOWN_STATUSES, readLivenessStatus } from "./monitoringStatus";
+
+const SCRIPT = join(import.meta.dir, "../../../scripts/bot-liveness-monitor.sh");
+
+/** 스크립트가 실제로 내는 status 값을 소스에서 뽑는다. */
+function emittedStatuses(): string[] {
+  const src = readFileSync(SCRIPT, "utf-8");
+  const found = new Set<string>();
+  for (const m of src.matchAll(/finish_status\s+([a-z][a-z0-9-]*)/gi)) found.add(m[1]!.toLowerCase());
+  return [...found].sort();
+}
+
+function logWith(resultLine: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "liveness-status-"));
+  const path = join(dir, "bot-liveness-monitor.log");
+  writeFileSync(path, `2026-08-04 10:00:00 bot-liveness START (dry_run=0)\n${resultLine}\n`);
+  return path;
+}
+
+describe("bot-liveness status ↔ 파서 결합", () => {
+  // ★이 테스트가 이 PR 의 핵심★
+  //   스크립트에 새 status 를 추가하고 파서를 안 고치면 여기서 실패한다. 안 그러면 그 값은
+  //   한국어 휴리스틱으로 떨어져 "추측"으로 판정되고, 아무도 그 사실을 모른다.
+  test("스크립트가 내는 모든 status 를 파서가 알고 있다", () => {
+    const emitted = emittedStatuses();
+    expect(emitted.length).toBeGreaterThan(0); // 정규식이 안 맞으면 빈 배열로 헛통과한다
+    const unknown = emitted.filter((s) => !BOT_LIVENESS_KNOWN_STATUSES.includes(s));
+    expect(unknown).toEqual([]);
+  });
+
+  test("정상 판정", () => {
+    for (const s of ["ok", "healed", "healed-unreported"]) {
+      expect(readLivenessStatus(logWith(`2026-08-04 10:00:01 bot-liveness DONE status=${s}`)).healthy).toBe(true);
+    }
+  });
+
+  test("이상 판정 — 알리지 못한 경우도 이상이다", () => {
+    for (const s of ["issues", "issues-unreported", "error"]) {
+      expect(readLivenessStatus(logWith(`2026-08-04 10:00:01 bot-liveness DONE status=${s}`)).healthy).toBe(false);
+    }
+  });
+
+  test("판정하지 않는 상태는 null — 휴리스틱으로 떨어져서가 아니라 의도된 null 이다", () => {
+    for (const s of ["skipped", "reset"]) {
+      expect(readLivenessStatus(logWith(`2026-08-04 10:00:01 bot-liveness DONE status=${s}`)).healthy).toBeNull();
+    }
+  });
+
+  test("접미사가 붙은 값이 짧은 값으로 잘려 매칭되지 않는다", () => {
+    // `issues-unreported` 를 `issues` 로 자르면 안 되고, 모르는 접미사는 아예 매칭되면 안 된다.
+    const unknownSuffix = readLivenessStatus(
+      logWith("2026-08-04 10:00:01 bot-liveness DONE status=issues-somethingnew"),
+    );
+    expect(unknownSuffix.healthy).not.toBe(false); // 허용목록에 없으므로 명시 판정이면 안 된다
+  });
+});

--- a/src/server/lib/monitoringStatus.ts
+++ b/src/server/lib/monitoringStatus.ts
@@ -20,9 +20,31 @@ export interface LivenessStatus {
   logMtime: string | null; // 로그 파일 mtime(ISO)
 }
 
+// ★스크립트가 내는 status 값은 전부 여기 있어야 한다★
+//   허용목록에 없으면 아래 한국어 휴리스틱으로 떨어진다. 그건 판정이 아니라 추측이다.
+//   실제로 `reset`·`skipped` 가 목록 밖이라 계속 그렇게 돌고 있었고, `issues-unreported` 는
+//   하이픈이 단어경계라 `issues` 로 ★우연히★ 맞았다 — `issuesUnreported` 였으면 조용히 샜다.
+//   scripts/bot-liveness-monitor.sh 의 finish_status 값과 이 목록은 테스트로 묶여 있다.
+const STATUS_HEALTHY = ["ok", "healthy", "healed", "healed-unreported"] as const;
+const STATUS_UNHEALTHY = ["issues", "issues-unreported", "failed", "error", "down", "unhealthy"] as const;
+// 판정하지 않는 상태 — "정상"도 "이상"도 아니다. 부팅 유예처럼 검사 자체를 건너뛴 경우다.
+//   null 이 맞는 답이지만, 휴리스틱에 떨어져서 우연히 null 이 되는 것과는 다르다.
+const STATUS_NO_VERDICT = ["skipped", "reset"] as const;
+
+export const BOT_LIVENESS_KNOWN_STATUSES: readonly string[] = [
+  ...STATUS_HEALTHY,
+  ...STATUS_UNHEALTHY,
+  ...STATUS_NO_VERDICT,
+];
+
 function classifyBotLivenessResult(line: string): boolean | null {
-  const explicitStatus = line.match(/\bstatus=(ok|healthy|healed|issues|failed|error|down|unhealthy)\b/i)?.[1]?.toLowerCase();
-  if (explicitStatus) return /^(ok|healthy|healed)$/.test(explicitStatus);
+  // 긴 값을 먼저 시도한다 — 안 그러면 `issues-unreported` 가 `issues` 로 잘려 매칭된다.
+  const alternation = [...BOT_LIVENESS_KNOWN_STATUSES].sort((a, b) => b.length - a.length).join("|");
+  const explicitStatus = line.match(new RegExp(`\\bstatus=(${alternation})(?![\\w-])`, "i"))?.[1]?.toLowerCase();
+  if (explicitStatus) {
+    if ((STATUS_NO_VERDICT as readonly string[]).includes(explicitStatus)) return null;
+    return (STATUS_HEALTHY as readonly string[]).includes(explicitStatus);
+  }
   if (/이상 없음|정상|\bOK\b|healthy/i.test(line)) return true;
   if (/이상|실패|error|재시작|down|무응답|죽|수동 확인 필요|[⚠❌]/i.test(line)) return false;
   return null;


### PR DESCRIPTION
## 핵심 3줄

1. 파서 허용목록에 없는 `status` 는 **한국어 휴리스틱으로 떨어진다.** 그건 판정이 아니라 추측이고, 떨어졌다는 사실이 어디에도 안 남는다.
2. 실측 — 스크립트가 내는 값 중 **`reset`·`skipped` 가 목록 밖이라 계속 휴리스틱으로 판정되고 있었다.** `issues-unreported` 는 하이픈이 단어경계라 `issues` 로 **우연히** 맞았다(`issuesUnreported` 였으면 조용히 샜다).
3. 허용목록을 세 갈래로 명시하고, **스크립트 소스에서 `finish_status` 값을 뽑아 파서가 전부 아는지 검사하는 테스트**로 묶었다. 코드 24줄 추가·2줄 삭제, 테스트 60줄.

## 무엇을 바꿨나

| 문제 | 고친 방법 |
|---|---|
| 허용목록 밖 status 가 조용히 휴리스틱으로 떨어짐 | 정상 / 이상 / **판정보류** 세 목록으로 명시 |
| `skipped`·`reset` 이 목록에 없음 | 판정보류로 명시. `null` 이 맞는 답이지만 **우연한 null 과 의도된 null 은 다르다** |
| `issues-unreported` 가 `issues` 로 잘려 매칭 | 긴 값을 먼저 시도 + 뒤에 `[\w-]` 가 오면 매칭하지 않음 |
| 새 status 를 추가해도 아무도 모름 | 테스트가 스크립트와 파서를 묶는다 |

### 왜 문서가 아니라 테스트인가

"새 status 를 추가할 때 파서 허용목록도 같이 본다" 는 **사람이 기억해야 지켜지는 규율**이다. 이 저장소에서 최근 반복해서 겪은 실패가 정확히 그 형태다 — 가드는 넣었는데 그 가드를 지켜주는 검사가 없어서, 나중에 조용히 무력화되는 것.

테스트는 스크립트 소스에서 `finish_status` 값을 직접 뽑는다. 새 값을 추가하고 파서를 안 고치면 그 자리에서 실패한다.

## 검증

```
검증 범위:  monitoringStatus.livenessStatus.test.ts (신규 5) ·
            monitoringStatus.dmHealth.test.ts · livenessMonitor.test.ts (기존 13) · 타입체크
baseline:   신규 5 PASS · 기존 13 PASS · 타입체크 통과
mutation:   스크립트에 새 status 추가하고 파서 미수정 → 실패 (이 PR 의 핵심 시나리오)
            판정보류를 healthy 로 처리                → 실패
미검증:     대시보드 화면에서의 실제 렌더는 확인하지 않았다(파서 단위까지만).
            휴리스틱 분기 자체는 손대지 않았다 — 허용목록 밖 값이 없어지면 도달 빈도가 줄 뿐이다.
```

테스트에 `expect(emitted.length).toBeGreaterThan(0)` 를 넣어뒀다. 값을 뽑는 정규식이 스크립트 형식 변화로 안 맞게 되면 **빈 배열이라 헛통과**하기 때문이다.

Submitted-by: lisa
