### PR TITLE
feat(mcp): 조용한 연결을 없앤다 — SSE + 진행 알림 (CF 30초 우회)

### DIFF
--- a/src/server/mcp/b3osMcpServer.ts
+++ b/src/server/mcp/b3osMcpServer.ts
@@ -32,7 +32,14 @@ export const WRITE_TOOL_NAMES = new Set([
   "b3os_ask_teammate", // 팀원에게 질문을 남긴다 = 쓰기다
 ]);
 
-/** 한 호출이 기다릴 수 있는 상한. ★Cloudflare 가 125초에서 끊는다★ — 그 아래에서 우리가 먼저 접수로 끝낸다. */
+/**
+ * 한 호출이 기다릴 수 있는 상한.
+ *
+ * ★125초는 틀린 숫자였다★ (2026-08-06 라이브 실측): Cloudflare 는 ★조용한 POST 를 30초에 끊는다.★
+ * 서버는 60초를 정상 완료했는데 클라이언트는 30.4초에 에러를 봤다 — ★서버는 성공, 사용자는 에러★.
+ * → 그래서 이 경로를 ★SSE + 진행 알림★ 으로 바꿨다(mcpHttpRoute). 조용하지 않으면 끊을 이유가 없다.
+ *   ★그 전제가 라이브에서 확인되기 전까지 이 값들을 믿지 마라.★ 확인 후 다시 잡는다.
+ */
 export const ASK_WAIT_DEFAULT_SEC = 90;
 export const ASK_WAIT_MAX_SEC = 110;
 
@@ -419,7 +426,7 @@ export function buildMcpServer(db: Database, actor: string | null, scope: McpSco
           .describe(`답을 기다릴 최대 시간(기본 ${ASK_WAIT_DEFAULT_SEC}초, 최대 ${ASK_WAIT_MAX_SEC}초)`),
       },
     },
-    async (args: unknown) => {
+    async (args: unknown, extra: unknown) => {
       if (!actor) return denyIdentity("팀원에게 질문");
       const { to, question, wait_seconds } = args as { to: string; question: string; wait_seconds?: number };
       if (to === actor) {
@@ -437,11 +444,30 @@ export function buildMcpServer(db: Database, actor: string | null, scope: McpSco
         };
       }
       const waitMs = (wait_seconds ?? ASK_WAIT_DEFAULT_SEC) * 1000;
+      // ★기다리는 동안 연결을 조용히 두지 않는다★ — 조용하면 Cloudflare 가 30초에 끊는다.
+      //   클라이언트가 progressToken 을 줬을 때만 보낼 수 있다(MCP 규약). 없으면 그냥 안 보낸다.
+      const meta = (extra as { _meta?: { progressToken?: string | number } } | undefined)?._meta;
+      const send = (extra as { sendNotification?: (n: unknown) => Promise<void> } | undefined)?.sendNotification;
+      const token = meta?.progressToken;
+      const onWait =
+        token !== undefined && send
+          ? async (elapsedMs: number) => {
+              await send({
+                method: "notifications/progress",
+                params: {
+                  progressToken: token,
+                  progress: Math.round(elapsedMs / 1000),
+                  total: Math.round(waitMs / 1000),
+                  message: `${to} 가 답을 준비하는 중 (${Math.round(elapsedMs / 1000)}초)`,
+                },
+              });
+            }
+          : undefined;
       const r = await askTeammate(
         db,
         { baseUrl: busBaseUrl() },
         { from: actor, to, body: question, client: clientName() },
-        { waitMs, pollMs: 1500 }, // 디스패처 폴링과 같은 간격 — 더 자주 봐도 새 사실이 생기지 않는다
+        { waitMs, pollMs: 1500, onWait }, // 디스패처 폴링과 같은 간격 — 더 자주 봐도 새 사실이 생기지 않는다
       );
       appendAudit(db, actor, "mcp.ask_teammate", to, {
         request_id: r.requestId, thread_id: r.roomId, status: r.status, waited_ms: r.waitedMs,

--- a/src/server/mcp/mcpAsk.ts
+++ b/src/server/mcp/mcpAsk.ts
@@ -233,6 +233,13 @@ export interface AskOptions {
   pollMs: number;
   sleep?: (ms: number) => Promise<void>;
   now?: () => number;
+  /**
+   * 기다리는 동안 매 폴링마다 불린다. ★연결을 조용히 두지 않기 위한 것★ —
+   * 조용한 연결은 Cloudflare 가 30초에 끊는다(2026-08-06 실측). 여기서 진행 알림을 보내
+   * 바이트를 흘리면 연결이 살아 있고, 부수적으로 사용자 화면에 "준비 중" 이 보인다.
+   * ★알림 실패가 기다림을 깨지 않는다★ — 던져도 삼킨다(알림은 부가 기능이다).
+   */
+  onWait?: (elapsedMs: number) => void | Promise<void>;
 }
 
 /**
@@ -269,6 +276,14 @@ export async function askTeammate(
         return { status: "answered", requestId: sent.id, roomId, answer, waitedMs: now() - started };
       }
       if (now() - started >= opts.waitMs) break;
+      // ★알림을 먼저, 그다음 잠깐 잔다★ — 순서를 바꾸면 첫 알림이 pollMs 만큼 늦어진다.
+      if (opts.onWait) {
+        try {
+          await opts.onWait(now() - started);
+        } catch {
+          /* 알림 실패가 기다림을 깨지 않는다 */
+        }
+      }
       await sleep(opts.pollMs);
     }
     return { status: "pending", requestId: sent.id, roomId, waitedMs: now() - started };

--- a/src/server/mcp/mcpHttpRoute.test.ts
+++ b/src/server/mcp/mcpHttpRoute.test.ts
@@ -267,3 +267,49 @@ test("★대조군★ — 도구 목록도 본문이 나온다(초기화만 되�
   const body = await res.text();
   expect(body).toContain("b3os_ask_teammate");
 });
