### PR TITLE
feat(mcp): 진행 표시를 '몇 초' 에서 '어디까지 왔나' 로

### DIFF
--- a/src/server/mcp/b3osMcpServer.ts
+++ b/src/server/mcp/b3osMcpServer.ts
@@ -16,7 +16,7 @@ import { listTasks, createTask, updateTask } from "../db/taskQueries";
 import { recallDmMessages } from "../db/dmCapture";
 import { classifyAll } from "../lib/health";
 import { leadActorId } from "../lib/opAuth"; // ★이름만 재사용★ — 신뢰 규칙(루프백=리드)은 쓰지 않는다
-import { askTeammate, fetchAnswer } from "./mcpAsk";
+import { askTeammate, fetchAnswer, askProgress } from "./mcpAsk";
 
 export const MCP_NAME = "b3os-mcp";
 export const MCP_VERSION = "0.0.3-m2";
@@ -451,14 +451,15 @@ export function buildMcpServer(db: Database, actor: string | null, scope: McpSco
       const token = meta?.progressToken;
       const onWait =
         token !== undefined && send
-          ? async (elapsedMs: number) => {
+          ? async (elapsedMs: number, requestId: string) => {
               await send({
                 method: "notifications/progress",
                 params: {
                   progressToken: token,
                   progress: Math.round(elapsedMs / 1000),
                   total: Math.round(waitMs / 1000),
-                  message: `${to} 가 답을 준비하는 중 (${Math.round(elapsedMs / 1000)}초)`,
+                  // ★'몇 초' 가 아니라 '어디까지 왔나'★ (팀 리드 2026-08-07). 초는 뒤에 붙인다.
+                  message: `${askProgress(db, requestId, to).label} (${Math.round(elapsedMs / 1000)}초)`,
                 },
               });
             }
@@ -486,12 +487,15 @@ export function buildMcpServer(db: Database, actor: string | null, scope: McpSco
           {
             type: "text",
             text:
-              `${to} 가 아직 답하지 않았습니다 (${Math.round((r.waitedMs ?? 0) / 1000)}초 기다림).\n` +
+              (r.stuckReason
+                // ★막힌 것은 '아직 안 왔다' 가 아니다★ — 기다려도 안 온다는 걸 그대로 말한다.
+                ? `${r.stuckReason}\n`
+                : `${to} 가 아직 답하지 않았습니다 (${Math.round((r.waitedMs ?? 0) / 1000)}초 기다림).\n`) +
               `요청 번호 ${r.requestId} — 질문은 살아 있습니다. 나중에 b3os_fetch_answer 로 받거나, ` +
               `늦게 오면 팀 리드의 평소 채널로 전달됩니다.`,
           },
         ],
-        structuredContent: { status: "pending", request_id: r.requestId, thread_id: r.roomId },
+        structuredContent: { status: "pending", request_id: r.requestId, thread_id: r.roomId, stuck: r.stuckReason ?? null },
       };
     },
   );

