### PR TITLE
fix(report): show public reports URL

### DIFF
--- a/skills/b3os-report/scripts/publish.sh
+++ b/skills/b3os-report/scripts/publish.sh
@@ -79,7 +79,7 @@ CODE="$(curl -s -o /tmp/b3os-report-register.json -w '%{http_code}' -X POST "$AP
   -H 'content-type: application/json' --data-binary "$PAYLOAD")"
 if [ "$CODE" = "200" ]; then
   echo "✅ /reports 게시 완료: id=$ID · forms=$(echo "$FORMS" | python3 -c 'import sys,json;print(",".join(f["type"] for f in json.load(sys.stdin)) or "none")')"
-  echo "   → your-team.example.com/reports (또는 http://127.0.0.1:7878/reports)"
+  echo "   → https://dev.b3rys.com/reports"
 else
   echo "❌ 등록 실패 (HTTP $CODE) — team-collab 동작 확인 필요"; cat /tmp/b3os-report-register.json 2>/dev/null; exit 2
 fi


### PR DESCRIPTION
## 핵심 3줄
1. publish 완료 안내가 localhost와 placeholder URL을 표시했습니다.
2. 사용자가 누르는 보고서 링크가 로컬 주소로 보일 수 있습니다.
3. 안내를 `https://dev.b3rys.com/reports`로 교체한 1줄 변경입니다.

## 검증
- `bash -n skills/b3os-report/scripts/publish.sh`
- `python3 skills/b3os-report/scripts/publish.test.py` — PASS
- `git diff --check` — PASS

미검증: 실제 보고서 재게시 없음(출력 문자열만 변경).

Submitted-by: Ames