### PR TITLE
feat(codex): app-server 를 codex 설정이 정하게 — 우리가 덮어쓰던 것을 뺀다

### DIFF
--- a/src/server/runtimes/codex/appServerApproval.test.ts
+++ b/src/server/runtimes/codex/appServerApproval.test.ts
@@ -82,3 +82,48 @@ test("★GD msg838★ 명령/파일 아닌 차단(외부전송·권한)은 요�
   expect(g).toContain("안전상");
   expect(g).toContain("send data to external endpoint");
 });
+
+// ── ★codex 설정이 정하게 한다★ (팀 리드 2026-08-11) ──
+//
+// startThread 에 sandbox·approvalPolicy 를 넘기면 ★CODEX_HOME 의 config.toml 을 덮어쓴다.★
+// runtimeWorkspaceRoots 는 ★experimentalApi capability 를 요구해서 turn 이 시작도 못 했다★ (실측 2/2).
+//
+// ★소스에 그 줄이 없는지가 아니라 startThread 가 실제로 무엇을 받는지를 잰다.★
+
+import { runViaAppServer } from "./appServerRunner";
+
+function fakeClient(seen: Record<string, unknown>[]) {
+  return () =>
+    ({
+      currentThreadId: "th_1",
+      async start() {},
+      async startThread(o: Record<string, unknown>) { seen.push(o); return "th_1"; },
+      async runTurn() { return { status: "completed", finalText: "ok", turnId: "t1", detail: "" }; },
+      close() {},
+    }) as unknown as import("./appServerClient").CodexAppServerClient;
+}
+const startArgs = async (opts: Record<string, unknown>) => {
+  const seen: Record<string, unknown>[] = [];
+  await runViaAppServer({ prompt: "p", ...opts } as never, undefined, fakeClient(seen));
+  return seen[0] ?? {};
+};
+
+test("★sandbox 를 넘기지 않는다★ — 넘기면 config.toml 의 권한 프로필이 무력화된다", async () => {
+  const a = await startArgs({ cwd: "/tmp/ws", sandbox: "workspace-write" });
+  expect("sandbox" in a).toBe(false);
+});
+
+test("★approvalPolicy 도 넘기지 않는다★ — 승인 레벨도 codex 설정이 정한다", async () => {
+  const a = await startArgs({ cwd: "/tmp/ws" });
+  expect("approvalPolicy" in a).toBe(false);
+});
+
+test("★runtimeWorkspaceRoots 를 넘기지 않는다★ — experimentalApi 를 요구해 turn 이 죽던 원인", async () => {
+  const a = await startArgs({ cwd: "/tmp/ws", writableRoots: ["/tmp/ws"] });
+  expect("runtimeWorkspaceRoots" in a).toBe(false);
+});
+
+test("★대조군 — 넘겨야 하는 것은 그대로 간다★ (cwd · model · resume)", async () => {
+  const a = await startArgs({ cwd: "/tmp/ws", model: "gpt-x", resumeSessionId: "th_prev" });
+  expect({ cwd: a.cwd, model: a.model, resume: a.resumeThreadId }).toEqual({ cwd: "/tmp/ws", model: "gpt-x", resume: "th_prev" });
+});

