### PR TITLE
feat(mcp): 판정을 보이는 자리로 옮기고, 도구 설명에 팀원 명부를 싣는다

### DIFF
--- a/src/server/mcp/b3osMcpServer.ts
+++ b/src/server/mcp/b3osMcpServer.ts
@@ -415,7 +415,19 @@ export function buildMcpServer(db: Database, actor: string | null, scope: McpSco
         "팀원에게 질문하고 그 답을 기다린다. 상대마다 고정된 1:1 방을 쓰므로 이어서 물으면 팀원이 앞 대화를 안다. " +
         "답이 제때 오면 답을, 늦으면 요청 번호와 함께 접수 상태를 돌려준다(요청은 살아 있다 — b3os_fetch_answer 로 회수).",
       inputSchema: {
-        to: z.string().min(1).describe("질문할 팀원 id (예: bill, codex)"),
+        // ★명부를 그때그때 읽어 설명에 싣는다★ — 손으로 적으면 팀원이 바뀔 때 갈린다.
+        //   왜 필요한가(실측 2026-08-07): 클라이언트가 "빌" 을 bill 로 ★음차로 추측★ 하고 있었고,
+        //   id 목록을 얻으려면 team_status 를 ★먼저 한 번 불러야★ 했다. 세션 첫 마디부터
+        //   "빌한테 물어봐" 라고 하면 추측이 된다. 도구 설명은 ★세션 시작 시 주어지므로★
+        //   여기 실으면 추가 호출 없이 정확해진다.
+        to: z
+          .string()
+          .min(1)
+          .describe(
+            `질문할 팀원 id. 지금 등록된 팀원: ${listAgents(db)
+              .map((a) => `${a.id}(${a.display_name})`)
+              .join(" · ")}`,
+          ),
         question: z.string().min(1).describe("질문 본문"),
         wait_seconds: z
           .number()
@@ -490,7 +502,10 @@ export function buildMcpServer(db: Database, actor: string | null, scope: McpSco
               (r.stuckReason
                 // ★막힌 것은 '아직 안 왔다' 가 아니다★ — 기다려도 안 온다는 걸 그대로 말한다.
                 ? `${r.stuckReason}\n`
-                : `${to} 가 아직 답하지 않았습니다 (${Math.round((r.waitedMs ?? 0) / 1000)}초 기다림).\n`) +
+                // ★진행 알림은 클라이언트가 progressToken 을 줘야 나간다★ — 안 주는 클라이언트에서는
+                //   같은 판정이 ★한 번도 안 보인다.★ 그래서 ★보이는 자리(접수 문구)★ 에 같은 판정을 쓴다.
+                //   실측 2026-08-07: 클로드 코드는 토큰을 안 보내 진행 알림이 0건 도착했다.
+                : `${askProgress(db, r.requestId, to).label} (${Math.round((r.waitedMs ?? 0) / 1000)}초 기다림).\n`) +
               `요청 번호 ${r.requestId} — 질문은 살아 있습니다. 나중에 b3os_fetch_answer 로 받거나, ` +
               `늦게 오면 팀 리드의 평소 채널로 전달됩니다.`,
           },

--- a/src/server/mcp/mcpAsk.test.ts
+++ b/src/server/mcp/mcpAsk.test.ts
@@ -657,3 +657,34 @@ test("★막힘에는 활동 줄을 안 붙인다★ — 그건 지금 하는 �
   expect(p.stuck).toBe(true);
   expect(p.label).not.toContain("Read(파일)");
 });
+
+// ── ★진행 알림이 안 나가는 클라이언트에서도 판정이 보인다★ (실측 2026-08-07) ──
+//
+// 클로드 코드는 progressToken 을 안 보낸다 → 진행 알림이 ★0건★ 도착한다(팀 리드 확인).
+// 규약상 토큰 없이는 서버가 보낼 수 없으므로 ★우리가 고를 수 있는 게 아니다.★
+// → 같은 판정을 ★보이는 자리(접수 문구)★ 에도 쓴다.
+
+test("★접수 문구가 '아직 답 안 함' 이 아니라 어디까지 왔는지를 말한다★", async () => {
+  const db = freshDb();
+  const tools = (buildMcpServer(db, "gd", "write") as unknown as {
+    _registeredTools: Record<string, { handler: (a: unknown, e: unknown) => Promise<{ content: { text: string }[] }> }>;
+  })._registeredTools;
+  // 버스가 없으므로 발신이 실패한다 — 그건 이 시험 대상이 아니다. 라벨 함수만 직접 검증한다.
+  db.prepare(`INSERT OR REPLACE INTO thread (id, title, kind, participants_json, opened_by) VALUES ('mcp-gd-bill','r','dm','[]','user')`).run();
+  db.prepare(`INSERT OR REPLACE INTO message (id, thread_id, from_agent_id, to_agent_id, type, body, source, created_at) VALUES ('q9','mcp-gd-bill','user','bill','dm','q','user',datetime('now'))`).run();
+  db.prepare(`INSERT OR REPLACE INTO message_recipient (message_id, agent_id, delivery_state, recipient_state) VALUES ('q9','bill','completed','in_progress')`).run();
+  expect(askProgress(db, "q9", "bill").label).toContain("읽고 작업 중");
+  expect(tools.b3os_ask_teammate).toBeDefined();
+});
+
+test("★도구 설명에 팀원 명부가 실린다★ — 세션 첫 마디부터 id 를 추측하지 않게", () => {
+  const db = freshDb();
+  const t = (buildMcpServer(db, "gd", "write") as unknown as {
+    _registeredTools: Record<string, { inputSchema?: { shape?: { to?: { description?: string } } } }>;
+  })._registeredTools.b3os_ask_teammate;
+  const desc = t?.inputSchema?.shape?.to?.description ?? "";
+  expect(desc).toContain("bill");
+  expect(desc).toContain("codex");
+  // ★손으로 적은 목록이 아니다★ — 명부에 없는 사람은 안 나온다
+  expect(desc).not.toContain("nova");
+});

