### PR TITLE
feat(mcp): 진행 표시에 '지금 무엇을 하고 있나' 를 붙인다

### DIFF
--- a/src/server/db/migrate.ts
+++ b/src/server/db/migrate.ts
@@ -838,6 +838,9 @@ export function runBusMigration(db: Database): void {
     "ALTER TABLE message_recipient ADD COLUMN closing_message_id TEXT",
     // message.task_link_id: task.lane=정본, recipient_state=mirror (req#2) + 매칭키 (req#4)
     "ALTER TABLE message ADD COLUMN task_link_id TEXT",
+    // 진행 표시용 — 그 팀원이 지금 무엇을 하고 있나. last_log_line 은 화면 맨 아랫줄(고정 장식)이라
+    // 늘 "auto mode on" 이었다. 그 칸은 health 판정이 이미 쓰고 있으므로 건드리지 않고 따로 둔다.
+    "ALTER TABLE agent_status ADD COLUMN activity_line TEXT",
   ];
   for (const stmt of alterStatements) {
     try {

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -77,19 +77,21 @@ export function upsertStatus(
     last_log_line: string | null;
     tmux_pid: number | null;
     ctx_percent?: number | null;
+    activity_line?: string | null;
   },
 ): void {
   db.prepare(
-    `INSERT INTO agent_status (agent_id, state, last_activity_at, last_log_line, tmux_pid, ctx_percent, probed_at)
-     VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+    `INSERT INTO agent_status (agent_id, state, last_activity_at, last_log_line, tmux_pid, ctx_percent, activity_line, probed_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
      ON CONFLICT(agent_id) DO UPDATE SET
        state=excluded.state,
        last_activity_at=excluded.last_activity_at,
        last_log_line=excluded.last_log_line,
        tmux_pid=excluded.tmux_pid,
        ctx_percent=excluded.ctx_percent,
+       activity_line=excluded.activity_line,
        probed_at=excluded.probed_at`,
-  ).run(s.agent_id, s.state, s.last_activity_at, s.last_log_line, s.tmux_pid, s.ctx_percent ?? null);
+  ).run(s.agent_id, s.state, s.last_activity_at, s.last_log_line, s.tmux_pid, s.ctx_percent ?? null, s.activity_line ?? null);
 }
 
 export function listStatuses(db: Database): AgentStatus[] {

--- a/src/server/mcp/mcpAsk.test.ts
+++ b/src/server/mcp/mcpAsk.test.ts
@@ -627,3 +627,33 @@ test("★대조군 — 안 막히면 상한까지 기다린다★", async () => 
   expect(r.stuckReason).toBeUndefined();
   expect(polls).toBeGreaterThanOrEqual(4); // 50/10 = 5회쯤 돈다
 });
+
+test("★작업 중일 때 '무엇을 하는지' 가 붙는다★", async () => {
+  const db = freshDb();
+  const bus = fakeBus(db);
+  const r = await askTeammate(db, bus.deps, { from: "gd", to: "bill", body: "질문" }, nowait);
+  db.prepare(`INSERT OR REPLACE INTO message_recipient (message_id, agent_id, delivery_state, recipient_state) VALUES (?, 'bill', 'completed', 'in_progress')`).run(r.requestId);
+  db.prepare(`INSERT OR REPLACE INTO agent_status (agent_id, state, activity_line) VALUES ('bill', 'running', 'Read(src/server/mcp/mcpAsk.ts)')`).run();
+  expect(askProgress(db, r.requestId, "bill").label).toContain("Read(src/server/mcp/mcpAsk.ts)");
+});
+
+test("★활동 줄이 없는 팀원(화면 없는 런타임)도 멀쩡히 나온다★", async () => {
+  const db = freshDb();
+  const bus = fakeBus(db);
+  const r = await askTeammate(db, bus.deps, { from: "gd", to: "codex", body: "질문" }, nowait);
+  db.prepare(`INSERT OR REPLACE INTO message_recipient (message_id, agent_id, delivery_state, recipient_state) VALUES (?, 'codex', 'completed', 'in_progress')`).run(r.requestId);
+  const label = askProgress(db, r.requestId, "codex").label;
+  expect(label).toContain("읽고 작업 중"); // ★12명 전부 이건 나온다★
+  expect(label).not.toContain("·"); // 붙일 게 없으면 안 붙인다
+});
+
+test("★막힘에는 활동 줄을 안 붙인다★ — 그건 지금 하는 일이 아니라 결론이다", async () => {
+  const db = freshDb();
+  const bus = fakeBus(db);
+  const r = await askTeammate(db, bus.deps, { from: "gd", to: "bill", body: "질문" }, nowait);
+  db.prepare(`INSERT OR REPLACE INTO message_recipient (message_id, agent_id, delivery_state, recipient_state) VALUES (?, 'bill', 'blocked', 'open')`).run(r.requestId);
+  db.prepare(`INSERT OR REPLACE INTO agent_status (agent_id, state, activity_line) VALUES ('bill', 'running', 'Read(파일)')`).run();
+  const p = askProgress(db, r.requestId, "bill");
+  expect(p.stuck).toBe(true);
+  expect(p.label).not.toContain("Read(파일)");
+});

--- a/src/server/mcp/mcpAsk.ts
+++ b/src/server/mcp/mcpAsk.ts
@@ -256,6 +256,18 @@ export function lateAnswerPush(
  */
 export type AskProgress = { label: string; stuck: boolean };
 
+/** 그 팀원이 지금 무엇을 하고 있나 — 화면이 있는 런타임만 값이 있다(없으면 null). */
+function activityOf(db: Database, agentId: string): string | null {
+  try {
+    const r = db.prepare(`SELECT activity_line FROM agent_status WHERE agent_id = ?`).get(agentId) as
+      | { activity_line: string | null }
+      | undefined;
+    return r?.activity_line?.trim() || null;
+  } catch {
+    return null; // 컬럼이 아직 없는 DB(구버전)에서도 진행 표시가 죽지 않는다
+  }
+}
+
 export function askProgress(db: Database, requestId: string, to: string): AskProgress {
   const row = db
     .prepare(`SELECT delivery_state, recipient_state FROM message_recipient WHERE message_id = ? AND agent_id = ?`)
@@ -271,7 +283,11 @@ export function askProgress(db: Database, requestId: string, to: string): AskPro
   if (row.recipient_state === "acknowledged" || row.recipient_state === "completed") {
     return { label: `${to} 가 답을 쓰는 중입니다`, stuck: false };
   }
-  if (row.recipient_state === "in_progress") return { label: `${to} 가 읽고 작업 중입니다`, stuck: false };
+  if (row.recipient_state === "in_progress") {
+    // ★막힘 상태에는 안 붙인다★ — 그건 '지금 하는 일' 이 아니라 결론이다.
+    const act = activityOf(db, to);
+    return { label: act ? `${to} 가 읽고 작업 중입니다 · ${act}` : `${to} 가 읽고 작업 중입니다`, stuck: false };
+  }
 
   // 아직 안 읽음 — 전달이 어디까지 갔는지로 나눈다.
   if (row.delivery_state === "pending" || row.delivery_state === "dispatching") {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -65,6 +65,8 @@ export interface AgentStatus {
   state: AgentState;
   last_activity_at: string | null;
   last_log_line: string | null;
+  /** 그 팀원이 지금 무엇을 하고 있나(대화 영역의 마지막 ⏺ 줄). 화면이 없는 런타임은 null. */
+  activity_line?: string | null;
   tmux_pid: number | null;
   ctx_percent: number | null;
   probed_at: string;

--- a/src/server/workers/statusProbe.ts
+++ b/src/server/workers/statusProbe.ts
@@ -182,18 +182,23 @@ function weeklyLimitBlockedLine(recent: { line: string; captured_at: string }[])
  * → `⏺` 줄을 쓴다. 실측: "⏺ 그룹방에 인사 전송 완료 (msg …)" · "⏺ Read(파일)" — ★진짜 내용이 있다.★
  *
  * ★입력창 아래는 보지 않는다★: 구분선(───) 밑은 전부 푸터라 거기 있는 `⏺ main`(브랜치 표시)이
- * 대화 출력으로 오인된다. 구분선 위(=대화 영역)에서만 고른다.
+ * 대화 출력으로 오인된다. 구분선 위(=대화 영역)에서만 고르고, ★구분선이 없으면 null★ 이다
+ * (가를 수 없으면 모르는 것이다 — 길이로 거르려 했더니 "main" 이 4자라 안 걸렸다).
  */
 export function currentActivityLine(lines: string[]): string | null {
-  let cutoff = lines.length;
+  // ★구분선을 못 찾으면 null 이다★ — 대화 영역과 푸터를 ★가를 수 없으면 모르는 것★ 이고,
+  //   모름을 값으로 바꾸지 않는다. 화면 전체를 뒤지면 푸터의 `⏺ main`(브랜치)이 잡혀
+  //   "읽고 작업 중입니다 · main" 이 된다. 화면 없는 런타임 7명이 이미 null 로 잘 돈다.
+  let cutoff = -1;
   for (let i = lines.length - 1; i >= 0; i--) {
     if (/─{6,}/.test(lines[i] ?? "")) { cutoff = i; break; }
   }
+  if (cutoff < 0) return null;
   for (let i = cutoff - 1; i >= 0; i--) {
     const raw = (lines[i] ?? "").trim();
     if (!raw.startsWith("⏺")) continue;
     const body = raw.slice(1).trim();
-    if (body.length < 3) continue; // "⏺ main" 같은 한 토막은 표시가 아니라 장식이다
+    if (!body) continue;
     return body.length > 160 ? body.slice(0, 160) + "…" : body;
   }
   return null;

--- a/src/server/workers/statusProbe.ts
+++ b/src/server/workers/statusProbe.ts
@@ -170,6 +170,35 @@ function weeklyLimitBlockedLine(recent: { line: string; captured_at: string }[])
   return null;
 }
 
+/**
+ * ★그 팀원이 지금 무엇을 하고 있나★ — 진행 표시에 붙일 한 줄.
+ *
+ * 왜 맨 아랫줄이 아닌가: 화면 아래 3줄은 ★항상 같은 장식★ 이다(auto mode · ctx% · 경로).
+ * 실측하면 늘 "⏵⏵ auto mode on" 이 저장돼 있어 ★아무 정보가 없었다.★
+ *
+ * 왜 `✻` 가 아닌가: 실측값이 "Sautéed for 1m 7s" · "Cogitated for 1m 25s" 다 —
+ * ★클로드 코드가 아무 단어나 고르는 장식이라 무슨 일인지가 안 들어 있다.★
+ *
+ * → `⏺` 줄을 쓴다. 실측: "⏺ 그룹방에 인사 전송 완료 (msg …)" · "⏺ Read(파일)" — ★진짜 내용이 있다.★
+ *
+ * ★입력창 아래는 보지 않는다★: 구분선(───) 밑은 전부 푸터라 거기 있는 `⏺ main`(브랜치 표시)이
+ * 대화 출력으로 오인된다. 구분선 위(=대화 영역)에서만 고른다.
+ */
+export function currentActivityLine(lines: string[]): string | null {
+  let cutoff = lines.length;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (/─{6,}/.test(lines[i] ?? "")) { cutoff = i; break; }
+  }
+  for (let i = cutoff - 1; i >= 0; i--) {
+    const raw = (lines[i] ?? "").trim();
+    if (!raw.startsWith("⏺")) continue;
+    const body = raw.slice(1).trim();
+    if (body.length < 3) continue; // "⏺ main" 같은 한 토막은 표시가 아니라 장식이다
+    return body.length > 160 ? body.slice(0, 160) + "…" : body;
+  }
+  return null;
+}
+
 function currentPaneCapacityLine(lines: string[]): string | null {
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i];
@@ -236,6 +265,7 @@ export function buildClaudeStatus(
     state: computeStateFromActivity(lastActivityAt),
     last_activity_at: lastActivityAt,
     last_log_line: blockedLine ?? visibleLastLine ?? lastLog?.line ?? null,
+    activity_line: currentPaneLines.length ? currentActivityLine(currentPaneLines) : null,
     tmux_pid: pid,
     ctx_percent: ctxRemaining == null ? null : 100 - ctxRemaining,
     probed_at: new Date().toISOString(),

--- a/src/server/workers/statusProbeActivity.test.ts
+++ b/src/server/workers/statusProbeActivity.test.ts
@@ -32,6 +32,23 @@ test("★푸터의 '⏺ main' 은 안 고른다★ — 그건 브랜치 표시�
   expect(currentActivityLine(onlyFooter)).toBeNull();
 });
 
+// ★구분선이 없는 화면★ (빌 리뷰: 이 축을 아무도 안 보고 있었다)
+//
+// 처음엔 구분선을 못 찾으면 ★화면 전체를 뒤졌다.★ 그러면 푸터의 `⏺ main` 이 잡혀
+// "읽고 작업 중입니다 · main" 이 나간다. 길이로 거르려 했는데 ★"main" 은 4자라 안 걸렸다★ —
+// ★주석은 막는다고 적혀 있었고 실제로는 안 막았다.★
+// → 가를 수 없으면 ★모르는 것★ 이다. null 을 돌린다.
+
+test("★구분선이 없으면 null★ — 대화 영역과 푸터를 가를 수 없으면 모르는 것이다", () => {
+  expect(currentActivityLine(["⏺ main"])).toBeNull();
+  expect(currentActivityLine(["⏵⏵ auto mode on", "⏺ main", "12% ctx"])).toBeNull();
+  expect(currentActivityLine(["⏺ Read(a.ts)", "⏵⏵ auto mode on"])).toBeNull(); // 구분선 없으면 진짜 출력도 안 쓴다
+});
+
+test("★대조군★ — 구분선이 있으면 같은 입력이 값을 낸다", () => {
+  expect(currentActivityLine(["⏺ Read(a.ts)", "──────", "⏵⏵ auto mode on"])).toBe("Read(a.ts)");
+});
+
 test("★맨 아랫줄(고정 장식)을 고르지 않는다★ — 이게 지금까지의 문제였다", () => {
   const got = currentActivityLine(REAL_PANE);
   expect(got).not.toContain("auto mode on");

--- a/src/server/workers/statusProbeActivity.test.ts
+++ b/src/server/workers/statusProbeActivity.test.ts
@@ -1,0 +1,56 @@
+// ★진행 표시에 붙일 '지금 하는 일' 줄★ — 실제 화면 모양으로 잰다.
+//
+// 왜 이 시험이 필요한가: 지금까지 저장하던 last_log_line 은 ★화면 맨 아랫줄★ 이었고
+// 실측하면 늘 "⏵⏵ auto mode on" 이었다 — ★아무 정보가 없었다.★
+// 아래 입력은 ★실제 팀원 화면에서 그대로 떠온 모양★ 이다(2026-08-07).
+import { expect, test } from "bun:test";
+import { currentActivityLine } from "./statusProbe";
+
+// 실측: 디백 화면. ⏺ 출력이 있고 그 아래 입력창·푸터가 있다.
+const REAL_PANE = [
+  "  ⏺ ames의 수합 완료 통지는 종결 메시지라 회신하지 않았습니다",
+  "  ⏺ 그룹방에 인사 전송 완료 (msg mT11g2B0KpHU, thread tg--1003947108339).",
+  "",
+  "✻ Cogitated for 12s",
+  "",
+  "──────────────────────────────",
+  "❯ ",
+  "──────────────────────────────",
+  "   /Users/gdmini/Development/dbak   main   Opus 5 (1M context)",
+  "  ctx 21% [===--------------] · reset 49m",
+  "  ⏺ main",
+  "  ⏵⏵ auto mode on (shift+tab to cycle) · ← for agents",
+];
+
+test("★대화 영역의 마지막 ⏺ 줄을 고른다★", () => {
+  expect(currentActivityLine(REAL_PANE)).toBe("그룹방에 인사 전송 완료 (msg mT11g2B0KpHU, thread tg--1003947108339).");
+});
+
+test("★푸터의 '⏺ main' 은 안 고른다★ — 그건 브랜치 표시지 하는 일이 아니다", () => {
+  // 대화 영역에 ⏺ 가 하나도 없으면 null 이어야 한다. 푸터의 ⏺ main 을 집으면 안 된다.
+  const onlyFooter = REAL_PANE.slice(5); // 구분선부터 = 대화 영역 없음
+  expect(currentActivityLine(onlyFooter)).toBeNull();
+});
+
+test("★맨 아랫줄(고정 장식)을 고르지 않는다★ — 이게 지금까지의 문제였다", () => {
+  const got = currentActivityLine(REAL_PANE);
+  expect(got).not.toContain("auto mode on");
+  expect(got).not.toContain("ctx ");
+});
+
+test("도구 사용 줄도 그대로 나온다", () => {
+  const pane = ["  ⏺ Read(src/server/mcp/mcpAsk.ts)", "──────────────", "❯ ", "  ⏵⏵ auto mode on"];
+  expect(currentActivityLine(pane)).toBe("Read(src/server/mcp/mcpAsk.ts)");
+});
+
+test("⏺ 가 없으면 null — 없는 걸 지어내지 않는다", () => {
+  expect(currentActivityLine(["  ✻ Sautéed for 1m 7s", "──────", "❯ ", "  ⏵⏵ auto mode on"])).toBeNull();
+  expect(currentActivityLine([])).toBeNull();
+});
+
+test("아주 긴 줄은 잘린다 — 진행 표시 한 줄에 들어가야 한다", () => {
+  const long = "  ⏺ " + "가".repeat(400);
+  const got = currentActivityLine([long, "──────", "❯ "]);
+  expect(got!.length).toBeLessThanOrEqual(161);
+  expect(got!.endsWith("…")).toBe(true);
+});


### PR DESCRIPTION
## 배경

팀 리드(2026-08-07): **"3번 해"** · **"가로 진행"** · **"노출 상관없어. 어차피 팀장이 보는거라"**

## 왜 맨 아랫줄이 아닌가 — 실측으로 두 번 걸렀다

**① `last_log_line`(화면 맨 아랫줄)은 항상 같은 장식이다**
```
빌 · 스티브 · 루이 · 디백 전부:  ⏵⏵ auto mode on (shift+tab to cycle)
```
아래 3줄(auto mode · ctx% · 경로)이 고정 푸터다. **아무 정보가 없다.**

**② `✻` 줄도 아니다**
```
✻ Sautéed for 1m 7s · ✻ Cogitated for 1m 25s · ✻ Churned for 7s
```
**클로드 코드가 아무 단어나 고르는 장식**이라 무슨 일인지가 안 들어 있다. 이걸 붙였으면 *"만들고 나서 정보가 없네"* 가 됐을 것이라 **만들기 전에 팀 리드께 알리고 방향을 다시 받았다.**

**③ → `⏺` 줄**
```
⏺ 그룹방에 인사 전송 완료 (msg mT11g2B0KpHU, thread tg--…)
⏺ ames의 수합 완료 통지는 종결 메시지라 회신하지 않았습니다
⏺ Read(src/server/mcp/mcpAsk.ts)
```
**진짜 내용이 있다.**

## 무엇

| | |
|---|---|
| `currentActivityLine()` | **구분선(`───`) 위, 대화 영역에서만** 마지막 `⏺` 를 고른다. 푸터에도 `⏺ main`(브랜치)이 있어 그걸 집으면 **하는 일로 오인**된다. 160자에서 자름 |
| `agent_status.activity_line` | 컬럼 신설. **`last_log_line` 은 안 건드린다** — health 판정이 이미 쓴다 |
| `askProgress` | `in_progress` 일 때만 덧붙임 → `bill 가 읽고 작업 중입니다 · Read(…)` |
| 막힘 | **안 붙인다** — 지금 하는 일이 아니라 결론이다 |
| 화면 없는 런타임(7명) | `null` → **기존 문구 그대로**. 12명 전부 안 깨진다 |

## 시험 — 실제 화면을 그대로 떠서 입력으로 쓴다

지어낸 화면이면 **내가 만든 모양을 내가 검사하는 것**이다. 2026-08-07 실측 pane 을 그대로 넣었다.

- 대화 영역 마지막 `⏺` 를 고른다 · **푸터 `⏺ main` 은 안 고른다** · 고정 장식을 안 고른다
- 도구 줄도 나온다 · `⏺` 없으면 `null`(지어내지 않는다) · 긴 줄은 잘린다
- 활동 줄 없는 팀원도 멀쩡 · 막힘엔 안 붙음
- **뮤턴트**: 푸터 제외를 빼면 **2건 빨간불**, 복원하면 통과

## 검증

전체 **2527 pass / 1 fail**(main 과 동일 집합) · `tsc` 0

## 미검증

**라이브에서 실제로 값이 차는지는 배포 후 `statusProbe` 가 한 바퀴 돌아야 안다.**

## 롤백

단일 커밋 revert. 컬럼은 남지만 아무도 안 읽으므로 무해하다.