### PR TITLE
fix(mcp): 발신이 주 스레드를 붙들지 않게 — 동기 spawn 제거

### DIFF
--- a/src/server/mcp/b3osMcpServer.ts
+++ b/src/server/mcp/b3osMcpServer.ts
@@ -281,10 +281,22 @@ export function buildMcpServer(db: Database, actor: string | null, scope: McpSco
           structuredContent: { dryRun: true, argv, direct_to_gd: input.direct_to_gd === true },
         };
       }
-      const proc = Bun.spawnSync(["bash", sendShPath(), ...argv]);
-      const stdout = proc.stdout ? new TextDecoder().decode(proc.stdout).trim() : "";
-      const stderr = proc.stderr ? new TextDecoder().decode(proc.stderr).trim() : "";
-      const ok = proc.exitCode === 0;
+      // ★동기 spawn 금지★ (팀 리드 원칙 2026-08-05: "외부확장 요청이 본 쓰레드를 멈추면 안 되지").
+      // b3os 서버는 프로세스 1개·주 스레드 1개다. spawnSync 는 자식이 끝날 때까지 그 스레드를 붙들어
+      // ★그동안 대시보드를 포함한 모든 요청이 멈춘다.★ stdio 시절엔 별도 프로세스라 자기만 멈췄는데,
+      // HTTP 창구가 같은 프로세스에 들어온 뒤로는 남을 멈춘다.
+      // 실측(2026-08-06): send.sh 는 인자 오류로 즉시 끝나는 경로에서도 25~32ms — 네트워크 호출 전이다.
+      // 실제 발신은 HTTP POST 가 붙어 더 길다. 대시보드 평소 응답이 0.6~1.2ms 이므로 한 번 보낼 때마다
+      // 그 수십 배를 서버 전체가 멈추고 있었다.
+      // → await 로 바꾼다. ★기다리는 것 자체는 무해하다★ — 기다리는 동안 다른 요청이 처리된다.
+      //   문제는 붙들고 안 놓는 것이었다. (둘은 비슷해 보이지만 다르다.)
+      const proc = Bun.spawn(["bash", sendShPath(), ...argv], { stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text().then((t) => t.trim()),
+        new Response(proc.stderr).text().then((t) => t.trim()),
+        proc.exited,
+      ]);
+      const ok = exitCode === 0;
       // minor(추적성): send.sh 출력에서 message_id·thread 파싱해 audit detail에 실어 direct_to_gd 릴레이 추적.
       const sentId = stdout.match(/sent\s+(\S+)/)?.[1] ?? null;
       const threadId = stdout.match(/thread=(\S+)/)?.[1] ?? input.thread ?? null;

