### PR TITLE
fix(report): make dark grid subtly visible

### DIFF
--- a/skills/b3os-report/assets/theme.css
+++ b/skills/b3os-report/assets/theme.css
@@ -20,7 +20,7 @@
   --blue:#9fc7ac;
   --y:#f4c96b;
   --glow:rgba(52,211,153,.16);
-  --grid:rgba(52,211,153,.026);
+  --grid:rgba(52,211,153,.040);
   --shadow:0 22px 70px rgba(0,0,0,.28);
   --mono:"SFMono-Regular",ui-monospace,"JetBrains Mono",Menlo,Consolas,monospace;
   --sans:-apple-system,BlinkMacSystemFont,"Pretendard","Apple SD Gothic Neo","Segoe UI",Roboto,sans-serif;

--- a/skills/b3os-report/references/ui-components.md
+++ b/skills/b3os-report/references/ui-components.md
@@ -237,7 +237,7 @@ RAG(Retrieval-Augmented Generation, 검색 증강 생성)
 - Secondary: amber/orange
 - Red: 위험·삭제·실패
 - Blue/cyan: 기본 accent로 쓰지 말고 링크·보조 정보에만 제한
-- Grid texture: 라이트 모드는 `--grid`를 은은하게 보여 종이 질감을 만들고, 다크 모드는 훨씬 낮은 대비로 깊이만 준다.
+- Grid texture: 라이트 모드는 `--grid`를 은은하게 보여 종이 질감을 만들고, 다크 모드는 낮은 대비를 유지하되 완전히 사라지지 않을 정도로 보이게 한다.
 
 새 보고서에서 하늘색 제목/탭/강조를 기본값으로 쓰지 않는다.
 

--- a/skills/b3os-report/scripts/render.test.mjs
+++ b/skills/b3os-report/scripts/render.test.mjs
@@ -19,7 +19,7 @@ try {
   assert.match(html, /--bg:#0a0f0d/);
   assert.match(html, /--card:#111a15/);
   assert.match(html, /--glow:rgba\(52,211,153,\.16\)/);
-  assert.match(html, /--grid:rgba\(52,211,153,\.026\)/);
+  assert.match(html, /--grid:rgba\(52,211,153,\.040\)/);
   assert.match(html, /--blue:#9fc7ac/);
   assert.match(html, /linear-gradient\(90deg,var\(--grid\) 1px,transparent 1px\)/);
   assert.match(html, /linear-gradient\(var\(--grid\) 1px,transparent 1px\)/);


### PR DESCRIPTION
## 핵심
- GD 피드백 반영: 다크 모드 배경 grid가 너무 안 보여서 `--grid`를 아주 조금 올렸습니다.
- 기존 `rgba(52,211,153,.026)` → `rgba(52,211,153,.040)`.
- 라이트 모드 grid는 기존 `.052` 유지.
- reference 문구도 “다크 모드에서 완전히 사라지지 않을 정도”로 조정했습니다.

## 로컬 live report 적용
`reports/`는 gitignore 대상이라 PR diff에는 포함되지 않지만, 기존 id에 재게시했습니다.
- id: `ai-milestone-papers-20260720`

추가로 GD가 지적한 publication status 인포그래픽의 검은 카드도 로컬 live report에서 수정했습니다.
- 원인: `fill="var(--diagram-neutral)beb"` invalid SVG fill → browser fallback으로 검게 표시
- 수정: `color-mix(in srgb,var(--diagram-neutral) 88%,var(--diagram-gold) 12%)`

## 검증
- dark grid token: `.040`
- light grid token: `.052`
- publication status black fill: 0
- invalid fill: false
- old blue/violet palette: `[]`
- SVG text overflow: `[]`
- duplicate generated report id removed
- 기존 report id 재게시 완료
- `bun run typecheck`
- `bun test skills/b3os-report/scripts/render.test.mjs`
- `bun run build`
- `git diff --check`
