### PR TITLE
fix(proposal): 리뷰 배정에서 blocked 상태를 안 본다 — 일하는 사람이 빠지고 있었다

### DIFF
--- a/src/server/db/proposal.ts
+++ b/src/server/db/proposal.ts
@@ -89,7 +89,11 @@ function reviewSkipIds(): Set<string> {
   ]);
 }
 
-// 리뷰 가능 팀원 수(비대화 제외).
+// (`activeReviewTeamSize` 는 제거했다 — 호출부가 0곳인 죽은 코드였다. 이 PR 이 만든 게 아니라
+//  원래 그랬고, 상태 필터를 걷어내는 뮤턴트가 전체 수트에서 살아남길래 드러났다. 코덱스 리뷰:
+//  "뮤턴트 생존은 테스트 누락이 아니라 미실행 경로의 증거다" — 시험을 붙이는 게 아니라 지우는 게 맞다.)
+
+// 제안자 제외 리뷰 후보 수(= 팀 크기 판단 기준. `requiredPmReviewCount` 가 이 값을 읽는다).
 //
 // ★state 를 안 본다★ (팀 리드 2026-08-08: "blocked 는 빼고 그냥 배정해").
 //   `blocked` 는 배정 근거로 쓸 수 있는 값이 아니다 — `health.ts` 가 같은 값을 두고
@@ -98,13 +102,11 @@ function reviewSkipIds(): Set<string> {
 //   실측(2026-08-08 라이브): claude 런타임 5명이 ★작업 중★ blocked 로 찍혀 있었고(내 활동줄은
 //   "Running 3 shell commands…" 였다), 배정은 idle 로 보이는 런타임에 쏠렸다 —
 //   devon 12 · hermes 9 · codex 6 · bill 0. 재배정 sweeper 도 같은 필터라 같은 쪽으로 다시 갔다.
-function activeReviewTeamSize(db: Database): number {
-  const skip = reviewSkipIds();
-  const rows = db.prepare(`SELECT id FROM agent`).all() as { id: string }[];
-  return rows.filter((r) => !skip.has(r.id)).length;
-}
-
-// 제안자 제외 리뷰 후보 수(= 팀 크기 판단 기준). state 를 안 보는 이유는 위와 같다.
+//
+// ★이 값이 바뀌면 무엇이 달라지나★ — `requiredPmReviewCount` 다.
+//   예전: 제안자 외 전원이 blocked → 후보 0 → pm review ★0건 필요★ = ★무검토로 gd_report 통과★
+//   지금: 상태와 무관하게 후보가 있으므로 ★1건 필요★ = 리뷰 없이는 409
+//   즉 이 변경은 배정 분포만이 아니라 ★검토를 건너뛸 수 있던 구멍도 같이 막는다.★
 function eligiblePeerReviewerCapacity(db: Database, proposer: string): number {
   const skip = reviewSkipIds();
   const rows = db.prepare(`SELECT id FROM agent WHERE id != ?`).all(proposer) as { id: string }[];

--- a/src/server/db/proposal.ts
+++ b/src/server/db/proposal.ts
@@ -89,28 +89,25 @@ function reviewSkipIds(): Set<string> {
   ]);
 }
 
-// 리뷰 가능 팀원 수(비대화 제외, blocked 제외).
+// 리뷰 가능 팀원 수(비대화 제외).
+//
+// ★state 를 안 본다★ (팀 리드 2026-08-08: "blocked 는 빼고 그냥 배정해").
+//   `blocked` 는 배정 근거로 쓸 수 있는 값이 아니다 — `health.ts` 가 같은 값을 두고
+//   ★"정상 활동중에도 떠서 노이즈"★ 라고 못박아 두었고, 그래서 건강 판정은 이걸 위험으로 안 본다.
+//   그런데 여기서만 '이 사람은 못 받는다' 로 읽어서 ★일하고 있는 사람일수록 후보에서 빠졌다.★
+//   실측(2026-08-08 라이브): claude 런타임 5명이 ★작업 중★ blocked 로 찍혀 있었고(내 활동줄은
+//   "Running 3 shell commands…" 였다), 배정은 idle 로 보이는 런타임에 쏠렸다 —
+//   devon 12 · hermes 9 · codex 6 · bill 0. 재배정 sweeper 도 같은 필터라 같은 쪽으로 다시 갔다.
 function activeReviewTeamSize(db: Database): number {
   const skip = reviewSkipIds();
-  const rows = db.prepare(
-    `SELECT a.id
-       FROM agent a
-       LEFT JOIN agent_status s ON s.agent_id = a.id
-      WHERE COALESCE(s.state, 'idle') != 'blocked'`,
-  ).all() as { id: string }[];
+  const rows = db.prepare(`SELECT id FROM agent`).all() as { id: string }[];
   return rows.filter((r) => !skip.has(r.id)).length;
 }
 