--- a/src/server/mcp/mcpNonBlocking.test.ts
+++ b/src/server/mcp/mcpNonBlocking.test.ts
@@ -1,0 +1,57 @@
+// ★본체를 멈추지 않는다★ 를 지키는 시험 (팀 리드 원칙 2026-08-05).
+//
+// 숫자(부하 측정)만으로는 안 보인다 — 부하가 가벼우면 동기 호출도 묻힌다(빌 지적).
+// 그래서 ①구조로 ②동작으로 두 겹으로 잰다.
+import { test, expect } from "bun:test";
+
+// ── ① 구조: MCP 경로에 동기 호출이 남아 있으면 잡는다 ──
+// 다시 들어오면 이 시험이 깨진다. 숫자는 안 드러나도 이건 드러난다.
+
+const MCP_FILES = ["b3osMcpServer.ts", "mcpHttpRoute.ts", "mcpAuth.ts"];
+// ★자식 프로세스 계열만 금지한다★ (리뷰, bill).
+// 본질은 "동기" 가 아니라 ★끝을 모르는 일을 주 스레드에서 하는 것★ 이다.
+// readFileSync 같은 건 작은 로컬 파일이면 마이크로초다 — 설정 한 줄 읽는 것까지 막으면 정당한 코드가 걸린다.
+// ★오탐이 미탐보다 위험하다★: 정당한 변경을 막는 가드는 결국 사람이 지우고, 그때 spawnSync 금지까지 같이 사라진다.
+const BLOCKING = ["spawnSync", "execSync", "execFileSync"];
+
+test("★MCP 경로에 주 스레드를 붙드는 호출이 없다★ — 하나라도 들어오면 깨진다", async () => {
+  const found: string[] = [];
+  for (const f of MCP_FILES) {
+    const src = await Bun.file(new URL(`./${f}`, import.meta.url)).text();
+    for (const line of src.split("\n")) {
+      if (line.trimStart().startsWith("//") || line.trimStart().startsWith("*")) continue; // 주석은 뺀다
+      for (const b of BLOCKING) if (line.includes(`${b}(`)) found.push(`${f}: ${b}`);
+    }
+  }
+  expect(found).toEqual([]);
+});
+
+test("★대조군★ — 이 검사가 실제로 잡는다(일부러 만든 문자열을 센다)", () => {
+  const fake = ["const x = Bun.spawnSync(['true']);", "  // spawnSync( 는 주석이라 안 세야 한다"];
+  const hits = fake.filter((l) => !l.trimStart().startsWith("//") && l.includes("spawnSync("));
+  expect(hits.length).toBe(1); // 코드 1건만, 주석은 제외
+});
+
+// ── ② 동작: 자식 프로세스를 기다리는 동안 이벤트 루프가 살아 있나 ──
+// ★차이가 큰 입력으로 재야 보인다★ — 25ms 로는 노이즈에 묻힌다. 그래서 넉넉히 잡는다.
+
+const SLEEP_MS = 600;
+
+test("★비동기 spawn 은 기다리는 동안 다른 일이 돈다★", async () => {
+  let ticks = 0;
+  const timer = setInterval(() => ticks++, 50); // 기다리는 동안 계속 돌아야 한다
+  const proc = Bun.spawn(["bash", "-c", `sleep ${SLEEP_MS / 1000}`], { stdout: "pipe", stderr: "pipe" });
+  await proc.exited;
+  clearInterval(timer);
+  // 600ms 를 50ms 간격으로 → 이론상 ~11회. 여유 있게 5회만 넘으면 '루프가 살아 있었다' 로 본다.
+  expect(ticks).toBeGreaterThan(5);
+});
+
+test("★대조군 — 동기 spawn 은 그 사이 아무것도 못 돈다★ (이 시험이 진짜 재는지 증명)", () => {
+  let ticks = 0;
+  const timer = setInterval(() => ticks++, 50);
+  Bun.spawnSync(["bash", "-c", `sleep ${SLEEP_MS / 1000}`]); // 일부러 동기
+  clearInterval(timer);
+  // 붙들려 있었으므로 타이머가 거의 못 돈다. 비동기(>5)와 명확히 갈린다.
+  expect(ticks).toBeLessThan(3);
+});

--- a/src/server/mcp/mcpNonBlocking.test.ts
+++ b/src/server/mcp/mcpNonBlocking.test.ts
@@ -7,7 +7,14 @@ import { test, expect } from "bun:test";
 // ── ① 구조: MCP 경로에 동기 호출이 남아 있으면 잡는다 ──
 // 다시 들어오면 이 시험이 깨진다. 숫자는 안 드러나도 이건 드러난다.
 
-const MCP_FILES = ["b3osMcpServer.ts", "mcpHttpRoute.ts", "mcpAuth.ts"];
+// ★목록을 손으로 들지 않는다★ (리뷰 P1, bill) — 폴더를 읽는다.
+// 손으로 들면 새 MCP 파일이 검사에서 빠지고, ★빠진 순간엔 아무 소리도 안 난다.★
+// (#274 의 WRITE_TOOLS 와 같은 계열의 실수를 반복했다. 목록은 언젠가 갈라진다.)
+async function mcpSourceFiles(): Promise<string[]> {
+  const dir = new URL("./", import.meta.url).pathname;
+  const names = [...new Bun.Glob("*.ts").scanSync(dir)];
+  return names.filter((n) => !n.endsWith(".test.ts"));
+}
 // ★자식 프로세스 계열만 금지한다★ (리뷰, bill).
 // 본질은 "동기" 가 아니라 ★끝을 모르는 일을 주 스레드에서 하는 것★ 이다.
 // readFileSync 같은 건 작은 로컬 파일이면 마이크로초다 — 설정 한 줄 읽는 것까지 막으면 정당한 코드가 걸린다.
