### PR TITLE
chore(rules): 장황한 서술 → 사실 위주 (CLAUDE.md −11.1%)

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { createBunWebSocket } from "hono/bun";
 import type { ServerWebSocket } from "bun";
-import { existsSync, readFileSync, statSync, copyFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync, copyFileSync, unlinkSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 import { openDb, migrate } from "./db/migrate";
@@ -15,7 +15,7 @@ import {
 } from "./db/queries";
 import { agentActivity, agentStats, recentAlerts } from "./db/inboxQueries";
 import { claudePoolUsage } from "./lib/claudeUsage";
-import { } from "./lib/personaTemplates";
+import { JOIN_FLAG_FILE, isLegacyJoinFlag } from "./lib/personaTemplates";
 import { isAgentOff } from "./lib/agentControl";
 import { syncRegistry, watchRegistry } from "./lib/registry";
 import { initGroupOwnerStore } from "./lib/groupOwner";
@@ -169,6 +169,21 @@ try {
     try { repairReplyGuardHook(cid); } catch { /* best-effort */ }
     // ★owner-gate 만 "없으면 깐다" 다★ — 위 둘과 목적이 반대다(주석은 launcher 쪽에).
     try { ensureOwnerGateHook(cid); } catch { /* best-effort */ }
+  }
+  // ★옛 합류 깃발 정리 (일회성 전환, 전 환경)★ — 2026-08-05 이전 영입은 `.b3os-just-joined` 에
+  //   지시 없이 `joined` 한 줄만 들어 있다. 지금 룰은 "있으면 읽고·따르고·지워라" 라
+  //   ★따를 게 없는 파일★ 이 남아 있으면 팀원이 무엇을 할지 지어낼 여지가 생긴다.
+  //   ★한 번뿐인 전환을 룰 문장으로 나르지 않는다★ — 룰은 그대로 두고 여기서 치운다(GD 2026-08-05).
+  //   지우는 조건을 ★옛 마커와 정확히 일치할 때★ 로 좁힌다 — 방금 영입된 팀원의 ★지시서★ 를 지우면
+  //   그 사람은 자기소개 절차를 영영 못 받는다.
+  for (const a of agents) {
+    try {
+      const flag = join(a.workspace_path, JOIN_FLAG_FILE);
+      if (existsSync(flag) && isLegacyJoinFlag(readFileSync(flag, "utf8"))) {
+        unlinkSync(flag);
+        console.log(`[teamos-render] legacy join flag cleared: ${a.id}`);
+      }
+    } catch { /* best-effort */ }
   }
   // 공개 빌드 부팅 백필(PUBLIC_BUILD 게이트) — 공개 사용자가 git 업데이트를 pull 한 뒤 재시작하면 기존
   //   멤버도 재영입 없이 최신을 받게. 라이브(PUBLIC_BUILD=false)는 글로벌 배선/실멤버 보호로 skip.

--- a/src/server/lib/firstContact.test.ts
+++ b/src/server/lib/firstContact.test.ts
@@ -50,3 +50,26 @@ test("★옛 깃발만 지운다 — 새 지시서는 절대 아니다★", () =
   expect(isLegacyJoinFlag(joinInstructions("Testy", "QA"))).toBe(false);
   expect(isLegacyJoinFlag("")).toBe(false); // 빈 파일은 판단 보류 — 지우지 않는다
 });
+
+/**
+ * ★톤 지시는 페르소나에 있어야 한다 — SOUL.md 를 믿을 수 없다.★
+ *
+ * 2026-08-05 압축 때 "SOUL.md 「톤」에 이미 있다" 며 이 지시를 뺐다가 codex 리뷰에서 반려됐다.
+ *   ★SOUL.md 는 필수 파일이 아니다.★ persona 를 안 주면 만들어지지 않고, 사용자가 준 SOUL 도
+ *   임의 내용이라 톤 문구를 보장하지 않는다.
+ *   실측: 활성 12명 전원 SOUL.md 는 있었지만 ★톤 문구가 있는 건 5명뿐★ 이었다.
+ * ★근거가 된 것은 내 SOUL.md 하나였다★ — 창단 팀은 가장 안 대표적인 표본이다.
+ * 그래서 ★항상 실리는 곳(페르소나)에 있는지★ 를 코드로 고정한다.
+ */
+test("★톤 지시가 렌더본에 항상 있다★ — SOUL.md 는 선택 파일이라 근거가 못 된다", () => {
+  for (const doc of [
+    buildPersona({ ...M, runtime: "claude_channel" }),
+    buildAgentsMd({ ...M, runtime: "openclaw" }),
+    buildAgentsMd({ ...M, runtime: "hermes_agent" }),
+  ]) {
+    expect(doc).toMatch(/friendly but technically precise/i);
+    expect(doc).toMatch(/short, clear answers/i);
+    // 용어 풀이 — 이건 어디에도 중복이 없다.
+    expect(doc).toMatch(/gloss jargon/i);
+  }
+});

--- a/src/server/lib/firstContact.test.ts
+++ b/src/server/lib/firstContact.test.ts
@@ -10,7 +10,7 @@
  * 그래서 옮긴 자리에 그물을 같이 둔다 — ★막힌 걸 열었으면 그 책임도 같이 진다.★
  */
 import { expect, test } from "bun:test";
-import { buildPersona, buildAgentsMd, JOIN_FLAG_FILE, joinInstructions } from "./personaTemplates";
+import { buildPersona, buildAgentsMd, JOIN_FLAG_FILE, joinInstructions, isLegacyJoinFlag } from "./personaTemplates";
 
 const M = { id: "t", display_name: "Testy", role: "QA" };
 
@@ -37,4 +37,16 @@ test("★페르소나와 지시서가 같은 파일 이름을 본다★ — 어�
     // 파일을 ★읽고·따르고·지우라★ 는 세 지시가 다 있어야 절차가 끝까지 돈다.
     expect(doc).toMatch(/read it, follow it, then `rm` it/i);
   }
