### PR TITLE
feat(hooks): push 전 타입체크 — .githooks 인리포 + install.sh 배선

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,46 @@
+#!/bin/bash
+# ★push 전에 타입체크만 돌린다.★ (CI 후속② · GD 스크린샷 제시 형태 · b3rys-translate 방식)
+#
+# ■ 왜 훅인가 — ★CI 는 알려주기만 하고 못 고친다★
+#   force-push 로 main 에 올렸을 때 아무 검사도 안 돌았던 적이 있다(bill 지적).
+#   로컬 훅이 그 구멍을 먼저 막는다. CI 는 그 뒤의 그물이다.
+#
+# ■ ★왜 타입체크'만' 인가★ (2026-08-11 실측, bill 결정)
+#   카드 원안은 `gen-test-map.sh --check` 도 넣는 것이었다. 그런데 재보니 main 에서 이미
+#   ★exit 3★ 이다 — 최상위 describe 가 없는 시험 파일이 7개(예외 목록의 19개까지 더하면 26/206).
+#   그 7개는 ★최상위 test(...) 로 쓴 정상 파일★ 이고, --check 가 잡는 실제 비용은
+#   ★"이름이 docs/TEST_CASES.md 에 안 실린다"★ 이지 코드가 깨진 게 아니다.
+#   ★문서 누락으로 모든 push 를 막으면 게이트가 아니라 벽이 된다★ — 그런 가드는 곧 꺼진다.
+#   → 추출기 쪽이 진짜 자리라 별건으로 뺐다. 그게 정리되면 여기에 한 줄 더 붙이면 된다.
+#
+# ■ 원칙
+#   · husky 안 쓴다 — git 기본 기능(core.hooksPath)만 쓴다
+#   · ★--no-verify 는 허용한다★ — 급할 때 막지 않는다. 훅은 실수를 막는 것이지 사람을 막는 게 아니다
+#   · 상한 60초 — 넘으면 사람이 훅을 끈다
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || exit 0   # ★루트를 못 찾으면 막지 않는다★ — 훅 때문에 push 를 못 하는 게 더 나쁘다
+
+command -v bunx >/dev/null 2>&1 || { echo "[pre-push] bunx 없음 — 타입체크 건너뜀"; exit 0; }
+
+# ★node_modules 가 없으면 돌리지 않는다★ (2026-08-11 bill 실측 · steve 재현)
+#   워크트리는 node_modules 를 안 들고 온다(우리는 손으로 심링크한다). 그 상태로 tsc 를 돌리면
+#   ★코드가 멀쩡한데 실패한다★ — 로컬 typescript 가 없어 bunx 가 다른 버전을 받아 쓰기 때문이다.
+#   (bill 은 TS2688 'Cannot find type definition file for bun', 나는 TS5102 tsconfig 에러를 봤다.
+#    에러는 갈렸지만 원인과 결론은 같다.) 게다가 bunx 가 그 워크트리에 의존성을 받아버린다.
+#   → ★"돌릴 수 없는 상황" 과 "코드가 틀린 상황" 을 가른다.★ 심링크를 한 번 빠뜨렸다고
+#     멀쩡한 브랜치의 push 가 막히면, 사람은 원인을 코드에서 찾다가 결국 훅을 끈다.
+[ -d node_modules ] || { echo "[pre-push] node_modules 없음 — 타입체크 건너뜀"; exit 0; }
+
+echo "[pre-push] 타입체크 중… (건너뛰려면 --no-verify)"
+START=$(date +%s)
+if bunx tsc --noEmit; then
+  echo "[pre-push] 타입체크 통과 ($(( $(date +%s) - START ))초)"
+  exit 0
+fi
+
+echo ""
+echo "[pre-push] ★타입 오류가 있어 push 를 멈춥니다.★"
+echo "           고치고 다시 push 하거나, 정말 급하면 git push --no-verify"
+exit 1

--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,18 @@ fi
 say "■ 의존성 설치 (bun install)…"
 bun install
 
