### PR TITLE
docs(report): define tokenized timeline infographics

### DIFF
--- a/skills/b3os-report/references/ui-components.md
+++ b/skills/b3os-report/references/ui-components.md
@@ -193,7 +193,7 @@ RAG(Retrieval-Augmented Generation, 검색 증강 생성)
 | Swimlane | 역할·주체별 책임이 나뉘는 프로세스 | lane별 row/column을 나누고 handoff만 arrow로 연결 |
 | Architecture map | 시스템 구성·데이터 흐름 | 입력 채널 → 중앙 bounded context → 런타임/저장소 |
 | Layer stack | 서버·DB·worker처럼 층이 있는 구조 | 큰 boundary 안에 row/column layer 배치 |
-| Timeline / lineage | 논문·릴리즈·사건 순서 | 축은 neutral, milestone만 small accent |
+| Timeline / lineage | 논문·릴리즈·사건 순서 | 하나의 report-card 안에 neutral axis를 두고 milestone을 위/아래로 stagger 배치한다. 날짜·이름·venue는 짧게, 인과가 아니라 순서임을 caption에 명시한다. dark/light 모두 CSS var로 전환되게 hard-coded white/blue/violet fill을 쓰지 않는다. |
 | Matrix / quadrant | 두 판단 축으로 위치 비교 | label을 점 위에 길게 쓰지 말고 작은 callout으로 분리 |
 | Funnel / narrowing | 후보를 줄여 선택하거나 우선순위를 좁힐 때 | 넓은 단계 → 좁은 단계. 면을 과하게 채우지 말고 outline 중심 |
 | Radial / hub-and-spoke | 하나의 중심 개념과 주변 요소 관계 | 중앙 node + 주변 작은 node. 선은 얇게, 중심만 강조 |

--- a/skills/b3os-report/scripts/render.test.mjs
+++ b/skills/b3os-report/scripts/render.test.mjs
@@ -71,6 +71,10 @@ try {
   assert.match(refs, /Funnel \/ narrowing/);
   assert.match(refs, /Radial \/ hub-and-spoke/);
   assert.match(refs, /Sankey-lite \/ weighted flow/);
+  assert.match(refs, /Timeline \/ lineage/);
+  assert.match(refs, /milestone을 위\/아래로 stagger 배치/);
+  assert.match(refs, /hard-coded white\/blue\/violet fill/);
+  assert.match(refs, /Matrix \/ quadrant/);
   assert.doesNotMatch(html, /&lt;(svg|rect|text|div)/);
   assert.match(html, /<p>본문입니다\.<\/p>/);
   console.log("PASS b3os-report dark/light theme + nested raw block passthrough");


### PR DESCRIPTION
## 핵심
- AI milestone report의 Story 탭 timeline이 괜찮다는 GD 피드백을 report reference로 남겼습니다.
- Timeline/lineage diagram은 report-card 안의 neutral axis + 위/아래 staggered milestone 배치가 적합하다고 명시했습니다.
- dark/light 전환을 위해 hard-coded white/blue/violet SVG fill을 쓰지 않도록 reference와 test를 보강했습니다.

## 로컬 live report 적용
`reports/`는 gitignore 대상이라 PR diff에는 포함되지 않지만, 로컬 live report에는 아래를 반영했습니다.
- `ai-milestone-papers-20260720/report.md`
- `ai-milestone-papers-20260720/report.html`

반영 내용:
- Story timeline의 구조는 유지하고 SVG 색상을 CSS var 기반으로 tokenized
- dark/light 모두 확인
- Story의 나머지 2개 도식과 각 논문 탭 다이어그램 old palette 제거
- 모든 논문 탭에 `먼저 쉽게 말하면` lead 추가
- 기존 `#tab=story`, `#tab=transformer`, `#tab=peft` 탭 라우팅 유지

## 점검 결과
- 탭 패널: 11개
- active panel: 1개
- 모든 탭 easy lead 있음
- 모든 탭 diagram old palette: `[]`
- 모든 active/temporarily-visible SVG text overflow: `[]`
- Story timeline dark/light browser 확인

## 검증
- `bun run typecheck`
- `bun test skills/b3os-report/scripts/render.test.mjs`
- `bun run build`
- `git diff --check`
