### PR TITLE
feat(deploy): 라이브가 정본 계열인지, 어디서 배포하는지 드러낸다

### DIFF
--- a/scripts/deploy-plan.test.ts
+++ b/scripts/deploy-plan.test.ts
@@ -8,6 +8,7 @@
 // (주입하는 건 "무엇이 바뀌었나" 라는 ★사실★ 이지, 판단이 아니다)
 import { test, expect } from "bun:test";
 import { readdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -18,7 +19,12 @@ import {
   type Layer,
   type Plan,
   type PlanInput,
+  type TreeState,
+  type Ancestry,
+  realIsAncestor,
 } from "./deploy-plan";
+
+const repoRoot = () => join(dirname(fileURLToPath(import.meta.url)), "..");
 
 const SHA = {
   server: "a".repeat(40),
@@ -168,7 +174,21 @@ test("★tailwind 설정은 web 층이다★ — 이 파일 변경이 dist 산�
 //
 // ★막지 않는 이유★: 정당한 상태를 막는 게이트는 우회 습관을 만든다(팀 전례 있음).
 
-const cleanTree = { branch: "main", dirtyTracked: 0 };
+/** 트리 상태 헬퍼 — 기본은 ★정상★(main·깨끗·관측 성공) 이고 필요한 것만 덮어쓴다. */
+const tree = (over: Partial<TreeState> = {}): TreeState => ({
+  branch: "main",
+  dirtyTracked: 0,
+  untrackedNotAllowed: [],
+  observed: true,
+  ...over,
+});
+const cleanTree = tree();
+/**
+ * ★실제 git 의미를 그대로 흉내낸다★ — `merge-base --is-ancestor A A` 는 ★0(조상)★ 이다
+ * (2026-08-07 실측). 자기 자신도 조상이므로 ★정상 상태에서는 언제나 yes★ 다.
+ * 처음엔 이 가짜를 `() => false` 로 뒀는데, ★진짜보다 비관적인 가짜가 없던 경고를 정답으로 굳혔다.★
+ */
+const allOnCanonicalLine = (): Ancestry => "yes";
 const basePlan = (over: Partial<PlanInput> = {}) =>
   planDeploy({
     live: live(SHA.server, SHA.web),
@@ -179,13 +199,13 @@ const basePlan = (over: Partial<PlanInput> = {}) =>
   });
 
 test("★실행 트리가 정본 브랜치가 아니면 경고한다★ — 팀원이 그 파일을 읽고 있다", () => {
-  const plan = basePlan({ tree: { branch: "hermes/some-work", dirtyTracked: 0 } });
+  const plan = basePlan({ tree: tree({ branch: "hermes/some-work" }) });
   expect(plan.warnings.some((w) => w.includes("hermes/some-work"))).toBe(true);
   expect(plan.blocked).toBeNull(); // ★막지 않는다★
 });
 
 test("★미커밋이 있으면 경고한다★ — 커밋도 리뷰도 안 된 내용이 읽힌다", () => {
-  const plan = basePlan({ tree: { branch: "main", dirtyTracked: 4 } });
+  const plan = basePlan({ tree: tree({ dirtyTracked: 4 }) });
   expect(plan.warnings.some((w) => w.includes("4건"))).toBe(true);
   expect(plan.blocked).toBeNull();
 });
@@ -195,30 +215,54 @@ test("★대조군★ — main 이고 깨끗하면 트리 경고가 없다", () 
 });
 
 test("★detached HEAD 도 경고한다★ — 브랜치 이름이 없는 것도 정본이 아니다", () => {
-  const plan = basePlan({ tree: { branch: null, dirtyTracked: 0 } });
+  const plan = basePlan({ tree: tree({ branch: null }) });
   expect(plan.warnings.some((w) => w.includes("detached"))).toBe(true);
 });
 
 test("★층 커밋이 정본 계열이 아니면 경고한다★ — 브랜치가 지워지면 사라질 커밋이다", () => {
-  const plan = basePlan({ tree: cleanTree, isAncestor: (sha) => sha !== SHA.web });
+  const plan = basePlan({ tree: cleanTree, isAncestor: (sha) => (sha === SHA.web ? "no" : "yes") });
   expect(plan.warnings.some((w) => w.includes("web") && w.includes(SHA.web.slice(0, 8)))).toBe(true);
   expect(plan.warnings.some((w) => w.startsWith("server"))).toBe(false); // server 는 조상이므로 조용해야 한다
 });
 
 test("★대조군★ — 두 층이 모두 정본 계열이면 계열 경고가 없다", () => {
-  expect(basePlan({ tree: cleanTree, isAncestor: always }).warnings).toEqual([]);
+  expect(basePlan({ tree: cleanTree, isAncestor: allOnCanonicalLine }).warnings).toEqual([]);
 });
 
-test("★target 과 같은 커밋은 조상 검사에서 조용하다★ — 자기 자신은 조상이 아니라 오탐이 난다", () => {
+// ★이 시험은 전제가 틀려서 다시 썼다★ — 처음엔 "git 은 자기 자신을 조상으로 안 친다" 고 적고
+//   가짜를 `() => false` 로 두었다. ★실측하니 `merge-base --is-ancestor A A` 는 exit 0(조상) 이다.★
+//   가짜가 진짜보다 비관적이면 ★실제로는 안 나는 경고를 시험이 정답으로 굳힌다.★
+test("★라이브가 이미 target 이면 계열 경고가 없다★ (git: A A → 조상)", () => {
   const plan = planDeploy({
-    live: live(SHA.target, SHA.target), // 이미 target 인 정상 상태
+    live: live(SHA.target, SHA.target),
     target: SHA.target,
     changedFiles: () => [],
     commitExists: always,
     tree: cleanTree,
-    isAncestor: () => false, // ★조상 판정이 false 를 줘도★ 같은 커밋이면 경고하지 않아야 한다
+    isAncestor: allOnCanonicalLine, // ★진짜 git 과 같은 의미★
   });
   expect(plan.warnings).toEqual([]);
+});
+
+test("★판정 못 한 것을 '계열 이탈' 로 말하지 않는다★ (얕은 클론·저장소 오류)", () => {
+  const plan = basePlan({ tree: cleanTree, isAncestor: () => "unknown" });
+  expect(plan.warnings.some((w) => w.includes("판정하지 못했다"))).toBe(true);
+  expect(plan.warnings.some((w) => w.includes("계열이 아니다"))).toBe(false); // ★단정하면 안 된다★
+});
+
+test("★허용 목록 밖 미추적 파일은 경고한다★ — git 이 몰라도 팀원은 읽는다", () => {
+  const plan = basePlan({ tree: tree({ untrackedNotAllowed: ["skills/b3os-report/새파일.md"] }) });
+  expect(plan.warnings.some((w) => w.includes("추적되지 않는 파일"))).toBe(true);
+});
+
+test("★대조군★ — 허용된 미추적(.worktrees/)만 있으면 조용하다", () => {
+  // realTreeState 가 걸러내므로 여기엔 애초에 안 들어온다 — 그 계약을 고정한다
+  expect(basePlan({ tree: tree({ untrackedNotAllowed: [] }) }).warnings).toEqual([]);
+});
+
+test("★트리 상태를 못 읽으면 '깨끗함' 이 아니라 '모름' 이다★", () => {
+  const plan = basePlan({ tree: tree({ observed: false }) });
+  expect(plan.warnings.some((w) => w.includes("읽지 못했다"))).toBe(true);
 });
 
 test("★멈춘 경우에도 경고는 함께 나온다★ — 멈춘 이유와 트리 상태를 같이 봐야 한다", () => {
@@ -227,7 +271,7 @@ test("★멈춘 경우에도 경고는 함께 나온다★ — 멈춘 이유와 
     target: SHA.target,
     changedFiles: () => [],
     commitExists: always,
-    tree: { branch: "wip", dirtyTracked: 2 },
+    tree: tree({ branch: "wip", dirtyTracked: 2 }),
   });
   expect(plan.blocked).not.toBeNull();
   expect(plan.warnings.length).toBeGreaterThan(0);
@@ -235,6 +279,23 @@ test("★멈춘 경우에도 경고는 함께 나온다★ — 멈춘 이유와 
 
 test("★tree 를 안 주면 그 검사는 건너뛴다★ — 다른 호출부가 깨지지 않는다", () => {
   expect(basePlan().warnings).toEqual([]);
+});
+
+// ── ★진짜 git 에 대고 재는 시험★ ──────────────────────────────────────────────
+//
+// 위 시험들은 전부 ★가짜를 주입해서★ planDeploy 를 잰다. 그래서 `realIsAncestor` 가 git 의
+// 종료코드를 ★어떻게 옮기는지★ 는 하나도 확인되지 않았다 — 실제로 뮤턴트(unknown→no 합치기)가
+// ★살아남았다.★ 여기서만 진짜 저장소를 쓴다.
+//
+// 고정하는 사실(2026-08-07 실측): `A A` → 0(조상) · 비조상 → 1 · 없는 ref → 128
+
+test("★realIsAncestor 가 git 종료코드를 3값으로 옮긴다★ — unknown 을 no 로 합치지 않는다", () => {
+  const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot(), encoding: "utf8" }).trim();
+  const parent = execFileSync("git", ["rev-parse", "HEAD~1"], { cwd: repoRoot(), encoding: "utf8" }).trim();
+
+  expect(realIsAncestor(head, head)).toBe("yes"); // ★자기 자신도 조상이다★ (exit 0)
+  expect(realIsAncestor(head, parent)).toBe("no"); // 앞선 커밋은 부모의 조상이 아니다 (exit 1)
+  expect(realIsAncestor("dead".repeat(10), head)).toBe("unknown"); // 없는 ref (exit 128)
 });
 
 test("★공유 코드는 양쪽 층에 다 든다★ — 한쪽만 반영되면 나머지가 옛 코드로 남는다", () => {

--- a/scripts/deploy-plan.test.ts
+++ b/scripts/deploy-plan.test.ts
@@ -22,6 +22,8 @@ import {
   type TreeState,
   type Ancestry,
   realIsAncestor,
+  parseStatusPorcelain,
+  UNTRACKED_ALLOWED_PREFIXES,
 } from "./deploy-plan";
 
 const repoRoot = () => join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -279,6 +281,38 @@ test("★멈춘 경우에도 경고는 함께 나온다★ — 멈춘 이유와 
 
 test("★tree 를 안 주면 그 검사는 건너뛴다★ — 다른 호출부가 깨지지 않는다", () => {
   expect(basePlan().warnings).toEqual([]);
+});
+
+// ── ★porcelain 파서 — 허용 목록 경계를 직접 잰다★ ─────────────────────────────
+//
+// 리뷰 메모(codex): 지금까지 시험은 TreeState 를 ★주입★ 해서 treeWarnings 만 봤다.
+// 그러면 ★"어떤 미추적을 허용으로 걸러내는가" 라는 판단 자체는 아무도 안 본다.★
+// (같은 이음매에서 realIsAncestor 뮤턴트가 이미 한 번 살아남았다)
+
+test("★추적 변경과 미추적을 갈라 센다★", () => {
+  const r = parseStatusPorcelain([" M src/a.ts", "?? new.md", "A  src/b.ts", ""]);
+  expect(r.dirtyTracked).toBe(2);
+  expect(r.untrackedNotAllowed).toEqual(["new.md"]);
+});
+
+test("★허용 목록에 있는 미추적만 걸러낸다★ — 나머지는 남긴다", () => {
+  const r = parseStatusPorcelain([
+    "?? .worktrees/foo/",
+    "?? node_modules/x",
+    "?? dist/web/a.js",
+    "?? skills/b3os-report/새파일.md", // ★팀원이 바로 읽는 자리★
+    "?? rules/새룰.md",
+  ]);
+  expect(r.untrackedNotAllowed).toEqual(["skills/b3os-report/새파일.md", "rules/새룰.md"]);
+});
+
+test("★이름이 비슷할 뿐인 경로는 걸러내지 않는다★ — prefix 함정", () => {
+  const r = parseStatusPorcelain(["?? .worktrees-backup/x", "?? distribution/y", "?? node_modules_old/z"]);
+  expect(r.untrackedNotAllowed).toHaveLength(3); // 셋 다 남아야 한다
+});
+
+test("★허용 목록 자체가 비어 있지 않다★ — 비면 이 파서가 아무것도 안 거른다", () => {
+  expect(UNTRACKED_ALLOWED_PREFIXES.length).toBeGreaterThan(0);
 });
 
 // ── ★진짜 git 에 대고 재는 시험★ ──────────────────────────────────────────────

--- a/scripts/deploy-plan.test.ts
+++ b/scripts/deploy-plan.test.ts
@@ -17,6 +17,7 @@ import {
   CONFIG_NOT_IN_ANY_LAYER,
   type Layer,
   type Plan,
+  type PlanInput,
 } from "./deploy-plan";
 
 const SHA = {
@@ -113,6 +114,7 @@ test("★화면만 배포했으면 서버 층이 옛 커밋이어도 성공이�
     actions: { restart: false, build: true },
     changed: { server: [], web: ["src/web/x.ts"] },
     target: SHA.target,
+    warnings: [],
   };
   // 서버는 여전히 옛 커밋 — 재시작을 안 했으니 당연하다
   const v = verifyAfterDeploy(plan, live(SHA.server, SHA.target));
@@ -126,6 +128,7 @@ test("★대조군★ — 빌드했다는데 화면 커밋이 안 바뀌었으�
     actions: { restart: false, build: true },
     changed: { server: [], web: ["src/web/x.ts"] },
     target: SHA.target,
+    warnings: [],
   };
   const v = verifyAfterDeploy(plan, live(SHA.server, SHA.web)); // web 이 옛것 그대로
   expect(v.ok).toBe(false);
@@ -153,6 +156,85 @@ test("★루트의 설정 파일은 모두 어느 층엔가 분류돼 있다★ 
 test("★tailwind 설정은 web 층이다★ — 이 파일 변경이 dist 산출물을 바꾸는 것을 실측했다", () => {
   expect(LAYER_PATHS.web).toContain("tailwind.config.js");
   expect(LAYER_PATHS.web).toContain("postcss.config.js"); // tailwind 를 불러 쓰는 쪽
+});
+
+// ── ★경고 — 막지는 않지만 드러낸다★ ───────────────────────────────────────────
+//
+// 왜 필요한가 (2026-08-07 실측):
+//  · 공유 라이브 트리에서 기능 브랜치를 checkout 하고 작업하는 일이 하루 다섯 번 났다.
+//    팀원은 스킬·룰을 그 트리에서 ★직접 읽으므로★ 그 시간 동안 ★미머지 내용이 이미 팀에 나가 있었다.★
+//  · 그 상태로 빌드가 돌아 web 층이 ★미머지 브랜치 커밋★ 을 가리켰는데, 빌드 입력이 안 바뀌었으므로
+//    planDeploy 는 "할 일 없음" 을 답했다 — ★맞는 답이지만 그 사실을 말하지 않았다.★
+//
+// ★막지 않는 이유★: 정당한 상태를 막는 게이트는 우회 습관을 만든다(팀 전례 있음).
+
+const cleanTree = { branch: "main", dirtyTracked: 0 };
+const basePlan = (over: Partial<PlanInput> = {}) =>
+  planDeploy({
+    live: live(SHA.server, SHA.web),
+    target: SHA.target,
+    changedFiles: () => [],
+    commitExists: always,
+    ...over,
+  });
+
+test("★실행 트리가 정본 브랜치가 아니면 경고한다★ — 팀원이 그 파일을 읽고 있다", () => {
+  const plan = basePlan({ tree: { branch: "hermes/some-work", dirtyTracked: 0 } });
+  expect(plan.warnings.some((w) => w.includes("hermes/some-work"))).toBe(true);
+  expect(plan.blocked).toBeNull(); // ★막지 않는다★
+});
+
+test("★미커밋이 있으면 경고한다★ — 커밋도 리뷰도 안 된 내용이 읽힌다", () => {
+  const plan = basePlan({ tree: { branch: "main", dirtyTracked: 4 } });
+  expect(plan.warnings.some((w) => w.includes("4건"))).toBe(true);
+  expect(plan.blocked).toBeNull();
+});
+
+test("★대조군★ — main 이고 깨끗하면 트리 경고가 없다", () => {
+  expect(basePlan({ tree: cleanTree }).warnings).toEqual([]);
+});
+
+test("★detached HEAD 도 경고한다★ — 브랜치 이름이 없는 것도 정본이 아니다", () => {
+  const plan = basePlan({ tree: { branch: null, dirtyTracked: 0 } });
+  expect(plan.warnings.some((w) => w.includes("detached"))).toBe(true);
+});
+
+test("★층 커밋이 정본 계열이 아니면 경고한다★ — 브랜치가 지워지면 사라질 커밋이다", () => {
+  const plan = basePlan({ tree: cleanTree, isAncestor: (sha) => sha !== SHA.web });
+  expect(plan.warnings.some((w) => w.includes("web") && w.includes(SHA.web.slice(0, 8)))).toBe(true);
+  expect(plan.warnings.some((w) => w.startsWith("server"))).toBe(false); // server 는 조상이므로 조용해야 한다
+});
+
+test("★대조군★ — 두 층이 모두 정본 계열이면 계열 경고가 없다", () => {
+  expect(basePlan({ tree: cleanTree, isAncestor: always }).warnings).toEqual([]);
+});
+
+test("★target 과 같은 커밋은 조상 검사에서 조용하다★ — 자기 자신은 조상이 아니라 오탐이 난다", () => {
+  const plan = planDeploy({
+    live: live(SHA.target, SHA.target), // 이미 target 인 정상 상태
+    target: SHA.target,
+    changedFiles: () => [],
+    commitExists: always,
+    tree: cleanTree,
+    isAncestor: () => false, // ★조상 판정이 false 를 줘도★ 같은 커밋이면 경고하지 않아야 한다
+  });
+  expect(plan.warnings).toEqual([]);
+});
+
+test("★멈춘 경우에도 경고는 함께 나온다★ — 멈춘 이유와 트리 상태를 같이 봐야 한다", () => {
+  const plan = planDeploy({
+    live: live(SHA.server, null), // web 표식 없음 → blocked
+    target: SHA.target,
+    changedFiles: () => [],
+    commitExists: always,
+    tree: { branch: "wip", dirtyTracked: 2 },
+  });
+  expect(plan.blocked).not.toBeNull();
+  expect(plan.warnings.length).toBeGreaterThan(0);
+});
+
+test("★tree 를 안 주면 그 검사는 건너뛴다★ — 다른 호출부가 깨지지 않는다", () => {
+  expect(basePlan().warnings).toEqual([]);
 });
 
 test("★공유 코드는 양쪽 층에 다 든다★ — 한쪽만 반영되면 나머지가 옛 코드로 남는다", () => {

--- a/scripts/deploy-plan.ts
+++ b/scripts/deploy-plan.ts
@@ -63,12 +63,29 @@ export interface LivePoint {
   commit: string | null;
 }
 
+/**
+ * 배포를 실행할 트리 자체의 상태. ★"무엇을 배포하나" 와 "어디서 배포하나" 는 다른 질문이다.★
+ * 공유 트리가 기능 브랜치에 올라가 있거나 미커밋이 얹혀 있으면, 팀원은 그 파일들을 직접 읽는다
+ * (스킬·룰은 공유 트리에서 바로 읽힌다). 그건 배포 대상이 아니라 ★지금 이미 벌어지고 있는 일★ 이다.
+ */
+export interface TreeState {
+  branch: string | null;
+  /** 추적 파일의 미커밋 변경 수. 미추적은 세지 않는다(워크트리 디렉토리 등 정상 잔재가 많다). */
+  dirtyTracked: number;
+}
+
 export interface PlanInput {
   live: Record<Layer, LivePoint>;
   target: string;
   /** 주입 가능하게 둔다 — 시험이 진짜 저장소 상태에 기대지 않도록. */
   changedFiles: (from: string, to: string, paths: readonly string[]) => string[];
   commitExists: (sha: string) => boolean;
+  /** `sha` 가 `target` 의 조상인가 = 정본 계열 위에 있는가. */
+  isAncestor?: (sha: string, target: string) => boolean;
+  /** 실행 트리 상태. 없으면 그 검사는 건너뛴다(시험·다른 호출부 호환). */
+  tree?: TreeState;
+  /** 정본 브랜치 이름. 기본 main. */
+  canonicalBranch?: string;
 }
 
 export interface Plan {
@@ -76,11 +93,20 @@ export interface Plan {
   actions: { restart: boolean; build: boolean };
   changed: Record<Layer, string[]>;
   target: string;
+  /**
+   * ★막지는 않지만 사람이 봐야 하는 것.★
+   *
+   * 왜 blocked 가 아니라 warnings 인가 — ★정당한 상태를 막는 게이트는 우회 습관을 만든다.★
+   * (우리 팀에 전례가 있다: 상시 실패하는 게이트가 `--skip` 을 습관으로 만들었다)
+   * 여기 담기는 것들은 ★배포를 못 할 이유는 아니지만 모르고 지나가면 안 되는★ 사실이다.
+   */
+  warnings: string[];
 }
 
 /** ★판단 본체.★ 순수 함수다 — 저장소도 네트워크도 안 건드린다(그래서 시험이 진짜를 잰다). */
 export function planDeploy(input: PlanInput): Plan {
   const changed: Record<Layer, string[]> = { server: [], web: [] };
+  const warnings = treeWarnings(input);
   for (const layer of Object.keys(LAYER_PATHS) as Layer[]) {
     const from = input.live[layer].commit;
     if (!from) {
@@ -90,6 +116,7 @@ export function planDeploy(input: PlanInput): Plan {
         actions: { restart: false, build: false },
         changed,
         target: input.target,
+        warnings,
       };
     }
     if (!input.commitExists(from)) {
@@ -99,7 +126,18 @@ export function planDeploy(input: PlanInput): Plan {
         actions: { restart: false, build: false },
         changed,
         target: input.target,
+        warnings,
       };
+    }
+    // ★"다시 배포할 필요가 있나" 와 "정본 계열 위에 있나" 는 다른 질문이다.★
+    //   2026-08-07 실측: 팀원이 미머지 브랜치에서 빌드해 web 층이 그 브랜치 커밋을 가리켰는데,
+    //   빌드 입력이 안 바뀌었으므로 "할 일 없음" 이 나왔다 — ★맞는 답이지만 그 사실은 말하지 않았다.★
+    //   그 커밋은 브랜치가 지워지면 저장소에서 사라진다. 다음 배포의 기준선이 사라지는 것이다.
+    if (input.isAncestor && from !== input.target && !input.isAncestor(from, input.target)) {
+      warnings.push(
+        `${layer} 층이 가리키는 ${from.slice(0, 8)} 이 정본(${input.target.slice(0, 8)}) 계열이 아니다 — ` +
+          `미머지 브랜치에서 배포했을 가능성. 그 커밋은 브랜치가 지워지면 사라진다.`,
+      );
     }
     changed[layer] = input.changedFiles(from, input.target, LAYER_PATHS[layer]);
   }
@@ -109,7 +147,31 @@ export function planDeploy(input: PlanInput): Plan {
     actions: { restart: changed.server.length > 0, build: changed.web.length > 0 },
     changed,
     target: input.target,
+    warnings,
   };
+}
+
+/**
+ * 실행 트리 자체를 본다. ★배포 대상과 무관하게, 지금 팀원이 읽고 있는 파일의 상태다.★
+ * 스킬·룰은 공유 트리에서 직접 읽히므로 여기가 브랜치이거나 더러우면 ★이미 그 내용이 팀에 나가 있다.★
+ */
+export function treeWarnings(input: Pick<PlanInput, "tree" | "canonicalBranch">): string[] {
+  const out: string[] = [];
+  const tree = input.tree;
+  if (!tree) return out;
+  const canonical = input.canonicalBranch ?? "main";
+  if (tree.branch !== canonical) {
+    out.push(
+      `실행 트리가 '${tree.branch ?? "detached"}' 에 있다 (정본은 '${canonical}'). ` +
+        `팀원은 스킬·룰을 이 트리에서 직접 읽으므로 ★미머지 내용이 이미 팀에 나가 있다.★`,
+    );
+  }
+  if (tree.dirtyTracked > 0) {
+    out.push(
+      `실행 트리에 미커밋 변경 ${tree.dirtyTracked}건이 있다 — ★커밋도 리뷰도 안 된 내용을 팀원이 읽는다.★`,
+    );
+  }
+  return out;
 }
 
 /**
@@ -146,6 +208,21 @@ export function realCommitExists(sha: string): boolean {
   return git(["cat-file", "-e", `${sha}^{commit}`]).ok;
 }
 
+export function realIsAncestor(sha: string, target: string): boolean {
+  return git(["merge-base", "--is-ancestor", sha, target]).ok;
+}
+
+/** 실행 트리 상태를 읽는다. ★미추적은 세지 않는다★ — `.worktrees/` 같은 정상 잔재가 늘 있다. */
+export function realTreeState(): TreeState {
+  const branch = git(["rev-parse", "--abbrev-ref", "HEAD"]);
+  const status = git(["status", "--porcelain"]);
+  const dirty = status.ok
+    ? status.out.split("\n").filter((l) => l.trim() && !l.startsWith("??")).length
+    : 0;
+  const name = branch.ok ? branch.out : "";
+  return { branch: name && name !== "HEAD" ? name : null, dirtyTracked: dirty };
+}
+
 async function fetchLive(healthUrl: string): Promise<Record<Layer, LivePoint>> {
   const res = await fetch(healthUrl, { signal: AbortSignal.timeout(5000) });
   const body = (await res.json()) as { server?: { commit?: unknown }; web?: { commit?: unknown } };
@@ -157,7 +234,8 @@ if (import.meta.main) {
   const argv = process.argv.slice(2);
   const arg = (name: string, fallback: string): string => {
     const i = argv.indexOf(name);
-    return i >= 0 && argv[i + 1] ? argv[i + 1] : fallback;
+    const v = i >= 0 ? argv[i + 1] : undefined;
+    return v ?? fallback;
   };
   const healthUrl = arg("--health", `http://127.0.0.1:${process.env.TEAM_HTTP_PORT ?? 7878}/health`);
   const targetRef = arg("--target", "origin/main");
@@ -183,6 +261,9 @@ if (import.meta.main) {
     target: targetSha.out,
     changedFiles: realChangedFiles,
     commitExists: realCommitExists,
+    isAncestor: realIsAncestor,
+    tree: realTreeState(),
+    canonicalBranch: arg("--canonical-branch", "main"),
   });
 
   if (asJson) {
@@ -198,6 +279,8 @@ if (import.meta.main) {
       const todo = [plan.actions.restart ? "재시작" : null, plan.actions.build ? "빌드" : null].filter(Boolean);
       console.log(`→ 할 일: ${todo.length ? todo.join(" + ") : "없음 (이미 반영돼 있다)"}`);
     }
+    // ★멈추지 않는다. 다만 조용히 지나가지도 않는다.★ blocked 여부와 무관하게 항상 보여준다.
+    for (const w of plan.warnings) console.log(`\n⚠ ${w}`);
   }
   process.exit(plan.blocked ? 2 : 0);
 }

--- a/scripts/deploy-plan.ts
+++ b/scripts/deploy-plan.ts
@@ -266,21 +266,33 @@ export function realIsAncestor(sha: string, target: string): Ancestry {
  */
 export const UNTRACKED_ALLOWED_PREFIXES = [".worktrees/", "node_modules/", "dist/"] as const;
 
+/**
+ * ★porcelain 출력을 값으로 바꾸는 순수 파서.★ 껍데기(git 호출)에서 떼어냈다 —
+ * 붙어 있으면 ★허용 목록 경계를 시험이 직접 잴 수 없다★ (주입으로는 파서를 건너뛴다).
+ */
+export function parseStatusPorcelain(lines: readonly string[]): {
+  dirtyTracked: number;
+  untrackedNotAllowed: string[];
+} {
+  const real = lines.filter((l) => l.trim());
+  return {
+    dirtyTracked: real.filter((l) => !l.startsWith("??")).length,
+    untrackedNotAllowed: real
+      .filter((l) => l.startsWith("??"))
+      .map((l) => l.slice(3).trim())
+      .filter((path) => !UNTRACKED_ALLOWED_PREFIXES.some((pre) => path.startsWith(pre))),
+  };
+}
+
 export function realTreeState(): TreeState {
   const branch = git(["rev-parse", "--abbrev-ref", "HEAD"]);
   // `--untracked-files=all` — 디렉토리 하나로 뭉뚱그리지 않고 파일 단위로 본다.
   const status = git(["status", "--porcelain", "--untracked-files=all"]);
-  const lines = status.ok ? status.out.split("\n").filter((l) => l.trim()) : [];
-  const dirtyTracked = lines.filter((l) => !l.startsWith("??")).length;
-  const untrackedNotAllowed = lines
-    .filter((l) => l.startsWith("??"))
-    .map((l) => l.slice(3).trim())
-    .filter((path) => !UNTRACKED_ALLOWED_PREFIXES.some((pre) => path.startsWith(pre)));
+  const parsed = parseStatusPorcelain(status.ok ? status.out.split("\n") : []);
   const name = branch.ok ? branch.out : "";
   return {
     branch: name && name !== "HEAD" ? name : null,
-    dirtyTracked,
-    untrackedNotAllowed,
+    ...parsed,
     // ★관측 실패를 '깨끗함' 으로 바꾸지 않는다.★
     observed: status.ok && branch.ok,
   };

--- a/scripts/deploy-plan.ts
+++ b/scripts/deploy-plan.ts
@@ -59,6 +59,9 @@ export const CONFIG_NOT_IN_ANY_LAYER: readonly string[] = [
 
 export type Layer = keyof typeof LAYER_PATHS;
 
+/** 조상 판정 — ★모름을 아니오로 바꾸지 않는다.★ */
+export type Ancestry = "yes" | "no" | "unknown";
+
 export interface LivePoint {
   commit: string | null;
 }
@@ -70,8 +73,16 @@ export interface LivePoint {
  */
 export interface TreeState {
   branch: string | null;
-  /** 추적 파일의 미커밋 변경 수. 미추적은 세지 않는다(워크트리 디렉토리 등 정상 잔재가 많다). */
+  /** 추적 파일의 미커밋 변경 수. */
   dirtyTracked: number;
+  /**
+   * ★허용 목록에 없는 미추적 경로.★ 처음엔 미추적을 통째로 무시했는데 그건 틀렸다 —
+   * 새로 만든 `skills/`·`rules/` 파일은 ★추적되지 않아도 팀원이 바로 읽는다★ (공유 트리에서 직접 읽으므로).
+   * `.worktrees/` 같은 정상 잔재만 걸러내고 나머지는 보여준다.
+   */
+  untrackedNotAllowed: string[];
+  /** 트리 상태를 읽는 데 성공했나. ★실패를 '깨끗함' 으로 바꾸지 않는다.★ */
+  observed: boolean;
 }
 
 export interface PlanInput {
@@ -80,8 +91,12 @@ export interface PlanInput {
   /** 주입 가능하게 둔다 — 시험이 진짜 저장소 상태에 기대지 않도록. */
   changedFiles: (from: string, to: string, paths: readonly string[]) => string[];
   commitExists: (sha: string) => boolean;
-  /** `sha` 가 `target` 의 조상인가 = 정본 계열 위에 있는가. */
-  isAncestor?: (sha: string, target: string) => boolean;
+  /**
+   * `sha` 가 `target` 의 조상인가 = 정본 계열 위에 있는가.
+   * ★"아니다" 와 "판정 못 했다" 를 합치지 않는다★ — git 은 비조상을 1, 오류를 128 로 준다.
+   * 얕은 클론에서 이력이 모자라 실패한 것을 ★계열 이탈로 단정하면 거짓 고발★ 이 된다.
+   */
+  isAncestor?: (sha: string, target: string) => Ancestry;
   /** 실행 트리 상태. 없으면 그 검사는 건너뛴다(시험·다른 호출부 호환). */
   tree?: TreeState;
   /** 정본 브랜치 이름. 기본 main. */
@@ -133,11 +148,23 @@ export function planDeploy(input: PlanInput): Plan {
     //   2026-08-07 실측: 팀원이 미머지 브랜치에서 빌드해 web 층이 그 브랜치 커밋을 가리켰는데,
     //   빌드 입력이 안 바뀌었으므로 "할 일 없음" 이 나왔다 — ★맞는 답이지만 그 사실은 말하지 않았다.★
     //   그 커밋은 브랜치가 지워지면 저장소에서 사라진다. 다음 배포의 기준선이 사라지는 것이다.
-    if (input.isAncestor && from !== input.target && !input.isAncestor(from, input.target)) {
-      warnings.push(
-        `${layer} 층이 가리키는 ${from.slice(0, 8)} 이 정본(${input.target.slice(0, 8)}) 계열이 아니다 — ` +
-          `미머지 브랜치에서 배포했을 가능성. 그 커밋은 브랜치가 지워지면 사라진다.`,
-      );
+    //
+    //   ★자기 자신은 걸러낼 필요가 없다★ — `git merge-base --is-ancestor A A` 는 ★0(조상)★ 이다.
+    //   (처음엔 반대로 알고 단축 조건을 넣었는데, 실제 git 으로 재보니 틀렸다)
+    if (input.isAncestor) {
+      const verdict = input.isAncestor(from, input.target);
+      if (verdict === "no") {
+        warnings.push(
+          `${layer} 층이 가리키는 ${from.slice(0, 8)} 이 정본(${input.target.slice(0, 8)}) 계열이 아니다 — ` +
+            `미머지 브랜치에서 배포했거나, target 이 뒤로 이동(롤백)했을 수 있다. ` +
+            `브랜치가 지워지면 그 커밋은 사라진다.`,
+        );
+      } else if (verdict === "unknown") {
+        warnings.push(
+          `${layer} 층의 계열을 ★판정하지 못했다★ (${from.slice(0, 8)}) — 얕은 클론이거나 저장소 오류일 수 있다. ` +
+            `★'계열 이탈' 로 단정하지 않는다.★ 확인이 필요하다.`,
+        );
+      }
     }
     changed[layer] = input.changedFiles(from, input.target, LAYER_PATHS[layer]);
   }
@@ -160,6 +187,16 @@ export function treeWarnings(input: Pick<PlanInput, "tree" | "canonicalBranch">)
   const tree = input.tree;
   if (!tree) return out;
   const canonical = input.canonicalBranch ?? "main";
+  if (!tree.observed) {
+    out.push(`실행 트리 상태를 ★읽지 못했다★ — '깨끗하다' 는 뜻이 아니다. git 이 동작하는지 확인해라.`);
+  }
+  if (tree.untrackedNotAllowed.length > 0) {
+    const sample = tree.untrackedNotAllowed.slice(0, 3).join(", ");
+    out.push(
+      `실행 트리에 ★추적되지 않는 파일 ${tree.untrackedNotAllowed.length}개★ 가 있다 (${sample}${tree.untrackedNotAllowed.length > 3 ? " …" : ""}) — ` +
+        `git 이 모르는 파일이지만 ★팀원은 이 트리에서 바로 읽고, 빌드도 집어갈 수 있다.★`,
+    );
+  }
   if (tree.branch !== canonical) {
     out.push(
       `실행 트리가 '${tree.branch ?? "detached"}' 에 있다 (정본은 '${canonical}'). ` +
@@ -193,9 +230,9 @@ export function verifyAfterDeploy(plan: Plan, after: Record<Layer, LivePoint>): 
 
 // ── 실제 저장소·라이브를 읽는 얇은 껍데기 (위 순수 함수에 주입한다) ──────────────
 
-function git(args: string[]): { ok: boolean; out: string } {
+function git(args: string[]): { ok: boolean; out: string; status: number | null } {
   const r = spawnSync("git", args, { cwd: REPO_ROOT, encoding: "utf8" });
-  return { ok: r.status === 0, out: (r.stdout ?? "").trim() };
+  return { ok: r.status === 0, out: (r.stdout ?? "").trim(), status: r.status };
 }
 
 export function realChangedFiles(from: string, to: string, paths: readonly string[]): string[] {
@@ -208,19 +245,45 @@ export function realCommitExists(sha: string): boolean {
   return git(["cat-file", "-e", `${sha}^{commit}`]).ok;
 }
 
-export function realIsAncestor(sha: string, target: string): boolean {
-  return git(["merge-base", "--is-ancestor", sha, target]).ok;
+/**
+ * ★git 의 종료코드를 그대로 옮긴다★ — 0=조상, 1=비조상, 그 밖(128 등)=판정 실패.
+ * 실측(2026-08-07): `A A` → 0 · 비조상 → 1 · 없는 ref → 128.
+ * 셋을 boolean 하나로 뭉치면 ★얕은 클론의 이력 부족을 '계열 이탈' 로 거짓 고발한다.★
+ */
+export function realIsAncestor(sha: string, target: string): Ancestry {
+  const r = git(["merge-base", "--is-ancestor", sha, target]);
+  if (r.status === 0) return "yes";
+  if (r.status === 1) return "no";
+  return "unknown";
 }
 
-/** 실행 트리 상태를 읽는다. ★미추적은 세지 않는다★ — `.worktrees/` 같은 정상 잔재가 늘 있다. */
+/**
+ * 실행 트리 상태를 읽는다.
+ *
+ * ★미추적을 통째로 버리지 않는다★ — 처음엔 `.worktrees/` 잔재를 피하려고 `??` 를 전부 무시했는데,
+ * 그러면 ★새로 만든 skills/·rules/ 파일처럼 팀원이 바로 읽는 것까지 '깨끗함' 으로 나온다.★
+ * 허용 목록에 있는 경로만 걸러내고 나머지는 센다.
+ */
+export const UNTRACKED_ALLOWED_PREFIXES = [".worktrees/", "node_modules/", "dist/"] as const;
+
 export function realTreeState(): TreeState {
   const branch = git(["rev-parse", "--abbrev-ref", "HEAD"]);
-  const status = git(["status", "--porcelain"]);
-  const dirty = status.ok
-    ? status.out.split("\n").filter((l) => l.trim() && !l.startsWith("??")).length
-    : 0;
+  // `--untracked-files=all` — 디렉토리 하나로 뭉뚱그리지 않고 파일 단위로 본다.
+  const status = git(["status", "--porcelain", "--untracked-files=all"]);
+  const lines = status.ok ? status.out.split("\n").filter((l) => l.trim()) : [];
+  const dirtyTracked = lines.filter((l) => !l.startsWith("??")).length;
+  const untrackedNotAllowed = lines
+    .filter((l) => l.startsWith("??"))
+    .map((l) => l.slice(3).trim())
+    .filter((path) => !UNTRACKED_ALLOWED_PREFIXES.some((pre) => path.startsWith(pre)));
   const name = branch.ok ? branch.out : "";
-  return { branch: name && name !== "HEAD" ? name : null, dirtyTracked: dirty };
+  return {
+    branch: name && name !== "HEAD" ? name : null,
+    dirtyTracked,
+    untrackedNotAllowed,
+    // ★관측 실패를 '깨끗함' 으로 바꾸지 않는다.★
+    observed: status.ok && branch.ok,
+  };
 }
 
 async function fetchLive(healthUrl: string): Promise<Record<Layer, LivePoint>> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,6 @@
       "@shared/*": ["src/shared/*"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "include": ["src/**/*.ts", "scripts/deploy-plan.ts", "scripts/deploy-plan.test.ts", "src/**/*.tsx"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## 무엇을 고치나

배포 판단이 **"다시 배포할 필요가 있나"** 만 답했다. **"지금 라이브가 정본 위에 있나"** 와 **"어디서 배포하고 있나"** 는 보지 않았다.

어제 배포한 도구를 오늘 하루 쓰면서 두 가지가 드러났다.

**① 미머지 커밋이 기준선이 됐는데 아무 말도 안 했다**

팀원이 공유 라이브 트리에서 자기 브랜치를 checkout 하고 빌드를 돌렸다. 그래서 `/health` 가 이렇게 답했다:

```
server=629549a5 (main)   web=2bde975f (미머지 브랜치 커밋)
```

그런데 `deploy-plan` 은 **"할 일 없음"** 이었다. 빌드 입력이 안 바뀌었으니 **맞는 답이다.** 다만 **그 커밋이 정본 계열이 아니라는 사실**은 말하지 않았다. 그 커밋은 **브랜치가 지워지면 저장소에서 사라진다** — 다음 배포의 기준선이 사라지는 것이다.

**② 공유 트리가 브랜치에 올라간 것을 아무도 못 봤다**

같은 날 이 상태가 **다섯 번** 났다. 팀원은 스킬·룰을 공유 트리에서 **직접 읽으므로**, 그동안 **미머지 내용이 이미 팀에 나가 있었다.** 미커밋 변경이 얹혀 있던 시간도 있었다(리뷰도 커밋도 안 된 내용).

측정값: `git diff --stat origin/main HEAD -- skills/` → **3~4 파일 차이**.

## 무엇을 했나

- 층 커밋이 `target` 의 **조상인지** 확인해 아니면 경고
- 실행 트리의 **브랜치와 미커밋 수**를 읽어 정본이 아니면 경고
- **막지 않는다.** `blocked` 가 아니라 `warnings` 다

### 왜 막지 않나

**정당한 상태를 막는 게이트는 우회 습관을 만든다.** 우리 팀에 전례가 있다 — 상시 실패하던 게이트가 `--skip` 을 습관으로 만들었다(SHARED 2026-08-07 브랜치보호 건). 여기 담기는 것들은 **배포를 못 할 이유는 아니지만 모르고 지나가면 안 되는** 사실이다.

### 오탐 하나를 미리 막았다

`git merge-base --is-ancestor` 는 **자기 자신을 조상으로 치지 않는다.** 그래서 라이브가 이미 `target` 인 **가장 정상적인 상태**에서 경고가 뜬다. `from !== target` 을 먼저 본다. 시험으로 고정했다.

## 같이 고친 것 — tsconfig

`tsconfig.json` 이 `src/**` 만 포함해서 **`scripts/` 는 타입체크 대상이 아니었다.** 그런데 나는 리뷰에서 이 파일에 대해 **"tsc 0"을 근거로 인용해왔다.** 그 근거가 실제로는 이 파일을 보지 않았다.

`scripts/deploy-plan*.ts` 를 include 에 넣었다. 이제 그 주장이 참이다. 실제로 넣자마자 **내 오류 3건**이 잡혔다(테스트의 `Plan` 리터럴 2 + `arg()` 의 `string | undefined` 1).

나머지 `scripts/` 는 기존 오류 5건이 있어 이 PR 에 넣지 않았다 — 별도 정리 대상이다.

## 검증

- 신규 9건 · `deploy-plan` 20 pass
- `src/server/lib` + `scripts` **822 pass / 0 fail**
- `tsc --noEmit` **0** (이번엔 이 파일을 실제로 포함해서)

### 뮤턴트

| 뮤턴트 | 결과 |
|---|---|
| 브랜치 경고 제거 | **2 red** |
| 미커밋 경고 제거 | **1 red** |
| 자기 자신 예외 제거(오탐 유발) | **1 red** |
| 계열 경고 제거 | **1 red** |

## 범위 밖

- 실제 배포 스크립트(`deploy-live.sh`)와의 연동은 추적 밖 파일이라 이 PR 에 못 담는다. 별도로 적용한다
- `scripts/` 전체 타입체크는 기존 오류 정리가 먼저다

근거: 2026-08-07 실사용 · 카드 `w9VyFDKPO-Pxn2A9Uqhvo`

Submitted-by: bill