--- a/src/server/mcp/mcpAsk.test.ts
+++ b/src/server/mcp/mcpAsk.test.ts
@@ -10,6 +10,7 @@ import {
   askTeammate,
   fetchAnswer,
   postQuestion,
+  askProgress,
   busIdentityFor,
   lateAnswerPush,
   THREAD_ID_MAX,
@@ -545,4 +546,84 @@ test("★askTeammate 가 보내는 payload 에 dispatch 가 실린다★", async
   await askTeammate(db, bus.deps, { from: "gd", to: "bill", body: "질문" }, nowait);
   expect(bus.calls[0]!.dispatch).toBe(true);
   expect(bus.calls[0]!.source).toBe("user"); // 리드는 user 로 나간다(#279) — 그래서 이 표시가 꼭 필요하다
+});
+
+// ── ★진행 표시: '몇 초' 가 아니라 '어디까지 왔나'★ (팀 리드 2026-08-07) ──
+
+function setRecipient(db: Database, messageId: string, agent: string, delivery: string, recipient: string) {
+  db.prepare(`UPDATE message_recipient SET delivery_state = ?, recipient_state = ? WHERE message_id = ? AND agent_id = ?`)
+    .run(delivery, recipient, messageId, agent);
+}
+
+test("★단계마다 다른 말을 한다★ — 전달 중 · 안 열어봄 · 작업 중 · 답 쓰는 중", async () => {
+  const db = freshDb();
+  const bus = fakeBus(db);
+  const r = await askTeammate(db, bus.deps, { from: "gd", to: "bill", body: "질문" }, nowait);
+  db.prepare(`INSERT OR IGNORE INTO message_recipient (message_id, agent_id, delivery_state, recipient_state) VALUES (?, 'bill', 'pending', 'open')`)
+    .run(r.requestId);
+
+  const label = () => askProgress(db, r.requestId, "bill").label;
+  expect(label()).toContain("전달 중");
+  setRecipient(db, r.requestId, "bill", "wake_dispatched", "open");
+  expect(label()).toContain("아직 열어보지 않았");
+  setRecipient(db, r.requestId, "bill", "completed", "in_progress");
+  expect(label()).toContain("읽고 작업 중");
+  setRecipient(db, r.requestId, "bill", "completed", "acknowledged");
+  expect(label()).toContain("답을 쓰는 중");
+  // ★네 단계가 서로 다른 말이어야 의미가 있다★ — 같은 말이면 '몇 초' 와 다를 게 없다
+});
+
+test("★막힌 것은 막혔다고 말한다★ — 기다려도 안 오는데 초만 세면 안 된다", async () => {
+  const db = freshDb();
+  const bus = fakeBus(db);
+  const r = await askTeammate(db, bus.deps, { from: "gd", to: "bill", body: "질문" }, nowait);
+  db.prepare(`INSERT OR IGNORE INTO message_recipient (message_id, agent_id, delivery_state, recipient_state) VALUES (?, 'bill', 'pending', 'open')`)
+    .run(r.requestId);
+  for (const [state, word] of [["blocked", "막혔"], ["dead_letter", "배달 실패"], ["expired", "만료"]] as const) {
+    setRecipient(db, r.requestId, "bill", state, "open");
+    const p = askProgress(db, r.requestId, "bill");
+    expect(p.label).toContain(word);
+    expect(p.stuck).toBe(true); // ★호출부가 이걸 보고 일찍 끝낼 수 있다★
+  }
+  // ★대조군★ — 정상 진행은 stuck 이 아니다
+  setRecipient(db, r.requestId, "bill", "completed", "in_progress");
+  expect(askProgress(db, r.requestId, "bill").stuck).toBe(false);
+});
+
+test("수신자 행이 아직 없어도 죽지 않는다", () => {
+  const db = freshDb();
+  expect(askProgress(db, "없는번호", "bill").label).toContain("전달 준비 중");
+});
+
+test("★막히면 상한까지 안 기다리고 바로 끝낸다★ — 판정을 계산만 하지 않는다", async () => {
+  const db = freshDb();
+  const bus = fakeBus(db);
+  let polls = 0;
+  const r = await askTeammate(
+    db, bus.deps, { from: "gd", to: "bill", body: "질문" },
+    {
+      waitMs: 60_000, pollMs: 1,
+      sleep: async () => {
+        polls++;
+        // 첫 대기 직후 배달이 막힌 상태로 바꾼다
+        db.prepare(`INSERT OR REPLACE INTO message_recipient (message_id, agent_id, delivery_state, recipient_state) VALUES ('q1', 'bill', 'blocked', 'open')`).run();
+      },
+      now: (() => { let t = 0; return () => (t += 10); })(),
+    },
+  );
+  expect(r.status).toBe("pending");
+  expect(r.stuckReason).toContain("막혔");
+  expect(polls).toBeLessThan(5); // ★상한(60초)까지 세지 않았다★
+});
+
+test("★대조군 — 안 막히면 상한까지 기다린다★", async () => {
+  const db = freshDb();
+  const bus = fakeBus(db);
+  let polls = 0;
+  const r = await askTeammate(
+    db, bus.deps, { from: "gd", to: "bill", body: "질문" },
+    { waitMs: 50, pollMs: 1, sleep: async () => { polls++; }, now: (() => { let t = 0; return () => (t += 10); })() },
+  );
+  expect(r.stuckReason).toBeUndefined();
+  expect(polls).toBeGreaterThanOrEqual(4); // 50/10 = 5회쯤 돈다
 });

