### PR TITLE
fix(reports): 태그 편집에서 아무것도 안 고르고 눌러도 조용히 닫히던 것

### DIFF
--- a/src/web/components/Reports.ts
+++ b/src/web/components/Reports.ts
@@ -511,6 +511,23 @@ export function collectTagEdit(root: HTMLElement): { tagId: string; tagName: str
   };
 }
 
+/**
+ * ★아무것도 고르지 않고 '다음' 을 눌렀을 때 보여줄 안내★ — 조용히 닫지 않기 위한 것.
+ *
+ * 눌렀는데 아무 일도 안 나면 사용자는 무엇이 잘못됐는지 알 수 없고 ★취소한 것과 구분도 안 된다.★
+ * 공용 다이얼로그에 버튼 비활성 옵션이 없어(`DialogOptions` 에 disabled 없음) 안내로 대신한다.
+ *
+ * ★태그가 하나도 없을 때와 있을 때는 할 수 있는 일이 다르므로 문구도 달라야 한다★ —
+ * 태그가 0개인데 "태그를 고르세요" 라고 하면 ★없는 것을 고르라고 시키는 것★ 이다.
+ */
+export function tagEditEmptyNotice(tagCount: number): string {
+  return tagCount === 0
+    ? pick("아직 만들어진 태그가 없습니다. 맨 아래 칸에 새 태그 이름을 적어 주세요.",
+           "No tags exist yet. Type a new tag name in the bottom field.")
+    : pick("고른 태그가 없습니다. 태그를 고르거나, 맨 아래 칸에 새 이름을 적어 주세요.",
+           "No tag selected. Pick a tag, or type a new name in the bottom field.");
+}
+
 async function manageTags(): Promise<void> {
   const picked = await showForm<{ tagId: string; tagName: string; action: string; newName: string }>({
     title: pick("태그 편집", "Edit tags"),
@@ -525,7 +542,11 @@ async function manageTags(): Promise<void> {
   if (picked == null) return;
   // ★새 이름을 적었으면 그게 우선★ — 태그가 하나도 없을 때는 고를 것 자체가 없다.
   if (picked.newName) { await createTag(picked.newName); return; }
-  if (!picked.tagId) return;
+  // ★아무것도 안 고르고 눌렀을 때 조용히 닫지 않는다★ (문구·근거 = tagEditEmptyNotice)
+  if (!picked.tagId) {
+    await showAlert({ title: pick("태그 편집", "Edit tags"), message: tagEditEmptyNotice(_tags.length) });
+    return;
+  }
   if (picked.action === "delete") { await deleteTag(picked.tagId, picked.tagName); return; }
   await renameTag(picked.tagId, picked.tagName);
 }

--- a/src/web/components/reportsTagPills.test.ts
+++ b/src/web/components/reportsTagPills.test.ts
@@ -10,7 +10,7 @@
  * 시험도 ★조작이 hover 에 걸려 있지 않다★ 는 것을 직접 단정하도록 바꾼다.
  */
 import { describe, expect, test } from "bun:test";
-import { collectTagEdit, tagEditBodyHtml, tagPillsHtml } from "./Reports";
+import { collectTagEdit, tagEditBodyHtml, tagEditEmptyNotice, tagPillsHtml } from "./Reports";
 
 const pillCls = (active: boolean) => (active ? "ACTIVE" : "IDLE");
 const tag = (id: string, name: string, count = 0) => ({ id, name, color: "blue", report_count: count });
@@ -123,5 +123,25 @@ describe("collectTagEdit — 팝업에서 고른 것을 읽어낸다", () => {
 
   test("아무것도 안 고른 상태는 빈 값 — 호출부가 아무 일도 하지 않는 근거가 된다", () => {
     expect(collectTagEdit(rootWith({}))).toEqual({ tagId: "", tagName: "", action: "", newName: "" });
+  });
+});
+
+describe("tagEditEmptyNotice — 아무것도 안 고르고 눌렀을 때", () => {
+  // ★이 함수가 왜 있나★: 예전엔 조용히 return 해서 ★눌렀는데 아무 일도 안 났다.★
+  //   사용자는 무엇이 잘못됐는지 알 수 없고 '취소' 와 구분도 안 된다.
+  test("★태그가 0개면 '고르라' 고 하지 않는다★ — 없는 것을 고르라고 시키는 셈이다", () => {
+    const msg = tagEditEmptyNotice(0);
+    expect(msg).toContain("새 태그 이름");
+    expect(msg, "태그가 없는데 고르라고 하면 안 된다").not.toContain("태그를 고르");
+  });
+
+  test("태그가 있으면 고르는 길과 새로 만드는 길을 둘 다 알려준다", () => {
+    const msg = tagEditEmptyNotice(2);
+    expect(msg).toContain("태그를 고르");
+    expect(msg).toContain("새 이름");
+  });
+
+  test("★어느 쪽이든 빈 문자열이 아니다★ — 빈 안내는 조용한 종료와 같다", () => {
+    for (const n of [0, 1, 5]) expect(tagEditEmptyNotice(n).trim().length, `tagCount=${n}`).toBeGreaterThan(10);
   });
 });

--- a/src/web/components/reportsTagPills.test.ts
+++ b/src/web/components/reportsTagPills.test.ts
@@ -145,3 +145,21 @@ describe("tagEditEmptyNotice — 아무것도 안 고르고 눌렀을 때", () =
     for (const n of [0, 1, 5]) expect(tagEditEmptyNotice(n).trim().length, `tagCount=${n}`).toBeGreaterThan(10);
   });
 });
