### PR TITLE
fix(report): derive published URL from environment

### DIFF
--- a/skills/b3os-report/scripts/publish.sh
+++ b/skills/b3os-report/scripts/publish.sh
@@ -79,7 +79,7 @@ CODE="$(curl -s -o /tmp/b3os-report-register.json -w '%{http_code}' -X POST "$AP
   -H 'content-type: application/json' --data-binary "$PAYLOAD")"
 if [ "$CODE" = "200" ]; then
   echo "✅ /reports 게시 완료: id=$ID · forms=$(echo "$FORMS" | python3 -c 'import sys,json;print(",".join(f["type"] for f in json.load(sys.stdin)) or "none")')"
-  echo "   → https://dev.b3rys.com/reports"
+  echo "   → ${TEAM_PUBLIC_BASE_URL:-${TEAM_BASE:-http://127.0.0.1:7878}}/reports"
 else
   echo "❌ 등록 실패 (HTTP $CODE) — team-collab 동작 확인 필요"; cat /tmp/b3os-report-register.json 2>/dev/null; exit 2
 fi


### PR DESCRIPTION
## 핵심 3줄
1. 게시 완료 안내에 특정 운영 도메인이 하드코딩되어 공개 설치본에서 잘못된 주소를 표시했습니다.
2. `TEAM_PUBLIC_BASE_URL` → `TEAM_BASE` → 로컬 기본값 순으로 URL을 선택합니다.
3. `publish.sh` 한 줄만 변경했습니다.

## 검증
- `bash -n skills/b3os-report/scripts/publish.sh` PASS
- `python3 skills/b3os-report/scripts/publish.test.py` PASS
- 3개 환경 조합 출력 확인 PASS
- 하드코딩 운영 도메인 0건
- `git diff --check` PASS

미검증: 실제 라이브 게시 호출은 수행하지 않음

Submitted-by: ames