### PR TITLE
feat(mcp): 팀 리드를 신원으로 인정 — 명부 등록 없이

### DIFF
--- a/src/server/mcp/b3osMcpServer.ts
+++ b/src/server/mcp/b3osMcpServer.ts
@@ -15,6 +15,7 @@ import { inboxFor } from "../db/inboxQueries";
 import { listTasks, createTask, updateTask } from "../db/taskQueries";
 import { recallDmMessages } from "../db/dmCapture";
 import { classifyAll } from "../lib/health";
+import { leadActorId } from "../lib/opAuth"; // ★이름만 재사용★ — 신뢰 규칙(루프백=리드)은 쓰지 않는다
 
 export const MCP_NAME = "b3os-mcp";
 export const MCP_VERSION = "0.0.3-m2";
@@ -61,7 +62,16 @@ export function buildSendArgs(input: SendMessageInput, actor: string): string[] 
 function validateActor(db: Database, declared: string | undefined | null): string | null {
   const id = declared?.trim();
   if (!id) return null; // non-empty
-  if (!listAgents(db).some((a) => a.id === id)) return null; // 레지스트리 등록 agent
+  // ★팀 리드는 팀원 명부(agent 테이블)에 없지만 기록 주체로는 이미 쓰인다★ —
+  // 대시보드가 그렇게 하고 있고 audit_event 에 actor='gd' 행이 실재한다(2026-08-06 실측 42건).
+  // 리드 id 의 단일 출처는 leadActorId(DB setting → env LEAD_ACTOR_ID → 기본 'gd') 이므로 그것만 재사용한다.
+  // → 리드를 agent 로 등록하지 않는다. 등록하면 깨우기·헬스·브로드캐스트 대상이 되어 사람이 팀원처럼 다뤄진다.
+  //
+  // ※ ★재사용하는 것은 '이름' 뿐이다.★ opAuth 의 신뢰 규칙("루프백이면 리드")은 쓰지 않는다 —
+  //   그건 같은 머신 전제라, 밖에서 오는 MCP 경로에 쓰면 서버에 닿은 모든 요청이 리드가 된다.
+  //   여기 도달했다는 건 이미 Cloudflare Access JWT 서명 검증 + 주체→신원 매핑을 통과했다는 뜻이다.
+  const isLeadId = id === leadActorId(db);
+  if (!isLeadId && !listAgents(db).some((a) => a.id === id)) return null; // 리드 또는 등록 agent
   const allow = process.env.B3OS_MCP_ALLOWED_AGENTS?.trim(); // 선택 게이트: 설정 시에만 추가 제한
   if (allow && !allow.split(",").map((s) => s.trim()).includes(id)) return null;
   return id;

--- a/src/server/mcp/mcpHttpRoute.test.ts
+++ b/src/server/mcp/mcpHttpRoute.test.ts
@@ -4,7 +4,7 @@ import { test, expect } from "bun:test";
 import { Database } from "bun:sqlite";
 import { migrate } from "../db/migrate";
 import { buildMcpHttpApp } from "./mcpHttpRoute";
-import { buildMcpServer, WRITE_TOOL_NAMES, resolveActorStrict } from "./b3osMcpServer";
+import { buildMcpServer, WRITE_TOOL_NAMES, resolveActorStrict, resolveActor } from "./b3osMcpServer";
 import type { McpAuthConfig, McpAuthResult } from "./mcpAuth";
 
 function addAgent(d: Database, id: string, name: string): void {
@@ -193,4 +193,50 @@ test("★리드도 쓰기 권한은 매핑이 정한다★ — 리드라고 자�
   const readSrv = buildMcpServer(db, "gd", "read");
   const names = new Set(Object.keys((readSrv as unknown as { _registeredTools: Record<string, unknown> })._registeredTools ?? {}));
   for (const w of WRITE_TOOL_NAMES) expect(names.has(w)).toBe(false);
+});
+
+// ── stdio 경로 동작 변화 (리뷰, bill) ──
+// ★이 PR 로 stdio 도 넓어진다★: B3OS_AGENT_ID=<리드id> 가 이전엔 null 이었는데 이제 통과한다.
+// 위험은 작다 — 로컬 프로세스는 원래 등록 멤버 id 를 선언해 그 사람 행세를 할 수 있었고,
+// 리드가 된다고 추가 권한이 붙지도 않는다(권한은 scope 가, 타멤버 읽기는 별도 env 가 정한다).
+// 다만 ★"stdio 는 미등록이면 무조건 막힌다" 로 알고 설계하는 것을 막기 위해★ 동작을 시험으로 고정한다.
+
+test("★stdio 도 리드 id 는 통과한다★ — 이 PR 로 바뀐 동작(이전엔 null)", () => {
+  const db = freshDb();
+  const prev = process.env.B3OS_AGENT_ID;
+  process.env.B3OS_AGENT_ID = "gd";
+  try {
+    expect(resolveActor(db)).toBe("gd");
+  } finally {
+    if (prev === undefined) delete process.env.B3OS_AGENT_ID;
+    else process.env.B3OS_AGENT_ID = prev;
+  }
+});
+
+test("★stdio 도 리드 아닌 미등록은 여전히 막힌다★ — 넓어진 건 리드 하나뿐", () => {
+  const db = freshDb();
+  const prev = process.env.B3OS_AGENT_ID;
+  try {
+    for (const ghost of ["ghost", "gd2", "admin"]) {
+      process.env.B3OS_AGENT_ID = ghost;
+      expect(resolveActor(db)).toBeNull();
+    }
+  } finally {
+    if (prev === undefined) delete process.env.B3OS_AGENT_ID;
+    else process.env.B3OS_AGENT_ID = prev;
+  }
+});
+
+test("★리드도 추가 제한(ALLOWED_AGENTS)을 우회하지 못한다★ — 빌 실측을 회귀로 고정", () => {
+  const db = freshDb();
+  const prev = process.env.B3OS_MCP_ALLOWED_AGENTS;
+  try {
+    process.env.B3OS_MCP_ALLOWED_AGENTS = "bill";
+    expect(resolveActorStrict(db, "gd")).toBeNull(); // 리드여도 allow 목록에 없으면 거부
+    process.env.B3OS_MCP_ALLOWED_AGENTS = "bill,gd";
+    expect(resolveActorStrict(db, "gd")).toBe("gd"); // 대조군
+  } finally {
+    if (prev === undefined) delete process.env.B3OS_MCP_ALLOWED_AGENTS;
+    else process.env.B3OS_MCP_ALLOWED_AGENTS = prev;
+  }
 });

--- a/src/server/mcp/mcpHttpRoute.test.ts
+++ b/src/server/mcp/mcpHttpRoute.test.ts
@@ -159,3 +159,38 @@ test("★공개 빌드 판정 기준이 바뀌면 알아챈다★ — PUBLIC_BUI
   const src = await Bun.file(new URL("../routes/settings.ts", import.meta.url)).text();
   expect(src).toContain('export const PUBLIC_BUILD = process.env.B3OS_LIVE !== "1"');
 });