+# ── 2a) git 훅 배선 (pre-push 타입체크) ──────────────────────────
+# ★clone 에서만 한다★ — 다운로드 zip 처럼 .git 이 없으면 건너뛴다.
+#   husky 를 안 쓰고 git 기본 기능만 쓴다. 훅 본체는 저장소에 있어(.githooks/) 버전 관리된다.
+#   ★실패해도 설치를 멈추지 않는다★ — 훅은 편의지 설치 조건이 아니다.
+if [ -d .git ] && command -v git >/dev/null 2>&1; then
+  if git config core.hooksPath .githooks 2>/dev/null; then
+    say "■ git 훅 배선 완료 (push 전 타입체크 · 끄려면 git config --unset core.hooksPath)"
+  else
+    say "· git 훅 배선 실패 — 건너뜁니다(설치는 계속됩니다)"
+  fi
+fi
+
 # ── 3) 대시보드 빌드 (서버가 정적 산출물을 서빙) ─────────────────
 say "■ 대시보드 빌드 (bun run build)…"
 bun run build


### PR DESCRIPTION
force-push 로 main 에 올렸을 때 아무 검사도 안 돌았다(bill 지적). CI 는 알려주기만 하고 못 고치므로 로컬 훅이 그 구멍을 먼저 막는다.

## 타입체크만 넣는다

카드 원안은 `gen-test-map.sh --check` 도 넣는 것이었다. 재보니 **main 에서 이미 `exit 3`** 이다 — 최상위 `describe` 가 없는 시험 파일이 7개(예외 목록 19개까지 더하면 **26/206 = 12.6%**). 그 7개는 **최상위 `test(...)` 로 쓴 정상 파일**이고, `--check` 가 잡는 실제 비용은 "이름이 `docs/TEST_CASES.md` 에 안 실린다" 이지 코드가 깨진 게 아니다.

**문서 누락으로 모든 push 를 막으면 게이트가 아니라 벽이 된다.** 추출기 쪽이 진짜 자리라 별건 카드로 뺐다(bill 담당). 정리되면 훅에 한 줄 더 붙이면 된다.

참고: `--check` 는 **CI 에서 돌지 않는다**(`ci.yml` 에 0건, 타입체크만). 그래서 7개가 조용히 쌓였다.

## "돌릴 수 없는 상황" 과 "코드가 틀린 상황" 을 가른다

열림 처리가 셋 — 루트를 못 찾음 · `bunx` 없음 · **`node_modules` 없음**. 전부 `exit 0`.

특히 마지막은 리뷰에서 bill 이 실측으로 잡았다. **워크트리는 `node_modules` 를 안 들고 온다**(우리는 손으로 심링크한다). 그 상태로 `tsc` 를 돌리면 **코드가 멀쩡한데 실패하고**, `bunx` 가 그 워크트리에 의존성까지 받아버린다. 심링크를 한 번 빠뜨렸다고 멀쩡한 브랜치가 막히면 사람은 원인을 코드에서 찾다가 결국 훅을 끈다.

(bill 은 `TS2688`, 나는 `TS5102` 를 봤다. 로컬 typescript 가 없어 `bunx` 가 다른 버전을 받아 쓰기 때문이고, 에러는 갈렸지만 원인과 결론은 같다.)

## 원칙

- husky 안 쓴다 — git 기본 `core.hooksPath` 만
- `--no-verify` 허용 — 훅은 실수를 막는 것이지 사람을 막는 게 아니다
- `install.sh` 배선은 `.git` 이 있을 때만, 실패해도 설치를 안 멈춘다

## 검증 (stop_rule = 실제 push 경로에서 도는 것)

- `bash -n` 통과 · `hooksPath` 설정 후 git 이 `.githooks/pre-push` 를 봄
- 정상 `exit 0`, **2초** (상한 60초에 여유)
- **뮤턴트**: 타입 오류 주입 → `exit 1` 로 막힘, 메시지에 `--no-verify` 안내
- `node_modules` 없는 워크트리 → `exit 0` 으로 건너뜀, 의존성·lockfile 안 건드림
- **`git push --dry-run` 에서 훅이 실제로 실행되는 것 확인**

## 검증 중 알게 된 것

워크트리에서 `git config core.hooksPath` 를 걸면 `.git/config` 공유라 **라이브 repo 에도 걸린다.** 확인 후 unset 했고 기존 활성 훅이 0건이라 피해는 없었다. **워크트리 격리는 파일에만 유효하다.** (`install.sh` 는 이 함정을 안 밟는다 — `[ -d .git ]` 인데 워크트리의 `.git` 은 파일이라 건너뛴다.)

Reviewed-by: bill (node_modules 가드 실측 제시)