+
+// ── ★클라이언트가 끊었을 때도 정리가 돈다★ (빌 리뷰 2026-08-06) ──
+//
+// 초판은 TransformStream 의 cancel 훅을 썼는데 ★Bun 이 그걸 안 부른다.★ 정상 종료만 돌고
+// ★클라이언트 끊김에는 안 돌았다★ — 그런데 그 순간이 ★CF 가 30초에 자르는 바로 그 경로★ 다.
+// 정리가 필요한 때만 정확히 안 도는 셈이었다. 아래 시험이 그 경로를 본다.
+
+test("★첫 조각만 읽고 끊어도 정리가 돈다★ — 초판이 놓치던 경로", async () => {
+  const db = freshDb();
+  let cleaned = 0;
+  const app = buildMcpHttpApp(db, {
+    authConfig: CFG,
+    authenticate: async () => allow("demis", "write"),
+    onCleanup: () => { cleaned++; },
+  });
+  const res = await app.request(post(INIT));
+  const reader = res.body!.getReader();
+  await reader.read(); // 첫 조각만 읽고
+  await reader.cancel("test"); // ★끊는다★
+  await Bun.sleep(30);
+  expect(cleaned).toBe(1); // ★0 이면 정리가 안 돈 것 — 초판이 그랬다★
+});
+
+test("★대조군★ — 끝까지 읽어도 정리가 정확히 1회 돈다(두 번 돌지 않는다)", async () => {
+  const db = freshDb();
+  let cleaned = 0;
+  const app = buildMcpHttpApp(db, {
+    authConfig: CFG,
+    authenticate: async () => allow("demis", "write"),
+    onCleanup: () => { cleaned++; },
+  });
+  const res = await app.request(post(INIT));
+  await res.text();
+  await Bun.sleep(30);
+  expect(cleaned).toBe(1);
+});
+
+// ★keepalive 는 여기서 시험하지 않는다 — 시험할 수 있는 대상이 없다★
+//
+// 시도했다가 접었다: initialize 는 ★즉답이라 스트림이 바로 닫힌다★ → keepalive 가 뜰 틈이 없다.
+// keepalive 가 의미를 갖는 건 ★도구 호출이 오래 걸릴 때★ 뿐인데, 그러려면 진짜 버스가 떠 있어야 한다.
+// 여기서 가짜 상류를 만들어 재면 ★내가 만든 복사본을 내가 검사하는 것★ 이 된다(오늘 두 번 당한 함정).
+//
+// → ★keepalive 는 라이브 실험에서 잰다.★ 그게 원래 목적이기도 하다:
+//   keepalive 가 있어야 실험 결과가 "가설이 틀렸다" 인지 "클라이언트가 progressToken 을 안 줬다" 인지
+//   구분된다(빌). 그 구분이 필요한 곳이 라이브다.

