### PR TITLE
feat(mcp): 창구 on/off 스위치 — 기본 꺼짐, 쓰던 설치는 안 끊긴다

### DIFF
--- a/src/server/db/migrate.ts
+++ b/src/server/db/migrate.ts
@@ -841,6 +841,11 @@ export function runBusMigration(db: Database): void {
     // 진행 표시용 — 그 팀원이 지금 무엇을 하고 있나. last_log_line 은 화면 맨 아랫줄(고정 장식)이라
     // 늘 "auto mode on" 이었다. 그 칸은 health 판정이 이미 쓰고 있으므로 건드리지 않고 따로 둔다.
     "ALTER TABLE agent_status ADD COLUMN activity_line TEXT",
+    // ★이미 MCP 를 쓰던 설치만 켜둔다★ — 기본은 꺼짐인데, 그대로 배포하면 ★쓰던 사람이 그 순간 끊긴다★
+    //   (그리고 끊긴 창이 그 사람이 우리에게 알릴 수단이다). 감사기록에 mcp.* 가 있으면 = 이미 쓰던 곳.
+    //   새 설치(공개 clone)는 그 기록이 없으니 행이 안 생기고 ★기본 꺼짐 그대로★ 다.
+    "INSERT OR IGNORE INTO setting(key,value) SELECT 'mcp_enabled','true' " +
+      "WHERE EXISTS(SELECT 1 FROM audit_event WHERE action LIKE 'mcp.%' LIMIT 1)",
   ];
   for (const stmt of alterStatements) {
     try {

--- a/src/server/db/migrate.ts
+++ b/src/server/db/migrate.ts
@@ -849,6 +849,9 @@ export function runBusMigration(db: Database): void {
     //   공개 설치가 스스로 열린다. 통과한 흔적만 센다 — 아래는 전부 ★신원이 확인된 뒤에★ 쓰인다.
     //   목록이 낡을 걱정은 없다: 이 백필이 의미를 갖는 건 행이 없는 동안뿐이고, 그동안엔
     //   창구가 꺼져 있어 새 mcp.* 기록 자체가 생기지 않는다.
+    //   ★보장 범위는 여기까지다★ (codex 리뷰): stdio 의 ★읽기 도구는 감사기록을 안 남긴다.★
+    //   = "이미 쓰던 설치를 전부 살린다" 가 아니라 ★"HTTP 로 썼거나, 기록이 남는 stdio 쓰기를 쓴 설치"★ 다.
+    //   읽기만 쓰던 stdio 설치는 신호가 없어 꺼진 채 올라온다 — 사람이 한 번 켜야 한다.
     "INSERT OR IGNORE INTO setting(key,value) SELECT 'mcp_enabled','true' " +
       "WHERE EXISTS(SELECT 1 FROM audit_event WHERE action IN " +
       "('mcp.http.request','mcp.send_message','mcp.ask_teammate','mcp.kanban_add','mcp.kanban_update') LIMIT 1)",

--- a/src/server/db/migrate.ts
+++ b/src/server/db/migrate.ts
@@ -842,10 +842,16 @@ export function runBusMigration(db: Database): void {
     // 늘 "auto mode on" 이었다. 그 칸은 health 판정이 이미 쓰고 있으므로 건드리지 않고 따로 둔다.
     "ALTER TABLE agent_status ADD COLUMN activity_line TEXT",
     // ★이미 MCP 를 쓰던 설치만 켜둔다★ — 기본은 꺼짐인데, 그대로 배포하면 ★쓰던 사람이 그 순간 끊긴다★
-    //   (그리고 끊긴 창이 그 사람이 우리에게 알릴 수단이다). 감사기록에 mcp.* 가 있으면 = 이미 쓰던 곳.
-    //   새 설치(공개 clone)는 그 기록이 없으니 행이 안 생기고 ★기본 꺼짐 그대로★ 다.
+    //   (그리고 끊긴 창이 그 사람이 우리에게 알릴 수단이다). 새 설치(공개 clone)는 이 기록이 없으니
+    //   행이 안 생기고 ★기본 꺼짐 그대로★ 다.
+    //   ★`mcp.%` 로 넓게 잡으면 안 된다★ (dex 리뷰): 인증 실패·미등록 신원·게이트 거절이 전부
+    //   `mcp.http.denied` 로 남는다. 즉 ★외부 스캐너가 한 번 두드리기만 해도★ 다음 부팅에
+    //   공개 설치가 스스로 열린다. 통과한 흔적만 센다 — 아래는 전부 ★신원이 확인된 뒤에★ 쓰인다.
+    //   목록이 낡을 걱정은 없다: 이 백필이 의미를 갖는 건 행이 없는 동안뿐이고, 그동안엔
+    //   창구가 꺼져 있어 새 mcp.* 기록 자체가 생기지 않는다.
     "INSERT OR IGNORE INTO setting(key,value) SELECT 'mcp_enabled','true' " +
-      "WHERE EXISTS(SELECT 1 FROM audit_event WHERE action LIKE 'mcp.%' LIMIT 1)",
+      "WHERE EXISTS(SELECT 1 FROM audit_event WHERE action IN " +
+      "('mcp.http.request','mcp.send_message','mcp.ask_teammate','mcp.kanban_add','mcp.kanban_update') LIMIT 1)",
   ];
   for (const stmt of alterStatements) {
     try {

--- a/src/server/lib/captureConfig.test.ts
+++ b/src/server/lib/captureConfig.test.ts
@@ -160,7 +160,11 @@ test("★두드리다 거절당한 기록만 있는 설치는 열리지 않는�
   expect(isMcpEnabled(d)).toBe(false);
 });
 
-test("★대조군 — 통과한 기록이 하나라도 있으면 열린다★ (stdio 도구 사용 포함)", () => {
+// ★이름을 실제로 재는 것보다 넓게 쓰지 않는다★ (codex 리뷰 2026-08-07):
+//   stdio 의 ★읽기 도구는 감사기록을 안 남긴다★(team_status·b3os_inbox·b3os_kanban_list·
+//   b3os_recall_dms·b3os_fetch_answer). 즉 ★읽기만 쓰던 stdio 설치는 식별할 수 없고 꺼진 채로 올라온다.★
+//   과거 신호가 아예 없어서 코드로 복구할 방법도 없다 — 그 설치는 사람이 한 번 켜야 한다.
+test("★대조군 — 감사기록이 남는 사용 5종은 각각 문을 연다★ (HTTP 통과 · stdio 쓰기)", () => {
   for (const action of ["mcp.http.request", "mcp.send_message", "mcp.ask_teammate", "mcp.kanban_add", "mcp.kanban_update"]) {
     const d = new Database(":memory:");
     migrate(d);

--- a/src/server/lib/captureConfig.test.ts
+++ b/src/server/lib/captureConfig.test.ts
@@ -142,3 +142,31 @@ test("★사람이 끈 것은 마이그레이션이 되살리지 않는다★", 
   migrate(d); // 재부팅
   expect(isMcpEnabled(d)).toBe(false); // ★끈 것을 되켜면 안 된다★
 });
+
+// ★거절 기록은 "쓴 흔적" 이 아니다★ (dex 리뷰 2026-08-07)
+//
+// 처음엔 action LIKE 'mcp.%' 로 잡았다. 그런데 ★인증 실패·미등록 신원·게이트 거절이 전부
+// mcp.http.denied 로 남는다.★ 즉 외부 스캐너가 한 번 두드리고 간 공개 설치가 ★다음 부팅에
+// 스스로 열린다.★ 문을 잠그려고 넣은 코드가 문을 여는 셈이었다.
+// ★내 원래 시험은 이걸 못 봤다★ — 통과 기록(mcp.http.request)만 넣고 재서 양쪽이 다 초록불이었다.
+
+test("★두드리다 거절당한 기록만 있는 설치는 열리지 않는다★ — 스캐너가 문을 열어주면 안 된다", () => {
+  const d = new Database(":memory:");
+  migrate(d);
+  for (const reason of ["mcp_disabled", "unauthorized", "actor_not_registered"]) {
+    d.prepare(`INSERT INTO audit_event (actor, action, target, at) VALUES ('unknown','mcp.http.denied',?,datetime('now'))`).run(reason);
+  }
+  migrate(d); // 재부팅
+  expect(isMcpEnabled(d)).toBe(false);
+});
+
+test("★대조군 — 통과한 기록이 하나라도 있으면 열린다★ (stdio 도구 사용 포함)", () => {
+  for (const action of ["mcp.http.request", "mcp.send_message", "mcp.ask_teammate", "mcp.kanban_add", "mcp.kanban_update"]) {
+    const d = new Database(":memory:");
+    migrate(d);
+    d.prepare(`INSERT INTO audit_event (actor, action, target, at) VALUES ('gd',?,'x',datetime('now'))`).run(action);
+    d.prepare(`INSERT INTO audit_event (actor, action, target, at) VALUES ('unknown','mcp.http.denied','unauthorized',datetime('now'))`).run();
+    migrate(d);
+    expect({ action, on: isMcpEnabled(d) }).toEqual({ action, on: true });
+  }
+});

--- a/src/server/lib/captureConfig.test.ts
+++ b/src/server/lib/captureConfig.test.ts
@@ -8,7 +8,7 @@ import { migrate } from "../db/migrate";
 import {
   hasCaptureToken, getCaptureToken, setCaptureToken,
   isRouterEnabled, setRouterEnabled, getCaptureGroupId, setCaptureGroupId,
-  captureConfigStatus,
+  captureConfigStatus, isMcpEnabled, setMcpEnabled,
 } from "./captureConfig";
 
 const TOKEN_FILE = join(tmpdir(), "captureconfig-test-token.txt");
@@ -106,8 +106,39 @@ describe("captureConfig — 상태 마스킹(★토큰 값 노출 금지)", () =
     setCaptureGroupId("-100g");
     setRouterEnabled(db, true);
     const status = captureConfigStatus(db);
-    expect(status).toEqual({ has_capture_token: true, capture_group_id: "-100g", router_enabled: true });
+    expect(status).toEqual({ has_capture_token: true, capture_group_id: "-100g", router_enabled: true, mcp_enabled: false });
     // 직렬화에도 토큰 값이 없어야 함
     expect(JSON.stringify(status)).not.toContain("SECRET-must-not-leak");
   });
+});
+
+// ── ★이미 쓰던 설치는 안 끊긴다★ (빌 리뷰 2026-08-07) ──
+//
+// 기본만 꺼짐으로 두고 배포하면 ★쓰고 있던 사람이 그 순간 끊긴다.★
+// 그리고 ★끊긴 그 창이 그 사람이 우리에게 알릴 수단★ 이다.
+// → 마이그레이션이 "이미 MCP 를 쓴 흔적(감사기록)" 이 있는 설치만 켜준다.
+// ★"off 면 막힌다" 만 재면 이 사고를 못 잡는다★ — 이쪽을 재야 한다.
+
+test("★이미 MCP 를 쓰던 설치는 켜진 채로 올라온다★", () => {
+  const d = new Database(":memory:");
+  migrate(d);
+  d.prepare(`INSERT INTO audit_event (actor, action, target, at) VALUES ('gd','mcp.http.request','x',datetime('now'))`).run();
+  migrate(d); // 다시 돌려도 안전해야 한다(운영은 부팅마다 돈다)
+  expect(isMcpEnabled(d)).toBe(true);
+});
+
+test("★새 설치는 꺼진 채로 올라온다★ — 공개 clone 은 아무것도 안 하면 닫혀 있다", () => {
+  const d = new Database(":memory:");
+  migrate(d);
+  expect(isMcpEnabled(d)).toBe(false);
+});
+
+test("★사람이 끈 것은 마이그레이션이 되살리지 않는다★", () => {
+  const d = new Database(":memory:");
+  migrate(d);
+  d.prepare(`INSERT INTO audit_event (actor, action, target, at) VALUES ('gd','mcp.http.request','x',datetime('now'))`).run();
+  migrate(d);
+  setMcpEnabled(d, false); // 사람이 명시적으로 끔
+  migrate(d); // 재부팅
+  expect(isMcpEnabled(d)).toBe(false); // ★끈 것을 되켜면 안 된다★
 });

--- a/src/server/lib/captureConfig.ts
+++ b/src/server/lib/captureConfig.ts
@@ -84,6 +84,21 @@ export function setRouterEnabled(db: Database, on: boolean): void {
   setSetting(db, "router_enabled", on ? "true" : "false");
 }
 
+/**
+ * MCP 창구가 열려 있나. ★기본은 꺼짐★ (팀 리드 2026-08-07: "mcp 는 일단 우리만 쓰는 걸로,
+ * 즉 리사팀도 못쓰는 거야"). 새 설치는 아무것도 안 하면 닫혀 있다.
+ *
+ * ★이미 쓰던 설치는 마이그레이션이 켜준다★ — migrate.ts 참고. 기본만 꺼짐으로 두고
+ * 배포하면 ★쓰고 있던 사람이 그 순간 끊긴다★ (그리고 끊긴 창이 그 사람의 연락 수단이다).
+ */
+export function isMcpEnabled(db: Database): boolean {
+  return getSetting(db, "mcp_enabled") === "true";
+}
+
+export function setMcpEnabled(db: Database, on: boolean): void {
+  setSetting(db, "mcp_enabled", on ? "true" : "false");
+}
+
 // group_id — 비밀 아니지만 *모듈 로드 시점*(워커 const)에서 읽혀야 해 파일 기반(그 시점엔 db 없음). file→env fallback.
 // (Codex 팀원리뷰: DB저장+env읽기 불일치 → UI로 바꿔도 미적용 "설정됐다 보이는데 안 됨" 버그. 파일로 통일=재시작 시 적용+GET 일치.)
 function groupPath(): string {
@@ -112,10 +127,12 @@ export function captureConfigStatus(db: Database): {
   has_capture_token: boolean;
   capture_group_id: string | null;
   router_enabled: boolean;
+  mcp_enabled: boolean;
 } {
   return {
     has_capture_token: hasCaptureToken(),
     capture_group_id: getCaptureGroupId(),
     router_enabled: isRouterEnabled(db),
+    mcp_enabled: isMcpEnabled(db),
   };
 }

--- a/src/server/mcp/b3osMcpServer.ts
+++ b/src/server/mcp/b3osMcpServer.ts
@@ -17,6 +17,7 @@ import { recallDmMessages } from "../db/dmCapture";
 import { classifyAll } from "../lib/health";
 import { ambientAgents } from "../lib/registry"; // 정규 팀원 여부·별칭의 정본은 agents.json 이다 (DB 표에는 없다)
 import { isTeamOfficialMember } from "../lib/agentMembership";
+import { isMcpEnabled } from "../lib/captureConfig"; // ★HTTP 와 같은 스위치★ — 창구를 끄면 stdio 도 안 붙는다
 import { leadActorId } from "../lib/opAuth"; // ★이름만 재사용★ — 신뢰 규칙(루프백=리드)은 쓰지 않는다
 import { askTeammate, fetchAnswer, askProgress } from "./mcpAsk";
 
@@ -623,11 +624,16 @@ function sendShPath(): string {
  * stdio 서버로 기동. ★M2부터 쓰기 오픈★(읽기전용 아님) — 단 쓰기는 도구 레벨에서 신원(B3OS_AGENT_ID)
  * 필수 + 매 호출 audit로 게이트. 읽기 도구는 읽기 전용 query만 사용. (M3에서 신원 allowlist/deny 추가.)
  */
-export async function main(): Promise<void> {
-  const db = new Database(dbPath());
+export async function main(
+  db: Database = new Database(dbPath()),
+  connect: (server: ReturnType<typeof buildMcpServer>) => Promise<void> = (s) => s.connect(new StdioServerTransport()),
+): Promise<void> {
+  // ★스위치는 창구 전체를 끈다★ (dex 리뷰): HTTP 만 막으면 같은 기계에서 stdio 로 그대로 들어온다.
+  //   그러면 "MCP 연결 off" 라고 적힌 화면과 실제 동작이 어긋난다 — 그게 스위치의 최악의 실패다.
+  if (!isMcpEnabled(db)) throw new Error("mcp_disabled: 이 설치에서는 MCP 창구가 꺼져 있습니다.");
   // stdio 는 종전대로 env 신원 + 쓰기 허용. ★둘 다 명시★ — 기본값에 기대지 않는다.
   const server = buildMcpServer(db, resolveActor(db), "write");
-  await server.connect(new StdioServerTransport());
+  await connect(server);
 }
 
 if (import.meta.main) {

--- a/src/server/mcp/mcpHttpRoute.test.ts
+++ b/src/server/mcp/mcpHttpRoute.test.ts
@@ -5,7 +5,7 @@ import { Database } from "bun:sqlite";
 import { migrate } from "../db/migrate";
 import { setMcpEnabled } from "../lib/captureConfig";
 import { buildMcpHttpApp } from "./mcpHttpRoute";
-import { buildMcpServer, WRITE_TOOL_NAMES, resolveActorStrict, resolveActor } from "./b3osMcpServer";
+import { buildMcpServer, WRITE_TOOL_NAMES, resolveActorStrict, resolveActor, main as stdioMain } from "./b3osMcpServer";
 import type { McpAuthConfig, McpAuthResult } from "./mcpAuth";
 
 function addAgent(d: Database, id: string, name: string): void {
@@ -345,4 +345,24 @@ test("★대조군★ — 켜면 그대로 통과한다", async () => {
   const db = freshDb(); // freshDb 가 켜둔다
   const app = buildMcpHttpApp(db, { authConfig: CFG, authenticate: async () => allow("demis", "write") });
   expect((await app.request(post(INIT))).status).toBe(200);
+});
+
+// ── ★스위치는 창구 전체를 끈다★ (dex 리뷰 2026-08-07) ──
+//
+// HTTP 만 막으면 ★같은 기계에서 stdio 로 그대로 들어온다.★ 그러면 "MCP 연결 off" 라고 적힌 화면과
+// 실제 동작이 어긋난다 — 스위치가 낼 수 있는 최악의 실패다(꺼진 줄 알고 열려 있다).
+
+test("★꺼져 있으면 stdio 로도 안 붙는다★", async () => {
+  const d = new Database(":memory:");
+  migrate(d); // 새 설치 = 꺼짐
+  let connected = false;
+  await expect(stdioMain(d, async () => { connected = true; })).rejects.toThrow(/mcp_disabled/);
+  expect(connected).toBe(false); // ★붙기 전에 멈춘다★
+});
+
+test("★대조군 — 켜져 있으면 stdio 가 붙는다★", async () => {
+  const d = freshDb(); // setMcpEnabled(true)
+  let connected = false;
+  await stdioMain(d, async () => { connected = true; });
+  expect(connected).toBe(true);
 });

--- a/src/server/mcp/mcpHttpRoute.test.ts
+++ b/src/server/mcp/mcpHttpRoute.test.ts
@@ -3,6 +3,7 @@
 import { test, expect } from "bun:test";
 import { Database } from "bun:sqlite";
 import { migrate } from "../db/migrate";
+import { setMcpEnabled } from "../lib/captureConfig";
 import { buildMcpHttpApp } from "./mcpHttpRoute";
 import { buildMcpServer, WRITE_TOOL_NAMES, resolveActorStrict, resolveActor } from "./b3osMcpServer";
 import type { McpAuthConfig, McpAuthResult } from "./mcpAuth";
@@ -17,6 +18,7 @@ function addAgent(d: Database, id: string, name: string): void {
 function freshDb(): Database {
   const d = new Database(":memory:");
   migrate(d);
+  setMcpEnabled(d, true); // ★창구 스위치는 기본 꺼짐★ — 기존 시험들은 열린 상태를 전제한다
   addAgent(d, "demis", "Demis");
   addAgent(d, "bill", "Bill");
   return d;
@@ -313,3 +315,34 @@ test("★대조군★ — 끝까지 읽어도 정리가 정확히 1회 돈다(�
 // → ★keepalive 는 라이브 실험에서 잰다.★ 그게 원래 목적이기도 하다:
 //   keepalive 가 있어야 실험 결과가 "가설이 틀렸다" 인지 "클라이언트가 progressToken 을 안 줬다" 인지
 //   구분된다(빌). 그 구분이 필요한 곳이 라이브다.
+
+// ── ★창구 스위치★ (팀 리드 2026-08-07) ──
+
+test("★꺼져 있으면 인증까지 안 가고 막힌다★ — 도구 하나가 아니라 입구에서", async () => {
+  const db = freshDb();
+  setMcpEnabled(db, false);
+  let authCalled = false;
+  const app = buildMcpHttpApp(db, {
+    authConfig: CFG,
+    authenticate: async () => { authCalled = true; return allow("demis", "write"); },
+  });
+  const res = await app.request(post(INIT));
+  expect(res.status).toBe(503);
+  expect((await res.json() as { error: string }).error).toBe("mcp_disabled");
+  expect(authCalled).toBe(false); // ★입구에서 막는다★ — 도구별로 막으면 나머지로 들어온다
+});
+
+test("★꺼졌을 때 문구는 사실만 말한다★ — 공개 빌드엔 토글이 없어 '켜달라' 는 못 할 일을 시키는 것", async () => {
+  const db = freshDb();
+  setMcpEnabled(db, false);
+  const app = buildMcpHttpApp(db, { authConfig: CFG, authenticate: async () => allow("demis", "write") });
+  const body = await (await app.request(post(INIT))).json() as { detail: string };
+  expect(body.detail).toContain("꺼져 있습니다");
+  expect(body.detail).not.toContain("관리자"); // 할 수 없는 일을 시키지 않는다
+});
+
+test("★대조군★ — 켜면 그대로 통과한다", async () => {
+  const db = freshDb(); // freshDb 가 켜둔다
+  const app = buildMcpHttpApp(db, { authConfig: CFG, authenticate: async () => allow("demis", "write") });
+  expect((await app.request(post(INIT))).status).toBe(200);
+});

--- a/src/server/mcp/mcpHttpRoute.ts
+++ b/src/server/mcp/mcpHttpRoute.ts
@@ -22,6 +22,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { buildMcpServer, resolveActorStrict } from "./b3osMcpServer";
 import { authenticateMcpRequest, loadMcpAuthConfig, type McpAuthConfig, type McpPrincipal } from "./mcpAuth";
 import { appendAudit } from "../db/queries";
+import { isMcpEnabled } from "../lib/captureConfig";
 
 // ★쓰기 도구 목록은 여기 두지 않는다★ — 관문은 b3osMcpServer 의 WRITE_TOOL_NAMES 하나뿐이다.
 // (리뷰 P1, bill) 목록이 두 곳이면 새 쓰기 도구를 추가할 때 한쪽만 고치고 '완료' 가 되는데,
@@ -62,6 +63,15 @@ export function buildMcpHttpApp(db: Database, deps: McpHttpDeps = {}): Hono {
   app.all("/mcp", async (c) => {
     // 설정은 요청 시점에 읽는다 — 재시작 없이 매핑을 갱신할 수 있게.
     const cfg = deps.authConfig ?? loadMcpAuthConfig();
+
+    // ★창구 자체를 닫는 스위치★ (팀 리드 2026-08-07). 도구가 여럿이라 ★한 도구만 막으면
+    //   나머지로 계속 들어온다★ — 그래서 입구 한 곳에서 막는다.
+    //   ★문구는 사실만 말한다★: 공개 빌드에는 토글이 없으므로 "관리자에게 켜달라" 는
+    //   ★할 수 없는 일을 시키는 안내★ 가 된다.
+    if (!isMcpEnabled(db)) {
+      audit(db, "unknown", "mcp.http.denied", "mcp_disabled", { status: 503 });
+      return c.json({ error: "mcp_disabled", detail: "이 설치에서는 MCP 창구가 꺼져 있습니다." }, 503);
+    }
 
     const auth = await authenticate(c.req.raw, cfg);
     if (!auth.ok) {

--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -12,6 +12,7 @@ import { migrate } from "../db/migrate";
 import { appendAudit, listAgents } from "../db/queries";
 import { syncRegistry } from "../lib/registry";
 import { allowedRuntimes, createSettingsApp, MAX_OFFICIAL_TEAM_MEMBERS, publicRuntimeOptions, removePathWithRetries } from "./settings";
+import { isMcpEnabled } from "../lib/captureConfig";
 import { MEMBERS_ROOT } from "../lib/personaTemplates";
 // 사용자가 붙여넣는 최종 JSON 은 서버 매니페스트 + 이 변환의 합성이다. 접합부를 검사하려고 가져온다.
 import { socketManifest } from "../../web/components/AgentSlack";
@@ -1663,5 +1664,30 @@ describe("system-op: MCP 창구 토글", () => {
     expect(on.mcp_enabled).toBe(true);
     const off = await (await app.request("/system-op", patch({ mcp_enabled: false }))).json();
     expect(off.mcp_enabled).toBe(false);
+  });
+
+  // ── ★공개 빌드 차단은 "소스에 조건식이 있다" 가 아니라 실제 응답으로 재야 한다★ (dex 리뷰 2026-08-07) ──
+  //   조건식이 남아 있어도 상수를 잘못 읽거나 응답이 새면 소스 검사는 초록불이다.
+  //   그래서 publicBuild 를 주입받게 고치고, ★같은 프로세스에서 양쪽 분기를 다 요청해 본다.★
+
+  test("★공개 빌드 GET 응답에는 MCP 칸이 아예 없다★ — 그런 기능이 있다는 것도 안 보인다", async () => {
+    const { app } = setup(AGENTS, { publicBuild: true });
+    const s = await (await app.request("/system-op")).json();
+    expect("mcp_enabled" in s).toBe(false);
+    expect(JSON.stringify(s)).not.toContain("mcp");
+  });
+
+  test("★공개 빌드는 PATCH 로도 못 켠다★ — 화면을 숨겨도 요청은 직접 보낼 수 있다", async () => {
+    const { app, db } = setup(AGENTS, { publicBuild: true });
+    const r = await app.request("/system-op", patch({ mcp_enabled: true }));
+    expect(r.status).toBe(200); // 다른 칸(router 등)까지 막지는 않는다 — MCP 만 무시한다
+    expect(isMcpEnabled(db)).toBe(false); // ★DB 가 안 바뀌었다★
+    expect("mcp_enabled" in (await r.json())).toBe(false);
+  });
+
+  test("★대조군 — 내부 빌드에서는 같은 요청이 실제로 켠다★", async () => {
+    const { app, db } = setup(AGENTS, { publicBuild: false });
+    await app.request("/system-op", patch({ mcp_enabled: true }));
+    expect(isMcpEnabled(db)).toBe(true);
   });
 });

--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -388,7 +388,7 @@ describe("settings: 시스템 OP (P0 floor — capture/router)", () => {
   test("GET 기본 상태 — 토큰 없음·router 기본 ON (setting·env 없으면 true, GD 0721)", async () => {
     const { app } = setup();
     const s = await (await app.request("/system-op")).json();
-    expect(s).toEqual({ has_capture_token: false, capture_group_id: null, router_enabled: true });
+    expect(s).toEqual({ has_capture_token: false, capture_group_id: null, router_enabled: true, mcp_enabled: false }); // ★MCP 기본 꺼짐★
   });
 
   test("PATCH router_enabled 토글 (PIN 없이 즉시 반영)", async () => {
@@ -1652,5 +1652,16 @@ describe("OT 조회가 claude 페어링 대기를 표면화한다", () => {
     claudeOt(db, dir);
     const ot = await (await app.request("/ot/ot_ui")).json() as any;
     expect(ot.awaiting_input).toBeNull();
+  });
+});
+
+// ★MCP 토글 — 공개 빌드에서는 존재 자체가 안 보인다★ (팀 리드 2026-08-07)
+describe("system-op: MCP 창구 토글", () => {
+  test("PATCH mcp_enabled 로 켜고 끈다", async () => {
+    const { app } = setup();
+    const on = await (await app.request("/system-op", patch({ mcp_enabled: true }))).json();
+    expect(on.mcp_enabled).toBe(true);
+    const off = await (await app.request("/system-op", patch({ mcp_enabled: false }))).json();
+    expect(off.mcp_enabled).toBe(false);
   });
 });

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -93,6 +93,8 @@ export interface SettingsDeps {
   //   이게 없어서 `bun test`의 DELETE /members/steve 테스트가 실제 telegram-steve 폴더를 삭제하던 치명 버그(GD 2026-07-01 fs_usage로 확정). 테스트는 true 주입.
   skipRuntimeCleanup?: boolean;
   checkRuntimeAuth?: typeof checkRuntimeAuth;
+  // ★공개 빌드 여부를 시험이 직접 정할 수 있게★ — 미주입이면 라이브와 같은 PUBLIC_BUILD(=B3OS_LIVE !== "1").
+  publicBuild?: boolean;
   activateMember?: typeof activateMember;
   // 활성화 직후 실제 첫 모델 호출 검증. 테스트는 mock 주입으로 라이브 계정/외부 상태 의존을 끊는다.
   firstModelCall?: (input: { id: string; runtime: string; workspacePath?: string }) => Promise<FirstModelCallResult>;
@@ -318,6 +320,9 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
   const doArchiveWorkspace = deps.archiveWorkspace ?? archiveWorkspace; // 주입 없으면 실제 함수(라이브). 테스트는 noop 주입.
   const skipRuntimeCleanup = deps.skipRuntimeCleanup ?? false; // 테스트=true → 실 HOME(~/.claude 등) 파일 rm 건너뜀(라이브 봇 데이터 삭제 방지).
   const doCheckRuntimeAuth = deps.checkRuntimeAuth ?? checkRuntimeAuth;
+  // ★공개 빌드 판정을 주입받는다★ (dex 리뷰): 모듈 상수를 그대로 읽으면 한 프로세스에서 한쪽 분기밖에
+  //   못 잰다 — 그래서 "소스에 조건식이 있다" 만 확인하는 시험이 됐고, 그건 동작을 증명하지 않는다.
+  const publicBuild = deps.publicBuild ?? PUBLIC_BUILD;
   const runtimeReadiness = async (runtime: string) => runtimeReadinessFromAuth(await doCheckRuntimeAuth(runtime));
   const publicRuntimeGate = async (runtime: string) => {
     if (PUBLIC_BUILD && LIVE_ONLY_RUNTIMES.has(runtime)) return { error: "runtime_not_public", hint: "이 런타임은 공개 온보딩에서 제공하지 않습니다." };
@@ -2149,7 +2154,7 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
   // ★공개 빌드에서는 MCP 칸을 아예 안 내려보낸다★ (팀 리드 2026-08-07: "퍼블릭에선 안보이게").
   //   UI 는 이 값이 boolean 일 때만 토글을 그린다 — 없으면 그런 기능이 있다는 것도 안 보인다.
   const stripMcpForPublic = (st: ReturnType<typeof captureConfigStatus>) => {
-    if (!PUBLIC_BUILD) return st;
+    if (!publicBuild) return st;
     const { mcp_enabled: _omit, ...rest } = st;
     return rest;
   };
@@ -2163,7 +2168,7 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
     const group = typeof body.capture_group_id === "string" ? body.capture_group_id.trim() : undefined;
     const router = typeof body.router_enabled === "boolean" ? body.router_enabled : undefined;
     // ★공개 빌드에서는 켤 수 없다★ — UI 를 숨기는 것만으로는 부족하다(요청은 직접 보낼 수 있다).
-    const mcpOn = !PUBLIC_BUILD && typeof body.mcp_enabled === "boolean" ? body.mcp_enabled : undefined;
+    const mcpOn = !publicBuild && typeof body.mcp_enabled === "boolean" ? body.mcp_enabled : undefined;
     if (token !== undefined && token !== "" && !CAPTURE_TOKEN_RE.test(token)) {
       return c.json({ ok: false, error: "capture_bot_token_invalid", hint: "봇 토큰 형식: 숫자:영숫자30~120 (BotFather)" }, 400);
     }

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -9,7 +9,7 @@ import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { writeMemberPersona, savePersonaFile } from "../lib/writeMemberPersona";
 import { memberPaths, personaTargetsForRuntime, injectCoreRule, stripCoreRule, coreRuleFor, injectClaudeComms, stripClaudeComms, JOIN_FLAG_FILE, joinInstructions } from "../lib/personaTemplates";
-import { captureConfigStatus, setCaptureToken, setCaptureGroupId, setRouterEnabled, getCaptureToken } from "../lib/captureConfig";
+import { captureConfigStatus, setCaptureToken, setCaptureGroupId, setRouterEnabled, setMcpEnabled, getCaptureToken } from "../lib/captureConfig";
 // ★설정 키 이름은 approvals.ts 정본을 쓴다★ — 문자열을 여기 다시 적으면 그 순간 갈린다.
 import { MERGE_APPROVERS_SETTING_KEY } from "../lib/approvals";
 import { configureLeadActorDb, leadActorId, leadActorSource, trustedActorFromRequest } from "../lib/opAuth";
@@ -2146,15 +2146,24 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
   // graceful PIN: PIN 설정돼 있으면 검증 필수(앱레벨 잠금, 자가호스터 보안), 없으면 dashboard-trusted(기본 floor UX 안 막음).
   const CAPTURE_TOKEN_RE = /^\d+:[A-Za-z0-9_-]{30,120}$/; // 하네스 LOW-1: 길이 상한(DoS 방지)
   const CAPTURE_GROUP_RE = /^-?\d{1,20}$/; // telegram chat_id(음수 supergroup 포함). 하네스 LOW-1: group 검증
-  app.get("/system-op", (c) => c.json(captureConfigStatus(db)));
+  // ★공개 빌드에서는 MCP 칸을 아예 안 내려보낸다★ (팀 리드 2026-08-07: "퍼블릭에선 안보이게").
+  //   UI 는 이 값이 boolean 일 때만 토글을 그린다 — 없으면 그런 기능이 있다는 것도 안 보인다.
+  const stripMcpForPublic = (st: ReturnType<typeof captureConfigStatus>) => {
+    if (!PUBLIC_BUILD) return st;
+    const { mcp_enabled: _omit, ...rest } = st;
+    return rest;
+  };
+  app.get("/system-op", (c) => c.json(stripMcpForPublic(captureConfigStatus(db))));
 
   app.patch("/system-op", async (c) => {
-    let body: { capture_bot_token?: unknown; capture_group_id?: unknown; router_enabled?: unknown };
+    let body: { capture_bot_token?: unknown; capture_group_id?: unknown; router_enabled?: unknown; mcp_enabled?: unknown };
     try { body = await c.req.json(); } catch { return c.json({ ok: false, error: "invalid_json" }, 400); }
     // (접근제어/PIN은 System OP에서 제거 — GD 2026-06-28. 추후 소셜로긴/이메일로 독립 레벨 설계.)
     const token = typeof body.capture_bot_token === "string" ? body.capture_bot_token.trim() : undefined;
     const group = typeof body.capture_group_id === "string" ? body.capture_group_id.trim() : undefined;
     const router = typeof body.router_enabled === "boolean" ? body.router_enabled : undefined;
+    // ★공개 빌드에서는 켤 수 없다★ — UI 를 숨기는 것만으로는 부족하다(요청은 직접 보낼 수 있다).
+    const mcpOn = !PUBLIC_BUILD && typeof body.mcp_enabled === "boolean" ? body.mcp_enabled : undefined;
     if (token !== undefined && token !== "" && !CAPTURE_TOKEN_RE.test(token)) {
       return c.json({ ok: false, error: "capture_bot_token_invalid", hint: "봇 토큰 형식: 숫자:영숫자30~120 (BotFather)" }, 400);
     }
@@ -2169,15 +2178,16 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
       if (group) { try { seedGroupIntoClaudeMembers(group, readAgents().filter((a: any) => a.runtime === "claude_channel").map((a: any) => a.id)); } catch { /* best-effort seed */ } }
     }
     if (router !== undefined) setRouterEnabled(db, router); // 라이브 — 재시작 불요
+    if (mcpOn !== undefined) setMcpEnabled(db, mcpOn); // 라이브 — 다음 요청부터 즉시 적용
     // ★토큰/그룹 변경을 서버 재시작 없이 즉시 적용★(GD 2026-07-19): capture 워커를 재init 한다(새 토큰으로 텔레그램 재연결).
     //   restartCapture 미주입(테스트 등)이면 종전대로 needs_restart=true 로 안내. 재init 은 best-effort(실패해도 저장은 유지).
     let applied = false;
     if (changedTokenOrGroup && deps.restartCapture) {
       try { deps.restartCapture(); applied = true; } catch { /* best-effort — 실패 시 needs_restart 로 폴백 */ }
     }
-    appendAudit(db, "user", "system_op_updated", "system", { token_set: !!token, group_set: group !== undefined, router_enabled: router, applied }); // ★토큰 값은 audit에 안 넣음
+    appendAudit(db, "user", "system_op_updated", "system", { token_set: !!token, group_set: group !== undefined, router_enabled: router, mcp_enabled: mcpOn, applied }); // ★토큰 값은 audit에 안 넣음
     const needsRestart = changedTokenOrGroup && !applied;
-    return c.json({ ok: true, ...captureConfigStatus(db), needs_restart: needsRestart, note: !changedTokenOrGroup ? "적용됨" : applied ? "적용됨(즉시 반영 — 재시작 불필요)" : "토큰/그룹 변경은 서버 재시작 시 적용(라우터는 즉시)" });
+    return c.json({ ok: true, ...stripMcpForPublic(captureConfigStatus(db)), needs_restart: needsRestart, note: !changedTokenOrGroup ? "적용됨" : applied ? "적용됨(즉시 반영 — 재시작 불필요)" : "토큰/그룹 변경은 서버 재시작 시 적용(라우터는 즉시)" });
   });
 
   // 저장된 토큰이 텔레그램에서 유효한지 확인(getMe). ★응답엔 bot_username 만, 토큰 값 노출 안 함.

--- a/src/web/components/Settings.ts
+++ b/src/web/components/Settings.ts
@@ -93,7 +93,8 @@ let _capabilities: Capability[] = [];
 let _slack: SlackStatus | null = null;
 let _slackHealth: SlackHealth | null = null; // auth.test 실측(2단계 갱신) — 배지 정확성용
 // 시스템 OP (P0 기본 협업 floor) — capture 토큰·router·그룹·PIN. 토큰값은 안 받음(has_*만).
-let _systemOp: { has_capture_token: boolean; capture_group_id: string | null; router_enabled: boolean } | null = null;
+// mcp_enabled 는 ★공개 빌드에서는 아예 안 내려온다★ — 그래서 optional 이고, UI 는 ★boolean 일 때만★ 토글을 그린다.
+let _systemOp: { has_capture_token: boolean; capture_group_id: string | null; router_enabled: boolean; mcp_enabled?: boolean } | null = null;
 let _systemOpOpen = false; // 기본 접힘 — 클릭하면 펼침(설정 필요 느낌만 주고 평소엔 간결).
 let _addOpen = false;
 let _ot: OtState | null = null;          // 진행 중인 신규 OT(영입). null이면 폼/버튼 표시.
@@ -580,6 +581,22 @@ function otZoneHtml(): string {
   return `<button id="rec-open" class="mt-2 w-full ${btnGhost} py-2.5 border-dashed" ${atLimit ? "disabled" : ""}>${atLimit ? pick(`공식 팀원 ${current}/${MAX_OFFICIAL_TEAM_MEMBERS} · 영입 상한 도달`, `Official members ${current}/${MAX_OFFICIAL_TEAM_MEMBERS} · limit reached`) : `+ ${pick("영입", "Onboard")}`}</button>`;
 }
 
+/**
+ * MCP 창구 토글 — ★값이 안 내려오면 아무것도 안 그린다.★
+ * 공개 빌드는 서버가 이 칸을 빼고 주므로 ★그런 기능이 있다는 것조차 안 보인다★ (팀 리드 2026-08-07).
+ */
+function mcpRowHtml(): string {
+  const on = _systemOp?.mcp_enabled;
+  if (typeof on !== "boolean") return "";
+  return `
+      <div class="flex items-center justify-between rounded-md border border-surface-3 bg-surface-0/60 px-3 py-2">
+        <span class="text-[13px] font-medium text-slate-200">${pick("MCP 창구", "MCP endpoint")} <span class="${on ? "text-accent-greenSoft" : "text-slate-500"} text-[11px]">${on ? "ON" : "OFF"}</span>
+          <span class="block text-[11px] text-slate-500 mt-0.5">${pick("클로드 코드·커서에서 팀원에게 직접 질문", "Ask teammates directly from Claude Code · Cursor")}</span>
+        </span>
+        <button id="sysop-mcp" class="${on ? "bg-accent-green/80" : "bg-slate-400/50"} shrink-0 relative inline-flex h-6 w-11 items-center rounded-full transition-colors" role="switch" aria-checked="${on}"><span class="${on ? "translate-x-6" : "translate-x-1"} inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"></span></button>
+      </div>`;
+}
+
 // ── 시스템 OP 패널 (P0 기본 협업 floor) ──────────────────────────────
 function systemOpHtml(): string {
   const s = _systemOp;
@@ -625,6 +642,7 @@ function systemOpHtml(): string {
         <span class="text-[13px] font-medium text-slate-200">${pick("라우터 (agent 응답)", "Router (agent replies)")} <span class="${routerOn ? "text-accent-greenSoft" : "text-slate-500"} text-[11px]">${routerOn ? "ON" : "OFF · shadow"}</span></span>
         <button id="sysop-router" class="${routerOn ? "bg-accent-green/80" : "bg-slate-400/50"} shrink-0 relative inline-flex h-6 w-11 items-center rounded-full transition-colors" role="switch" aria-checked="${routerOn}"><span class="${routerOn ? "translate-x-6" : "translate-x-1"} inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform"></span></button>
       </div>
+      ${mcpRowHtml()}
       <div class="text-[11px] text-slate-500 -mt-1 leading-relaxed">${pick("ON = 팀방(그룹방)에서 팀원이 자동으로 응답 · OFF = 팀방에선 조용(결정만 기록). ★OFF여도 1:1 DM·팀원끼리 버스 협업은 그대로 동작★ — 라우터는 '그룹방 자동응답'만 켜고 끕니다.", "ON = teammates auto-reply in the team room · OFF = quiet in the room (decisions only logged). ★1:1 DM & teammate bus collab still work when OFF★ — the router only toggles group-room auto-reply.")}</div>
       <div class="flex items-center gap-3 pt-1">
         <button id="sysop-save" class="${btnPrimary}">${pick("저장", "Save")}</button>
@@ -648,13 +666,21 @@ function wireSystemOp(): void {
   _root.querySelector<HTMLButtonElement>("#sysop-toggle")?.addEventListener("click", () => { _systemOpOpen = !_systemOpOpen; render(); });
   const val = (id: string) => (_root!.querySelector<HTMLInputElement>(id)?.value ?? "").trim();
   const setMsg = (t: string) => { const m = _root!.querySelector<HTMLSpanElement>("#sysop-msg"); if (m) m.textContent = t; };
-  const setState = (j: { has_capture_token: boolean; capture_group_id: string | null; router_enabled: boolean }) => {
-    _systemOp = { has_capture_token: j.has_capture_token, capture_group_id: j.capture_group_id, router_enabled: j.router_enabled };
+  const setState = (j: { has_capture_token: boolean; capture_group_id: string | null; router_enabled: boolean; mcp_enabled?: boolean }) => {
+    _systemOp = { has_capture_token: j.has_capture_token, capture_group_id: j.capture_group_id, router_enabled: j.router_enabled, mcp_enabled: j.mcp_enabled };
   };
   // (접근제어/PIN은 System OP에서 제거 — GD 2026-06-28. 라우터/저장/봇확인은 바로 동작.)
 
   _root.querySelector<HTMLButtonElement>("#sysop-router")?.addEventListener("click", async () => {
     const r = await fetch(api("/system-op"), { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ router_enabled: !_systemOp?.router_enabled }) });
+    const j = await r.json();
+    if (!r.ok) { setMsg(`${pick("실패:", "Failed:")} ${j.error ?? ""}`); return; }
+    setState(j); render();
+  });
+
+  // ★값이 안 내려온 빌드에서는 버튼 자체가 없다★ — querySelector 가 null 이라 아무 일도 안 한다.
+  _root.querySelector<HTMLButtonElement>("#sysop-mcp")?.addEventListener("click", async () => {
+    const r = await fetch(api("/system-op"), { method: "PATCH", headers: { "content-type": "application/json" }, body: JSON.stringify({ mcp_enabled: !_systemOp?.mcp_enabled }) });
     const j = await r.json();
     if (!r.ok) { setMsg(`${pick("실패:", "Failed:")} ${j.error ?? ""}`); return; }
     setState(j); render();


### PR DESCRIPTION
## 배경

팀 리드(2026-08-07): **"mcp 연결 on/off 간단히 만들어서 대시보드 Settings 에 시스템 OP 밑에"** · **"퍼블릭에선 안보이게"**

**이 스위치의 실제 값어치는 "라이브 모드로 도는 설치의 끔 스위치"다** (빌 정정). 공개 빌드에는 `index.ts` 의 `if (!PUBLIC_BUILD) app.route(...)` 가 이미 MCP 라우트를 안 붙인다 — *"리사팀도 못 쓰게"* 는 이 PR 이 아니라 그 마운트 가드가 하고 있다.

## 배포하는 순간 라이브를 끊을 뻔했다 (빌)

첫 설계는 *"기본 꺼짐 + 우리 라이브만 나중에 켠다"* 였다. 그대로 배포하면 **설정 행이 없으니 게이트가 기본값(꺼짐)을 읽어 팀 리드의 MCP 가 그 순간 죽는다.** *"켜면 되지"* 가 아니다 — **끊긴 그 창이 팀 리드가 우리에게 알릴 수단**이다.

→ 마이그레이션이 **이미 MCP 를 통과한 흔적이 있는 설치만** 켜준 채로 올린다.

## 거절 기록으로 문이 열리던 구멍 (dex)

처음엔 `action LIKE 'mcp.%'` 로 잡았다. 그런데 **인증 실패·미등록 신원·게이트 거절이 전부 `mcp.http.denied` 로 남는다.** 즉 **외부 스캐너가 한 번 두드리고 간 공개 설치가 다음 부팅에 스스로 열린다.** 문을 잠그려고 넣은 코드가 문을 여는 셈이었다.

```sql
INSERT OR IGNORE INTO setting(key,value) SELECT 'mcp_enabled','true'
WHERE EXISTS(SELECT 1 FROM audit_event WHERE action IN
  ('mcp.http.request','mcp.send_message','mcp.ask_teammate','mcp.kanban_add','mcp.kanban_update') LIMIT 1)
```

**목록이 낡을 걱정은 없다**: 이 백필이 의미를 갖는 건 행이 없는 동안뿐이고, 그동안엔 창구가 꺼져 있어 새 `mcp.*` 기록 자체가 안 생긴다.

**보장 범위는 여기까지다** (codex): stdio 의 **읽기 도구는 감사기록을 안 남긴다**(`team_status`·`b3os_inbox`·`b3os_kanban_list`·`b3os_recall_dms`·`b3os_fetch_answer`). 즉 *"이미 쓰던 설치를 전부 살린다"* 가 아니라 **"HTTP 로 썼거나, 기록이 남는 stdio 쓰기를 쓴 설치"** 다. 읽기만 쓰던 stdio 설치는 신호가 없어 꺼진 채 올라오고, **과거 신호가 없어 코드로 복구할 방법도 없다** — 사람이 한 번 켜야 한다.

**우리 라이브는 켜진다** (빌·codex 각각 라이브 DB 사본에 실측):

| action | 건수 | 좁힌 목록 |
|---|---|---|
| `mcp.http.request` | 264 | 포함 |
| `mcp.ask_teammate` | 22 | 포함 |
| **`mcp.http.denied`** | **15** | **제외** |
| `mcp.send_message` | 3 | 포함 |
| `mcp.kanban_add` | 1 | 포함 |

**우리 라이브에도 거절 기록이 15건 있었다** — 넓은 신호였으면 그것만 있는 설치도 열렸다. dex 지적이 실물로 확인됐다.

## 무엇

| | |
|---|---|
| 설정 | `mcp_enabled` · **기본 false** |
| HTTP | 꺼지면 **인증까지 가기 전에** 503 |
| stdio | **같은 스위치를 본다** (빌·dex 공통 지적). HTTP 만 막으면 같은 기계에서 stdio 로 그대로 들어온다 — **꺼진 줄 알고 열려 있는 것**이 스위치의 최악의 실패다 |
| UI | Settings ▸ 시스템 OP 밑 토글. 공개 빌드는 서버가 그 칸을 **응답에서 빼고** 준다 → UI 가 안 그린다 |
| PATCH | 공개 빌드에서는 무시 — **화면을 숨겨도 요청은 직접 보낼 수 있다** |

## 시험 — "소스에 조건식이 있다" 는 동작이 아니다 (dex·빌)

공개 빌드 차단 시험이 소스 문자열만 읽고 있었다. `!PUBLIC_BUILD` 를 `!PUBLIC_BUILD || true` 로 바꿔도 통과한다(빌). → `createSettingsApp` 이 **`publicBuild` 를 주입받게** 고쳐서(집안 관례: `allowedRuntimes`·`slashCommands` 와 같은 꼴) **같은 프로세스에서 양쪽 분기를 실제 요청으로 잰다.**

- 공개: GET 에 `mcp_enabled` 없음 · PATCH `{mcp_enabled:true}` 후 **DB 가 여전히 false** · **대조군** 내부 빌드는 같은 요청이 실제로 켠다
- **거절 기록만 있는 설치는 안 열린다** · **대조군** 통과 action 5종은 각각 연다
- stdio: 꺼짐 → **붙기 전에 멈춘다**(connect 주입으로 확인) · **대조군** 켜짐 → 붙는다
- 이미 쓰던 설치는 켜진 채 · 새 설치는 꺼진 채 · **사람이 끈 것은 재부팅해도 안 되켜진다**

**뮤턴트**(치환이 목표 줄에 1회 앉았는지 세고 돌린다 — 안 그러면 원본이 그대로 돌면서 "생존" 으로 읽힌다):

| | 결과 |
|---|---|
| M1 넓은 신호로 되돌림 | 사망 — *거절 기록만 있는 설치는 안 열린다* **단독 red** |
| M3 기본값 뒤집기(`=== "true"` → `!== "false"`) | 사망 — 6건 red |
| N1 stdio 게이트 제거 (빌 재측정) | 사망 — *꺼져 있으면 stdio 로도 안 붙는다* **단독 red** |

## 리뷰

**빌 승인** · **codex 조건부 승인**(보장 범위 문구 → 위에 반영) · dex 가 거절기록 구멍을 찾음.

## 검증

전체 **2552 pass / 1 fail**(온보딩 문서 시험 — main 과 동일 집합, 이 변경과 무관) · `tsc` 0.
개수는 트리마다 다르므로 **실패 이름으로** 대조했다.

## 배포 주의

**라이브 MCP 를 끊을 수 있는 변경**이라 오늘치 재시작 승인에 묶지 않는다. 팀 리드 승인 후 배포한다.

**재시작만으로는 안 된다** — `src/web/components/Settings.ts` 를 건드리므로 **빌드 + 재시작 둘 다** 필요하다(빌).

## 롤백

커밋 revert. 설정 행은 남지만 아무도 안 읽으므로 무해하다.