--- a/src/server/mcp/mcpAsk.test.ts
+++ b/src/server/mcp/mcpAsk.test.ts
@@ -664,27 +664,35 @@ test("★막힘에는 활동 줄을 안 붙인다★ — 그건 지금 하는 �
 // 규약상 토큰 없이는 서버가 보낼 수 없으므로 ★우리가 고를 수 있는 게 아니다.★
 // → 같은 판정을 ★보이는 자리(접수 문구)★ 에도 쓴다.
 
-test("★접수 문구가 '아직 답 안 함' 이 아니라 어디까지 왔는지를 말한다★", async () => {
+test("★접수 문구가 실제로 판정을 담는다★ — 진행 알림이 0건이어도 화면에 보이는 줄이다", async () => {
+  // ★이 시험이 읽어야 하는 건 '접수 문구' 자체다.★ 앞판은 askProgress 를 직접 불러서
+  // ★이 PR 이 바꾼 한 줄을 되돌려도 통과했다★(빌 뮤턴트 실측: 51개 전부 통과).
+  // mcpAsk.ts 가 `deps.fetchImpl ?? fetch` 라 ★전역 fetch 를 갈면 핸들러 경로가 그대로 돈다.★
   const db = freshDb();
-  const tools = (buildMcpServer(db, "gd", "write") as unknown as {
-    _registeredTools: Record<string, { handler: (a: unknown, e: unknown) => Promise<{ content: { text: string }[] }> }>;
-  })._registeredTools;
-  // 버스가 없으므로 발신이 실패한다 — 그건 이 시험 대상이 아니다. 라벨 함수만 직접 검증한다.
-  db.prepare(`INSERT OR REPLACE INTO thread (id, title, kind, participants_json, opened_by) VALUES ('mcp-gd-bill','r','dm','[]','user')`).run();
-  db.prepare(`INSERT OR REPLACE INTO message (id, thread_id, from_agent_id, to_agent_id, type, body, source, created_at) VALUES ('q9','mcp-gd-bill','user','bill','dm','q','user',datetime('now'))`).run();
-  db.prepare(`INSERT OR REPLACE INTO message_recipient (message_id, agent_id, delivery_state, recipient_state) VALUES ('q9','bill','completed','in_progress')`).run();
-  expect(askProgress(db, "q9", "bill").label).toContain("읽고 작업 중");
-  expect(tools.b3os_ask_teammate).toBeDefined();
+  const bus = fakeBus(db);
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = bus.deps.fetchImpl!;
+  try {
+    const tools = (buildMcpServer(db, "gd", "write") as unknown as {
+      _registeredTools: Record<string, { handler: (a: unknown, e: unknown) => Promise<{ content: { text: string }[] }> }>;
+    })._registeredTools;
+    // extra 를 {} 로 준다 = ★progressToken 없는 클라이언트★. 그 상태에서 무엇이 보이는지가 이 PR 의 전부다.
+    const r = await tools.b3os_ask_teammate!.handler({ to: "bill", question: "q", wait_seconds: 1 }, {});
+    const text = r.content[0]!.text;
+    expect(text).not.toContain("아직 답하지 않았습니다");
+    expect(text).toContain("전달");
+  } finally {
+    globalThis.fetch = realFetch;
+  }
 });
 
-test("★도구 설명에 팀원 명부가 실린다★ — 세션 첫 마디부터 id 를 추측하지 않게", () => {
+test("★명부를 DB 에서 읽는다★ — 손으로 박으면 이 시험이 죽는다", () => {
+  // 앞판은 not.toContain("nova") 였는데 ★nova 는 원래 없으니 손으로 박아도 통과★ 했다.
+  // ★코드에 있을 수 없는 id 를 넣어야★ 생성인지 박은 건지 갈린다.
   const db = freshDb();
+  addAgent(db, "zzqa");
   const t = (buildMcpServer(db, "gd", "write") as unknown as {
     _registeredTools: Record<string, { inputSchema?: { shape?: { to?: { description?: string } } } }>;
   })._registeredTools.b3os_ask_teammate;
-  const desc = t?.inputSchema?.shape?.to?.description ?? "";
-  expect(desc).toContain("bill");
-  expect(desc).toContain("codex");
-  // ★손으로 적은 목록이 아니다★ — 명부에 없는 사람은 안 나온다
-  expect(desc).not.toContain("nova");
+  expect(t?.inputSchema?.shape?.to?.description ?? "").toContain("zzqa");
 });


### PR DESCRIPTION
## ① 진행 알림은 클라이언트가 안 받아간다 — 실측으로 확정

**내가 직접 `progressToken` 을 넣어 쏘면 정상적으로 온다:**
```
0초  bill 에게 전달 중입니다
2초  bill 에게 전달 중입니다
5초  bill 가 아직 열어보지 않았습니다
```
CF · MCP 창구 · 서버 전부 정상이다.

그런데 **클로드 코드에서는 한 건도 도착하지 않는다**(팀 리드 확인: 두 번 물었는데 도구 응답이 단일 객체로 끝났고 중간 표시 0건). **규약상 `progressToken` 이 없으면 서버는 진행 알림을 보낼 수 없다** — 우리가 고를 수 있는 게 아니다.

→ **같은 판정을 보이는 자리(접수 문구)에도 쓴다.**

| | |
|---|---|
| 전 | `bill 가 아직 답하지 않았습니다 (61초 기다림)` |
| 후 | **`bill 가 읽고 작업 중입니다 (61초 기다림)`** |

클라이언트가 안 바뀌어도 보인다. **만든 판정이 한 번도 안 보이는 상태**를 없앤다.

## ② 이름→id 를 음차로 추측하고 있었다

팀 리드가 클로드 코드 쪽 설명을 전해줬다 — `"빌"→bill` 은 **조회가 아니라 발음으로 맞춘 것**이고, id 목록을 얻으려면 **`team_status` 를 먼저 한 번 불러야** 했다. 세션 첫 마디부터 *"빌한테 물어봐"* 라고 하면 **추측**이 된다. 발음이 겹치는 팀원이 생기면 **조용히 엉뚱한 사람에게 간다.**

→ 도구 설명에 **명부를 그때그때 읽어** 싣는다. 도구 설명은 **세션 시작 시 주어지므로 추가 호출 없이** 정확해진다.

```
질문할 팀원 id. 지금 등록된 팀원: ames(Ames) · bill(Bill) · brief(Brief) · …
```

**손으로 적지 않는다** — 적으면 팀원이 바뀔 때 갈린다. 시험이 그것도 본다(명부에 없는 이름 부재 확인).

## 이 PR 이 푸는 범위 — id 목록까지다

빌 확인: `display_name` 이 **id 를 대문자로 쓴 것뿐**이라 `bill(Bill)` 의 괄호가 아무 정보도 안 준다.
즉 **"빌"→bill 문제는 이걸로 안 풀린다.** 풀리는 것은 **"어떤 id 가 있나"** 까지다.

(은퇴자 섞임은 없다 — `agent` 표에 상태 컬럼이 없어 **그 표가 곧 현재 명부**다.)

## 한글 표기는 넣지 않았다

DB · `agents.json` 어디에도 **한글 이름 정본이 없다.** 지어내면 그게 정본이 된다. 지금은 음차가 안 겹쳐 동작하므로 **정본을 만들지 말지는 별도 판단**으로 남긴다.

## 검증

mcp **90 pass**(신규 2) · `tsc` 0 · 전체 **2533 pass / 1 fail**(main 과 동일 집합)

## 롤백

단일 커밋 revert.


## 추가 커밋 — 시험 2건이 뮤턴트를 못 죽이던 것 (빌 리뷰)

처음 올린 시험 **2건 다 뮤턴트 생존**이었다. 둘 다 **이름은 넓고 검사는 좁은** 같은 모양이다.

| 뮤턴트 | 전 | 후 |
|---|---|---|
| 접수 문구 되돌림 | **51개 전부 통과** | **1건 red** |
| 명부를 손으로 박음 | **51개 전부 통과** | **1건 red** |

- 접수 문구 시험이 **접수 문구를 안 읽었다** — `askProgress` 를 직접 부르고 도구 등록만 봤다. `deps.fetchImpl ?? fetch` 라 **전역 fetch 를 갈면 핸들러 경로가 그대로 돈다** → `extra: {}`(progressToken 없는 클라이언트)로 실제 응답 문구를 읽는다
- 명부 시험이 `not.toContain("nova")` 였는데 **nova 는 원래 없으니 손으로 박아도 통과**한다 → **코드에 있을 수 없는 id(`zzqa`)** 를 넣어 생성인지 확인

## 팀 리드가 본 것의 정체 (빌 확인)

"몇 초만 나온다" 는 **진행 알림이 아니라 변경 전 접수 문구**였다. 즉 **#292·#293 의 라벨은 지금까지 화면에 한 번도 안 나왔다.** 이 PR 이 그것을 처음 보이게 한다.