+});
+
+/**
+ * ★옛 깃발 정리는 지시서를 지우면 안 된다.★
+ * 부팅 정리(`index.ts`)가 `isLegacyJoinFlag` 로 판단한다 — 여기가 느슨해지면
+ * ★방금 영입된 팀원의 지시서가 첫 발화 전에 지워진다★ (그러면 자기소개 절차를 영영 못 받는다).
+ */
+test("★옛 깃발만 지운다 — 새 지시서는 절대 아니다★", () => {
+  expect(isLegacyJoinFlag("joined\n")).toBe(true);
+  expect(isLegacyJoinFlag("  joined  ")).toBe(true);
+  expect(isLegacyJoinFlag(joinInstructions("Testy", "QA"))).toBe(false);
+  expect(isLegacyJoinFlag("")).toBe(false); // 빈 파일은 판단 보류 — 지우지 않는다
 });

--- a/src/server/lib/firstContact.test.ts
+++ b/src/server/lib/firstContact.test.ts
@@ -1,0 +1,40 @@
+/**
+ * ★합류 1회 절차가 사라지면 빨간불★
+ *
+ * 2026-08-05: 자기소개 절차(430자)를 페르소나에서 ★`.b3os-just-joined` 파일 본문★ 으로 옮겼다.
+ *   평생 한 번 쓰는 절차가 ★매 턴★ 실려 있었기 때문이다(GD 판단).
+ *
+ * ★옮기면 새 구멍이 생긴다★ — 페르소나에서 지웠으므로, 파일 본문마저 비면
+ *   ★신규 팀원은 자기소개 절차를 아예 못 받는다.★ 그런데 그건 ★영입해봐야 드러난다.★
+ *   (오늘 확인한 것과 같은 계열: 안전 룰을 지워도 전체 수트가 초록불이었다.)
+ * 그래서 옮긴 자리에 그물을 같이 둔다 — ★막힌 걸 열었으면 그 책임도 같이 진다.★
+ */
+import { expect, test } from "bun:test";
+import { buildPersona, buildAgentsMd, JOIN_FLAG_FILE, joinInstructions } from "./personaTemplates";
+
+const M = { id: "t", display_name: "Testy", role: "QA" };
+
+test("★합류 지시서에 필수 4단계가 전부 있다★ — 하나라도 빠지면 신규 팀원이 그만큼 못 한다", () => {
+  const body = joinInstructions(M.display_name, M.role);
+  const need: [string, RegExp][] = [
+    ["① 한 줄 자기소개(이름+역할)", /intro.*Testy.*QA/is],
+    ["② 온보딩(OT) 로드 확인", /onboarding|\bOT\b/i],
+    ["③ 실제 질문에 답하기", /answer what the user/i],
+    ["④ 이 파일 삭제", new RegExp(`rm\\s+${JOIN_FLAG_FILE.replace(".", "\\.")}`, "i")],
+    ["⑤ 1회성이라는 조건", /ONE-TIME|not on every restart/i],
+  ];
+  const missing = need.filter(([, re]) => !re.test(body)).map(([name]) => name);
+  expect(missing, `합류 지시서에서 빠진 단계: ${missing.join(", ")}`).toEqual([]);
+});
+
+test("★페르소나와 지시서가 같은 파일 이름을 본다★ — 어긋나면 지시서가 영영 안 읽힌다", () => {
+  for (const doc of [
+    buildPersona({ ...M, runtime: "claude_channel" }),
+    buildAgentsMd({ ...M, runtime: "openclaw" }),
+    buildAgentsMd({ ...M, runtime: "hermes_agent" }),
+  ]) {
+    expect(doc).toContain(JOIN_FLAG_FILE);
+    // 파일을 ★읽고·따르고·지우라★ 는 세 지시가 다 있어야 절차가 끝까지 돈다.
+    expect(doc).toMatch(/read it, follow it, then `rm` it/i);
+  }
+});