+
+// ── 팀 리드 신원 (GD 2026-08-06: "쓰기 켤때 팀장이름이 필요해") ──
+
+test("★팀 리드는 명부에 없어도 신원으로 통과한다★ — 대시보드가 이미 그렇게 쓴다", () => {
+  const db = freshDb(); // demis·bill 만 등록. gd 는 없다
+  expect(db.query("select count(*) as n from agent where id='gd'").get()).toEqual({ n: 0 });
+  expect(resolveActorStrict(db, "gd")).toBe("gd");
+});
+
+test("★그렇다고 아무 미등록 이름이나 통과하지는 않는다★ — 리드 하나만 예외", () => {
+  const db = freshDb();
+  for (const ghost of ["ghost", "gd2", "GD", "admin", "root", ""]) {
+    expect(resolveActorStrict(db, ghost)).toBeNull();
+  }
+});
+
+test("리드 id 는 leadActorId 한 곳에서 온다 — LEAD_ACTOR_ID 를 바꾸면 따라간다", () => {
+  const db = freshDb();
+  const prev = process.env.LEAD_ACTOR_ID;
+  process.env.LEAD_ACTOR_ID = "boss";
+  try {
+    expect(resolveActorStrict(db, "boss")).toBe("boss");
+    expect(resolveActorStrict(db, "gd")).toBeNull(); // 옛 이름은 더 이상 리드가 아니다
+  } finally {
+    if (prev === undefined) delete process.env.LEAD_ACTOR_ID;
+    else process.env.LEAD_ACTOR_ID = prev;
+  }
+});
+
+test("★리드도 쓰기 권한은 매핑이 정한다★ — 리드라고 자동으로 쓰기가 열리지 않는다", () => {
+  const db = freshDb();
+  const readSrv = buildMcpServer(db, "gd", "read");
+  const names = new Set(Object.keys((readSrv as unknown as { _registeredTools: Record<string, unknown> })._registeredTools ?? {}));
+  for (const w of WRITE_TOOL_NAMES) expect(names.has(w)).toBe(false);
+});


