### PR TITLE
fix(report): 인라인 코드가 폰 화면을 밀어내는 것 — overflow-wrap 을 준다

### DIFF
--- a/skills/b3os-report/assets/theme.css
+++ b/skills/b3os-report/assets/theme.css
@@ -101,8 +101,8 @@ table{width:100%;margin:18px 0 28px;border-collapse:separate;border-spacing:0;fo
 th,td{border-bottom:1px solid var(--line-soft);padding:13px 15px;text-align:left;vertical-align:top}tr:last-child td{border-bottom:0}
 th{background:var(--card-2);color:var(--mut);font:800 12px/1.4 var(--mono);text-transform:none;letter-spacing:.02em}
 td:first-child,th:first-child{font-weight:650}tr:hover td{background:color-mix(in srgb,var(--card) 92%,var(--green) 8%)}
-code{background:var(--card-3);border:1px solid var(--line);padding:1px 6px;border-radius:6px;font-size:.9em;color:color-mix(in srgb,var(--green) 76%,var(--ink));font-family:var(--mono)}
-pre{background:linear-gradient(180deg,color-mix(in srgb,var(--card-3) 94%,#fff 6%),var(--card-3));border:1px solid var(--line-strong);border-radius:12px;padding:16px;overflow-x:auto;margin:18px 0 28px;box-shadow:var(--surface-shadow-soft)}pre code{background:none;border:0;padding:0;color:var(--ink)}
+code{background:var(--card-3);border:1px solid var(--line);padding:1px 6px;border-radius:6px;font-size:.9em;color:color-mix(in srgb,var(--green) 76%,var(--ink));font-family:var(--mono);overflow-wrap:anywhere}
+pre{background:linear-gradient(180deg,color-mix(in srgb,var(--card-3) 94%,#fff 6%),var(--card-3));border:1px solid var(--line-strong);border-radius:12px;padding:16px;overflow-x:auto;margin:18px 0 28px;box-shadow:var(--surface-shadow-soft)}pre code{background:none;border:0;padding:0;color:var(--ink);overflow-wrap:normal}
 ul,ol{margin:0 0 24px;padding-left:1.35em}li{margin:.42em 0;color:var(--ink)}li::marker{color:var(--green)}
 hr{border:0;border-top:1px solid var(--line);margin:34px 0}
 figure{margin:24px 0 30px;background:linear-gradient(180deg,color-mix(in srgb,var(--card) 96%,#fff 4%),var(--card));border:1px solid var(--line-strong);border-radius:14px;padding:12px;box-shadow:var(--surface-shadow)}


### PR DESCRIPTION
데미스가 아이폰 폭에서 보고서에 가로 스크롤이 생긴다고 알려왔다. **재보니 원인이 알려온 것과 달랐다.**

## 실측 (390px · 렌더된 문서를 브라우저에서 요소별로 측정)

```
수정 전   body scrollWidth 432   (뷰포트 390 → 42px 넘침)
          넘치는 요소 = 인라인 <code> 414px   ← ★이것 하나가 페이지를 민다★
          표    scrollWidth 596 / clientWidth 352 → ★이미 내부 스크롤됨★
          pre   → ★이미 overflow-x:auto★

수정 후   body scrollWidth 390   (넘침 0)
          인라인 <code> 347px · overflow-wrap: anywhere
          표·pre 는 그대로 내부 스크롤
```

## 알려온 진단과 다른 점

| 알려온 것 | 실제 |
|---|---|
| 표가 `display:block + width 고정`인데 `overflow-x`가 없다 | `@media(max-width:720px)` 가 이미 `table{display:block}` + `overflow-x:auto` 를 건다. 표는 내부 스크롤된다 |
| 긴 코드 조각이 안 쪼개져 넘친다 | `pre` 는 이미 `overflow-x:auto`. 처리가 없던 것은 **인라인 `code`** 뿐 |

긴 파일 경로를 백틱으로 감싸면 그 한 줄이 페이지 전체를 넓혔다. 표를 목록으로 바꿔도 해결되지 않았던 이유가 이것이다 — 목록 안에도 백틱 경로가 있으면 그대로 난다.

## 무엇을 바꿨나

- `code` 에 `overflow-wrap:anywhere`
- `pre code` 에 `overflow-wrap:normal` — 코드 블록은 종전대로 가로 스크롤로 둔다. 줄바꿈되면 코드가 읽기 나빠진다

## 배포

`skills/` 라 재시작·빌드 불필요.

**다만 이미 발행된 보고서는 안 바뀐다.** `theme.css` 는 렌더 시점에 HTML 안으로 복사되므로, 기존 문서는 다시 렌더해야 반영된다.

## 미검증

실제 아이폰에서는 안 봤다. 측정은 데스크톱 브라우저를 390px 로 강제한 것이다.