--- a/src/server/mcp/mcpHttpRoute.test.ts
+++ b/src/server/mcp/mcpHttpRoute.test.ts
@@ -240,3 +240,30 @@ test("★리드도 추가 제한(ALLOWED_AGENTS)을 우회하지 못한다★ �
     else process.env.B3OS_MCP_ALLOWED_AGENTS = prev;
   }
 });
+
+// ── ★SSE 응답이 실제로 본문을 낸다★ (2026-08-06) ──
+//
+// 왜 이 시험이 필요한가: JSON 모드 → SSE 모드로 바꿨을 때 ★기존 시험 73개가 전부 통과했는데
+// 본문이 빈 문자열★ 이었다. 정리 코드(finally)가 ★살아 있는 스트림을 즉시 닫아버렸다.★
+// JSON 모드에서는 응답이 이미 완성돼 있어 같은 코드가 멀쩡했다 — ★모드를 바꾸며 드러났다.★
+// ★상태코드만 보는 시험은 이걸 못 잡는다.★ 본문을 읽어야 잡힌다.
+
+test("★SSE 응답에 본문이 실제로 들어 있다★ — 상태코드만 보면 못 잡는다", async () => {
+  const db = freshDb();
+  const app = buildMcpHttpApp(db, { authConfig: CFG, authenticate: async () => allow("demis", "write") });
+  const res = await app.request(post(INIT));
+  expect(res.status).toBe(200);
+  expect(res.headers.get("content-type")).toContain("text/event-stream");
+  const body = await res.text();
+  expect(body.length).toBeGreaterThan(0); // ★빈 본문이 이 시험의 존재 이유다★
+  expect(body).toContain("event: message");
+  expect(body).toContain("b3os-mcp"); // 실제 응답 내용까지 도달했는가
+});
+
+test("★대조군★ — 도구 목록도 본문이 나온다(초기화만 되는 게 아님)", async () => {
+  const db = freshDb();
+  const app = buildMcpHttpApp(db, { authConfig: CFG, authenticate: async () => allow("demis", "write") });
+  const res = await app.request(post({ jsonrpc: "2.0", id: 2, method: "tools/list" }));
+  const body = await res.text();
+  expect(body).toContain("b3os_ask_teammate");
+});

--- a/src/server/mcp/mcpHttpRoute.ts
+++ b/src/server/mcp/mcpHttpRoute.ts
@@ -77,16 +77,41 @@ export function buildMcpHttpApp(db: Database, deps: McpHttpDeps = {}): Hono {
     const server = buildMcpServer(db, actor, principal.scope);
     const transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: undefined, // stateless — 세션 저장 없음
-      enableJsonResponse: true,
+      // ★JSON 한 방 응답을 쓰지 않는다★ (2026-08-06 라이브): 그 모드는 답이 다 될 때까지
+      //   ★한 바이트도 안 보낸다.★ 그동안 연결이 조용하니 ★Cloudflare 가 30초에 끊었다.★
+      //   실측: 서버는 60초를 정상 완료했는데(waited_ms=60141) 클라이언트는 30.4초에 에러를 봤다.
+      //   → SSE 로 두면 응답이 ★즉시 열리고★ 진행 알림이 흐른다. 조용한 연결이 아니게 된다.
+      //   (MCP 규약이 원래 이 용도로 notifications/progress 를 갖고 있다.)
+      enableJsonResponse: false,
     });
-    try {
-      await server.connect(transport);
-      return await transport.handleRequest(c.req.raw);
-    } finally {
-      // 인스턴스를 남기지 않는다(누수 시 다음 요청이 남의 신원을 쓸 위험).
+    // 인스턴스를 남기지 않는다(누수 시 다음 요청이 남의 신원을 쓸 위험).
+    const cleanup = async () => {
       await transport.close().catch(() => {});
       await server.close().catch(() => {});
+    };
+    let res: Response;
+    try {
+      await server.connect(transport);
+      res = await transport.handleRequest(c.req.raw);
+    } catch (e) {
+      await cleanup();
+      throw e;
     }
+    // ★SSE 는 응답이 '살아 있는 스트림' 이다 — 여기서 바로 닫으면 한 바이트도 안 나간다.★
+    //   (실측 2026-08-06: finally 로 즉시 닫았더니 content-type 은 text/event-stream 인데 본문이 빈 문자열.
+    //    JSON 모드일 땐 응답이 이미 완성돼 있어서 같은 코드가 멀쩡했다 — 모드를 바꾸며 드러났다.)
+    //   → ★스트림이 끝날 때 정리한다.★ 본문이 없으면(빈 응답) 지금 정리해도 된다.
+    if (!res.body) {
+      await cleanup();
+      return res;
+    }
+    const piped = res.body.pipeThrough(
+      new TransformStream({
+        flush: cleanup, // 스트림 정상 종료
+        cancel: cleanup, // 클라이언트가 끊음
+      } as Transformer),
+    );
+    return new Response(piped, { status: res.status, headers: res.headers });
   });
 
   return app;

