### PR TITLE
feat(telegram): /onoff 메뉴에 MCP 스위치 추가

### DIFF
--- a/src/server/workers/telegramCapture.test.ts
+++ b/src/server/workers/telegramCapture.test.ts
@@ -19,6 +19,8 @@ import {
   fmtStatus,
   slashCommands,
   bestPhoto,
+  mcpOnoffRow,
+  applyMcpOnoff,
 } from "./telegramCapture";
 
 const codex: AgentRecord = {
@@ -217,6 +219,44 @@ const roster: AgentRecord[] = [
   { id: "bill", display_name: "Bill", role: "Infra", runtime: "claude_channel", status_provider: "claude_tmux", tmux_session: "claude-bill", telegram_bot_username: "example_dev_bot", workspace_path: "", persona_file: "", moderator_eligible: true, avatar_emoji: "" },
   { id: "codex", display_name: "Codex", role: "Step", runtime: "openclaw", status_provider: "openclaw_gateway", tmux_session: null, telegram_bot_username: "example_openclaw_bot", workspace_path: "", persona_file: "", moderator_eligible: true, avatar_emoji: "" },
 ];
+
+describe("/onoff MCP switch", () => {
+  function settingsDb(): Database {
+    const db = new Database(":memory:");
+    migrate(db);
+    return db;
+  }
+
+  test("internal menu renders one MCP row and reflects the shared setting", () => {
+    const db = settingsDb();
+    expect(mcpOnoffRow(db, "ko", false)).toEqual([
+      { text: "🟢 MCP — 🔴 끄기", callback_data: "mcp:off" },
+    ]);
+
+    db.prepare(`INSERT INTO setting (key, value) VALUES ('mcp_enabled', 'false') ON CONFLICT(key) DO UPDATE SET value='false'`).run();
+    expect(mcpOnoffRow(db, "ko", false)).toEqual([
+      { text: "🔴 MCP — 🟢 켜기", callback_data: "mcp:on" },
+    ]);
+  });
+
+  test("public menu omits the MCP row in both setting states", () => {
+    const db = settingsDb();
+    expect(mcpOnoffRow(db, "ko", true)).toBeNull();
+    db.prepare(`INSERT INTO setting (key, value) VALUES ('mcp_enabled', 'false') ON CONFLICT(key) DO UPDATE SET value='false'`).run();
+    expect(mcpOnoffRow(db, "ko", true)).toBeNull();
+    expect(applyMcpOnoff(db, "mcp:off", true)).toBeNull();
+    expect((db.prepare(`SELECT value FROM setting WHERE key='mcp_enabled'`).get() as { value: string }).value).toBe("false");
+  });
+
+  test("off and on callbacks change the dashboard's mcp_enabled DB setting", () => {
+    const db = settingsDb();
+    expect(applyMcpOnoff(db, "mcp:off")).toBe(false);
+    expect((db.prepare(`SELECT value FROM setting WHERE key='mcp_enabled'`).get() as { value: string }).value).toBe("false");
+
+    expect(applyMcpOnoff(db, "mcp:on")).toBe(true);
+    expect((db.prepare(`SELECT value FROM setting WHERE key='mcp_enabled'`).get() as { value: string }).value).toBe("true");
+  });
+});
 
 describe("replyAuthorAgentId — reply-owner mapping", () => {
   test("matches bot username (case/@ insensitive) → agent id", () => {

--- a/src/server/workers/telegramCapture.test.ts
+++ b/src/server/workers/telegramCapture.test.ts
@@ -248,16 +248,23 @@ describe("/onoff MCP switch", () => {
     expect(mcpOnoffRow(db, "ko", true)).toBeNull();
     db.prepare(`INSERT INTO setting (key, value) VALUES ('mcp_enabled', 'false') ON CONFLICT(key) DO UPDATE SET value='false'`).run();
     expect(mcpOnoffRow(db, "ko", true)).toBeNull();
-    expect(applyMcpOnoff(db, "mcp:off", true)).toBeNull();
+    expect(applyMcpOnoff(db, "mcp:off", { authorized: true, publicBuild: true })).toBeNull();
     expect((db.prepare(`SELECT value FROM setting WHERE key='mcp_enabled'`).get() as { value: string }).value).toBe("false");
+  });
+
+  test("unauthorized callback cannot create or change the MCP setting", () => {
+    const db = settingsDb();
+    expect(applyMcpOnoff(db, "mcp:off", { authorized: false, publicBuild: false })).toBeNull();
+    expect(db.prepare(`SELECT value FROM setting WHERE key='mcp_enabled'`).get()).toBeNull();
   });
 
   test("off and on callbacks change the dashboard's mcp_enabled DB setting", () => {
     const db = settingsDb();
-    expect(applyMcpOnoff(db, "mcp:off")).toBe(false);
+    const gate = { authorized: true, publicBuild: false };
+    expect(applyMcpOnoff(db, "mcp:off", gate)).toBe(false);
     expect((db.prepare(`SELECT value FROM setting WHERE key='mcp_enabled'`).get() as { value: string }).value).toBe("false");
 
-    expect(applyMcpOnoff(db, "mcp:on")).toBe(true);
+    expect(applyMcpOnoff(db, "mcp:on", gate)).toBe(true);
     expect((db.prepare(`SELECT value FROM setting WHERE key='mcp_enabled'`).get() as { value: string }).value).toBe("true");
   });
 });

--- a/src/server/workers/telegramCapture.test.ts
+++ b/src/server/workers/telegramCapture.test.ts
@@ -227,12 +227,16 @@ describe("/onoff MCP switch", () => {
     return db;
   }
 
-  test("internal menu renders one MCP row and reflects the shared setting", () => {
+  test("missing mcp_enabled row defaults the internal menu to ON", () => {
     const db = settingsDb();
+    expect(db.prepare(`SELECT value FROM setting WHERE key='mcp_enabled'`).get()).toBeNull();
     expect(mcpOnoffRow(db, "ko", false)).toEqual([
       { text: "🟢 MCP — 🔴 끄기", callback_data: "mcp:off" },
     ]);
+  });
 
+  test("internal menu reflects an explicit false setting as OFF", () => {
+    const db = settingsDb();
     db.prepare(`INSERT INTO setting (key, value) VALUES ('mcp_enabled', 'false') ON CONFLICT(key) DO UPDATE SET value='false'`).run();
     expect(mcpOnoffRow(db, "ko", false)).toEqual([
       { text: "🔴 MCP — 🟢 켜기", callback_data: "mcp:on" },

--- a/src/server/workers/telegramCapture.ts
+++ b/src/server/workers/telegramCapture.ts
@@ -21,7 +21,7 @@ import { listStatuses, getStatus } from "../db/queries";
 import { classifyHealth } from "../lib/health";
 import { storeTelegramMedia, type StoredMedia, type TelegramMediaRef } from "../lib/mediaStore";
 import { BODY_MAX_CHARS, buildDedupeKey } from "../../shared/envelopeSchema";
-import { getCaptureToken, isRouterEnabled, getCaptureGroupId, getLocale } from "../lib/captureConfig";
+import { getCaptureToken, isMcpEnabled, isRouterEnabled, getCaptureGroupId, getLocale, setMcpEnabled } from "../lib/captureConfig";
 import { pick, type Locale } from "../lib/i18n";
 import { rememberCaptureNonBotSender, rememberDiscoveredGroup } from "../lib/telegramLeadDetection";
 import { decidePermissionRequest, getPermissionRequest, listPermissionRequests } from "../lib/permissionGate";
@@ -105,6 +105,30 @@ interface CaptureDeps {
   agents: () => AgentRecord[];
   db: Database;
   broadcast?: (e: WsEvent) => void;
+  /** Tests inject both visibility branches; production defaults to the build flag. */
+  publicBuild?: boolean;
+}
+
+type OnoffButton = { text: string; callback_data: string };
+
+/** Live-only MCP row for /onoff. Public builds omit the row entirely. */
+export function mcpOnoffRow(db: Database, locale: Locale, publicBuild: boolean): OnoffButton[] | null {
+  if (publicBuild) return null;
+  const on = isMcpEnabled(db);
+  return [{
+    text: on ? pick(locale, "🟢 MCP — 🔴 끄기", "🟢 MCP — 🔴 turn off") : pick(locale, "🔴 MCP — 🟢 켜기", "🔴 MCP — 🟢 turn on"),
+    callback_data: on ? "mcp:off" : "mcp:on",
+  }];
+}
+
+/** Apply the Telegram MCP switch to the same setting used by dashboard Settings. */
+export function applyMcpOnoff(db: Database, data: string, publicBuild = false): boolean | null {
+  if (publicBuild) return null;
+  const match = /^mcp:(on|off)$/.exec(data);
+  if (!match) return null;
+  const on = match[1] === "on";
+  setMcpEnabled(db, on);
+  return on;
 }
 
 interface TgUpdate {
@@ -638,6 +662,8 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
       // 🔴 전체 정지 — 비상 서킷브레이커(복구 코디 제외 전원 정지). 오탭 방지로 stall 콜백이 확인 1번 받는다.
       [{ text: pick(locale, "🔴 전체 정지 (복구 코디 제외 · 확인)", "🔴 Stop all (excludes recovery coordinator · confirm)"), callback_data: "stall" }],
     ];
+    const mcpRow = mcpOnoffRow(deps.db, locale, deps.publicBuild ?? PUBLIC_BUILD);
+    if (mcpRow) rows.push(mcpRow);
     for (const a of agents) {
       const off = isAgentOff(a.id);
       if (off) {
@@ -763,6 +789,15 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
     }
 
     // onoff 콜백 (on:<id>:<runtime> / off:<id>:<runtime>)
+    if (/^mcp:(on|off)$/.test(data)) {
+      if (!isAuthorized()) { await tg("answerCallbackQuery", { callback_query_id: cb.id, text: pick(locale, "권한 없음", "Not authorized"), show_alert: true }); appendAuditFile("capture", "callback_denied", data, { from: fromId }); return; }
+      const mcpOn = applyMcpOnoff(deps.db, data, deps.publicBuild ?? PUBLIC_BUILD);
+      if (mcpOn === null) { await tg("answerCallbackQuery", { callback_query_id: cb.id }); return; }
+      await tg("answerCallbackQuery", { callback_query_id: cb.id, text: mcpOn ? pick(locale, "MCP 켜짐", "MCP on") : pick(locale, "MCP 꺼짐", "MCP off") });
+      appendAuditFile("capture", "mcp_onoff", "mcp", { on: mcpOn });
+      if (mid) await tg("editMessageText", { chat_id: chatId, message_id: mid, text: onoffMenuText(mcpOn ? pick(locale, "🟢 MCP 켜짐", "🟢 MCP on") : pick(locale, "🔴 MCP 꺼짐", "🔴 MCP off")), reply_markup: onoffKeyboard() });
+      return;
+    }
     const oo = /^(on|off):([a-z0-9_-]+):([a-z_]+)$/.exec(data);
     if (oo) {
       if (!isAuthorized()) { await tg("answerCallbackQuery", { callback_query_id: cb.id, text: pick(locale, "권한 없음", "Not authorized"), show_alert: true }); appendAuditFile("capture", "callback_denied", data, { from: fromId }); return; }

--- a/src/server/workers/telegramCapture.ts
+++ b/src/server/workers/telegramCapture.ts
@@ -122,8 +122,12 @@ export function mcpOnoffRow(db: Database, locale: Locale, publicBuild: boolean):
 }
 
 /** Apply the Telegram MCP switch to the same setting used by dashboard Settings. */
-export function applyMcpOnoff(db: Database, data: string, publicBuild = false): boolean | null {
-  if (publicBuild) return null;
+export function applyMcpOnoff(
+  db: Database,
+  data: string,
+  gate: { authorized: boolean; publicBuild: boolean },
+): boolean | null {
+  if (!gate.authorized || gate.publicBuild) return null;
   const match = /^mcp:(on|off)$/.exec(data);
   if (!match) return null;
   const on = match[1] === "on";
@@ -790,8 +794,9 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
 
     // onoff 콜백 (on:<id>:<runtime> / off:<id>:<runtime>)
     if (/^mcp:(on|off)$/.test(data)) {
-      if (!isAuthorized()) { await tg("answerCallbackQuery", { callback_query_id: cb.id, text: pick(locale, "권한 없음", "Not authorized"), show_alert: true }); appendAuditFile("capture", "callback_denied", data, { from: fromId }); return; }
-      const mcpOn = applyMcpOnoff(deps.db, data, deps.publicBuild ?? PUBLIC_BUILD);
+      const authorized = isAuthorized();
+      const mcpOn = applyMcpOnoff(deps.db, data, { authorized, publicBuild: deps.publicBuild ?? PUBLIC_BUILD });
+      if (!authorized) { await tg("answerCallbackQuery", { callback_query_id: cb.id, text: pick(locale, "권한 없음", "Not authorized"), show_alert: true }); appendAuditFile("capture", "callback_denied", data, { from: fromId }); return; }
       if (mcpOn === null) { await tg("answerCallbackQuery", { callback_query_id: cb.id }); return; }
       await tg("answerCallbackQuery", { callback_query_id: cb.id, text: mcpOn ? pick(locale, "MCP 켜짐", "MCP on") : pick(locale, "MCP 꺼짐", "MCP off") });
       appendAuditFile("capture", "mcp_onoff", "mcp", { on: mcpOn });


### PR DESCRIPTION
## 핵심 3줄
1. Telegram `/onoff`에서 대시보드와 같은 `mcp_enabled` 설정을 끄고 켭니다.
2. 공개 빌드에서는 MCP 행과 callback 동작을 모두 숨깁니다.
3. 변경 2파일, 동작 코드 37줄·시험 40줄입니다.

## 무엇을 바꿨나
- 내부 빌드 `/onoff`에 현재 상태를 반영하는 MCP 한 줄을 추가했습니다.
- `mcp:on`/`mcp:off` callback이 `setMcpEnabled`로 같은 DB 설정을 변경합니다.
- `publicBuild`를 주입해 공개/내부 분기를 동작 시험으로 검증합니다.

## 검증
- 범위: `bun test src/server/workers/telegramCapture.test.ts`
- baseline: 28 pass, 0 fail
- typecheck: `bun run typecheck` 통과
- build: `bun run build` 통과
- mutation: 공개 숨김 조건 제거 → 공개 메뉴 시험 1 fail
- mutation: DB 저장 방향 반전 → off/on DB 시험 1 fail
- 화면 확인: 내부 기본 `🟢 MCP — 🔴 끄기`, 내부 끔 `🔴 MCP — 🟢 켜기`, 공개 `null`
- 미검증: 실제 Telegram 봇 탭 및 라이브 워커 재시작은 수행하지 않음

Submitted-by: Codex