--- a/src/server/runtimes/codex/appServerRunner.ts
+++ b/src/server/runtimes/codex/appServerRunner.ts
@@ -29,25 +29,38 @@ export function makeAppServerCaller(db: Database): CodexCaller {
 /** db 없는 기본 caller(ask=fail-closed denied). 팝업 원하면 makeAppServerCaller(db) 사용. */
 export const runCodexTurnViaAppServer: CodexCaller = (opts) => runViaAppServer(opts);
 
-async function runViaAppServer(opts: CodexTurnOptions, db?: Database): Promise<CodexTurnResult> {
+/** ★클라이언트를 주입 가능하게★ — startThread 에 실제로 무엇이 넘어가는지 재려면 대신 세울 자리가 필요하다. */
+export type AppServerClientFactory = () => CodexAppServerClient;
+
+export async function runViaAppServer(
+  opts: CodexTurnOptions,
+  db?: Database,
+  makeClient: AppServerClientFactory = () => new CodexAppServerClient(),
+): Promise<CodexTurnResult> {
   const startedAt = nowMs();
-  const client = new CodexAppServerClient();
+  const client = makeClient();
   // 승인 판정용 최소 agent/ctx (Tier-D는 id 불필요, 워크스페이스-write는 cwd 기준).
   const permAgent: PermissionAgent = { id: "codex", workspace_path: opts.cwd ?? opts.writableRoots?.[0] ?? "" };
   const permCtx: PermissionContext = { workspaceRoot: opts.cwd ?? opts.writableRoots?.[0] ?? null };
   try {
     await client.start();
+    // ★codex 설정이 정하게 한다★ (팀 리드 2026-08-11: "codex 설정으로 돌게 해. 별도 우리 코드가 아닌").
+    //
+    //   여기서 sandbox·approvalPolicy 를 넘기면 ★CODEX_HOME 의 config.toml 을 덮어쓴다.★
+    //   그러면 권한 프로필(파일 경로 deny 등)을 아무리 써놔도 효과가 없다 — 실측으로 확인했다:
+    //     프로필만            → .env 읽기 차단됨
+    //     + sandbox 를 넘기면  → 그냥 읽힘
+    //
+    //   ★runtimeWorkspaceRoots 도 빼야 한다.★ 그게 experimentalApi capability 를 요구해서
+    //   지금 flag on 이 ★턴 시작도 못 하고 죽는 원인★ 이었다(2/2 재현). 실측 3종:
+    //     전부 넘김 + caps null        → 거부(runtimeWorkspaceRoots requires experimentalApi)
+    //     ★cwd 만 넘김 + caps null★    → 성공  ← 이 길로 간다
+    //     roots + experimentalApi:true → 성공 (다른 길이지만 설정을 덮어쓰는 쪽으로 되돌아간다)
+    //
+    //   작업 폴더 범위는 cwd + config.toml 의 workspace_roots 가 정한다.
     await client.startThread({
       cwd: opts.cwd,
       model: opts.model,
-      // ★안전 F2 픽스(하네스 재검증 최우선): sandbox를 read-only로 하드 강제.★
-      // 이유: workspace-write면 codex가 writable_roots 안의 파괴(rm·overwrite·git reset·훅 심기)를
-      // 승인요청 없이 자체 실행 → 게이트에 안 옴 → Tier-D dead code → 게이트 전체 무력화(F2).
-      // read-only면 모든 쓰기/실행이 escalation → 승인요청 → 게이트(F1: Tier-D deny 아니면 ask=거절).
-      // ★쓰기 지원은 M5 팝업(GD 승인) 배선 후 별도 설계. 그 전엔 안전 우선으로 read-only 고정.★
-      sandbox: "read-only",
-      approvalPolicy: "on-request", // 모든 escalation을 승인요청으로(게이트가 보게)
-      runtimeWorkspaceRoots: opts.writableRoots && opts.writableRoots.length ? opts.writableRoots : undefined,
       resumeThreadId: opts.resumeSessionId, // ★정확성 #1: 멀티턴 맥락 이어감(exec resume 동등)★
     });
     const threadId = client.currentThreadId;


### PR DESCRIPTION
## 배경

팀 리드(2026-08-11): **"codex 설정으로 돌게 해. 별도 우리 코드가 아닌."** · **"codex cli 이젠 안쓰니 app server 는 연동해야지."**

## 무엇을 뺐나

`startThread` 에서 **`sandbox` · `approvalPolicy` · `runtimeWorkspaceRoots`** 세 개를 안 넘깁니다. 넘기는 것은 `cwd` · `model` · `resumeThreadId` 뿐입니다.

## 왜 — 실측 2가지

**① 넘기면 `config.toml` 의 권한 프로필이 무력화된다**

임시 `CODEX_HOME` 에 파일 deny 프로필을 두고 가짜 `.env` 로 측정:

| 조건 | `.env` |
|---|---|
| 프로필만 | **READ_BLOCKED** |
| + `sandbox` 를 넘기면 | 그냥 읽힘 |
| + `--ignore-user-config` | 그냥 읽힘 |

설정을 아무리 잘 써도 **우리가 덮어쓰고 있었습니다.**

**② `runtimeWorkspaceRoots` 가 flag on 을 죽이던 원인**

app-server 에 직접 붙어 3종 측정:

| 조건 | 결과 |
|---|---|
| 전부 넘김 + `capabilities:null` | **거부** — `requires experimentalApi capability` |
| **`cwd` 만 넘김 + `capabilities:null`** | **성공** ← 이 길 |
| roots + `experimentalApi:true` | 성공 (되지만 설정을 덮어쓰는 쪽으로 되돌아감) |

아메스 실측의 *"wake 는 `codex_dispatched` 인데 39ms 에 조용히 실패"* 가 이것이었습니다.
**experimentalApi 를 켜는 대신 안 넘기는 쪽**을 골랐습니다 — 팀 리드 방침에 맞고 capability 협상도 늘지 않습니다.

## 작업 폴더 범위는 어디가 정하나

`cwd` + `CODEX_HOME` 의 `config.toml`(workspace_roots). **우리 코드가 아니라 설정입니다.**

## 시험 — 소스가 아니라 실제 인자를 잽니다

`runViaAppServer` 에 클라이언트 주입 지점을 두고 **`startThread` 가 받는 객체**를 검사합니다.

- `sandbox` 없음 · `approvalPolicy` 없음 · `runtimeWorkspaceRoots` 없음
- **대조군** — `cwd`·`model`·`resume` 은 그대로 전달
- **뮤턴트**: `sandbox` 를 도로 넣으면 → **사망** ✓

## 검증

`tsc` 0 · 전체 **2583 pass / 0 fail**

**flag on 으로 실제 턴을 돌린 것은 아직 아닙니다** — 다음 단계입니다. 이 PR 은 그 앞을 막고 있던 것을 치웁니다.

## 남는 것 (이 PR 밖)

- dex `CODEX_HOME` 에 권한 프로필 넣기 (작성·검증 완료)
- 진행 표시를 이벤트에 물리기 · 웹 검색 · 브라우저 MCP 배선
- exec 경로는 건드리지 않았습니다. 안 쓰게 되면 나중에 정리