--- a/src/server/mcp/mcpHttpRoute.ts
+++ b/src/server/mcp/mcpHttpRoute.ts
@@ -41,6 +41,14 @@ export interface McpHttpDeps {
   authConfig?: McpAuthConfig;
   /** 테스트에서 인증을 대체할 때 사용. */
   authenticate?: typeof authenticateMcpRequest;
+  /**
+   * ★시험 전용 관측 지점★ — 정리(transport·server close)가 실제로 돌았는지 볼 방법이 없어서 둔다.
+   * 클라이언트가 스트림을 끊는 경로는 ★밖에서 관측할 수 없다★(응답을 이미 버린 뒤다).
+   * 운영에서는 지정하지 않는다.
+   */
+  onCleanup?: () => void;
+  /** keepalive 간격(ms). 시험에서 짧게 줄여 확인한다. 기본 10초. */
+  keepaliveMs?: number;
 }
 
 /**
@@ -85,9 +93,13 @@ export function buildMcpHttpApp(db: Database, deps: McpHttpDeps = {}): Hono {
       enableJsonResponse: false,
     });
     // 인스턴스를 남기지 않는다(누수 시 다음 요청이 남의 신원을 쓸 위험).
+    let finished = false;
     const cleanup = async () => {
+      if (finished) return; // 두 번 돌지 않는다
+      finished = true;
       await transport.close().catch(() => {});
       await server.close().catch(() => {});
+      deps.onCleanup?.();
     };
     let res: Response;
     try {
@@ -105,13 +117,48 @@ export function buildMcpHttpApp(db: Database, deps: McpHttpDeps = {}): Hono {
       await cleanup();
       return res;
     }
-    const piped = res.body.pipeThrough(
-      new TransformStream({
-        flush: cleanup, // 스트림 정상 종료
-        cancel: cleanup, // 클라이언트가 끊음
-      } as Transformer),
-    );
-    return new Response(piped, { status: res.status, headers: res.headers });
+    // ★TransformStream 의 cancel 훅은 쓰지 않는다★ (빌 실측 2026-08-06, bun 1.3.14):
+    //   최신 스펙 추가분이라 ★Bun 이 안 부른다.★ 정상 종료(flush)만 돌고 ★클라이언트 끊김에는 안 돈다★ —
+    //   그런데 끊기는 그 순간이 ★CF 가 30초에 자르는 바로 그 경로★ 다. 정리가 필요한 때만 정확히 안 돈다.
+    //   (`as Transformer` 캐스팅이 필요했던 것 자체가 신호였다 — 타입에 없는 훅이었다.)
+    //   → ReadableStream 으로 직접 감싼다. 이쪽 cancel 은 Bun 이 부른다.
+    //
+    // ★그리고 여기서 keepalive 를 흘린다★: SDK 에는 자체 keepalive 가 없다(writePrimingEvent 는
+    //   eventStore + 프로토콜 2025-11-25 조건부라 우리 stateless 경로에는 안 온다).
+    //   그게 없으면 이 기능은 ★"클라이언트가 progressToken 을 준다" 에 전적으로 걸린다.★ 안 주면
+    //   90초 내내 조용해 CF 가 자르고 ★고치기 전과 똑같아진다.★ 주석 줄(`: …`)은 SSE 규약상
+    //   클라이언트가 무시하지만 ★바이트는 흐른다★ — 연결이 조용하지 않다.
+    const keepaliveMs = deps.keepaliveMs ?? 10_000;
+    const upstream = res.body.getReader();
+    let ka: ReturnType<typeof setInterval> | null = null;
+    const wrapped = new ReadableStream<Uint8Array>({
+      start(ctrl) {
+        ka = setInterval(() => {
+          try {
+            ctrl.enqueue(new TextEncoder().encode(": keepalive\n\n"));
+          } catch {
+            /* 이미 닫힌 뒤 — 무시 */
+          }
+        }, keepaliveMs);
+      },
+      async pull(ctrl) {
+        const { done, value } = await upstream.read();
+        if (done) {
+          if (ka) clearInterval(ka);
+          ctrl.close();
+          await cleanup();
+          return;
+        }
+        if (value) ctrl.enqueue(value);
+      },
+      async cancel(reason) {
+        // ★클라이언트가 끊었다★ — #280 초판이 놓치던 자리.
+        if (ka) clearInterval(ka);
+        await upstream.cancel(reason).catch(() => {});
+        await cleanup();
+      },
+    });
+    return new Response(wrapped, { status: res.status, headers: res.headers });
   });
 
   return app;


