### PR TITLE
fix(proposal): 리뷰 배정 알림 발신자를 예약 id 로

### DIFF
--- a/src/server/routes/proposals.test.ts
+++ b/src/server/routes/proposals.test.ts
@@ -8,6 +8,7 @@ import { Database } from "bun:sqlite";
 import { migrate } from "../db/migrate";
 import { createProposal as createProposalRow } from "../db/proposal";
 import { createProposalRoutes, sweepStaleProposals } from "./proposals";
+import { checkPingpong } from "../bus/antiPingpong";
 import type { AgentRecord } from "../types";
 
 const OP_TOKEN = "proposal-route-test-op-token";
@@ -286,7 +287,17 @@ describe("proposals — 상태기계 + Guard", () => {
     const msg = db.prepare("SELECT from_agent_id, to_agent_id, body FROM message WHERE to_agent_id = ? ORDER BY created_at DESC LIMIT 1").get(peer) as {
       from_agent_id: string; to_agent_id: string; body: string;
     };
-    expect(msg.from_agent_id).toBe("codex");
+    expect(msg.from_agent_id).toBe("system");
+    // ★발신자 id 만 고정해서는 부족하다★ — 이 알림이 실제로 수신자를 깨우려면 발신자가
+    // antiPingpong 의 unknown_sender 검사를 통과해야 한다. 이전 값 "codex" 는 이 테스트의
+    // seed 에 codex 가 팀원으로 들어 있어서 통과했을 뿐이고, codex 런타임 멤버가 없는 팀에서는
+    // 전부 dispatch_blocked 로 막혔다. 그래서 ★게이트 자체를 태워★ 회귀를 잡는다.
+    expect(checkPingpong(db, {
+      message_id: followup!.messageId!, agent_id: peer, delivery_state: "pending", retry_count: 0, last_error: null,
+      from_agent_id: msg.from_agent_id, to_agent_id: peer, body: msg.body, source: "agent", created_by: null,
+      max_hop: 16, hop_count: 0, in_reply_to: null, parent_message_id: null, sync: "none",
+      thread_id: "t", type: "dm", created_at: "2026-08-08", priority: "normal",
+    }, new Set(["bill", "steve", "demis", "devon", "gd"])).allowed).toBe(true); // codex 없는 명부 = 실제 팀 구성
     expect(msg.body).toContain(id);
     const recipient = db.prepare("SELECT delivery_state FROM message_recipient WHERE message_id = ? AND agent_id = ?").get(followup!.messageId!, peer) as {
       delivery_state: string;

--- a/src/server/routes/proposals.ts
+++ b/src/server/routes/proposals.ts
@@ -324,16 +324,21 @@ function createLinkedFollowup(
     ).run(task.id);
   }
   const threadId = `prop-${p.id.replace(/^prop_/, "").slice(0, 12)}-${statusKey.replace(/[^a-z0-9]+/g, "").slice(0, 8)}`;
+  // ★발신자는 예약 id 여야 한다★ — antiPingpong 의 unknown_sender 검사는 발신자가
+  // RESERVED_SENDER_IDS 이거나 명부에 있는 팀원일 때만 통과시킨다. "codex" 는 런타임 이름이지
+  // 팀원 id 가 아니라서, codex 런타임 멤버가 없는 팀에서는 이 알림이 전부 dispatch_blocked
+  // (unknown_sender:codex) 로 막혔다 — message 행은 남고 수신자는 안 깨워지므로 조용히 사라진다.
+  // 서버가 스스로 보내는 알림이라 "system" 이 맞다(다른 자동 알림도 이미 이 id 를 쓴다).
   const { thread_id } = ensureThread(db, {
     thread_id: threadId,
-    from_agent_id: "codex",
+    from_agent_id: "system",
     to_agent_id: owner,
     type: "dm",
     body,
   });
   const message = insertMessage(db, {
     thread_id,
-    from_agent_id: "codex",
+    from_agent_id: "system",
     to_agent_id: owner,
     type: "dm",
     body: `${body}\n\nTasks 카드: ${task.id}`,


### PR DESCRIPTION
## 문제

proposal follow-up 알림(리뷰 배정 통지)이 `from_agent_id: "codex"` 로 나간다. `"codex"` 는 b3os 가 지원하는 **런타임 이름**이지 팀원 id 가 아니다.

`antiPingpong` 의 unknown_sender 검사는 발신자가 `RESERVED_SENDER_IDS`(`moderator`/`system`/`user`) 이거나 팀 명부에 있을 때만 통과시킨다. 따라서 **codex 런타임 멤버가 없는 팀에서는 이 알림이 전부 차단된다.**

실제 관측(설치 1곳, 팀원 4명 중 codex 없음):

```
dispatch_blocked  clo   unknown_sender:codex
dispatch_blocked  herm  unknown_sender:codex
dispatch_blocked  clo   unknown_sender:codex
dispatch_blocked  clo   unknown_sender:codex
dispatch_blocked  herm  unknown_sender:codex   (2건)
```

같은 설치의 발신자 분포 — `codex` 22건은 전부 이 경로이고 전부 차단된다:

| from_agent_id | 건수 | 게이트 |
|---|---|---|
| `system` | 54 | 통과 |
| `user` | 102 | 통과 |
| `codex` | 22 | **차단** |

## 왜 조용히 사라지나

`message` 행과 `message_recipient` 행은 정상 생성되고 **wake 만 차단된다.** 그래서:

- 발신 측 기록은 `delivery_status=delivered` 로 남는다 — 보낸 사람은 성공으로 읽는다
- 리뷰어는 배정 사실 자체를 모른다
- 서버는 리뷰 0건을 무응답으로 판단해 재배정 sweeper 를 돌린다
- 재배정도 같은 발신자로 나가므로 다시 차단된다

## 왜 테스트로 안 잡혔나

`proposals.test.ts` 의 seed 가 `codex` 를 팀원으로 넣는다. 그래서 테스트 명부에서는 `codex` 가 알려진 발신자이고 게이트를 통과한다. 기존 단언은 `expect(msg.from_agent_id).toBe("codex")` 로 **id 만** 비교하므로, 게이트 통과 여부는 검증 대상이 아니었다.

## 수정

`createLinkedFollowup` 의 발신자를 `"system"` 으로 바꾼다. 서버가 스스로 보내는 알림이고, 다른 자동 알림도 이미 이 id 를 쓴다(위 표의 54건).

`RESERVED_SENDER_IDS` 에 `codex` 를 추가하는 방향은 택하지 않았다. 그 상수의 주석이 신뢰-출처 문을 넓히지 말라고 명시하고 있고, 런타임 이름을 예약 발신자로 올리면 그 런타임을 쓰는 실제 멤버 id 와 구분이 사라진다.

## 검증

- `bun test src/server/routes/proposals.test.ts` → 53 pass / 0 fail
- `bun test proposalAutomation.test.ts proposalRoutingSim.steve.test.ts antiPingpong.test.ts` → 35 pass / 0 fail
- `bun run typecheck` → 통과
- **뮤테이션**: 수정을 `"codex"` 로 되돌리면 52 pass / **1 fail**. 가드가 이 회귀를 실제로 잡는다.

테스트는 발신자 id 고정에 더해 `checkPingpong` 을 **codex 없는 명부**로 직접 태운다. id 비교만으로는 이 회귀를 잡지 못하기 때문이다.

## 범위 밖

같은 설치에서 리뷰 배정이 특정 팀원에게 한 번도 가지 않은 현상을 함께 관측했다. 다만 `agent_status` 는 이력을 남기지 않아 배정 시점 상태를 확인할 수 없었다. 원인 미확정이라 이 PR 에 넣지 않는다.

Submitted-by: Lisa
