### PR TITLE
test(bus): 같은 것을 세 번 재던 시험을 하나로 — 마커 없는 본문 축을 더한다

### DIFF
--- a/src/server/db/inbox/broadcastRecipients.test.ts
+++ b/src/server/db/inbox/broadcastRecipients.test.ts
@@ -168,20 +168,24 @@ describe("★팀원 broadcast 팬아웃은 @all 과 같은 규칙을 쓴다★",
   //   실측: 그날 팀원이 쓴 @all 중 전체공지 목적은 검증용 1건뿐이고, 나머지는 전부
   //   ★"@all 이라는 단어를 문장 안에서 언급"★ 한 것이었다. ★언급만 해도 8명이 깨어났다.★
   describe("★@all 마커는 팀장님(source=user) 전용★", () => {
-    test("팀원이 @all 을 써도 수신행 0", () => {
+    // ★판정은 source 로만 한다 — 이 경로는 본문을 읽지 않는다.★ (messages.ts 팀원 분기)
+    //   그래서 "@all 을 써서 0" 이 아니라 ★"팀원이라서 0"★ 이다. 예전 시험 3건은 본문만
+    //   바꿔 나열해서 ★셋 다 같은 것을 재고 있었고★, 본문을 '오늘 점심 뭐 먹지' 로 바꿔도
+    //   전부 통과했다(실측). 마커를 정규식에서 지워도 안 깨지니 ★회귀를 못 잡는다.★
+    //   → 본문 목록을 한 시험에 모아 ★"본문이 무엇이든 결과가 같다" 를 단언★ 한다.
+    //     이러면 나중에 누가 이 경로에 본문 파싱을 넣는 순간 깨진다. 그게 잡아야 할 회귀다.
+    test("★팀원 발신은 본문과 무관하게 0★ — 판정은 source 하나로만 한다", () => {
       const db = withRoster(ROSTER);
-      expect(broadcastFrom(db, "sender", "agent", "@all 다들 확인")).toEqual([]);
-    });
-
-    test("★단어로 언급만 한 경우도 0★ — 그날 실제로 있던 형태", () => {
-      const db = withRoster(ROSTER);
-      expect(broadcastFrom(db, "sender", "agent", "결함은 그중 하나(@all)에만 있습니다")).toEqual([]);
-    });
-
-    test("@b3rys · @group 도 같다", () => {
-      const db = withRoster(ROSTER);
-      expect(broadcastFrom(db, "sender", "agent", "@b3rys 확인")).toEqual([]);
-      expect(broadcastFrom(db, "sender", "agent", "@group 확인")).toEqual([]);
+      const bodies = [
+        "@all 다들 확인",                          // 마커를 의도적으로 쓴 경우
+        "결함은 그중 하나(@all)에만 있습니다",      // ★단어로 언급만★ — 그날 실제로 있던 형태
+        "@b3rys 확인",
+        "@group 확인",
+        "오늘 점심 뭐 먹지",                        // 마커가 아예 없는 경우
+      ];
+      for (const body of bodies) {
+        expect(broadcastFrom(db, "sender", "agent", body), `본문: ${body}`).toEqual([]);
+      }
     });
 
     test("★coordinator 도 예외 없다★ — 판정은 source 하나로만 한다", () => {
@@ -191,10 +195,15 @@ describe("★팀원 broadcast 팬아웃은 @all 과 같은 규칙을 쓴다★",
       expect(broadcastFrom(db, "sender", "agent", "@all 공지")).toEqual([]);
     });
 
-    test("팀장님(source=user)이 쓰면 예전 그대로 — 전원", () => {
+    // ★이 시험 이름이 '@all 을 쓰면' 으로 읽히면 안 된다★ — user 분기도 본문을 안 읽는다.
+    //   전원이 되는 이유는 마커가 아니라 ★source=user★ 다. 예전 시험은 본문에 '@all' 이 있어서
+    //   ★마커 때문에 전원인 것처럼 오해를 만들었고★, 본문을 '안녕하세요' 로 바꿔도 통과했다(실측).
+    test("★팀장님(source=user)은 본문과 무관하게 전원★ — 마커가 아니라 source 가 가른다", () => {
       const db = withRoster(ROSTER);
       const all = (db.prepare(`SELECT id FROM agent WHERE id != ?`).all("sender") as Array<{ id: string }>).map((r) => r.id).sort();
-      expect(broadcastFrom(db, "sender", "user", "@all 다들 확인")).toEqual(all);
+      for (const body of ["@all 다들 확인", "안녕하세요"]) {
+        expect(broadcastFrom(db, "sender", "user", body), `본문: ${body}`).toEqual(all);
+      }
     });
   });
 


### PR DESCRIPTION
`broadcastFrom` 의 팀원 분기(`messages.ts:179~`)는 **본문을 읽지 않는다.** `all_hands` 와 `explicit_recipients` 만 본다. 그래서 "@all 을 써서 0" 이 아니라 **"팀원이라서 0"** 이다.

그런데 `★@all 마커는 팀장님 전용★` 블록의 시험 3건이 본문만 바꿔 나열돼 있었다 — `@all 다들 확인` · `결함은 그중 하나(@all)에만` · `@b3rys`·`@group`. **셋 다 같은 것을 잰다.** 실측: 본문을 `오늘 점심 뭐 먹지` 로 바꿔도 전부 통과했다(21 pass).

`팀장님이 쓰면 전원` 도 본문에 `@all` 이 들어 있어 **마커 때문에 전원인 것처럼 오해**를 만들었다. 실제로는 `source=user` 라서고, 본문이 `안녕하세요` 여도 통과한다.

## 무엇을 했나

본문 목록을 한 시험에 모아 **"본문이 무엇이든 결과가 같다"** 를 명시적으로 단언한다. 지운 3건의 본문은 **전부 루프 안에 남아 있고**, 거기에 **마커가 없는 본문(`오늘 점심 뭐 먹지`)** 을 더했다. user 분기에도 `안녕하세요` 를 더했다.

실패 메시지에 `본문: ${body}` 를 붙여, 루프 시험의 약점(몇 번째가 깨졌는지 모른다)을 막았다.

## 이 변경이 실제로 무엇을 더 잡나

처음에 "본문에 마커가 **있으면** 전원" 뮤턴트로 쟀더니 옛 5 fail / 새 4 fail 이라 **개선을 입증하지 못했다.** 옛 시험 3건이 전부 마커를 갖고 있어 어느 쪽이든 잡히기 때문이다. 그 사실을 그대로 적어 올렸고, 리뷰에서 bill 이 **반대 방향**을 짚었다.

"마커가 **없을** 때 전원" 뮤턴트로 다시 쟀다:

```
새 시험 → 4 fail · error: 본문: 오늘 점심 뭐 먹지   ← 새로 더한 축이 잡는다
정리 대상 describe 3건 → 0 fail                      ← 전부 마커가 든 본문이라 조건에 안 걸린다
```

(파일 전체로는 옛 3 fail / 새 4 fail 이다. 옛 3건은 다른 블록 `★팀원 broadcast 팬아웃은 @all 과 같은 규칙을 쓴다★` 의 시험들이 잡은 것이고, 내가 정리한 블록 기준으로는 **0 → 1** 이다.)

= **"본문이 무엇이든 같다" 를 진짜로 재려면 마커 없는 본문이 있어야 한다.** 개선은 중복 제거만이 아니라 축 추가다.

## 범위 밖

`@b3rys` 마커 정규식은 `teamRouter/ownerDecision.ts` 에 있어 이 시험 파일과 무관하다 — 거기서 지워도 이 시험은 통과한다. **그 축은 별도 시험이 필요하고 이번에 건드리지 않았다.** 한 PR 에 두 축을 섞으면 무엇이 무엇을 잡는지 흐려진다.

## 검증

- `broadcastRecipients` 19 pass · `inbox`+`bus` 378 pass / 0 fail · `tsc --noEmit` 통과
- 소스 무변경 — 시험 파일 1개만
- 배포 불필요

Reviewed-by: bill (반대 방향 뮤턴트로 축 추가 확인)