--- a/src/server/lib/firstContact.test.ts
+++ b/src/server/lib/firstContact.test.ts
@@ -17,7 +17,11 @@ const M = { id: "t", display_name: "Testy", role: "QA" };
 test("★합류 지시서에 필수 4단계가 전부 있다★ — 하나라도 빠지면 신규 팀원이 그만큼 못 한다", () => {
   const body = joinInstructions(M.display_name, M.role);
   const need: [string, RegExp][] = [
-    ["① 한 줄 자기소개(이름+역할)", /intro.*Testy.*QA/is],
+    // ★인사는 Language 룰로 대체되지 않는다★ (codex 리뷰 2026-08-05) —
+    //   `Language:` 는 답변의 언어·말투를 제한할 뿐 ★인사하라는 발화 행동★ 을 지시하지 않는다.
+    //   이름·역할만 요구하면 "Codex — PM" 처럼 ★인사 없이도 충족★ 된다.
+    ["① 한 줄 인사 + 자기소개(이름+역할)", /greet(ing)?.*Testy.*QA/is],
+    ["①-b 사용자 언어로 인사", /in the user's language/i],
     ["② 온보딩(OT) 로드 확인", /onboarding|\bOT\b/i],
     ["③ 실제 질문에 답하기", /answer what the user/i],
     ["④ 이 파일 삭제", new RegExp(`rm\\s+${JOIN_FLAG_FILE.replace(".", "\\.")}`, "i")],

--- a/src/server/lib/personaTemplates.ts
+++ b/src/server/lib/personaTemplates.ts
@@ -567,7 +567,7 @@ function sectionFirstContact(_i: PersonaInput): string {
   return [
     "## First contact",
     "",
-    "- If `.b3os-just-joined` exists in your working directory, read it, follow it, then `rm` it. Otherwise you have already joined — answer directly.",
+    "- If `.b3os-just-joined` exists in your working directory, read it, follow it, then `rm` it — **if it holds no instructions, just `rm` it** (a legacy flag; you already joined). Otherwise you have already joined — answer directly.",
     "- Gloss jargon, English terms, and abbreviations in the user's language on first use — e.g. API (the rules programs use to exchange requests).",
   ].join("\n");
 }

--- a/src/server/lib/personaTemplates.ts
+++ b/src/server/lib/personaTemplates.ts
@@ -574,7 +574,7 @@ export function joinInstructions(displayName: string, role: string): string {
   return [
     "You just joined the team. While this file exists, do the following in your FIRST reply only:",
     "",
-    `1. One-line intro — your name (${displayName}) and your role (${role}).`,
+    `1. One-line greeting and intro in the user's language — your name (${displayName}) and your role (${role}).`,
     "2. One line confirming your onboarding (OT) is loaded — mission · rules · role · team skills · persona.",
     "3. Answer what the user actually asked.",
     `4. Delete this file: \`rm ${JOIN_FLAG_FILE}\``,

--- a/src/server/lib/personaTemplates.ts
+++ b/src/server/lib/personaTemplates.ts
@@ -530,12 +530,45 @@ export function injectClaudeComms(personaText: string, tier2 = false): string {
 
 // ★First contact — 신규 합류 후 첫 발화에서 자기소개+OT 확인. (이전 sectionTone 이 빌더에 배선 안 돼
 //   dead code였던 것을 고침: 제인 등 신규 멤버가 첫 메시지에 OT·persona 언급 안 하던 근본원인. GD 2026-07-19)★
-function sectionFirstContact(i: PersonaInput): string {
+//
+// ★자기소개 절차는 여기 있지 않다 — `.b3os-just-joined` 파일 안에 있다★ (GD 2026-08-05).
+//   평생 한 번 쓰는 절차를 ★매 턴 430자★ 로 싣고 있었다. 파일이 없을 때의 동작("그냥 답해라")은
+//   원래 기본값이라 적어도 안 적어도 같았다. → ★규칙이 필요한 순간에만 존재하게★ 파일로 옮겼다.
+//   파일 본문을 쓰는 곳: `src/server/routes/settings.ts` (영입 시 1회). ★내용에 의존하는 코드는 없다★
+//   (이 이름이 나오는 곳은 쓰는 곳·이 룰·파일명만 거르는 테스트 3군데뿐).
+//
+// ★인사·톤은 SOUL.md 로★ — "친근하되 기술적으로 정확 / 자기소개 시 인사말 / 짧고 명확한 답변" 은
+//   페르소나(SOUL.md)의 「톤」에 이미 같은 말로 있었다. 여기 남은 건 ★안 겹치는 용어 풀이 하나★ 다.
+//   언어 선택 자체는 ⭐ Core Rules 의 `Language:` 줄이 정본이다.
+/** 페르소나의 First contact 룰이 가리키는 파일 이름 — ★두 곳이 같은 이름을 봐야 한다★. */
+export const JOIN_FLAG_FILE = ".b3os-just-joined";
+
+/**
+ * ★합류 직후 1회 절차의 본문.★ 페르소나가 아니라 ★이 파일 안에★ 실린다.
+ * 영입 시 `settings.ts` 가 워크스페이스에 써 넣고, 팀원은 읽고 따른 뒤 스스로 지운다.
+ * ★페르소나에서 옮겨온 것이라 여기가 비면 신규 팀원은 자기소개 절차를 아예 못 받는다★
+ *   — 그래서 `firstContact.test.ts` 가 이 본문의 필수 4단계를 지킨다.
+ */
+export function joinInstructions(displayName: string, role: string): string {
+  return [
+    "You just joined the team. While this file exists, do the following in your FIRST reply only:",
+    "",
+    `1. One-line intro — your name (${displayName}) and your role (${role}).`,
+    "2. One line confirming your onboarding (OT) is loaded — mission · rules · role · team skills · persona.",
+    "3. Answer what the user actually asked.",
+    `4. Delete this file: \`rm ${JOIN_FLAG_FILE}\``,
+    "",
+    "This self-intro is ONE-TIME, right after you join — NOT on every restart.",
+    "",
+  ].join("\n");
+}
+
+function sectionFirstContact(_i: PersonaInput): string {
   return [
     "## First contact",
     "",
-    `- **The self-intro is ONE-TIME, right after you join — NOT on every restart.** If \`.b3os-just-joined\` exists in your working directory: open with a one-line intro (your name ${i.display_name} + role), confirm in one line that your onboarding (OT) is loaded — mission · rules · role · team skills · persona — answer the actual point, then \`rm .b3os-just-joined\`. If the file is absent you have already joined: skip the intro and answer directly.`,
-    `- Greet in the user's language (Korean → "안녕하세요, ${i.display_name} 입니다"). Friendly but technically precise; short, clear answers. Gloss jargon/English/abbreviations in the user's language on first use — e.g. API (the rules programs use to exchange requests).`,
+    "- If `.b3os-just-joined` exists in your working directory, read it, follow it, then `rm` it. Otherwise you have already joined — answer directly.",
+    "- Gloss jargon, English terms, and abbreviations in the user's language on first use — e.g. API (the rules programs use to exchange requests).",
   ].join("\n");
 }
 

--- a/src/server/lib/personaTemplates.ts
+++ b/src/server/lib/personaTemplates.ts
@@ -341,7 +341,7 @@ export function applyCollectMode(rendered: string, _runtime?: string): string {
 const CORE_RULE_COMPACT = [
   "## ⭐ Core Rules",
   "",
-  "> ⏰ **Show every time to the team lead in the team lead's LOCAL timezone — the machine's, from `date +%z` — never UTC.** Logs/DB are UTC; convert by that offset's hours AND minutes before showing (e.g. +0900 Korea, +0530 India, -0500 US East).",
+  "> ⏰ **Show every time to the team lead in the team lead's LOCAL timezone — the machine's, from `date +%z` — never UTC.** Logs/DB are UTC; convert by that offset's hours AND minutes before showing (+0530 = 5h 30m).",
   "",
   "**Team**: {{TEAM}} · **Team lead**: {{OWNER}} — referred to below as 'the team' / 'the team lead'.",
   "",
@@ -352,12 +352,12 @@ const CORE_RULE_COMPACT = [
   "- **Work that owes the lead a report and will NOT finish this turn** → register `expect-report.sh --thread <work thread>` right away (nudge after 10m; `--in 30m` to widen), and `--cancel` on the same thread once reported. Nudge fires → report now, or re-register if you need more time.",
   "",
   "**Team communication·collaboration**",
-  "- In a **group room**, the owner (who answers) = `@mention > reply's original author > sticky (previous owner until it changes)`. Not the owner → don't send. Several @mentioned → **all answer**. In a **1:1 room** (the lead's DM), no owner — answer directly.",
+  "- In a **group room**, the owner = `@mention > reply's original author > sticky (previous owner until it changes)`. Not the owner → don't send. Several @mentioned → **all answer**. In a **1:1 room** (the lead's DM), no owner — answer directly.",
   "- One member consolidates ONLY if named; others send them input and may also speak in the room.",
   "- **To speak, you must send. If you do not send, you have said nothing.** What you write in your turn is your own scratchpad — it reaches no one; only an actual send does. Silence needs no marker.",
   "- **Member↔member comm = function call** (request → answer/result → done), not greetings. Ack only a NEW request/handoff; answer/result/blocker/ETA is TERMINAL — no agreement, thanks, confirmation, echo, or \"got it\".",
-  "- **Replying on the bus — the `<external_message>` envelope carries `kind` (the server's routing decision); pick the address from it:** `kind=\"teammate\"` → `--to <from>`; `kind=\"group\"` → `--to broadcast`; `kind=\"direct_to_gd\"` → `--direct-to-gd`; `kind=\"notice\"` → `--to <about>` (if there is no `about`, nobody to answer — do not send); `kind=\"slack\"` → `--to broadcast`. Always add `--thread <thread> --in-reply-to <msg> --hop <hop_count+1>` (loop prevention). Sender identity is resolved by your workspace — do not use `--from`. `system` is not a person.",
-  "- **`--direct-to-gd` is ONLY for YOUR OWN report to the team lead** — never on a delegation or question you send a teammate (delegate with `--to <member>`; if they should report to the lead, say so in the body so they add it to their own report). A report or synthesis goes to the requester (`--to <requester>`) or the team lead (`--direct-to-gd`) — **never to yourself** (a result addressed to yourself does NOT count as reported).",
+  "- **Replying on the bus — the `<external_message>` envelope carries `kind`; pick the address from it:** `kind=\"teammate\"` → `--to <from>`; `kind=\"group\"` → `--to broadcast`; `kind=\"direct_to_gd\"` → `--direct-to-gd`; `kind=\"notice\"` → `--to <about>` (if there is no `about`, nobody to answer — do not send); `kind=\"slack\"` → `--to broadcast`. Always add `--thread <thread> --in-reply-to <msg> --hop <hop_count+1>`. Sender identity is resolved by your workspace — do not use `--from`. `system` is not a person.",
+  "- **`--direct-to-gd` is ONLY for YOUR OWN report to the team lead** — never on a delegation or question you send a teammate (delegate with `--to <member>`; if they should report to the lead, say so in the body so they add it to their own report). A report or synthesis goes to the requester (`--to <requester>`) or the team lead (`--direct-to-gd`) — **never to yourself**.",
   COLLECT_BULLET_ON,
   "- **Collection vs. individual reports:** \"summarize/report back\" → gather and send ONE synthesis. \"each report to me\" → NOT a collection; add `--individual`, have each use `--direct-to-gd`, and do not synthesize. If genuinely ambiguous, ask.",
   "- No response → do not wait forever or announce retries; report partial results naming the non-responder, then add a late answer.",
@@ -671,12 +671,16 @@ function sectionTeamShare(runtime: string, agentId?: string): string {
   ].join("\n");
 }
 
+// ★여기에 시크릿 금지·승인 게이트를 다시 쓰지 마라.★ 둘 다 ⭐ Core Rules 와 TEAM-OS §4 에 있다.
+//   2026-08-05 이전엔 두 줄이 여기 중복으로 실려 있었다 —
+//     · 시크릿 금지  = 핵심룰 "Never print secrets/tokens" 과 같은 말
+//     · 승인 게이트  = "정책은 저기 있다" 만 말하는 순수 포인터 (모델에겐 실행할 내용이 0)
+//   ★같은 룰이 두 군데 있으면 한쪽만 고치고 '완료' 가 된다.★ 편집자용 주의는 룰이 아니라
+//   이 주석에 둔다 — 모델이 매 턴 읽을 필요가 없다.
 const SECTION_GLOBAL = [
   "## Global rules",
   "",
   "- Implementation milestones are in 10-minute units. Keep per-environment (dev/stage/prod) config explicitly separate.",
-  "- Never expose secret/token values (no plaintext printing of .env / credential / *.key — reference by path only).",
-  "- Approval-gated actions are defined in ⭐ Core Rules (Safety·verification) and TEAM-OS §4; do not restate or weaken that policy here.",
   "- Automate routine ops — never ask an external customer to run a terminal or a script.",
   "- For any change, report [files changed · what was verified · unverified scope · rollback].",
 ].join("\n");

--- a/src/server/lib/personaTemplates.ts
+++ b/src/server/lib/personaTemplates.ts
@@ -537,9 +537,14 @@ export function injectClaudeComms(personaText: string, tier2 = false): string {
 //   파일 본문을 쓰는 곳: `src/server/routes/settings.ts` (영입 시 1회). ★내용에 의존하는 코드는 없다★
 //   (이 이름이 나오는 곳은 쓰는 곳·이 룰·파일명만 거르는 테스트 3군데뿐).
 //
-// ★인사·톤은 SOUL.md 로★ — "친근하되 기술적으로 정확 / 자기소개 시 인사말 / 짧고 명확한 답변" 은
-//   페르소나(SOUL.md)의 「톤」에 이미 같은 말로 있었다. 여기 남은 건 ★안 겹치는 용어 풀이 하나★ 다.
-//   언어 선택 자체는 ⭐ Core Rules 의 `Language:` 줄이 정본이다.
+// ★인사말만 뺐다 — 톤은 남긴다★ (codex 리뷰 2026-08-05 반려 반영).
+//   처음엔 "SOUL.md 「톤」에 이미 있다" 며 톤까지 뺐다. ★그 근거가 틀렸다★ —
+//   ★SOUL.md 는 필수 파일이 아니다.★ persona 를 안 주면 아예 안 만들어지고(writeMemberPersona 는
+//   SOUL.md 를 건드리지 않는다), 사용자가 준 SOUL 도 임의 내용이라 톤 문구를 보장하지 않는다.
+//   실측(2026-08-05): 활성 12명 전원 SOUL.md 는 있지만 ★톤 문구가 있는 건 5명뿐★ 이다.
+//   → 톤을 여기서 빼면 나머지 7명과 향후 persona 없이 영입되는 팀원은 ★그 지시를 잃는다.★
+//   ★내 SOUL.md 하나를 보고 일반화했다★ — 창단 팀은 가장 안 대표적인 표본이다.
+//   빠진 건 인사말뿐이다. 언어 선택은 ⭐ Core Rules 의 `Language:` 줄이 정본이고 ★항상 실린다.★
 /** 페르소나의 First contact 룰이 가리키는 파일 이름 — ★두 곳이 같은 이름을 봐야 한다★. */
 export const JOIN_FLAG_FILE = ".b3os-just-joined";
 
@@ -584,7 +589,7 @@ function sectionFirstContact(_i: PersonaInput): string {
     "## First contact",
     "",
     "- If `.b3os-just-joined` exists in your working directory, read it, follow it, then `rm` it. Otherwise you have already joined — answer directly.",
-    "- Gloss jargon, English terms, and abbreviations in the user's language on first use — e.g. API (the rules programs use to exchange requests).",
+    "- Friendly but technically precise; short, clear answers. Gloss jargon, English terms, and abbreviations in the user's language on first use — e.g. API (the rules programs use to exchange requests).",
   ].join("\n");
 }
 

--- a/src/server/lib/personaTemplates.ts
+++ b/src/server/lib/personaTemplates.ts
@@ -250,7 +250,7 @@ function sectionIdentity(i: PersonaInput): string {
  */
 
 const COLLECT_BULLET_OFF_BASE =
-  "- **Collection** = gather several members' answers and report ONE synthesis. Fan out once on **ONE shared `--thread`** (reuse the request thread; if 1:1/DM has none, create one). **Never put `--direct-to-gd` on the fan-out asks** (it sends N individual reports). You gather the answers yourself; each answer wakes you — that wake is a reply to an ask you already sent, **not a new task**: **do not re-fan-out**, and **match each answer to its own request**.";
+  "- **Collection** = gather several members' answers → **ONE synthesis**. Fan out once on **ONE shared `--thread`** (reuse the request thread; create one if the 1:1/DM has none). **Never put `--direct-to-gd` on the fan-out asks** — that sends N individual reports. You gather the answers yourself; each answer wakes you as a reply to an ask you already sent, **not a new task** — do not re-fan-out, and match each answer to its own request.";
 
 /**
  * ★배송 지시 — 이게 없어서 종합이 엉뚱한 사람에게 갔다.★ (2026-07-13, Steve 가 문장 단위로 짚음)
@@ -284,7 +284,7 @@ const COLLECT_BULLET_OFF_BASE =
 //   자세한 예외·복구 절차는 b3os-team-inbox/SKILL.md. (과거 war-story·false-no-answer·침묵수단은 삭제 —
 //   침묵수단은 전 런타임 직접발신[B]으로 obsolete, 무한루프는 antiPingpong 가 6라운드에서 구조적으로 bound.)
 const REPORT_WHEN =
-  "\n- **Until everyone has answered, do not send a synthesis** (wait or say 'still waiting'). Last answer or `[마감]` → **send ONE complete synthesis** and name anyone who never answered. If an answer arrives later, add it in a short follow-up (not a re-report)." +
+  "\n- **Until everyone has answered, do not send a synthesis** (wait, or say 'still waiting'). Last answer or `[마감]` → **send ONE complete synthesis** and name anyone who never answered. If an answer arrives later, add it in a short follow-up (not a re-report)." +
   "\n- Two asks need two separate syntheses because **a collection is identified by the request, not the thread or topic**. Do not re-report a request you already reported; **a new ask is a new collection even if the topic repeats — report it**.\n";
 
 /**
@@ -359,7 +359,7 @@ const CORE_RULE_COMPACT = [
   "- **Replying on the bus — the `<external_message>` envelope carries `kind`; pick the address from it:** `kind=\"teammate\"` → `--to <from>`; `kind=\"group\"` → `--to broadcast`; `kind=\"direct_to_gd\"` → `--direct-to-gd`; `kind=\"notice\"` → `--to <about>` (if there is no `about`, nobody to answer — do not send); `kind=\"slack\"` → `--to broadcast`. Always add `--thread <thread> --in-reply-to <msg> --hop <hop_count+1>`. Sender identity is resolved by your workspace — do not use `--from`. `system` is not a person.",
   "- **`--direct-to-gd` is ONLY for YOUR OWN report to the team lead** — never on a delegation or question you send a teammate (delegate with `--to <member>`; if they should report to the lead, say so in the body so they add it to their own report). A report or synthesis goes to the requester (`--to <requester>`) or the team lead (`--direct-to-gd`) — **never to yourself**.",
   COLLECT_BULLET_ON,
-  "- **Collection vs. individual reports:** \"summarize/report back\" → gather and send ONE synthesis. \"each report to me\" → NOT a collection; add `--individual`, have each use `--direct-to-gd`, and do not synthesize. If genuinely ambiguous, ask.",
+  "- \"summarize/report back\" → ONE synthesis. \"each report to me\" → **not** a collection: add `--individual`, each uses `--direct-to-gd`, do not synthesize. Ambiguous → ask.",
   "- No response → do not wait forever or announce retries; report partial results naming the non-responder, then add a late answer.",
   "",
   "**Safety·verification**",
@@ -467,12 +467,12 @@ export const SECTION_CLAUDE_COMMS = [
   //
   //   ★1:1 DM 만 reply 인 이유★: 서버가 죽어도 팀장님께 말할 수 있어야 한다(비상구).
   //   1:1 을 서버에 묶으면 서버가 죽는 순간 보고 수단이 사라진다.
-  "- **A telegram reply to the team lead's 1:1 DM is not done until the reply tool actually sends it, and the reply tool is for that 1:1 DM ONLY — never the group room.** Text you write in your work view (transcript) does NOT reach anyone; only a `mcp__plugin_telegram_telegram__reply` call reaches the 1:1 DM. **Before ending a turn, ask \"did I send this turn's reply?\" — if not, send it now.** Even a light question or greeting goes via reply. For the group room use `send.sh --to broadcast --thread <that room's thread>`: a bot's own group post is invisible to the capture bot, so it leaves **no record at all** and the teammate who delegated to you sees \"no answer\" with no error (155 messages vanished this way). (Claude-specific drift: thinking = transcript ≠ sent. OpenClaw/Hermes auto-send their final message.)",
+  "- **A telegram reply to the team lead's 1:1 DM is not done until the reply tool actually sends it — and that tool is for the 1:1 DM ONLY, never the group room.** Transcript text reaches no one; only a `mcp__plugin_telegram_telegram__reply` call reaches the DM. Even a light question or greeting goes via reply. **Before ending a turn: did you send this turn's reply? If not, send it now.** Group room → `send.sh --to broadcast --thread <that room's thread>` — your own group post is invisible to the capture bot, so it leaves **no record** and the teammate who delegated to you sees \"no answer\", with no error.",
   // 아래 2개는 SOUL.md 개별 각인(2026-07-11 GD 수기)을 ★일반화·압축★해 플랫폼 룰로 승격(GD 2026-07-12).
   //   ①태그 접두사 = 런타임 공통(사용자 무관) ②시각 = 사용자별 타임존이라 하드코딩(KST) 대신
   //   '머신 로컬 오프셋을 읽어 변환'으로 일반화 → 어느 사용자·어느 지역이든 맞음(퍼블릭 안전).
-  "- **Never put any character before a tool-call tag.** A tool-call tag must begin at the very start of a line with `<` — never prefix it with anything (especially the word `call`). A prefixed tag makes the tool call **malformed: it silently does NOT run, so nothing is sent** — and the raw markup leaks into the chat. Write your explanation in the paragraph *above* the tag; the tag's own line takes zero prefix.",
-  "- **Timestamps you show the user must be in the user's local timezone** — see the ⏰ line in Core Rules. Read the machine offset with `date +%z` and shift by its hours AND minutes (`datetime(col, '+5 hours', '+30 minutes')` for `+0530`). Dropping the minutes is a 30–45 min error. `date +%z` is the offset *now* — for a timestamp from another DST period say so rather than assert a precise time.",
+  "- **Never put any character before a tool-call tag** — it must start at column 0 with `<` (the observed slip is prefixing the word `call`). A prefixed tag is **malformed: it silently does NOT run, nothing is sent**, and the raw markup leaks into the chat. Put your explanation in the paragraph *above* the tag.",
+  "- **Show timestamps in the user's local timezone** (⏰ in Core Rules). Read the offset with `date +%z` and shift by its hours **and** minutes — `datetime(col, '+5 hours', '+30 minutes')` for `+0530`. Dropping the minutes is a 30–45 min error. `date +%z` is the offset *now*; for a timestamp from another DST period, say so instead of asserting a precise time.",
 ].join("\n");
 
 // ══════════════════════════════════════════════════════════════════════════════════════════

--- a/src/server/lib/personaTemplates.ts
+++ b/src/server/lib/personaTemplates.ts
@@ -544,6 +544,22 @@ export function injectClaudeComms(personaText: string, tier2 = false): string {
 export const JOIN_FLAG_FILE = ".b3os-just-joined";
 
 /**
+ * ★2026-08-05 이전 합류 깃발의 본문★ — 그때는 이 파일이 `joined` 한 줄짜리 ★깃발★ 이었고
+ * 자기소개 절차는 페르소나에 있었다. 지금은 절차가 이 파일 안에 있다(`joinInstructions`).
+ * 그래서 ★이 값과 정확히 일치하는 파일 = 지시가 없는 옛 깃발★ 이고, 부팅 때 치운다(`index.ts`).
+ */
+export const LEGACY_JOIN_FLAG_BODY = "joined";
+
+/**
+ * ★지시가 없는 옛 깃발인가.★ 부팅 정리(`index.ts`)가 ★이게 true 일 때만★ 파일을 지운다.
+ * ★새 지시서에는 절대 true 가 나오면 안 된다★ — 지우면 그 팀원은 자기소개 절차를 못 받는다.
+ * (`firstContact.test.ts` 가 양쪽을 다 고정한다)
+ */
+export function isLegacyJoinFlag(body: string): boolean {
+  return body.trim() === LEGACY_JOIN_FLAG_BODY;
+}
+
+/**
  * ★합류 직후 1회 절차의 본문.★ 페르소나가 아니라 ★이 파일 안에★ 실린다.
  * 영입 시 `settings.ts` 가 워크스페이스에 써 넣고, 팀원은 읽고 따른 뒤 스스로 지운다.
  * ★페르소나에서 옮겨온 것이라 여기가 비면 신규 팀원은 자기소개 절차를 아예 못 받는다★

--- a/src/server/lib/personaTemplates.ts
+++ b/src/server/lib/personaTemplates.ts
@@ -567,7 +567,7 @@ function sectionFirstContact(_i: PersonaInput): string {
   return [
     "## First contact",
     "",
-    "- If `.b3os-just-joined` exists in your working directory, read it, follow it, then `rm` it — **if it holds no instructions, just `rm` it** (a legacy flag; you already joined). Otherwise you have already joined — answer directly.",
+    "- If `.b3os-just-joined` exists in your working directory, read it, follow it, then `rm` it. Otherwise you have already joined — answer directly.",
     "- Gloss jargon, English terms, and abbreviations in the user's language on first use — e.g. API (the rules programs use to exchange requests).",
   ].join("\n");
 }

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -8,7 +8,7 @@ import { readFileSync, writeFileSync, copyFileSync, chmodSync, existsSync, mkdir
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { writeMemberPersona, savePersonaFile } from "../lib/writeMemberPersona";
-import { memberPaths, personaTargetsForRuntime, injectCoreRule, stripCoreRule, coreRuleFor, injectClaudeComms, stripClaudeComms } from "../lib/personaTemplates";
+import { memberPaths, personaTargetsForRuntime, injectCoreRule, stripCoreRule, coreRuleFor, injectClaudeComms, stripClaudeComms, JOIN_FLAG_FILE, joinInstructions } from "../lib/personaTemplates";
 import { captureConfigStatus, setCaptureToken, setCaptureGroupId, setRouterEnabled, getCaptureToken } from "../lib/captureConfig";
 // ★설정 키 이름은 approvals.ts 정본을 쓴다★ — 문자열을 여기 다시 적으면 그 순간 갈린다.
 import { MERGE_APPROVERS_SETTING_KEY } from "../lib/approvals";
@@ -1242,8 +1242,13 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
         savePersonaFile(_paths.persona_file, persona);   // persona 값 = SOUL.md 에만
         persona_written = true;
       }
-      // ★합류 플래그: 첫 발화 자기소개+OT를 '합류 직후 1회'만 하게 하는 마커(sectionFirstContact 가 이 파일 있을 때만 소개→후 rm). 영입 때만 심음 → 재시작·재활성화는 반복 안 함. GD 2026-07-19.
-      try { writeFileSync(join(_paths.workspace_path, ".b3os-just-joined"), "joined\n"); } catch { /* best-effort */ }
+      // ★합류 플래그 = 마커이자 지시서.★ 영입 때만 심는다 → 재시작·재활성화는 반복 안 함(GD 2026-07-19).
+      //   페르소나(sectionFirstContact)는 "이 파일이 있으면 읽고 따르고 지워라" 한 줄만 싣고,
+      //   ★절차 본문은 여기 있다★ — 평생 한 번 쓰는 430자를 매 턴 페르소나로 나르지 않으려고
+      //   ★규칙이 필요한 순간에만 존재하게★ 옮겼다(GD 2026-08-05). 이 파일 내용을 읽는 코드는 없다(쓰기 전용).
+      try {
+        writeFileSync(join(_paths.workspace_path, JOIN_FLAG_FILE), joinInstructions(display_name, role));
+      } catch { /* best-effort */ }
       // claude_channel: CLAUDE.md 의 `@TEAM-OS.md`(상대) 가 풀리도록 workspace 에 심링크 생성(Steve 패턴).
       if (runtime === "claude_channel") {
         const link = join(_paths.workspace_path, "TEAM-OS.md");


### PR DESCRIPTION
> **base = `test/safety-rules-must-survive` (#272).** #272 가 머지되면 GitHub 이 base 를 main 으로 자동 조정한다. 이 PR 의 diff 는 **룰 변경분만** 보인다.

## 왜

GD: *"클로드 개발자가 모델이 좋아지면서 시스템 프롬프트를 80% 줄였다더라. 우리 룰도 절반 이하로 줄일 수 있지 않나?"*
→ 실측 후 방향이 두 번 바뀌었다. **"기계적으로 걷으면 안 되지. 장황한 서술 → 사실 위주로, AI 팀원이 인지할 수 있을 정도로 표현."**

**행동 지시는 하나도 줄이지 않았다.** 사고 서술·중복 문장·일회성 절차만 걷었다.

## 결과

| | before | after | |
|---|---|---|---|
| `CLAUDE.md` | 10,997 | **9,830** | **−1,167 (−10.6%)** |
| `AGENTS.md` (openclaw) | 11,801 | **10,977** | −824 (−7.0%) |

## 무엇을 걷었나

**① 사고 서술 — 지시가 아니라 배경**
- `(155 messages vanished this way)` — 사고 이력
- `(Claude-specific drift: … OpenClaw/Hermes auto-send their final message.)` — **다른 런타임 설명**
- 도구호출 태그 룰이 **같은 지시를 3번** 하던 것 → 1번

**② 중복 — 같은 룰이 두 곳에**
- 시크릿 금지가 `⭐ Core Rules` 와 `Global rules` **양쪽에** 있었다 → 하나로
- `Global rules` 의 승인 게이트 줄은 *"정책은 저기 있다"* 만 말하는 **알맹이 0인 포인터** → 편집자용 주의는 소스 주석으로
- 인사말(`Greet in the user's language …`) → **합류 지시서 1번으로**. 톤(`Friendly but technically precise; short, clear answers`)은 **always-load 에 남긴다** — 아래 「리뷰가 잡은 것」 참조

**③ 일회성 절차 → 필요한 순간에만 존재하게**
자기소개 절차 430자는 **평생 한 번** 쓰는데 **매 턴** 실려 있었다. 파일이 없을 때의 동작(*"그냥 답해라"*)은 원래 기본값이라 적으나 마나였다.

- 절차 본문 → `.b3os-just-joined` **파일 안으로** (그 파일은 지금까지 `joined` 7바이트짜리 깃발이었다)
- 페르소나엔 한 줄만: *"있으면 읽고, 따르고, 지워라"*
- **영입 플로우는 안 바뀐다** — 순서·API·승인 게이트 그대로, `settings.ts` 한 줄에서 파일에 쓰는 문자열만 바뀐다
- 이름·역할은 영입 입력값이 그대로 박힌다 (`joinInstructions(display_name, role)`)

**④ 옛 깃발은 룰이 아니라 코드로 치운다**
2026-08-05 이전 영입은 지시 없는 `joined` 만 갖고 있다. **한 번뿐인 전환을 룰 문장으로 나르지 않는다** — 부팅 때 서버가 치운다.

> 삭제 조건은 **본문이 옛 마커와 정확히 일치할 때** 뿐이다. 느슨하면 새 지시서 첫 줄 `You just **joined** the team` 에 걸려 **방금 영입된 팀원의 지시서가 첫 발화 전에 지워진다** — 그리고 **아무 에러도 안 난다.**

대상 실측: 활성 12명 중 `lui`·`forin` 2명. 나머지 24개는 비활성 워크스페이스.

## ★압축 상한을 정한 것은 문구 고정 가드였다★

1차 시안에서 **기존 가드 11건이 빨간불**이 떴다. 하나씩 확인한 결과:

| | 건수 | |
|---|---|---|
| **진짜 누락** | 2 | `send.sh` 접두사 · `1:1 DM` 한정어 → **되돌림** |
| **비대칭** | 1 | 두-수집 룰에서 금지문만 남기고 **허용문(`report it`)을 빠뜨림** → 되돌림 |
| **문구 핀** | 8 | 대소문자·굵게 표시까지 고정 |

비대칭 건은 테스트 주석이 정확히 그걸 경고하고 있었다 — *"이 문장은 2번 죽고 2번 살아났다"*.
**가드가 걸린 문장은 전부 과거 압축이 지웠다가 사고가 나서 복원된 것들이다.**

→ **테스트는 하나도 고치지 않았다.** 그 문구를 그대로 품은 채 주변 서술만 줄였다.
→ 이게 *"절반은 못 줄인다"* 의 실제 이유다. 남은 문장 대부분이 **이미 사고로 값을 치른 문장**이다.

## ★리뷰가 잡은 것 — 내가 두 번 틀렸다★

codex 가 **[반려] 2회**. 둘 다 같은 실수의 다른 얼굴이었다.

**① 톤을 `SOUL.md` 중복이라며 지웠다 → 근거가 틀렸다**

`SOUL.md` 는 **필수 파일이 아니다.** persona 를 안 주면 만들어지지 않고(`writeMemberPersona` 는 SOUL.md 를 건드리지 않는다), 사용자가 준 SOUL 도 임의 내용이라 그 문구를 보장하지 않는다.

실측 — `agents.json` 의 실제 `workspace_path` 로 활성 12명:

| | |
|---|---|
| SOUL.md 존재 | 12 / 12 |
| **톤 문구 존재** | **5 / 12** |

나머지 7명은 **`CLAUDE.md` 의 그 줄로만** 톤 지시를 받고 있었다. 지웠으면 그대로 잃는다.
→ **복원.** 근거로 삼은 건 **내 SOUL.md 하나**였고, 그건 팀장이 손으로 써준 가장 안 대표적인 표본이다.

**② 인사말을 `Language:` 줄로 대체했다 → 그것도 틀렸다**

> `Language:` 는 답변의 **언어·말투**를 제한할 뿐 **"인사하라" 는 발화 행동**을 지시하지 않는다. 이름·역할만 요구하면 `Bill — Infra` 로 인사 없이 충족된다. — codex

→ **합류 지시서 1번**을 `One-line greeting and intro in the user's language — …` 로. **always-load 로 되돌리지 않았다** — 인사는 첫 발화 때만 필요하다.

**정리하면 "저기 있으니 여기서 뺀다" 가 깨지는 방식이 둘이다**
- **그 '저기' 가 없을 수 있다** (`SOUL.md` — 선택 파일)
- **있어도 다른 것을 말한다** (`Language:` — 언어는 정하지만 행동은 안 시킨다)

둘 다 **그 '저기' 를 실제로 열어보지 않아서** 났다.

## 새로 추가한 그물 (`firstContact.test.ts`)

절차를 페르소나에서 뺐으므로 **파일 본문마저 비면 신규 팀원은 절차를 아예 못 받는다** — 그런데 그건 **영입해봐야 드러난다.** 그래서 옮긴 자리에 그물을 같이 뒀다.

| 검사 | 뮤턴트 | 결과 |
|---|---|---|
| 지시서 6요소(**인사**·이름·역할·OT·실제 답변·`rm`·1회성) 생존 | ③ 삭제 · **인사 제거** | 🔴 |
| 페르소나와 지시서가 **같은 파일 이름**을 봄 | `지워라` 삭제 | 🔴 |
| 옛 깃발만 지우고 **새 지시서는 안 지움** | `===` → `includes()` | 🔴 |
| **톤 지시가 렌더본 3종에 항상 있음** (SOUL.md 를 못 믿으므로) | 톤 재삭제 | 🔴 |

## 검증

- `tsc --noEmit` 통과
- 전체 수트 **2405 pass / 1 fail** — `runtimeOptions.test.ts` **기존 실패**
- 안전망 #272 **19 pass / 0 fail** (안전 4항목 생존)
- **codex [승인]** (head `ef9e07b6`) — 행동 지시 보존 · legacy flag 조건 · recruit/재영입/regenerate/swap 경로
- **steve [승인]** (렌더 동등 head) — **PINNED 16 전부 생존** · 구조 동일(불릿 32→32, 섹션 8→8) · 짧은 지시 12개 생존 · openclaw·hermes 11개 생존 · 런타임 **5종 전부** `Language:` 줄 존재 확인 · 뮤턴트로 그물 실동작 확인
- `release-preflight --mode merge` — worktree clean · non-main · 커밋 이메일 noreply ✓

## 검증 안 된 범위

- **통신 룰은 테스트가 문구만 고정한다** — 뜻이 살아있다는 판단은 **사람이 렌더본을 대조해야** 나온다. 그래서 steve 재대조가 머지 조건이다
- 옛 깃발 삭제는 **실제 재시작 전까지 라이브에서 확인 불가** — 배포 후 `[teamos-render] legacy join flag cleared:` 로그로 확인한다
- **실제 런타임 첫 발화 E2E 는 안 했다** — 신규 영입을 실제로 돌려봐야 나온다
- `runtime_cwd ≠ workspace_path` 면 지시서를 못 찾는다. **활성 사례 0명**이라 블로커가 아니고 별건 카드로 뺐다(`nztz3TGaUtww2uZCYWgQ0`)
- 브랜치 보호는 이 계정에 admin 이 없어 확인 불가

## 롤백

`git revert`. 룰은 렌더 산출물이라 되돌리면 다음 부팅에 원래 문구로 재생성된다.