--- a/src/server/mcp/mcpAsk.ts
+++ b/src/server/mcp/mcpAsk.ts
@@ -19,6 +19,8 @@ export const THREAD_ID_MAX = 32;
 
 export interface AskResult {
   status: "answered" | "pending";
+  /** 기다려도 안 오는 상태로 끝났을 때의 사유(막힘·배달실패·만료). 정상 시간 초과면 없다. */
+  stuckReason?: string;
   /** 질문 message id = 요청 번호. pending 이어도 이 번호로 나중에 회수한다. */
   requestId: string;
   roomId: string;
@@ -234,6 +236,43 @@ export function lateAnswerPush(
   };
 }
 
+/**
+ * ★진행 상황을 '몇 초' 대신 '어디까지 왔나' 로 말한다★ (팀 리드 2026-08-07:
+ * "그냥 몇초가 지났다는 것만 나오니깐.. 별로다").
+ *
+ * 근거는 ★수신자 행 두 칸★ 이다 — delivery_state(전달이 어디까지) · recipient_state(그 사람이 어디까지).
+ * ★런타임과 무관하다★: 터미널 화면이 있는 팀원은 5명뿐이고 나머지 7명은 화면 자체가 없다.
+ * 이 두 칸은 ★12명 전부 똑같이★ 남으므로 누구에게 물어도 같은 말이 나온다.
+ *
+ * ★막힌 것을 알려주는 게 이 함수의 값이다★ — blocked·dead_letter 는 ★영영 안 온다★.
+ * 그걸 모르면 사용자는 상한까지 기다린 뒤에야 실패를 안다.
+ */
+export type AskProgress = { label: string; done: boolean; stuck: boolean };
+
+export function askProgress(db: Database, requestId: string, to: string): AskProgress {
+  const row = db
+    .prepare(`SELECT delivery_state, recipient_state FROM message_recipient WHERE message_id = ? AND agent_id = ?`)
+    .get(requestId, to) as { delivery_state: string; recipient_state: string } | undefined;
+  if (!row) return { label: `${to} 에게 전달 준비 중`, done: false, stuck: false };
+
+  // ★막힘이 먼저다★ — 이 상태들은 기다려도 안 온다. 초를 세는 것보다 이걸 말해야 한다.
+  if (row.delivery_state === "blocked") return { label: `${to} 에게 배달이 막혔습니다 (더 기다려도 안 옵니다)`, done: false, stuck: true };
+  if (row.delivery_state === "dead_letter") return { label: `${to} 에게 배달 실패로 종료됐습니다`, done: false, stuck: true };
+  if (row.delivery_state === "expired") return { label: `${to} 에게 보낸 것이 시간이 지나 만료됐습니다`, done: false, stuck: true };
+
+  // 그 사람이 어디까지 갔나 — 이쪽이 전달 상태보다 뒤에 있으므로 먼저 본다.
+  if (row.recipient_state === "acknowledged" || row.recipient_state === "completed") {
+    return { label: `${to} 가 답을 쓰는 중입니다`, done: true, stuck: false };
+  }
+  if (row.recipient_state === "in_progress") return { label: `${to} 가 읽고 작업 중입니다`, done: false, stuck: false };
+
+  // 아직 안 읽음 — 전달이 어디까지 갔는지로 나눈다.
+  if (row.delivery_state === "pending" || row.delivery_state === "dispatching") {
+    return { label: `${to} 에게 전달 중입니다`, done: false, stuck: false };
+  }
+  return { label: `${to} 가 아직 열어보지 않았습니다`, done: false, stuck: false };
+}
+
 export interface AskOptions {
   waitMs: number;
   pollMs: number;
@@ -245,7 +284,7 @@ export interface AskOptions {
    * 바이트를 흘리면 연결이 살아 있고, 부수적으로 사용자 화면에 "준비 중" 이 보인다.
    * ★알림 실패가 기다림을 깨지 않는다★ — 던져도 삼킨다(알림은 부가 기능이다).
    */
-  onWait?: (elapsedMs: number) => void | Promise<void>;
+  onWait?: (elapsedMs: number, requestId: string) => void | Promise<void>;
 }
 
 /**
@@ -276,23 +315,31 @@ export async function askTeammate(
   awaiting.add(sent.id);
   try {
     // 넣자마자 한 번 본다 — 아주 빠른 답(캐시된 상태 질의 등)이 첫 대기를 통째로 기다리지 않게.
+    let stuckReason: string | undefined;
     for (;;) {
       const answer = findAnswer(db, roomId, sent.id, env.to);
       if (answer) {
         return { status: "answered", requestId: sent.id, roomId, answer, waitedMs: now() - started };
       }
+      // ★막힌 걸 알면서 상한까지 세지 않는다★ — blocked·dead_letter·expired 는 기다려도 안 온다.
+      //   (판정을 만들어놓고 안 쓰면 그건 계산만 한 것이다 — 빌이 #279 에서 잡은 그 모양.)
+      const prog = askProgress(db, sent.id, env.to);
+      if (prog.stuck) {
+        stuckReason = prog.label;
+        break;
+      }
       if (now() - started >= opts.waitMs) break;
       // ★알림을 먼저, 그다음 잠깐 잔다★ — 순서를 바꾸면 첫 알림이 pollMs 만큼 늦어진다.
       if (opts.onWait) {
         try {
-          await opts.onWait(now() - started);
+          await opts.onWait(now() - started, sent.id);
         } catch {
           /* 알림 실패가 기다림을 깨지 않는다 */
         }
       }
       await sleep(opts.pollMs);
     }
