### PR TITLE
feat(mcp): 누구 말인지 클라이언트가 채워 넣는 파라미터

### DIFF
--- a/src/server/mcp/b3osMcpServer.ts
+++ b/src/server/mcp/b3osMcpServer.ts
@@ -452,6 +452,16 @@ export function buildMcpServer(db: Database, actor: string | null, scope: McpSco
           .min(1)
           .describe(`질문할 팀원 id. 지금 등록된 팀원: ${officialRoster(db)}`),
         question: z.string().min(1).describe("질문 본문"),
+        // ★누구 말인지 클라이언트가 채워 넣는다★ (팀 리드 2026-08-07: "함수 파라미터를 채워 넣는 걸로").
+        //   서버는 이걸 만들어낼 수 없다 — 도착하는 건 글자뿐이고 ★누가 썼는지는 클라이언트만 안다.★
+        //   ★주장이지 증거가 아니다★: 권한 판정에 쓰지 않고, 사람이 오해하지 않게 보여주기만 한다.
+        speaker: z
+          .enum(["lead", "client"])
+          .optional()
+          .describe(
+            "이 질문이 누구 말인지. lead=사용자가 친 원문 그대로 · client=당신(클라이언트)이 정리하거나 지어낸 말. " +
+              "정리해서 보낼 때는 반드시 client 로 채우세요 — 받는 팀원이 사용자 지시로 오해합니다.",
+          ),
         wait_seconds: z
           .number()
           .int()
@@ -463,7 +473,9 @@ export function buildMcpServer(db: Database, actor: string | null, scope: McpSco
     },
     async (args: unknown, extra: unknown) => {
       if (!actor) return denyIdentity("팀원에게 질문");
-      const { to, question, wait_seconds } = args as { to: string; question: string; wait_seconds?: number };
+      const { to, question, wait_seconds, speaker } = args as {
+        to: string; question: string; wait_seconds?: number; speaker?: "lead" | "client";
+      };
       if (to === actor) {
         return {
           content: [{ type: "text", text: `거부: 자기 자신(${actor})에게는 물을 수 없다.` }],
@@ -502,11 +514,12 @@ export function buildMcpServer(db: Database, actor: string | null, scope: McpSco
       const r = await askTeammate(
         db,
         { baseUrl: busBaseUrl() },
-        { from: actor, to, body: question, client: clientName() },
+        { from: actor, to, body: question, client: clientName(), speaker },
         { waitMs, pollMs: 1500, onWait }, // 디스패처 폴링과 같은 간격 — 더 자주 봐도 새 사실이 생기지 않는다
       );
       appendAudit(db, actor, "mcp.ask_teammate", to, {
         request_id: r.requestId, thread_id: r.roomId, status: r.status, waited_ms: r.waitedMs,
+        speaker: speaker ?? null, // 안 채우면 null — ★안 채운 것과 lead 를 구분한다★
       });
       if (r.status === "answered" && r.answer) {
         return {

--- a/src/server/mcp/mcpAsk.test.ts
+++ b/src/server/mcp/mcpAsk.test.ts
@@ -771,3 +771,47 @@ test("★설명을 좁히는 것이지 문을 좁히는 게 아니다★ — 비
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+// ── ★누구 말인지 클라이언트가 채워 넣는다★ (팀 리드 2026-08-07) ──
+//
+// 서버는 이걸 만들어낼 수 없다 — 도착하는 건 글자뿐이고 ★누가 썼는지는 클라이언트만 안다.★
+// ★주장이지 증거가 아니다★: 클라이언트가 본문에 "— GD" 라고 서명한 적이 있고 그걸 믿어서 틀렸다.
+// 그래서 ★권한 판정에 안 쓰고 보여주기만★ 한다.
+
+test("★client 로 채우면 받는 팀원 화면에 표시가 붙는다★ — meta 에만 두면 팀원은 못 본다", async () => {
+  const db = freshDb();
+  const bus = fakeBus(db);
+  await askTeammate(db, bus.deps, { from: "gd", to: "bill", body: "정리한 질문", speaker: "client" }, nowait);
+  const p = bus.calls[0]!;
+  expect(p.body as string).toContain("[클라이언트가 정리한 말입니다");
+  expect(p.body as string).toContain("정리한 질문");
+  expect((p.meta as Record<string, unknown>).mcp_speaker).toBe("client");
+});
+
+test("★lead 면 본문을 안 건드린다★ — 팀 리드 원문은 그대로 간다", async () => {
+  const db = freshDb();
+  const bus = fakeBus(db);
+  await askTeammate(db, bus.deps, { from: "gd", to: "bill", body: "원문 그대로", speaker: "lead" }, nowait);
+  const p = bus.calls[0]!;
+  expect(p.body).toBe("원문 그대로");
+  expect((p.meta as Record<string, unknown>).mcp_speaker).toBe("lead");
+});
+
+test("★안 채우면 '채워서 lead' 와 구분된다★ — 없는 것을 lead 로 치지 않는다", async () => {
+  const db = freshDb();
+  const bus = fakeBus(db);
+  await askTeammate(db, bus.deps, { from: "gd", to: "bill", body: "표시 없음" }, nowait);
+  const p = bus.calls[0]!;
+  expect(p.body).toBe("표시 없음");
+  expect((p.meta as Record<string, unknown>).mcp_speaker).toBeUndefined();
+});
+
+test("★도구가 speaker 를 받고, 설명이 '정리했으면 client' 를 말한다★", () => {
+  const db = freshDb();
+  const t = (buildMcpServer(db, "gd", "write") as unknown as {
+    _registeredTools: Record<string, { inputSchema?: { shape?: Record<string, { description?: string }> } }>;
+  })._registeredTools.b3os_ask_teammate;
+  const desc = t?.inputSchema?.shape?.speaker?.description ?? "";
+  expect(desc).toContain("client");
+  expect(desc).toContain("정리"); // ★언제 채우는지가 설명에 있어야 클라이언트가 채운다★
+});

--- a/src/server/mcp/mcpAsk.ts
+++ b/src/server/mcp/mcpAsk.ts
@@ -137,11 +137,20 @@ function busSourceFor(db: Database, actor: string): "agent" | "user" {
 
 export async function postQuestion(
   deps: PostQuestionDeps,
-  env: { from: string; source: "agent" | "user"; actor: string; to: string; body: string; roomId: string; client?: string },
+  env: {
+    from: string; source: "agent" | "user"; actor: string; to: string; body: string; roomId: string;
+    client?: string;
+    /** 사람이 친 원문인지, 클라이언트가 정리한 것인지. ★주장이지 증거가 아니다★ — 아래 주석 참고. */
+    speaker?: "lead" | "client";
+  },
 ): Promise<{ id: string; thread_id: string }> {
   // ★actor 는 버스 발신자와 다를 수 있다★ (리드 = user 로 나간다) — 그래서 신원을 meta 에 남긴다.
   // ★mcp_actor 는 기록용이다 — 권한 판정에 읽지 마라★ (위 busIdentityFor 주석). 누가 물었는지 사람이 볼 때만 쓴다.
   const meta: Record<string, unknown> = { reply_route: MCP_REPLY_ROUTE, mcp_actor: env.actor };
+  // ★이건 클라이언트의 '주장' 이지 '증거' 가 아니다★ (2026-08-07 실사고):
+  //   클라이언트가 본문 끝에 "— GD" 라고 서명한 적이 있고, 그걸 신원 증거로 읽어서 틀렸다.
+  //   → 이 값으로 ★권한을 정하지 않는다.★ 사람이 오해하지 않게 ★보여주는 용도★ 다.
+  if (env.speaker) meta.mcp_speaker = env.speaker;
   // 어느 클라이언트였는지는 ★기록용★이다. 동작은 reply_route 하나가 정한다.
   if (env.client) meta.mcp_client = env.client;
   const doFetch = deps.fetchImpl ?? fetch;
@@ -151,7 +160,12 @@ export async function postQuestion(
     body: JSON.stringify({
       from_agent_id: env.from,
       to_agent_id: env.to,
-      body: env.body,
+      // ★받는 사람이 보는 자리에 붙인다★ — meta 에만 두면 팀원은 못 본다.
+      //   기본(표시 없음)은 건드리지 않는다. 명시적으로 client 일 때만 붙인다.
+      body:
+        env.speaker === "client"
+          ? `[클라이언트가 정리한 말입니다 — 팀 리드 원문 아님]\n${env.body}`
+          : env.body,
       type: "dm",
       priority: "normal",
       source: env.source,
@@ -319,7 +333,7 @@ export interface AskOptions {
 export async function askTeammate(
   db: Database,
   deps: PostQuestionDeps,
-  env: { from: string; to: string; body: string; client?: string },
+  env: { from: string; to: string; body: string; client?: string; speaker?: "lead" | "client" },
   opts: AskOptions,
 ): Promise<AskResult> {
   // ★방 이름은 신원으로 짓는다★(mcp-gd-bill) — 버스 발신자가 user 여도 방은 리드의 방이다.


### PR DESCRIPTION
## 배경

팀 리드(2026-08-07): **"함수 파라미터를 채워 넣는 걸로."**

## 왜 서버가 못 정하나

MCP 로 도착하는 건 **질문 글자 하나**다. 그 글자를 사람이 쳤는지 클라이언트가 지어냈는지는 **클라이언트만 안다.** 봉투에도 안 실려 온다.

→ **클라이언트가 신고하게 한다.**

## 무엇

```ts
speaker?: "lead" | "client"
```

| 값 | 동작 |
|---|---|
| `lead` | 사용자가 친 원문 그대로 → **본문 그대로** |
| `client` | 클라이언트가 정리·작성 → 본문 앞에 표시 |
| **안 채움** | 표시도 meta 도 **없음** |

```
[클라이언트가 정리한 말입니다 — 팀 리드 원문 아님]
#295 배포 후 화면 확인 결과 알려주세요
```

**표시는 본문에 붙인다** — meta 에만 두면 **받는 팀원이 못 본다.** 오늘 빌이 내 시험 메시지를 팀 리드 지시로 이해한 지점이 정확히 거기다.

**"채워서 lead" 와 "아예 안 채움" 을 구분한다.** 없는 것을 `lead` 로 치면 **거짓 보증**이 된다.

## 주장이지 증거가 아니다

오늘 클라이언트가 본문 끝에 **`— GD`** 라고 서명했고 나는 그것을 신원 증거로 읽어 틀렸다. 같은 실수를 코드로 반복하지 않는다:

- **권한 판정에 쓰지 않는다.** 보여주기 전용
- 감사기록에는 `speaker`(없으면 `null`)를 남긴다 — 규칙이 깨졌을 때 **알아채는 장치**

## 시험 + 뮤턴트

- `client` → 본문 표시 + meta · `lead` → 본문 무변경 + meta · 미기재 → 둘 다 없음
- 도구 설명이 **언제 채우는지**를 말하는지 — 안 그러면 클라이언트가 안 채운다
- **뮤턴트 A** 본문 표시 제거 → red · **뮤턴트 B** 미기재를 `lead` 로 처리 → red

## 검증

`mcpAsk` **55 pass** · `tsc` 0

## 롤백

단일 커밋 revert. 파라미터는 optional 이라 안 쓰던 클라이언트에 영향 없다.