+
+// ★이 시험은 소스 문자열을 본다 — 약한 시험이라는 걸 먼저 적는다.★
+//   `manageTags` 는 export 되지 않아 흐름을 직접 못 부른다. 그래서 저장소 선례
+//   (`src/server/mcp/mcpHttpRoute.test.ts:149-157`, 공개빌드 마운트 가드)와 같은 방식으로
+//   ★"안내 호출이 그 분기 안에 남아 있는지" 만★ 소스로 고정한다.
+//
+//   ★무엇을 잡나★: 안내를 지우고 조용한 return 으로 되돌리는 변경. 그게 원래 버그였다.
+//   ★무엇을 못 잡나★: 조건을 `|| true` 로 무력화하거나, showAlert 가 실제로 화면에 뜨는지.
+//     후자를 재려면 manageTags export + 다이얼로그 스텁이 필요하고 그건 별건이다.
+test("★고른 태그가 없을 때 조용히 닫지 않는다★ — 안내를 지우면 이 시험이 깨진다", async () => {
+  const src = await Bun.file(new URL("./Reports.ts", import.meta.url)).text();
+  const idx = src.indexOf("if (!picked.tagId)");
+  expect(idx, "!picked.tagId 분기가 사라졌다 — 흐름이 바뀌었으면 이 시험도 다시 써라").toBeGreaterThan(-1);
+  const branch = src.slice(idx, idx + 260);
+  expect(branch, "이 분기가 조용히 return 한다 — 눌렀는데 아무 일도 안 나면 취소와 구분이 안 된다")
+    .toContain("showAlert");
+  expect(branch, "안내 문구는 태그 개수에 따라 갈려야 한다").toContain("tagEditEmptyNotice");
+});


### PR DESCRIPTION
'다음' 을 눌렀는데 고른 태그도 없고 새 이름도 비어 있으면 `manageTags` 가 그냥 return 했다. 눌렀는데 아무 일도 안 나면 사용자는 무엇이 잘못됐는지 알 수 없고, **'취소' 와 구분도 안 된다.**

공용 다이얼로그에 버튼 비활성 옵션이 없어(`DialogOptions` 에 disabled 없음) 안내로 대신한다. 카드의 stop_rule 이 정한 대로이며 **공용 `dialogs.ts` 는 건드리지 않았다.**

문구는 태그 개수에 따라 다르다. 태그가 0개인데 "태그를 고르세요" 라고 하면 **없는 것을 고르라고 시키는 셈**이다. 그 판단을 `tagEditEmptyNotice()` 로 뽑아 시험 가능하게 했다.

## 커밋 두 개가 각각 무엇을 지키나

| 커밋 | 지키는 것 | 뮤턴트 |
|---|---|---|
| `38932f2d` | **문구 선택** (태그 0개 vs 있음) | 0개 문구를 "태그를 고르세요" 로 → 2 fail |
| `880dcac4` | **안내가 그 분기에 남아 있는 것** | 안내 지우고 조용한 return 으로 → 1 fail |

첫 커밋만으로는 **안내를 지우고 원래 버그로 되돌아가는 길이 열려 있었다**(17 pass 로 통과). 리뷰에서 그 한계를 먼저 밝혔고, bill 이 재현해 확인한 뒤 저장소 선례를 알려줘 둘째 커밋으로 메웠다.

## 둘째 커밋의 시험은 약하다 — 그렇게 적어뒀다

`manageTags` 가 export 되지 않아 흐름을 직접 못 부른다. `src/server/mcp/mcpHttpRoute.test.ts:149-157` 이 공개빌드 마운트 가드를 같은 이유로 소스 단언하는 선례를 따랐다.

- **잡는다** — 안내를 지우는 변경
- **못 잡는다** — 조건을 `|| true` 로 무력화하는 것, `showAlert` 가 실제로 화면에 뜨는지

후자를 재려면 `manageTags` export + 다이얼로그 스텁이 필요하고 **범위가 다른 일이라 별건으로 둔다.** 약한 시험인 것을 시험 이름과 주석에 박아뒀다 — 강한 시험처럼 보이는 게 더 나쁘다.

## 검증

- `reportsTagPills` 18 pass · `src/web` 141 tests 0 fail · `tsc --noEmit` 통과
- 뮤턴트 2종 각각 확인 (위 표)

## 미검증

**실제 브라우저에서 눌러보지 않았다.** 대시보드가 main 을 서빙하므로 워크트리 변경을 띄우려면 별도 빌드가 필요하다. 배포 후 **태그 0개일 때와 있을 때 문구가 갈리는지** 둘 다 확인할 것 — 문구 분기가 이 변경의 알맹이다.

Reviewed-by: bill (뮤턴트② 재현 · 소스단언 선례 제시)