-    return { status: "pending", requestId: sent.id, roomId, waitedMs: now() - started };
+    return { status: "pending", requestId: sent.id, roomId, waitedMs: now() - started, stuckReason };
   } finally {
     // ★예외로 빠져나가도 반드시 지운다★ — 남으면 그 질문의 늦은 답이 영원히 안 밀린다(조용한 손실).
     awaiting.delete(sent.id);

--- a/src/server/mcp/mcpAsk.ts
+++ b/src/server/mcp/mcpAsk.ts
@@ -247,30 +247,37 @@ export function lateAnswerPush(
  * ★막힌 것을 알려주는 게 이 함수의 값이다★ — blocked·dead_letter 는 ★영영 안 온다★.
  * 그걸 모르면 사용자는 상한까지 기다린 뒤에야 실패를 안다.
  */
-export type AskProgress = { label: string; done: boolean; stuck: boolean };
+/**
+ * ★done 필드를 두지 않는다★ (빌 리뷰 2026-08-07). 처음엔 넣었는데 ★아무도 안 읽었고★,
+ * 그냥 죽은 필드가 아니라 ★장전된 총★ 이었다: acknowledged 에 done=true 를 주고 있었는데
+ * 우리 코드는 그 상태를 ★"engaged, not done"★ 이라고 못박아 뒀다(ackClose.ts:122).
+ * ★이름은 done 인데 값은 '아직 안 끝났다' 일 때 true★ 라, 다음 사람이 "done 이면 기다림 끝" 으로
+ * 읽으면 ★답이 오기 전에 끊는다.★ 안 쓰는 값을 남기지 않는다.
+ */
+export type AskProgress = { label: string; stuck: boolean };
 
 export function askProgress(db: Database, requestId: string, to: string): AskProgress {
   const row = db
     .prepare(`SELECT delivery_state, recipient_state FROM message_recipient WHERE message_id = ? AND agent_id = ?`)
     .get(requestId, to) as { delivery_state: string; recipient_state: string } | undefined;
-  if (!row) return { label: `${to} 에게 전달 준비 중`, done: false, stuck: false };
+  if (!row) return { label: `${to} 에게 전달 준비 중`, stuck: false };
 
   // ★막힘이 먼저다★ — 이 상태들은 기다려도 안 온다. 초를 세는 것보다 이걸 말해야 한다.
-  if (row.delivery_state === "blocked") return { label: `${to} 에게 배달이 막혔습니다 (더 기다려도 안 옵니다)`, done: false, stuck: true };
-  if (row.delivery_state === "dead_letter") return { label: `${to} 에게 배달 실패로 종료됐습니다`, done: false, stuck: true };
-  if (row.delivery_state === "expired") return { label: `${to} 에게 보낸 것이 시간이 지나 만료됐습니다`, done: false, stuck: true };
+  if (row.delivery_state === "blocked") return { label: `${to} 에게 배달이 막혔습니다 (더 기다려도 안 옵니다)`, stuck: true };
+  if (row.delivery_state === "dead_letter") return { label: `${to} 에게 배달 실패로 종료됐습니다`, stuck: true };
+  if (row.delivery_state === "expired") return { label: `${to} 에게 보낸 것이 시간이 지나 만료됐습니다`, stuck: true };
 
   // 그 사람이 어디까지 갔나 — 이쪽이 전달 상태보다 뒤에 있으므로 먼저 본다.
   if (row.recipient_state === "acknowledged" || row.recipient_state === "completed") {
-    return { label: `${to} 가 답을 쓰는 중입니다`, done: true, stuck: false };
+    return { label: `${to} 가 답을 쓰는 중입니다`, stuck: false };
   }
-  if (row.recipient_state === "in_progress") return { label: `${to} 가 읽고 작업 중입니다`, done: false, stuck: false };
+  if (row.recipient_state === "in_progress") return { label: `${to} 가 읽고 작업 중입니다`, stuck: false };
 
   // 아직 안 읽음 — 전달이 어디까지 갔는지로 나눈다.
   if (row.delivery_state === "pending" || row.delivery_state === "dispatching") {
-    return { label: `${to} 에게 전달 중입니다`, done: false, stuck: false };
+    return { label: `${to} 에게 전달 중입니다`, stuck: false };
   }
-  return { label: `${to} 가 아직 열어보지 않았습니다`, done: false, stuck: false };
+  return { label: `${to} 가 아직 열어보지 않았습니다`, stuck: false };
 }
 
 export interface AskOptions {


### PR DESCRIPTION
## 배경

팀 리드(2026-08-07): **"그냥 몇초가 지났다는 것만 나오니깐.. 별로다. 어떤 작업을 하는 지가 나오게 할 수 있나?"**

## 무엇으로 말하나 — 수신자 행 두 칸

```
전달 중 → 아직 열어보지 않음 → 읽고 작업 중 → 답을 쓰는 중
```

`delivery_state`(전달이 어디까지) · `recipient_state`(그 사람이 어디까지).

**런타임과 무관하다.** 터미널 화면이 있는 팀원은 **5명뿐**이고 나머지 7명은 화면이 없다:

| 런타임 | 지금 저장된 상태줄 |
|---|---|
| claude (5명) | `⏵⏵ auto mode on` · ctx% |
| codex (덱스) | `codex bus idle; telegram bridge ready` |
| hermes (3명) | `Launchd plist: /Users/…` ← **설치 경로다** |
| openclaw (3명) | `gateway healthy (per-agent probe TBD)` ← **미구현** |

이 두 칸은 **12명 전부 똑같이** 남으므로 누구에게 물어도 같은 말이 나온다.

## 막힌 것을 막혔다고 말한다 — 이게 진짜 값이다

`blocked` · `dead_letter` · `expired` 는 **기다려도 안 온다.** 그걸 모르면 사용자는 상한까지 기다린 뒤에야 실패를 안다.

→ 그 상태를 보면 **상한을 안 세고 바로 끝낸다.**

**판정을 계산만 하지 않는다** — #279 에서 빌이 잡은 게 정확히 그 모양이었다(`late.lead` 를 계산해놓고 호출부가 안 씀). 그래서 `stuck` 을 만들자마자 `askTeammate` 가 직접 쓰고, 도구 응답 문구와 `structuredContent` 에도 실었다.

## 시험

- **네 단계가 서로 다른 말**인지 — 같은 말이면 '몇 초' 와 다를 게 없다
- 막힘 3종이 각각 다른 말 + `stuck=true` · **대조군** 정상 진행은 `stuck=false`
- **조기 종료**: 상한 60초인데 막히면 5회 미만 폴링에 끝난다 + **대조군** 안 막히면 상한까지 돈다
- 수신자 행이 아직 없어도 안 죽는다
- **뮤턴트**: 조기 종료를 빼면(= 계산만 하는 상태) **빨간불**, 복원하면 통과

## 이 PR 에 없는 것

**터미널 활동 줄(`✻ …하는 중`)은 없다.** 화면이 있는 5명만 되고, `statusProbe` 가 지금 **맨 아랫줄(고정 장식)** 을 저장하고 있어 별도 작업이 필요하다. 팀 리드와 **①(전원) 먼저, ③(있는 사람만) 다음**으로 합의했다.

## 검증

mcp **46 pass**(신규 5) · `tsc` 0 · 전체 **2518 pass / 1 fail**(main 과 동일 집합)

## 롤백

단일 커밋 revert. 되돌리면 다시 초만 표시된다.