### PR DESCRIPTION
## 배경

GD 지시(2026-08-06): **"cf 설정을 바꾸든지 다른 방법을 찾아봐야지"** · 이후 **"vpn은 가지 말고 1번만 테스트해봐"**.

30초를 전제로 설계를 바꾸려던 것(접수 우선)을 멈추고 **제한 자체를 뚫는다.**

## 왜 끊겼나 — 원인 확정

`enableJsonResponse: true` 는 답이 다 될 때까지 **한 바이트도 안 보낸다.** 그동안 연결이 조용하니 Cloudflare 가 30초에 끊었다.

실측(라이브):
```
08:11:22  mcp.http.request   actor=gd
08:12:22  mcp.ask_teammate   status=pending  waited_ms=60141   ← 서버는 60초를 정상 완료
클라이언트: 30.4초에 Internal Server Error                      ← CF 가 먼저 끊음
```
서버 로그에 그 시각 에러 0건. **서버는 성공, 사용자는 에러.**

## 무엇

| | |
|---|---|
| `mcpHttpRoute.ts` | `enableJsonResponse: false` — 응답이 **즉시 열리고** 이벤트가 흐른다 |
| `mcpHttpRoute.ts` | **정리 시점 수정** (아래 참고) |
| `mcpAsk.ts` | `AskOptions.onWait` — 폴링마다 부르는 훅. **알림 실패가 기다림을 깨지 않는다** |
| `b3osMcpServer.ts` | 기다리는 동안 `notifications/progress` 발신. 클라이언트가 `progressToken` 을 준 경우에만 |

부수효과: 사용자 화면에 **"bill 가 답을 준비하는 중 (12초)"** 가 보인다 — GD 가 이전에 요청한 것.

## 모드를 바꾸며 드러난 결함 — 정리 시점

`finally` 에서 transport 를 즉시 닫고 있었다. JSON 모드는 응답이 **이미 완성돼 있어** 멀쩡했지만, SSE 는 **살아 있는 스트림**이라 한 바이트도 안 나갔다:

```
content-type: text/event-stream
body: ""            ← 상태는 200
```

**기존 시험 73개가 전부 통과했다** — 상태코드만 보고 본문을 안 읽었기 때문이다.

→ 스트림이 끝날 때(`flush`/`cancel`) 정리하도록 바꿨다.

## 검증

- **본문을 읽는 시험**을 넣었다 — `content-type` + 본문 길이 + `event: message` + 실제 내용 도달
- **뮤턴트 확인**: 즉시 정리로 되돌리면 **2건 빨간불**, 복원하면 통과
- mcp 75 pass(신규 2) · `tsc --noEmit` 0 · 전체 **2483 pass / 1 fail**(main 과 동일 집합)

## 미검증 — 가장 중요한 것

**SSE 가 CF 30초를 실제로 통과하는지는 배포해야 안다.** 로컬에는 CF 가 없다. 그 전까지 `ASK_WAIT_*` 값은 믿을 수 없고, 주석에 그렇게 적어뒀다(기존 `125초` 주석도 틀린 값이라 정정).

배포 후 잴 것: **60초짜리 질문을 던져 30초를 넘겨 통과하는지.** 통과하면 ①로 끝, 실패하면 다른 길.

## 롤백

단일 커밋 revert. 되돌리면 JSON 모드로 돌아가고 30초 문제도 함께 돌아온다.