### PR TITLE
fix(mcp): 질문이 팀원을 깨우게 한다 — dispatch 표시 누락

### DIFF
--- a/src/server/mcp/mcpAsk.test.ts
+++ b/src/server/mcp/mcpAsk.test.ts
@@ -500,3 +500,49 @@ test("소유권 판정이 meta 를 읽지 않는다 — 위조한 mcp_actor 로 
   expect(fetchAnswer(db, r.requestId, "hermes").found).toBe(false); // meta 를 믿었다면 열렸다
   expect(fetchAnswer(db, r.requestId, "gd").found).toBe(true); // 실제 발신자 기준이라 본인은 그대로
 });
+
+// ── ★깨우기 회귀★ (2026-08-07 라이브 사고) ──
+//
+// #279 로 리드를 'user' 로 바꾼 뒤, 질문은 DB 에 들어가는데 ★아무도 안 깨웠다.★
+// source='user' 는 dispatch 표시가 없으면 수신자 행이 ★'completed' 로 박혀★ 디스패처가
+// 영영 안 집는다(messages.ts:152). ★메시지는 멀쩡히 있고 팀원만 모른다.★
+//
+// ★이 시험은 가짜 버스를 쓰지 않는다.★ 가짜는 이 규칙을 안 갖고 있어서 넣어봐야 못 잡는다 —
+// 어제 우리를 통과시킨 그 함정이다. ★진짜 insert 경로(acceptInbound)에 그대로 넣어서 잰다.★
+import { acceptInbound } from "../db/inboxQueries";
+
+function postThroughRealBus(db: Database, extra: Record<string, unknown>) {
+  return acceptInbound(
+    db,
+    {
+      from_agent_id: "user", to_agent_id: "bill", body: "질문 " + JSON.stringify(extra),
+      type: "dm", priority: "normal", source: "user", thread_id: "mcp-gd-bill", ...extra,
+    } as never,
+    { dedupeWindowSec: 0 },
+  );
+}
+const recipientState = (db: Database, messageId: string) =>
+  db.prepare(`SELECT delivery_state FROM message_recipient WHERE message_id = ? AND agent_id = 'bill'`)
+    .get(messageId) as { delivery_state: string } | undefined;
+
+test("★dispatch 표시가 있으면 배달 대기(pending) 로 들어간다★ — 그래야 팀원을 깨운다", () => {
+  const db = freshDb();
+  const r = postThroughRealBus(db, { dispatch: true });
+  if (!r.ok) throw new Error("접수됐어야 한다");
+  expect(recipientState(db, r.stored.id)?.delivery_state).toBe("pending");
+});
+
+test("★대조군 — 표시가 없으면 completed 로 박혀 영영 안 깨운다★ (2026-08-07 에 실제로 이랬다)", () => {
+  const db = freshDb();
+  const r = postThroughRealBus(db, {});
+  if (!r.ok) throw new Error("접수됐어야 한다");
+  expect(recipientState(db, r.stored.id)?.delivery_state).toBe("completed"); // ← 이게 사고였다
+});
+
+test("★askTeammate 가 보내는 payload 에 dispatch 가 실린다★", async () => {
+  const db = freshDb();
+  const bus = fakeBus(db);
+  await askTeammate(db, bus.deps, { from: "gd", to: "bill", body: "질문" }, nowait);
+  expect(bus.calls[0]!.dispatch).toBe(true);
+  expect(bus.calls[0]!.source).toBe("user"); // 리드는 user 로 나간다(#279) — 그래서 이 표시가 꼭 필요하다
+});

--- a/src/server/mcp/mcpAsk.ts
+++ b/src/server/mcp/mcpAsk.ts
@@ -153,6 +153,12 @@ export async function postQuestion(
       type: "dm",
       priority: "normal",
       source: env.source,
+      // ★이게 없으면 아무도 안 깨운다★ (2026-08-07 라이브): source='user' 는 dispatch 표시가 없으면
+      //   수신자 행이 ★'completed' 로 박혀서 들어간다★(messages.ts:152) → 디스패처가 'pending' 만
+      //   집으므로 ★영영 안 집는다.★ 메시지는 DB 에 멀쩡히 있는데 팀원은 모른다.
+      //   대시보드 1:1 이 쓰는 그 표시와 같은 것이다(envelopeSchema:71 "채널-poller 없는 user 메시지").
+      //   ★#279 에서 리드를 'user' 로 바꾸면서 이걸 같이 안 붙였다.★
+      dispatch: true,
       thread_id: env.roomId,
       meta,
     }),


### PR DESCRIPTION
## 라이브에서 터진 것

GD 가 클로드 코드에서 빌과 데미스에게 각각 물었는데 **둘 다 아무 답이 없었다**(2026-08-07 17:37·17:39).

DB 를 보니 **메시지는 멀쩡히 들어와 있었다.** 그런데:
```
recipient_state = open · delivery_state = completed
```
**배달을 시작도 안 한 상태로 완료 처리**돼 있었다.

## 원인 — `messages.ts:152`

```js
const rcptState = env.source === "user" && !env.dispatch ? "completed" : "pending";
```

**`source='user'` 는 `dispatch` 표시가 없으면 `completed` 로 박힌다.** 디스패처는 `pending` 만 집으므로(`dispatch.ts:125`) **영영 안 집는다.**

이 필드는 원래 *"채널-poller 없는 user 메시지"*(대시보드 1:1)를 위해 있던 것이다(`envelopeSchema:71`). **MCP 가 정확히 같은 모양인데 안 썼다.** #279 에서 리드를 `user` 로 바꾸면서 같이 안 붙였다.

## 어제 라이브 검증이 이걸 왜 못 잡았나

어제 빌이 답한 건 **내가 팀 버스로 "지금 답해줘" 라고 따로 말했기 때문**이다. **깨우기는 그때도 안 됐다** — 사람이 옆에서 손으로 메우고 있어서 안 보였다.

"라이브에서 통과"라고 적었지만 통과한 것은 **전달·짝짓기·늦은답 밀기**였고 **깨우기는 아니었다.** 검증 범위를 내가 넓게 적었다.

## 시험 — 가짜 버스를 쓰지 않는다

가짜 버스에는 이 규칙이 없어서 넣어봐야 못 잡는다(어제와 같은 함정). **진짜 insert 경로(`acceptInbound`)에 그대로 넣어서 잰다.**

| 시험 | 기대 |
|---|---|
| `dispatch: true` | `delivery_state = pending` (깨울 수 있는 상태) |
| **대조군** — 표시 없음 | `completed` ← 2026-08-07 에 실제로 이랬다 |
| payload 검사 | `dispatch: true` · `source: user` |

**뮤턴트**: `dispatch` 를 빼면 빨간불, 복원하면 통과.

## 검증

mcp **41 pass**(신규 3) · `tsc` 0 · 전체 **2513 pass / 1 fail**(main 과 동일 집합)

## 미검증

**실제로 팀원이 깨어나는지는 배포해야 안다.** 이 시험이 재는 것은 "깨울 수 있는 상태로 들어가는가"까지이고, 깨우기 자체는 디스패처 몫이라 라이브에서 확인한다.

## 롤백

단일 커밋 revert. 되돌리면 다시 아무도 안 깨운다.