-// 제안자 제외 리뷰 후보 수(= 팀 크기 판단 기준).
+// 제안자 제외 리뷰 후보 수(= 팀 크기 판단 기준). state 를 안 보는 이유는 위와 같다.
 function eligiblePeerReviewerCapacity(db: Database, proposer: string): number {
   const skip = reviewSkipIds();
-  const rows = db.prepare(
-    `SELECT a.id
-       FROM agent a
-       LEFT JOIN agent_status s ON s.agent_id = a.id
-      WHERE a.id != ?
-        AND COALESCE(s.state, 'idle') != 'blocked'`,
-  ).all(proposer) as { id: string }[];
+  const rows = db.prepare(`SELECT id FROM agent WHERE id != ?`).all(proposer) as { id: string }[];
   return rows.filter((r) => !skip.has(r.id)).length;
 }
 

--- a/src/server/routes/proposals.test.ts
+++ b/src/server/routes/proposals.test.ts
@@ -1069,6 +1069,26 @@ describe("proposals — GD 심플 모델 (팀 크기별 라우팅)", () => {
     expect((await transition(app, id, "gd_report", "alice")).status).toBe(409);
   });
 
+  // ★legacy pm_review 경로도 같이 막힌다★ (코덱스 리뷰 2026-08-08).
+  //   `eligiblePeerReviewerCapacity` 는 `requiredPmReviewCount` 가 읽는다:
+  //     예전 — 제안자 외 전원 blocked → 후보 0 → 필요 리뷰 ★0건★ → ★무검토로 gd_report 통과★
+  //     지금 — 상태를 안 보므로 후보가 있고 → ★1건 필요★ → 409
+  //   위 시험(peer 배정)만으로는 이 축이 안 잡힌다. 그래서 따로 둔다.
+  test("★제안자 외 전원이 blocked 여도 PM review 1건 없이는 gd_report 불가★", async () => {
+    const { app, db } = setupTeam(["alice", "bob", "carol"], { coordinator: "bob" });
+    db.prepare("INSERT INTO agent_status (agent_id, state) VALUES (?, 'blocked')").run("bob");
+    db.prepare("INSERT INTO agent_status (agent_id, state) VALUES (?, 'blocked')").run("carol");
+
+    // ★검증된 생성 경로를 쓴다★ — createProposalRow 직삽입은 이 팀에서 unknown_proposal 이 됐다
+    //   (그 상태로도 409 라서 시험이 통과했다. 409 를 받았다고 원하는 가드를 탄 게 아니다).
+    const id = await createBy(app, "alice");
+    db.prepare("UPDATE proposal SET status = 'pm_review' WHERE id = ?").run(id);
+
+    const r = await transition(app, id, "gd_report", "alice");
+    expect(r.status).toBe(409);
+    expect(await r.text()).toContain("PM review"); // ★그 가드가 맞는지 이유까지 본다★
+  });
+
   test("LEAD_ACTOR_ID 설정은 리뷰 후보 계산에 관여하지 않는다", async () => {
     process.env.LEAD_ACTOR_ID = "lead";
     const { app, db } = setupTeam(["lead", "alice", "bob"], { coordinator: "bob" });

--- a/src/server/routes/proposals.test.ts
+++ b/src/server/routes/proposals.test.ts
@@ -1042,19 +1042,31 @@ describe("proposals — GD 심플 모델 (팀 크기별 라우팅)", () => {
     expect(statusOf(db, id)).toBe("accepted");
   });
 
-  test("다인 팀의 다른 팀원이 모두 blocked면 무검토 gd_report 대신 peer_review blocked 유지", async () => {
+  // ★blocked 는 배정 자격이 아니다★ (팀 리드 2026-08-08: "blocked 는 빼고 그냥 배정해").
+  //   예전에는 이 상황에서 후보가 0이 되어 아무에게도 안 갔다. 그런데 `blocked` 는 `health.ts` 가
+  //   ★"정상 활동중에도 떠서 노이즈"★ 라고 적어둔 값이라, 실제로는 ★일하는 사람이 빠지는★ 필터였다.
+  //   라이브 실측: claude 런타임 5명이 작업 중 blocked 였고 배정은 idle 로 보이는 쪽에 쏠렸다.
+  //   ★두 축을 같이 잰다★ — 배정이 되는가(새 동작) · 그래도 무검토 직행은 막히는가(원래 안전 속성).
+  test("★blocked 인 팀원도 후보에 남아 실제로 배정된다★ — 그래도 무검토 gd_report 직행은 막는다", async () => {
     const { app, db } = setupTeam(["alice", "bob", "carol"], { coordinator: "bob" });
     db.prepare("INSERT INTO agent_status (agent_id, state) VALUES (?, 'blocked')").run("bob");
     db.prepare("INSERT INTO agent_status (agent_id, state) VALUES (?, 'blocked')").run("carol");
 
     const id = await createBy(app, "alice");
     expect(statusOf(db, id)).toBe("peer_review");
+
+    // ★owner 로 재면 안 된다★ — 후보가 0일 때 만들어지는 'blocked 안내' 도 조정자(bob)가 owner 라
+    //   둘이 구분되지 않는다(이 시험을 처음 그렇게 썼다가 뮤턴트가 살아남아서 알았다).
+    //   ★가르는 것은 status★ — 실제 배정은 `peer_review:*`, 후보 없음 안내는 `review_route_decision`.
+    const rows = db.prepare(
+      "SELECT owner, status FROM proposal_followup_task WHERE proposal_id = ?",
+    ).all(id) as { owner: string; status: string }[];
+    expect(rows.some((r) => r.status.startsWith("peer_review:"))).toBe(true); // ★실제로 배정됐다★
+    expect(rows.some((r) => r.status === "review_route_decision")).toBe(false); // 후보 없음 경로가 아니다
+    for (const r of rows) expect(["bob", "carol"]).toContain(r.owner);
+
+    // ★원래 안전 속성은 그대로★ — 리뷰 없이 팀장 보고로 못 넘어간다.
     expect((await transition(app, id, "gd_report", "alice")).status).toBe(409);
-    const task = db.prepare(
-      "SELECT description FROM task WHERE id IN (SELECT task_id FROM proposal_followup_task WHERE proposal_id = ?)",
-    ).get(id) as { description: string };
-    expect(task.description).toContain("blocked:");
-    expect(task.description).toContain("무검토 gd_report 직행 금지");
   });
 
   test("LEAD_ACTOR_ID 설정은 리뷰 후보 계산에 관여하지 않는다", async () => {

--- a/src/server/routes/proposals.ts
+++ b/src/server/routes/proposals.ts
@@ -111,17 +111,17 @@ function firstAvailableAgent(db: Database, candidates: string[], fallback: strin
   return candidates.find((id) => existingAgent(db, id)) ?? fallback;
 }
 
-// interactive 팀원(비대화 non_interactive · team_official_member:false · 제안자 · blocked 제외) 중 리뷰 후보 id 목록.
+// interactive 팀원(비대화 non_interactive · team_official_member:false · 제안자 제외) 중 리뷰 후보 id 목록.
+//
+// ★지금 무엇을 하고 있는지는 안 본다★ (팀 리드 2026-08-08: "blocked 는 빼고 그냥 배정해").
+//   예전에는 `agent_status.state != 'blocked'` 로 걸렀는데, 그 값은 ★일하는 중에도 뜬다.★
+//   `health.ts` 가 같은 값을 "정상 활동중에도 떠서 노이즈" 라고 적어두고 위험 판정에서 빼는데,
+//   배정만 그걸 자격으로 읽어서 ★바쁜 사람이 후보에서 사라졌다.★ 상세는 `db/proposal.ts` 의
+//   `activeReviewTeamSize` 주석 참고. 누구에게 갈지는 아래 배정부의 ★부하 분산★ 이 정한다.
 export function otherReviewers(db: Database, proposer: string, agents: AgentRecord[]): string[] {
   const nonInteractive = new Set(agentsWith(agents, "non_interactive").map((a) => a.id));
   const registry = new Map(agents.map((a) => [a.id, a]));
-  const rows = db.prepare(
-    `SELECT a.id
-      FROM agent a
-       LEFT JOIN agent_status s ON s.agent_id = a.id
-      WHERE a.id != ?
-        AND COALESCE(s.state, 'idle') != 'blocked'`,
-  ).all(proposer) as { id: string }[];
+  const rows = db.prepare(`SELECT id FROM agent WHERE id != ?`).all(proposer) as { id: string }[];
   return rows
     .map((r) => r.id)
     .filter((id) => {

--- a/src/server/routes/proposals.ts
+++ b/src/server/routes/proposals.ts
@@ -117,7 +117,7 @@ function firstAvailableAgent(db: Database, candidates: string[], fallback: strin
 //   예전에는 `agent_status.state != 'blocked'` 로 걸렀는데, 그 값은 ★일하는 중에도 뜬다.★
 //   `health.ts` 가 같은 값을 "정상 활동중에도 떠서 노이즈" 라고 적어두고 위험 판정에서 빼는데,
 //   배정만 그걸 자격으로 읽어서 ★바쁜 사람이 후보에서 사라졌다.★ 상세는 `db/proposal.ts` 의
-//   `activeReviewTeamSize` 주석 참고. 누구에게 갈지는 아래 배정부의 ★부하 분산★ 이 정한다.
+//   `eligiblePeerReviewerCapacity` 주석 참고. 누구에게 갈지는 아래 배정부의 ★부하 분산★ 이 정한다.
 export function otherReviewers(db: Database, proposer: string, agents: AgentRecord[]): string[] {
   const nonInteractive = new Set(agentsWith(agents, "non_interactive").map((a) => a.id));
   const registry = new Map(agents.map((a) => [a.id, a]));


### PR DESCRIPTION
팀 리드 지시(2026-08-08 1:1): **"blocked 는 빼고 그냥 배정해"**

리뷰 배정이 특정 팀원에게 몰리는 현상의 원인을 고친다. 리사팀(외부 설치)이 PR #303 에서 '범위 밖'으로 남겼고, 팀 리드도 같은 현상을 관측했다 — 두 곳에서 독립적으로 나왔다.

## 원인

리뷰 후보를 고르는 세 곳이 `agent_status.state != 'blocked'` 로 걸렀다. 그런데 `health.ts:109` 가 같은 값을 두고 이렇게 적어 두었다:

> 일반 'blocked'는 statusProbe 상 **정상 활동중에도 떠서 노이즈**지만, rate-limit/feedback/confirm prompt처럼 입력을 점유하는 명확한 런타임 정지는 danger로 잡는다.

건강 판정은 그래서 일반 `blocked` 를 위험으로 보지 않는다. **그런데 배정만 그 값을 자격으로 읽었다.** 결과적으로 일하고 있는 사람일수록 후보에서 빠졌다.

## 실측 (2026-08-08 02:24, 라이브 DB)

```
배정 누적:  devon 12 · hermes 9 · codex 6 · lui 5 · dex 4 · demis 3 · steve 2 · ames 2 · bill 0
같은 시각:  blocked = bill · dbak · demis · lui · steve      ← 전부 claude 런타임
            idle    = ames · brief · codex · devon · dex · forin · hermes
```
`bill` 은 `blocked` 인데 `activity_line` 이 `"Running 3 shell commands…"` 였다. 상태는 2초 전에 찍힌 최신값이다.

claude 런타임 멤버는 작업 중 `blocked` 로 보여 구조적으로 배제되고, `idle` 로 보이는 런타임에 배정이 쏠린다. 분포가 정확히 그 모양이다. 재배정 sweeper 도 같은 필터를 거치므로 같은 쪽으로 다시 간다.

## 무엇을 바꿨나

`activeReviewTeamSize` · `eligiblePeerReviewerCapacity` · `otherReviewers` 세 곳에서 상태 필터를 뺐다. 누구에게 갈지는 **기존 부하 분산**(열린/최근 배정 수)이 그대로 정한다 — 이 PR 은 후보 자격만 건드린다.

## 시험

'다른 팀원이 모두 blocked 면 후보 0' 을 고정하던 시험을 **지우지 않고 축을 바꿨다**:
- **새 동작** — blocked 여도 실제로 배정되는가
- **원래 안전 속성** — 그래도 무검토 `gd_report` 직행은 막히는가 (409)

**owner 로 재면 안 된다.** 후보가 0일 때 만들어지는 'blocked 안내' 도 조정자가 owner 라 실제 배정과 구분되지 않는다. 처음 그렇게 썼다가 **뮤턴트가 살아남아서** 알았다. 가르는 것은 `status` 다 — 실제 배정은 `peer_review:*`, 후보 없음 안내는 `review_route_decision`.

## 검증

- `proposals.test.ts` 53 pass / 0 fail · `tsc` 0
- 전체 수트 0 fail (기준선과 동일)
- **뮤턴트**: `otherReviewers` 에 필터를 되살리면 위 시험이 **단독 red**

## 검증 못 한 것 (그대로 적는다)

`activeReviewTeamSize` · `eligiblePeerReviewerCapacity` 의 필터를 되살리는 뮤턴트는 **전체 수트에서 살아남는다**. 이름으로 대조했고 실패 집합이 그대로였다 = **이 두 함수의 변경을 잡는 시험이 저장소 어디에도 없다.**

이 두 함수는 `requiredPmReviewCount` / 팀 규모 판정에 쓰인다. 즉 "모두 blocked 인 팀에서 pm_review 가 필요한가" 가 이 PR 로 바뀌는데 그걸 고정하는 시험이 없다. 급히 시험을 하나 써 넣기보다 **리뷰어가 이 축을 봐 주는 쪽**이 낫다고 판단했다 — 이 PR 에서 이미 한 번 잘못된 축으로 시험을 썼다.

## 배포

서버 층 → **재시작 필요, 빌드 불필요.** 되돌리기는 이 커밋 revert + 재시작.