### PR DESCRIPTION
## 왜

팀 리드 지시(2026-08-06): **"쓰기 켤때 팀장이름이 필요해"**

지금은 팀원 명부(`agent` 테이블)에 있는 id 만 신원으로 통과한다. **팀 리드는 명부에 없다.** 그래서 리드가 MCP 로 쓰기를 하면 **남의 이름(예: `demis`)으로 기록된다** — 누가 한 일인지 갈린다.

## 왜 명부에 등록하지 않았나

리드를 `agent` 로 넣으면 **깨우기·헬스체크·브로드캐스트 대상**이 된다. 사람이 팀원처럼 다뤄진다.

## 어떻게

**리드 id 는 이미 시스템에 있다.** 대시보드가 `leadActorId`(DB setting → env `LEAD_ACTOR_ID` → 기본 `gd`)를 쓰고, **`audit_event` 에 `actor='gd'` 행이 42건 실재**한다(실측). 새 개념을 만들지 않고 **그 단일 출처만 재사용**한다.

```ts
const isLeadId = id === leadActorId(db);
if (!isLeadId && !listAgents(db).some((a) => a.id === id)) return null; // 리드 또는 등록 agent
```

> ⚠ **재사용하는 것은 '이름' 뿐이다.** `opAuth` 의 **신뢰 규칙**("루프백이면 리드")은 쓰지 않는다 — 같은 머신 전제라 밖에서 오는 MCP 경로에 쓰면 **서버에 닿은 모든 요청이 리드가 된다.** 여기 도달했다는 건 이미 CF Access JWT **서명 검증 + 주체→신원 매핑**을 통과했다는 뜻이다.

## 검증 (24 → **28 pass**, tsc 0)

- 리드는 명부에 없어도 통과
- **미등록 이름 6종**(`ghost`·`gd2`·`GD`·`admin`·`root`·빈값) 전부 거부 — 리드 하나만 예외
- `LEAD_ACTOR_ID` 를 바꾸면 새 이름이 통과하고 **옛 이름은 거부** — 출처가 하나임을 고정
- **리드라고 쓰기가 자동으로 열리지 않는다** — 권한은 매핑이 정한다(read 리드는 쓰기 도구 0개)

### 뮤턴트로 판정기가 실제로 재는지 확인 (양방향)

| 뮤턴트 | 결과 |
|---|---|
| 리드 예외 삭제 | 리드 통과 시험 **2건 실패** |
| 리드 검사를 무조건 `true` | 미등록 거부 시험 **2건 실패** |
| 복구 | 28 pass |

**한 방향만 재면 '다 막혔다' 와 '다 열렸다' 를 구분 못 한다.** 그래서 양쪽을 다 깨봤다.

### 전체 회귀

실패 **목록**을 stash 전/후로 대조 — **항목 동일, 이 PR 이 만든 실패 0건.** (기존 3건은 워크트리에 부팅 생성물 `rules/TEAM-OS.md` 가 없어서 나는 것)

## 라이브 영향

**없다.** 신원 판정만 넓어지고, 실제로 리드가 들어오려면 `.env` 의 `B3OS_MCP_PRINCIPALS` 매핑에 리드가 있어야 한다. **현재 매핑은 `…access:demis:read` 하나뿐**이라 이 PR 만으로는 아무것도 안 바뀐다.

## 봐주셨으면 하는 곳

1. `leadActorId` 를 **이름 용도로만** 쓴 것이 맞는지 (신뢰 규칙 유입 없는지)
2. 리드 예외가 **stdio 경로**에도 적용되는데 그게 문제 없는지 (`validateActor` 공유)
3. 미등록 거부가 정말 빈틈없는지 — 대소문자·공백·빈값