@@ -15,8 +22,10 @@ const MCP_FILES = ["b3osMcpServer.ts", "mcpHttpRoute.ts", "mcpAuth.ts"];
 const BLOCKING = ["spawnSync", "execSync", "execFileSync"];
 
 test("★MCP 경로에 주 스레드를 붙드는 호출이 없다★ — 하나라도 들어오면 깨진다", async () => {
+  const files = await mcpSourceFiles();
+  expect(files.length).toBeGreaterThan(2); // 폴더를 못 읽어 빈 목록이면 '통과' 가 거짓이 된다
   const found: string[] = [];
-  for (const f of MCP_FILES) {
+  for (const f of files) {
     const src = await Bun.file(new URL(`./${f}`, import.meta.url)).text();
     for (const line of src.split("\n")) {
       if (line.trimStart().startsWith("//") || line.trimStart().startsWith("*")) continue; // 주석은 뺀다


### PR DESCRIPTION
## 왜

팀 리드 원칙(2026-08-05): **"외부확장 요청이 본 쓰레드를 멈추면 안 되지"**

b3os 서버는 **프로세스 1개·주 스레드 1개**다. `send_message` 가 `Bun.spawnSync` 로 `send.sh` 를 부르는데, 자식이 끝날 때까지 그 스레드를 붙들어 **그동안 대시보드를 포함한 모든 요청이 멈춘다.**

stdio 시절엔 별도 프로세스라 자기만 멈췄다. **HTTP 창구가 같은 프로세스에 들어온 뒤로는 남을 멈춘다.**

## 실측부터 (짐작으로 고치지 않으려고)

| | 값 |
|---|---|
| `send.sh` — **인자 오류로 즉시 끝나는 경로** | **25~32ms** (네트워크 호출 **전**) |
| 실제 발신 | 여기에 HTTP POST 가 붙어 더 김 |
| 대시보드 평소 응답 | 0.6~1.2ms |

**한 번 보낼 때마다 평소 응답의 수십 배를 서버 전체가 멈추고 있었다.** "원래 느린 호출" 로 넘길 수 없는 이유가 이 숫자다.

## 고친 것

`Bun.spawnSync` → `Bun.spawn` + `await`(`Promise.all` 로 stdout·stderr·exit 동시 수집). 핸들러가 이미 `async` 라 구조 변경 없음.

> **기다리는 것 자체는 무해하다** — 기다리는 동안 다른 요청이 처리된다. 문제는 **붙들고 안 놓는 것**이었다. 둘은 비슷해 보이지만 다르다.

## ★고쳤다는 걸 어떻게 재나★ — 숫자만으론 안 보여서 두 겹

리뷰 질문(bill): *"비동기로 바꿨는데 여전히 붙드는 경로가 남아 있으면 숫자로만 봐선 안 보인다"*

**(가) 구조** — MCP 경로에 자식 프로세스 동기 호출(`spawnSync`·`execSync`·`execFileSync`)이 0인지 검사. 다시 들어오면 깨진다. 부하가 가벼우면 숫자엔 안 드러나지만 **이건 드러난다.**

> ⚠ `readFileSync` 는 **일부러 뺐다**(리뷰 반영). 본질은 '동기' 가 아니라 **끝을 모르는 일**이다. 작은 파일 읽기까지 막으면 정당한 코드가 걸리고, **오탐이 미탐보다 위험하다** — 가드가 지워지면 `spawnSync` 금지도 같이 사라진다.

**(나) 동작** — 자식을 기다리는 동안 **이벤트 루프가 사는지**. `sleep 600ms` 로 잰다. **차이가 큰 입력이어야 보인다**(25ms 는 노이즈에 묻힌다). **대조군으로 `spawnSync` 버전도 같이 재서** 비동기(타이머 >5회) / 동기(<3회) 가 갈리는 것을 증명한다.

**(다) 실제 부하** — 쓰기 경로 동시 요청 중 대시보드 응답. **이건 재시작 후에 잰다**(지금 숫자는 인증 거부 경로 기준이라 재사용하면 안 됨).

## 검증

- 신규 4건 포함 **35 pass**, tsc 0
- **가드를 뮤턴트로 확인** — `spawnSync` 를 한 줄 되돌리니 **구조 시험만 정확히 실패**(3 pass/1 fail), 복구 시 통과. *통과만 보면 '검사 범위가 비어서 통과' 를 못 거른다*(리뷰 지적)
- 전체 회귀: 실패 **목록**을 stash 전후 대조 — **항목 동일**

> **덤으로 발견**: 한 번 `rotateToken` 시험이 추가로 실패했는데 **단독 3회·전체 2회 재실행에서 재발 안 함** = 불안정 테스트. 내 변경과 무관하지만 **그런 시험이 있다는 사실은 남긴다** — 건수만 보면 다음에 누가 자기 변경 탓으로 오해한다.

## 라이브 영향

**없다.** 쓰기 도구는 현재 매핑(`demis:read`)에서 노출되지 않는다. 이 PR 은 **쓰기를 켜기 위한 선행 조건**이다.