### PR TITLE
feat(mcp): 도구 설명 명부를 정규 팀원만으로 좁힌다

### DIFF
--- a/src/server/mcp/b3osMcpServer.ts
+++ b/src/server/mcp/b3osMcpServer.ts
@@ -15,6 +15,8 @@ import { inboxFor } from "../db/inboxQueries";
 import { listTasks, createTask, updateTask } from "../db/taskQueries";
 import { recallDmMessages } from "../db/dmCapture";
 import { classifyAll } from "../lib/health";
+import { ambientAgents } from "../lib/registry"; // 정규 팀원 여부·별칭의 정본은 agents.json 이다 (DB 표에는 없다)
+import { isTeamOfficialMember } from "../lib/agentMembership";
 import { leadActorId } from "../lib/opAuth"; // ★이름만 재사용★ — 신뢰 규칙(루프백=리드)은 쓰지 않는다
 import { askTeammate, fetchAnswer, askProgress } from "./mcpAsk";
 
@@ -133,6 +135,28 @@ function denyCrossMember(self: string, target: string) {
     isError: true,
     structuredContent: { error: "cross_member_denied", self, target },
   };
+}
+
+/**
+ * 도구 설명에 실을 명부 — ★정규 팀원만★ (팀 리드 2026-08-07: "정규팀원만 해").
+ *
+ * ★정본이 두 군데로 갈려 있다★: 누가 있는지는 DB(`agent` 표), 정규 여부는 agents.json 이다.
+ * `agent` 표에는 `team_official_member` 칸이 없다 — 그래서 DB 만 읽으면 12명 전부가 나온다.
+ *
+ * ★빼는 쪽으로만 판단한다★: 레지스트리가 ★명시적으로 비정규라고 한 id★ 만 뺀다.
+ * agents.json 이 없는 환경(공개 clone 첫 부팅)에서는 `ambientAgents()` 가 빈 배열이라
+ * ★아무도 안 빠진다.★ 반대로 짰다면(정규인 사람만 남기기) 같은 상황에서 ★명부가 통째로 빈다.★
+ */
+export function officialRoster(db: Database): string {
+  const nonOfficial = new Set(
+    ambientAgents()
+      .filter((a) => !isTeamOfficialMember(a))
+      .map((a) => a.id),
+  );
+  return listAgents(db)
+    .filter((a) => !nonOfficial.has(a.id))
+    .map((a) => `${a.id}(${a.display_name})`)
+    .join(" · ");
 }
 
 /**
@@ -420,14 +444,13 @@ export function buildMcpServer(db: Database, actor: string | null, scope: McpSco
         //   id 목록을 얻으려면 team_status 를 ★먼저 한 번 불러야★ 했다. 세션 첫 마디부터
         //   "빌한테 물어봐" 라고 하면 추측이 된다. 도구 설명은 ★세션 시작 시 주어지므로★
         //   여기 실으면 추가 호출 없이 정확해진다.
+        //   ★설명에는 정규 팀원만 싣는다★ (팀 리드 2026-08-07). 12명 전부가 아니라 9명이다.
+        //   ★설명을 좁히는 것이지 문을 좁히는 게 아니다★ — 아래 `to` 검증(listAgents)은 그대로라
+        //   비정규 팀원에게 묻는 것 자체는 계속 된다. 안내와 허용을 같이 줄이면 조용히 못 묻게 된다.
         to: z
           .string()
           .min(1)
-          .describe(
-            `질문할 팀원 id. 지금 등록된 팀원: ${listAgents(db)
-              .map((a) => `${a.id}(${a.display_name})`)
-              .join(" · ")}`,
-          ),
+          .describe(`질문할 팀원 id. 지금 등록된 팀원: ${officialRoster(db)}`),
         question: z.string().min(1).describe("질문 본문"),
         wait_seconds: z
           .number()

--- a/src/server/mcp/mcpAsk.test.ts
+++ b/src/server/mcp/mcpAsk.test.ts
@@ -15,7 +15,10 @@ import {
   lateAnswerPush,
   THREAD_ID_MAX,
 } from "./mcpAsk";
-import { buildMcpServer, ASK_WAIT_MAX_SEC, ASK_WAIT_DEFAULT_SEC } from "./b3osMcpServer";
+import { buildMcpServer, officialRoster, ASK_WAIT_MAX_SEC, ASK_WAIT_DEFAULT_SEC } from "./b3osMcpServer";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 function addAgent(d: Database, id: string) {
   d.prepare(
@@ -695,4 +698,76 @@ test("★명부를 DB 에서 읽는다★ — 손으로 박으면 이 시험이 
     _registeredTools: Record<string, { inputSchema?: { shape?: { to?: { description?: string } } } }>;
   })._registeredTools.b3os_ask_teammate;
   expect(t?.inputSchema?.shape?.to?.description ?? "").toContain("zzqa");
+});
+
+// ── ★도구 설명에는 정규 팀원만★ (팀 리드 2026-08-07: "정규팀원만 해") ──
+//
+// 정규 여부의 정본은 ★agents.json★ 이다 — `agent` 표에는 그 칸이 없다.
+// 그래서 레지스트리를 격리해서 재고, ★라이브 agents.json 에 기대지 않는다★
+// (기대면 팀원이 바뀔 때마다 시험이 갈린다).
+
+function withRegistry(entries: Array<Record<string, unknown>>): string {
+  const dir = mkdtempSync(join(tmpdir(), "mcp-roster-"));
+  // 캐시 키에 경로가 들어가므로 시험마다 새 파일을 쓰면 서로 안 섞인다.
+  const path = join(dir, `agents-${entries.length}.json`);
+  writeFileSync(path, JSON.stringify(entries));
+  process.env.TEAM_AGENT_REGISTRY = path;
+  return dir;
+}
+function agentEntry(id: string, official: boolean): Record<string, unknown> {
+  return {
+    id, display_name: id, role: "t", runtime: "claude_channel", status_provider: "claude_tmux",
+    workspace_path: `/tmp/${id}`, persona_file: `/tmp/${id}/SOUL.md`, team_official_member: official,
+  };
+}
+
+test("★비정규 팀원은 도구 설명에서 빠진다★ — 12명이 아니라 정규만", () => {
+  const prev = process.env.TEAM_AGENT_REGISTRY;
+  const dir = withRegistry([agentEntry("bill", true), agentEntry("codex", true), agentEntry("hermes", false)]);
+  try {
+    const db = freshDb(); // 표에는 bill·codex·hermes·demis 넷 다 있다
+    const desc = officialRoster(db);
+    expect(desc).toContain("bill");
+    expect(desc).toContain("codex");
+    expect(desc).not.toContain("hermes"); // ★레지스트리가 비정규라고 한 사람★
+    expect(desc).toContain("demis"); // 레지스트리에 없는 사람은 ★안 뺀다★ (모르는 것 ≠ 비정규)
+  } finally {
+    if (prev === undefined) delete process.env.TEAM_AGENT_REGISTRY; else process.env.TEAM_AGENT_REGISTRY = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("★레지스트리가 없으면 아무도 안 뺀다★ — 공개 clone 첫 부팅에서 명부가 통째로 비면 안 된다", () => {
+  const prev = process.env.TEAM_AGENT_REGISTRY;
+  const dir = mkdtempSync(join(tmpdir(), "mcp-roster-none-"));
+  process.env.TEAM_AGENT_REGISTRY = join(dir, "없는파일.json"); // 읽히지 않는다 → 빈 로스터
+  try {
+    const desc = officialRoster(freshDb());
+    for (const id of ["bill", "codex", "hermes", "demis"]) expect(desc).toContain(id);
+  } finally {
+    if (prev === undefined) delete process.env.TEAM_AGENT_REGISTRY; else process.env.TEAM_AGENT_REGISTRY = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("★설명을 좁히는 것이지 문을 좁히는 게 아니다★ — 비정규 팀원에게도 계속 물을 수 있다", async () => {
+  const prev = process.env.TEAM_AGENT_REGISTRY;
+  const dir = withRegistry([agentEntry("bill", true), agentEntry("hermes", false)]);
+  const db = freshDb();
+  const bus = fakeBus(db);
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = bus.deps.fetchImpl;
+  try {
+    expect(officialRoster(db)).not.toContain("hermes"); // 설명에는 없는데
+    const tools = (buildMcpServer(db, "gd", "write") as unknown as {
+      _registeredTools: Record<string, { handler: (a: unknown, e: unknown) => Promise<{ content: { text: string }[]; isError?: boolean }> }>;
+    })._registeredTools;
+    const r = await tools.b3os_ask_teammate!.handler({ to: "hermes", question: "q", wait_seconds: 1 }, {});
+    expect(r.isError).toBeUndefined(); // ★묻는 것은 그대로 된다★
+    expect(r.content[0]!.text).not.toContain("등록된 팀원이 아니다");
+  } finally {
+    globalThis.fetch = realFetch;
+    if (prev === undefined) delete process.env.TEAM_AGENT_REGISTRY; else process.env.TEAM_AGENT_REGISTRY = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
팀 리드 지시(2026-08-07 1:1): **"팀원 12명이 다 할 필요는 없고.. 정규팀원만 해."**
#295 로 방금 들어간 도구 설명 명부를 **정규 팀원 9명**으로 좁힌다.

## 실측 — 실제로 나오는 문자열

```
전(12명, 165자): ames(Ames) · bill(Bill) · brief(Brief) · codex(Codex) · dbak(Dbak) · demis(Demis)
                 · devon(Devon) · dex(Dex) · forin(Forin) · hermes(Hermes) · lui(Lui) · steve(Steve)

후( 9명, 124자): ames(Ames) · bill(Bill) · codex(Codex) · dbak(Dbak) · demis(Demis) · devon(Devon)
                 · hermes(Hermes) · lui(Lui) · steve(Steve)
```
빠지는 3명: `brief`(꺼져 있음) · `dex` · `forin`(team_scope=personal) — 셋 다 `team_official_member: false`.

## 왜 레지스트리를 같이 읽나

**정본이 두 군데로 갈려 있다.** 누가 있는지는 DB(`agent` 표), **정규 여부는 `agents.json`** 이다.
`agent` 표에는 `team_official_member` 칸이 아예 없다 — 그래서 DB 만 읽으면 12명이 나온다.
(`regular_teammate` 같은 이름은 코드·설정·문서 어디에도 없다. 확인했다.)

## 설계 판단 2개 — 둘 다 뮤턴트로 고정했다

**1. 빼는 쪽으로만 판단한다.** 레지스트리가 **명시적으로 비정규라고 한 id 만** 뺀다.
`agents.json` 이 없는 환경(공개 clone 첫 부팅)에서 `ambientAgents()` 는 빈 배열을 준다.
지금 방향이면 **아무도 안 빠진다.** 반대로 짰다면(정규인 사람만 남기기) 같은 상황에서 **명부가 통째로 빈다.**
레지스트리가 모르는 id 도 안 뺀다 — **모르는 것과 비정규는 다르다.**

**2. 설명을 좁히는 것이지 문을 좁히는 게 아니다.**
`to` 검증(`listAgents`)은 그대로라 **비정규 팀원에게 묻는 것 자체는 계속 된다.**
안내와 허용을 같이 줄이면 조용히 못 묻게 된다.

## 검증

**뮤턴트 3종 — 각각 해당 시험만 정확히 빨간불**

| 뮤턴트 | 죽는 시험 |
|---|---|
| 필터 자체를 뺀다 | `비정규 팀원은 도구 설명에서 빠진다` + `설명을 좁히는 것이지…` |
| 방향을 뒤집는다(정규만 남기기) | `비정규 팀원은…` + **`레지스트리가 없으면 아무도 안 뺀다`** |
| 문까지 좁힌다 | `설명을 좁히는 것이지 문을 좁히는 게 아니다` |

- 시험은 **레지스트리를 임시 파일로 격리**한다 — 라이브 `agents.json` 에 기대면 팀원이 바뀔 때마다 갈린다
- `mcpAsk` 54 pass / 0 fail · tsc 0
- 전체 수트를 **개수가 아니라 이름으로** main 과 대조 → **실패 집합 완전히 동일**
  (기존 실패 3건은 `rules/TEAM-OS.md` 가 `.gitignore:113` 에 있어서 나는 것으로, 이 PR 과 무관하고 별건으로 잡혀 있다)

## 안 한 것

**한글 이름은 안 넣었다.** `agents.json` 의 `nicknames` 에 `빌`·`코덱스`·`헤르메스` 가 **이미 있어서**
지어내지 않고도 넣을 수 있다는 걸 확인했지만, 팀 리드 확인 전이라 **이 PR 에는 안 담았다.**

배포 층: **서버만 → 재시작 필요, 빌드 불필요.** 되돌리기는 이 커밋 revert + 재시작.
