### PR TITLE
docs(skill): 온보딩 런타임 선택의 실행 지시 복원 — 주제만 남고 세부가 빠져 있었다

### DIFF
--- a/skills/b3os/SKILL.md
+++ b/skills/b3os/SKILL.md
@@ -105,7 +105,7 @@ curl -s -X PUT http://localhost:$PORT/team/api/settings -H 'content-type: applic
 
 > ★★이 단계에 들어오면 **먼저 `references/recruit.md` 를 펼쳐 읽고** 진행한다★★ — 물어볼 필드·질문 문구·복사용 폼·기본값이 거기 다 있다. "이름·역할" 몇 개만 묻고 넘어가지 말 것.
 
-**① 런타임 선택** — `claude_channel`(권장·쉬움) / `openclaw`·`hermes_agent`(ChatGPT 구독 BYO 고급). 목록·권장 이유·고른 순간의 preflight 명령 = `references/runtime-setup.md`.
+**① 런타임 선택 모드** — `claude_channel`(권장·쉬움) / `openclaw`·`hermes_agent`(ChatGPT 구독 BYO 고급). 셋을 **항상 보여주되**, 설치+인증 readiness 가 안 되면 **disabled 상태와 `references/runtime-setup.md` CTA** 를 함께 보여준다(고르지 못하는 이유를 화면에서 알 수 있어야 한다). **이 세 가지 외 내부 런타임은 온보딩에 노출하지 않는다.** 목록·권장 이유·고른 순간의 preflight 명령 = `references/runtime-setup.md`.
 
 **② 사용자에게 먼저 다 묻는다** — **id**(영문 slug, ★display_name 과 별개이며 빠뜨리기 쉽다★) · **display_name** · **role** · **멘션명(별칭)** · **runtime+모델** · **persona**(선택).
 


### PR DESCRIPTION
b3os SKILL.md 슬림화(#214) 때 「런타임 선택 모드」 항목의 실행 지시 두 개가 같이 떨어졌다. 옮긴 게 아니라 손실이다 — `skills/`·`docs/` 전체에 없었다.

빠져 있던 것:
- 셋을 **항상 보여주되**, readiness 가 안 되면 **disabled + `references/runtime-setup.md` CTA**
- **이 세 가지 외 내부 런타임은 온보딩에 노출하지 않는다**

주제(`① 런타임 선택`)는 살아 있었고 세부만 사라진 형태라 눈에 띄지 않았다. 그래서 설치자가 "왜 이 런타임을 못 고르는지" 를 화면에서 알 수 없었고, 내부 런타임 노출 금지 정책도 근거가 사라진 상태였다.

diff 만 보면 `① 런타임 선택` → `① 런타임 선택 모드` 로 제목만 바뀐 것처럼 보인다. 실제로 복원된 것은 그 뒤의 실행 지시다. **리뷰는 '없는 것' 을 못 본다** — 이런 손실은 diff 가 아니라 시험이 잡는다.

시험은 고치지 않았다. 시험을 고치면 문서 손실이 영구히 정상이 된다.

## 검증

- `runtimeOptions` 4 pass — 이 시험은 main 에서 빨간불이었다
- `src/web` 137 tests 0 fail · `tsc --noEmit` 통과
- **뮤턴트**: 복원 문구를 다시 빼면 해당 시험 단독 red, 복원하면 4 pass
- Bill 독립 재측정(격리 워크트리): main 2550 pass / 1 fail → 이 커밋 2551 pass / 0 fail

## 범위 (정확히)

이 PR 은 **온보딩 문서 시험 1건**을 닫는다. **main 이 완전히 초록이 되는 것은 아니다** — `uninstall.sh` 가드 시험은 설치 상태에 의존해 라이브 트리에서만 실패하고 워크트리에서는 보이지 않는다. 위 수치는 모두 워크트리 기준이다.

## 배포

불필요하다. `skills/` 는 공유 라이브 트리에서 직접 읽으므로 재시작·빌드가 필요 없다. 머지 후 `git pull` 이면 반영된다.

Reviewed-by: bill (독립 재측정 · push 승인)