### PR TITLE
fix: blocked 를 경과시간으로 판정하지 않는다 — 리뷰 배정·등록의 엇갈린 state 판정을 맞춘다

### DIFF
--- a/src/server/db/proposal.ts
+++ b/src/server/db/proposal.ts
@@ -362,9 +362,12 @@ export function addReview(db: Database, r: { proposal_id: string; reviewer_agent
   if (proposal.status !== expectedStatus) return { ok: false, error: `review stage/status mismatch: ${r.stage} requires ${expectedStatus}, current ${proposal.status}` };
   const reviewer = r.reviewer_agent.trim();
   // ★여기서도 state 를 안 본다★ — 배정(`eligiblePeerReviewerCapacity`)과 같은 이유다.
-  //   `agent_status.state` 의 `blocked` 는 "막혔다" 가 아니라 ★"마지막 활동에서 5분이 지났다"★ 다
-  //   (`statusProbe.ts` 의 `computeStateFromActivity`: 1분 → running · 5분 → idle · 그 이상 → blocked).
-  //   불려야 움직이는 런타임은 아무도 안 부르면 조용한 게 정상이라, ★가만히 두면 전원이 blocked 가 된다.★
+  //   ★예전에는★ `agent_status.state` 의 `blocked` 가 "막혔다" 가 아니라 "마지막 활동에서 5분이 지났다"
+  //   였다. 불려야 움직이는 런타임은 아무도 안 부르면 조용한 게 정상이라 ★가만히 두면 전원이 blocked★ 였고,
+  //   그 값을 자격으로 읽던 이 검사가 ★일하고 있는 사람의 리뷰를 거절했다.★
+  //   그 경계는 같은 PR 의 앞 커밋에서 없앴다 — 지금 `computeStateFromActivity` 는 running·idle·offline 만
+  //   낸다. ★그래도 이 검사는 되살리지 않는다★: blocked 는 이제 openclaw·codex 가 자기 차단 신호로 낼 수
+  //   있고, 그 경우에도 아래 이유로 등록을 막을 근거가 되지 못한다.
   //
   // ★등록에서는 이 검사가 특히 성립하지 않는다★ — 배정은 "이 사람이 할 수 있을까" 라는 예측이지만,
   //   등록은 ★그 사람이 리뷰를 다 써서 내미는 시점★ 이다. 제출하고 있다는 사실 자체가 살아있다는 증거고,

--- a/src/server/db/proposal.ts
+++ b/src/server/db/proposal.ts
@@ -361,14 +361,20 @@ export function addReview(db: Database, r: { proposal_id: string; reviewer_agent
   const expectedStatus = r.stage === "peer" ? "peer_review" : r.stage === "pm" ? "pm_review" : "gd_report";
   if (proposal.status !== expectedStatus) return { ok: false, error: `review stage/status mismatch: ${r.stage} requires ${expectedStatus}, current ${proposal.status}` };
   const reviewer = r.reviewer_agent.trim();
-  const reviewerRow = db.prepare(
-    `SELECT a.id, COALESCE(s.state, 'idle') AS state
-       FROM agent a
-       LEFT JOIN agent_status s ON s.agent_id = a.id
-      WHERE a.id = ?`,
-  ).get(reviewer) as { id: string; state: string } | undefined;
+  // ★여기서도 state 를 안 본다★ — 배정(`eligiblePeerReviewerCapacity`)과 같은 이유다.
+  //   `agent_status.state` 의 `blocked` 는 "막혔다" 가 아니라 ★"마지막 활동에서 5분이 지났다"★ 다
+  //   (`statusProbe.ts` 의 `computeStateFromActivity`: 1분 → running · 5분 → idle · 그 이상 → blocked).
+  //   불려야 움직이는 런타임은 아무도 안 부르면 조용한 게 정상이라, ★가만히 두면 전원이 blocked 가 된다.★
+  //
+  // ★등록에서는 이 검사가 특히 성립하지 않는다★ — 배정은 "이 사람이 할 수 있을까" 라는 예측이지만,
+  //   등록은 ★그 사람이 리뷰를 다 써서 내미는 시점★ 이다. 제출하고 있다는 사실 자체가 살아있다는 증거고,
+  //   정말 죽은 팀원은 애초에 이 경로에 도달하지 못한다. 즉 이 검사가 막을 수 있는 것은
+  //   ★"조용했지만 살아서 일한 리뷰" 뿐이었다★ — 지키는 것 없이 결과물만 버렸다.
+  //
+  // 배정만 고쳤을 때(#304) 무엇이 남았나: 후보에는 들어가고 배정도 받는데, 리뷰를 내러 오면 여기서 막혔다.
+  //   같은 값을 배정은 "못 믿는다", 등록은 "믿는다" 로 읽던 불일치다.
+  const reviewerRow = db.prepare("SELECT id FROM agent WHERE id = ?").get(reviewer) as { id: string } | undefined;
   if (!reviewerRow) return { ok: false, error: `reviewer_agent는 실제 팀원 id여야 함: ${reviewer}` };
-  if (reviewerRow.state === "blocked") return { ok: false, error: `blocked reviewer는 새 리뷰를 등록할 수 없음: ${reviewer}` };
   if (r.stage === "peer" && (reviewer === proposal.proposer_agent || reviewSkipIds().has(reviewer))) {
     return { ok: false, error: `peer reviewer는 제안자/owner/비대화/비운영 agent가 아니어야 함: ${reviewer}` };
   }

--- a/src/server/routes/proposals.test.ts
+++ b/src/server/routes/proposals.test.ts
@@ -1069,6 +1069,35 @@ describe("proposals — GD 심플 모델 (팀 크기별 라우팅)", () => {
     expect((await transition(app, id, "gd_report", "alice")).status).toBe(409);
   });
 
+  // ★배정만으로는 반쪽이다 — 낸 리뷰가 접수돼야 끝난다.★
+  //   위 시험은 blocked 인 팀원에게 ★배정이 가는 것★ 까지만 잰다. 그런데 배정과 등록은 다른 관문이라,
+  //   배정만 열어두면 ★명단에는 있는데 답안지는 안 받는★ 상태가 된다(등록 쪽에 같은 state 검사가 남아 있었다).
+  //   그 구멍은 여기까지 이어서 재야만 드러난다 — 그래서 배정된 사람이 ★실제로 등록에 성공하는지★ 를 잰다.
+  //
+  // ★막히면 저절로 풀리지도 않는다★ — 재배정(`peerReviewOwners`)은 "이미 배정된 적 있는 사람" 만 빼고
+  //   state 는 안 보므로, 남은 후보도 blocked 면 같은 곳으로 다시 간다. 사람이 손대기 전엔 진행이 멈춘다.
+  test("★blocked 인 팀원이 배정받은 리뷰를 실제로 등록할 수 있다★", async () => {
+    const { app, db } = setupTeam(["alice", "bob", "carol"], { coordinator: "bob" });
+    db.prepare("INSERT INTO agent_status (agent_id, state) VALUES (?, 'blocked')").run("bob");
+    db.prepare("INSERT INTO agent_status (agent_id, state) VALUES (?, 'blocked')").run("carol");
+
+    const id = await createBy(app, "alice");
+    // ★배정된 당사자로 낸다★ — 등록은 배정받은 사람만 할 수 있어서(미배정은 403),
+    //   아무나 넣으면 blocked 가 아니라 미배정 때문에 막혀 ★엉뚱한 축을 재게 된다.★
+    const assigned = db.prepare(
+      "SELECT owner FROM proposal_followup_task WHERE proposal_id = ? AND status LIKE 'peer_review:%' AND closed_at IS NULL",
+    ).get(id) as { owner: string };
+    expect(["bob", "carol"]).toContain(assigned.owner);
+
+    expect((await peerReview(app, id, assigned.owner)).status).toBe(201);
+
+    // ★행이 실제로 들어갔는지까지 본다★ — 201 만 보면 응답만 맞고 저장이 빠진 경우를 놓친다.
+    const stored = db.prepare(
+      "SELECT COUNT(*) AS c FROM proposal_review WHERE proposal_id = ? AND reviewer_agent = ?",
+    ).get(id, assigned.owner) as { c: number };
+    expect(stored.c).toBe(1);
+  });
+
   // ★legacy pm_review 경로도 같이 막힌다★ (코덱스 리뷰 2026-08-08).
   //   `eligiblePeerReviewerCapacity` 는 `requiredPmReviewCount` 가 읽는다:
   //     예전 — 제안자 외 전원 blocked → 후보 0 → 필요 리뷰 ★0건★ → ★무검토로 gd_report 통과★

--- a/src/server/workers/statusProbe.test.ts
+++ b/src/server/workers/statusProbe.test.ts
@@ -58,13 +58,17 @@ describe("computeStateFromActivity — 마지막 활동 시각 → 상태", () =
     const justNow = new Date(Date.now() - 5_000).toISOString();
     expect(computeStateFromActivity(justNow)).toBe("running");
   });
-  test("60s~5min 사이 → idle", () => {
+  test("60s 초과 → idle", () => {
     const twoMinAgo = new Date(Date.now() - 2 * 60_000).toISOString();
     expect(computeStateFromActivity(twoMinAgo)).toBe("idle");
   });
-  test("5min 초과 → blocked", () => {
-    const tenMinAgo = new Date(Date.now() - 10 * 60_000).toISOString();
-    expect(computeStateFromActivity(tenMinAgo)).toBe("blocked");
+  // ★아무리 오래 조용해도 blocked 가 아니다★ (팀 리드 2026-08-09: "진짜 blocked 가 아닌 상황은 idle 로").
+  //   예전에는 5분에서 blocked 로 넘어갔다. 불려야 움직이는 런타임에게 침묵은 정상이라,
+  //   그 값을 '일 못 맡길 사람' 으로 읽던 곳들(리뷰 배정·등록)이 ★멀쩡한 팀원을 빼버렸다.★
+  //   ★하루가 지나도 idle★ 이어야 한다 — 시간은 막혔다는 증거가 될 수 없다.
+  test("★10분이든 하루든, 조용하기만 한 것은 idle★", () => {
+    expect(computeStateFromActivity(new Date(Date.now() - 10 * 60_000).toISOString())).toBe("idle");
+    expect(computeStateFromActivity(new Date(Date.now() - 24 * 60 * 60_000).toISOString())).toBe("idle");
   });
   test("경계 직후(60s 막 지남) → idle", () => {
     const justOverIdle = new Date(Date.now() - 61_000).toISOString();
@@ -231,6 +235,17 @@ describe("buildClaudeStatus — claude_tmux 상태 생성", () => {
     expect(s.tmux_pid).toBe(99);
     expect(s.last_activity_at).toBe(null);
     expect(s.ctx_percent).toBe(null);
+  });
+
+  // ★claude 경로에서 blocked 는 이제 나오지 않는다★ — 경과시간이 유일한 근거였기 때문이다.
+  //   한도 소진 같은 실제 차단 증거는 `last_log_line` 에 그대로 남고, 위험 판정은 `health.ts` 의
+  //   `runtimeBlockedReason` 이 그 줄을 읽어서 한다 — state 를 거치지 않는다.
+  test("★하루를 조용해도 idle★ — 시간은 막혔다는 근거가 아니다", () => {
+    const dayAgo = new Date(Date.now() - 24 * 60 * 60_000).toISOString();
+    const s = buildClaudeStatus("bill", true, 1234, [
+      { line: "Ready for input", captured_at: dayAgo },
+    ]);
+    expect(s.state).toBe("idle");
   });
 });
 

--- a/src/server/workers/statusProbe.ts
+++ b/src/server/workers/statusProbe.ts
@@ -12,7 +12,6 @@ import { hermesBinary } from "../lib/paths";
 
 const POLL_INTERVAL_MS = 5000;
 const IDLE_AFTER_MS = 60_000;
-const BLOCKED_AFTER_MS = 5 * 60_000;
 
 async function tmuxSessionExists(session: string): Promise<boolean> {
   return new Promise((resolve) => {
@@ -213,16 +212,28 @@ function currentPaneCapacityLine(lines: string[]): string | null {
 }
 
 // ★DB 시각은 UTC 인데 Z 가 없다 ("2026-07-13 04:48:15").★ 맨 `new Date()` 로 읽으면 ★로컬★ 로 해석돼
-//   KST 서버에서 9시간 어긋나고, elapsed 가 9시간 부풀어 ★방금 답한 에이전트가 blocked 로 뒤집힌다.★
+//   KST 서버에서 9시간 어긋나고, elapsed 가 9시간 부풀어 ★방금 답한 에이전트가 조용한 쪽으로 뒤집힌다.★
 //   parseCapturedAt 이 Z 를 붙여 UTC 로 고정한다 — 다른 호출부는 이미 이걸 쓰고 있었고 ★여기만 안 썼다.★
+//
+// ★조용한 것은 막힌 것이 아니다★ (팀 리드 2026-08-09: "진짜 blocked 가 아닌 상황은 idle 로 해.
+//   idle 은 정상상태이면서 대기").
+//   예전에는 5분 넘게 조용하면 `blocked` 를 줬다. 그런데 ★불려야 움직이는 런타임은 아무도 안 부르면
+//   조용한 것이 정상★ 이라, 가만히 두면 멀쩡한 팀원이 차례로 blocked 가 됐다.
+//   실측(2026-08-09 라이브): 그 시각 서로 대화 중이던 멤버 2명이 ★마지막 활동 11분 경과★ 만으로 blocked.
+//   그 값을 '일 못 맡길 사람' 으로 읽던 곳이 실제로 오작동했다 — 리뷰 배정(#304)과 리뷰 등록.
+//
+// ★막혔다는 판정은 시간이 아니라 신호로 한다.★ 한도 소진 같은 실제 증거는 `blockedLine` 이 잡아
+//   `last_log_line` 에 남기고, 위험 판정은 `health.ts` 의 `runtimeBlockedReason` 이 그 줄을 읽어서 한다.
+//   ★그 신호를 여기서 state 로 승격하지는 않는다★ — `CAPACITY_RE` 에는 "now using usage credits"
+//   처럼 ★막힌 게 아니라 크레딧으로 계속 도는 중★ 인 줄도 함께 걸리기 때문이다(그 경계는 바로 아래
+//   `buildClaudeStatus` 시험이 "usage credits 인데 running" 으로 고정해 두었다).
+//   즉 claude 경로의 state 는 running·idle·offline 뿐이고, blocked 는 자기 차단 신호를 가진
+//   openclaw·codex 경로에서만 나온다.
 export function computeStateFromActivity(lastActivityAt: string | null): AgentState {
   if (!lastActivityAt) return "offline";
   const at = parseCapturedAt(lastActivityAt);
-  if (at === null) return "offline"; // 파싱 불가 = 활동을 모른다 (0 으로 읽어 blocked 로 단정하지 않는다)
-  const elapsed = Date.now() - at;
-  if (elapsed < IDLE_AFTER_MS) return "running";
-  if (elapsed < BLOCKED_AFTER_MS) return "idle";
-  return "blocked";
+  if (at === null) return "offline"; // 파싱 불가 = 활동을 모른다 (0 으로 읽어 단정하지 않는다)
+  return Date.now() - at < IDLE_AFTER_MS ? "running" : "idle";
 }
 
 // ── status-builder 순수 함수 (P1b: 루프 인라인 AgentStatus 생성을 추출 → 테스트 가능 + LivenessAdapter 씨앗) ──

--- a/src/web/components/AgentCard.ts
+++ b/src/web/components/AgentCard.ts
@@ -294,11 +294,15 @@ function activityLabel(state: string, agent: Agent): { label: string; title: str
     };
   }
   if (state === "running") return { label: pick("최근 활동 시간", "Recent activity"), title: pick("최근 1분 안에 터미널 출력이 갱신됨", "Terminal output refreshed within the last minute") };
-  if (state === "idle") return { label: pick("최근 활동 시간", "Recent activity"), title: pick("최근 1-5분 사이 터미널 출력 갱신 없음", "No terminal output refresh in the last 1–5 minutes") };
+  // ★상한을 적지 않는다★ — idle 에는 이제 위쪽 경계가 없다. 얼마나 조용했든 그것만으로는 idle 이다.
+  //   (예전 문구는 "1-5분 사이" 였다. 5분이 넘으면 blocked 로 넘어간다는 뜻이었고, 그 경계를 없앴다.)
+  if (state === "idle") return { label: pick("최근 활동 시간", "Recent activity"), title: pick("1분 넘게 터미널 출력 갱신 없음. 정상 대기 상태입니다.", "No terminal output refresh for over a minute. This is a normal waiting state.") };
   if (state === "blocked") {
+    // ★이제 blocked 는 시간이 아니라 신호다.★ 예전 문구는 "5분 이상 조용함, 다만 작업 중단이라는 뜻은
+    //   아님" 이라고 단서를 달고 있었다 — 그 단서가 필요했다는 것 자체가 판정이 틀렸다는 증거였다.
     return {
       label: pick("최근 활동 시간", "Recent activity"),
-      title: pick("최근 5분 이상 터미널 출력 갱신 없음. 실제 작업 중단이나 문맥 포화라는 뜻은 아닙니다.", "No terminal output refresh for over 5 minutes. This does not necessarily mean the work stopped or the context is full."),
+      title: pick("런타임이 막혔다는 신호를 보냈습니다(한도 소진·런타임 차단 등). 조용한 것과는 다릅니다.", "The runtime reported a blocking condition (usage limit, runtime block, and so on). This is different from simply being quiet."),
     };
   }
   return { label: pick("최근 활동 시간", "Recent activity"), title: pick("세션이 없거나 상태 확인 실패", "No session, or status check failed") };


### PR DESCRIPTION
## 핵심 3줄

1. `agent_status.state` 의 `blocked` 는 "막혔다" 가 아니라 **"마지막 활동에서 5분이 지났다"** 였다. 불려야 움직이는 런타임에게 침묵은 정상이라, 가만히 두면 멀쩡한 팀원이 차례로 `blocked` 가 된다.
2. 그 값을 자격 판정으로 읽던 곳이 오작동했다 — #304 가 고친 **리뷰 배정**, 그리고 아직 남아 있던 **리뷰 등록**. 배정만 고쳐서 *명단에는 있는데 답안지는 안 받는* 상태가 됐다.
3. 시간 기반 `blocked` 를 걷어내 `idle` 로 두고(+2/-8), 등록 쪽 state 검사도 제거했다(+13/-6). 시험 2파일 +52/-11.

## 무엇을 바꿨나

| 문제 | 고친 방법 |
|---|---|
| 5분 조용하면 `blocked` — 침묵이 정상인 런타임이 전부 걸린다 | `computeStateFromActivity` 에서 5분 경계 제거. `running`/`idle`/`offline` 만 남긴다 |
| 등록(`addReview`)이 `state === "blocked"` 를 거절 — 배정은 받고 제출은 막힌다 | 검사 제거. state 를 안 쓰게 되어 `agent_status` 조인도 걷어냄 |

---

## 무엇이 문제였나 (실측)

`statusProbe.ts` 의 판정은 경과시간 하나였다.

```
elapsed < 60s   → running
elapsed < 5min  → idle
그 이상          → blocked
```

2026-08-09 라이브 `agent_status`:

```
lisa  blocked  (last_activity 10:05)
jane  blocked  (last_activity 10:04)
clo   idle
herm  idle
```

`lisa`·`jane` 은 그 시각 **서로 리뷰를 주고받는 중**이었다. 막힌 것이 아니라 11분간 조용했을 뿐이다.

`blocked` 를 자격으로 읽는 곳이 두 군데 있었다.

- **배정** — #304 가 이미 고쳤다. 주석에 이유가 적혀 있다: *"`health.ts` 가 같은 값을 두고 정상 활동중에도 떠서 노이즈라고 못박아 두었다"*
- **등록** — `db/proposal.ts` 에 그대로 남아 있었다

그래서 #304 이후 상태는 이렇다. blocked 로 찍힌 사람이 후보에 들어가고, 배정도 받고, 리뷰를 써서 제출하면 **거기서 거절된다.**

**막히면 저절로 풀리지도 않는다.** 재배정(`peerReviewOwners`)은 *이미 배정된 적 있는 사람* 만 빼고 state 는 안 본다. 4인 팀에서 제안자를 빼면 후보 3인이고, 그중 둘이 blocked 면 재배정이 남은 blocked 쪽으로 다시 간다. 사람이 손대기 전엔 진행이 멈춘다.

## 왜 등록에서는 이 검사가 성립하지 않나

배정은 *"이 사람이 할 수 있을까"* 라는 예측이다. 등록은 **그 사람이 리뷰를 다 써서 내미는 시점**이다.

제출하고 있다는 사실 자체가 살아있다는 증거고, 정말 죽은 팀원은 이 경로에 도달하지 못한다. 이 검사가 막을 수 있는 것은 **"조용했지만 살아서 일한 리뷰"** 뿐이었다 — 지키는 것 없이 결과물만 버렸다.

## 어디까지만 건드렸나

한도 소진 같은 **실제 차단 증거**는 `blockedLine` 이 잡아 `last_log_line` 에 남기고, 위험 판정은 `health.ts` 의 `runtimeBlockedReason` 이 그 줄을 읽어서 한다. 이 PR 은 그 경로를 건드리지 않는다.

그 신호를 `state` 로 승격하는 것도 **의도적으로 하지 않았다.** `CAPACITY_RE` 에는

```
now using usage credits | usage credit balance
```

처럼 **막힌 게 아니라 크레딧으로 계속 도는 중**인 줄이 함께 걸린다. 기존 시험이 그 경계를 `usage credits 인데 state=running` 으로 고정해 두었고, 승격하면 그 시험이 깨진다. 실제로 한 번 그렇게 짰다가 시험에 걸려 되돌렸다 — 그 경계가 맞다.

따라서 claude 경로의 state 는 `running`·`idle`·`offline` 이고, `blocked` 는 자기 차단 신호를 가진 openclaw·codex 경로에서만 나온다.

## 검증

**범위**: 전체 수트 209파일 2577시험 (`bun test`, registry 는 tmp 로 격리)

| | pass | fail | error |
|---|---|---|---|
| baseline (`origin/main`) | 2567 | 3 | 1 |
| 이 브랜치 | 2569 | 3 | 1 |

**신규 실패 0건.** baseline 실패 3건은 이 변경과 무관하다(`tmuxInject.test.ts` 의 템플릿 시험 2건 외). 같은 트리에서 stash 로 원복해 대조했다.

`tsc --noEmit` 통과.

## 뮤턴트

시험이 진짜로 그 가드를 겨냥하는지 각각 되돌려 확인했다.

| 뮤턴트 | 결과 |
|---|---|
| 등록의 `state === "blocked"` 거절을 되살림 | `blocked 인 팀원이 배정받은 리뷰를 실제로 등록할 수 있다` **1건만** 실패 (54 pass) |
| 5분 경계를 되살림 | `10분이든 하루든, 조용하기만 한 것은 idle` + `하루를 조용해도 idle` **2건** 실패 (100 pass) |

두 뮤턴트 모두 다른 시험은 건드리지 않았다 — 새 시험이 정확히 이 가드만 고정한다는 뜻이다. 뮤턴트는 전부 원복했고 잔재 0건을 확인했다.

## 새 시험이 재는 것

- `blocked 인 팀원이 배정받은 리뷰를 실제로 등록할 수 있다` — 배정된 당사자로 제출해 201 을 받고, `proposal_review` 에 행이 실제로 들어갔는지까지 본다 (미배정은 403 이라 아무나 넣으면 엉뚱한 축을 재게 된다)
- `10분이든 하루든, 조용하기만 한 것은 idle` — 시간이 아무리 지나도 blocked 로 넘어가지 않는다
- `하루를 조용해도 idle` — 빌더 경로에서 같은 축

## 리뷰 반영 (6a891d1)

`0004a10` 이 5분 경계를 지우는데, 그 경계를 **현재 규칙처럼 설명하는 문구**가 세 곳 남아 있었다. 머지되면 코드에 없는 규칙을 가리킨다.

| 위치 | 고친 내용 |
|---|---|
| `db/proposal.ts` 주석 | "5분 → idle · 그 이상 → blocked" 를 과거형으로. 지금 규칙을 가리키게 함 |
| `AgentCard` idle 툴팁 | "최근 1-5분 사이" → 상한 제거. idle 에는 이제 위쪽 경계가 없다 |
| `AgentCard` blocked 툴팁 | "5분 이상 조용함. 다만 실제 작업 중단이라는 뜻은 아닙니다" → 차단 신호를 뜻한다고 그대로 적음 |

마지막 항목은 그 자체로 이 버그의 증거였다. UI 가 **"blocked 인데 막힌 게 아닐 수 있다"** 는 단서를 달아야 했다는 것은, 그 값이 그런 뜻이 아니었다는 뜻이다.

### 영향 없음을 확인한 것

`monitoringStatus.ts:202` 의 `online = idle + running` 집계는 이 변경으로 숫자가 바뀔 수 있어 보였으나, 같은 쿼리가 `WHERE a.runtime = 'hermes_agent'` 로 **hermes 만** 센다. hermes state 는 `buildHermesStatus` 가 `health.ok ? "idle" : "offline"` 로 내며 경과시간을 쓰지 않는다. 이 PR 은 claude 경로만 바꾸므로 이 집계는 그대로다.

`agent_status.state` 의 `blocked` 를 읽어 **무언가를 막던** 서버 코드는 `proposal.ts` 의 그 한 줄이 유일했다. 나머지는 표시용(`AgentCard`·`Settings` 배지) 또는 세기용이며, `TopologyView:88` 은 원래 `blocked` 를 "응답가능" 으로 친다.

Submitted-by: Lisa
