### PR TITLE
fix(codex): 승인 요청에 실제 팀원 id 를 싣는다 — 팀원 방으로 보내기 위한 전제

### DIFF
--- a/src/server/lib/runtimeSubscription.ts
+++ b/src/server/lib/runtimeSubscription.ts
@@ -69,6 +69,7 @@ export async function verifyFirstModelCall(input: { id: string; runtime: string;
     }
     const result = await runCodexTurn({
       prompt: FIRST_MODEL_PROMPT,
+      agentId: input.id, // ★필수★ — 승인 요청의 주인이 된다
       cwd: input.workspacePath ?? paths.workdir,
       codexHome: paths.codexHome,
       timeoutMs: FIRST_MODEL_TIMEOUT_MS,

--- a/src/server/runtimes/codex/appServerApproval.test.ts
+++ b/src/server/runtimes/codex/appServerApproval.test.ts
@@ -127,3 +127,66 @@ test("★대조군 — 넘겨야 하는 것은 그대로 간다★ (cwd · model
   const a = await startArgs({ cwd: "/tmp/ws", model: "gpt-x", resumeSessionId: "th_prev" });
   expect({ cwd: a.cwd, model: a.model, resume: a.resumeThreadId }).toEqual({ cwd: "/tmp/ws", model: "gpt-x", resume: "th_prev" });
 });
+
+// ── ★승인 요청에 실제 팀원 id 가 실린다★ (팀 리드 2026-08-11: "dex 방에 떠야지") ──
+//
+// 전에는 runViaAppServer 안에서 id 를 "codex" 로 박아놨다. 그래서 permission_request.agent_id 가
+// 전부 "codex" 였고 ★누구 요청인지 구분이 안 돼 팀원 방으로 라우팅할 수 없었다.★ 전부 op 방으로 갔다.
+// 그리고 "codex" 는 ★실재하는 다른 팀원의 id★ 다 — 허가증도 이 id 로 저장되니 서랍이 겹쳤다.
+//
+// ★이 시험은 runViaAppServer 가 실제로 무슨 id 로 승인 요청을 만드는지 잰다.★
+// (앞서 buildOperationFromApproval 을 직접 부르는 시험을 썼다가 ★뮤턴트가 살아남았다★ —
+//  그 함수는 원래 id 를 인자로 받으므로 이 결함을 못 잡는다. 장식이었다.)
+
+import { Database as ApprDb } from "bun:sqlite";
+import { migrate as apprMigrate } from "../../db/migrate";
+import { runViaAppServer as runApprServer } from "./appServerRunner";
+
+/** codex 가 승인 요청을 올리는 상황을 흉내내는 클라이언트. */
+function approvalRaisingClient() {
+  return () =>
+    ({
+      currentThreadId: "th_1",
+      async start() {},
+      async startThread() { return "th_1"; },
+      async runTurn(_p: string, handlers: { onApproval?: (r: unknown) => Promise<string> }) {
+        await handlers.onApproval?.({
+          method: "item/commandExecution/requestApproval",
+          params: { command: "/bin/zsh -lc 'echo hi'", threadId: "th_1", turnId: "t1" },
+        });
+        return { status: "completed", finalText: "ok", turnId: "t1", detail: "" };
+      },
+      close() {},
+    }) as unknown as import("./appServerClient").CodexAppServerClient;
+}
+
+/**
+ * ★결정을 기다리지 않는다★ — onApproval 은 사람이 누를 때까지 폴링한다(기본 TTL 1시간).
+ * 우리가 재려는 것은 ★어떤 id 로 요청이 만들어지는가★ 뿐이므로, 행이 생기는 즉시 읽고
+ * 거절로 마감해 턴을 풀어준다. (그냥 await 하면 시험이 타임아웃까지 매달린다 — 실제로 그랬다.)
+ */
+const ownerOfRequest = async (agentId?: string) => {
+  const db = new ApprDb(":memory:");
+  apprMigrate(db);
+  const turn = runApprServer(
+    { prompt: "p", cwd: "/tmp/ws", agentId } as never,
+    db,
+    approvalRaisingClient(),
+  );
+  let row: { id: string; agent_id: string } | undefined;
+  for (let i = 0; i < 200 && !row; i++) {
+    row = db.query("select id, agent_id from permission_request order by created_at desc limit 1").get() as never;
+    if (!row) await new Promise((r) => setTimeout(r, 10));
+  }
+  if (row) db.run("update permission_request set status='denied' where id=?", [row.id]); // 턴을 풀어준다
+  await turn.catch(() => {});
+  return row?.agent_id;
+};
+
+test("★승인 요청의 주인이 dex 로 찍힌다★ — 팀원 방으로 보내려면 이게 있어야 한다", async () => {
+  expect(await ownerOfRequest("dex")).toBe("dex");
+}, 20000);
+
+test("★대조군 — 다른 팀원이면 그 id 가 찍힌다★ (한 값으로 고정돼 있지 않다)", async () => {
+  expect(await ownerOfRequest("cody")).toBe("cody");
+}, 20000);

--- a/src/server/runtimes/codex/appServerRunner.ts
+++ b/src/server/runtimes/codex/appServerRunner.ts
@@ -39,8 +39,19 @@ export async function runViaAppServer(
 ): Promise<CodexTurnResult> {
   const startedAt = nowMs();
   const client = makeClient();
-  // 승인 판정용 최소 agent/ctx (Tier-D는 id 불필요, 워크스페이스-write는 cwd 기준).
-  const permAgent: PermissionAgent = { id: "codex", workspace_path: opts.cwd ?? opts.writableRoots?.[0] ?? "" };
+  // ★승인 요청에 실제 팀원 id 를 싣는다★ (팀 리드 2026-08-11: "dex 방에 떠야지").
+  //
+  //   전에는 id 를 "codex" 로 박아놨다. 그래서 permission_request 의 agent_id 가 전부 "codex" 였고,
+  //   ★누구 요청인지 구분이 안 돼 팀원 방으로 보낼 수가 없었다.★ 전부 op 방으로 갔다.
+  //   (그리고 "codex" 는 ★실재하는 다른 팀원의 id★ 다 — 명부에 codex(openclaw)와 dex(codex 런타임)가 따로 있다.
+  //    허가증도 이 id 로 저장되니, 두 사람이 같은 서랍을 쓰고 있었다.)
+  //
+  //   앞 주석은 "Tier-D는 id 불필요" 라고 했는데 ★틀렸다★ — permissionGate.checkPermission 은
+  //   id 가 없으면 예외를 던지고, Tier-D 판정은 그 뒤에 있다. id 없이는 도달조차 못 한다.
+  const permAgent: PermissionAgent = {
+    id: opts.agentId ?? "codex",
+    workspace_path: opts.cwd ?? opts.writableRoots?.[0] ?? "",
+  };
   const permCtx: PermissionContext = { workspaceRoot: opts.cwd ?? opts.writableRoots?.[0] ?? null };
   try {
     await client.start();

--- a/src/server/runtimes/codex/appServerRunner.ts
+++ b/src/server/runtimes/codex/appServerRunner.ts
@@ -48,8 +48,9 @@ export async function runViaAppServer(
   //
   //   앞 주석은 "Tier-D는 id 불필요" 라고 했는데 ★틀렸다★ — permissionGate.checkPermission 은
   //   id 가 없으면 예외를 던지고, Tier-D 판정은 그 뒤에 있다. id 없이는 도달조차 못 한다.
+  //   ★그래서 기본값을 두지 않는다★ — CodexTurnOptions.agentId 를 필수로 만들어 컴파일이 막게 했다.
   const permAgent: PermissionAgent = {
-    id: opts.agentId ?? "codex",
+    id: opts.agentId,
     workspace_path: opts.cwd ?? opts.writableRoots?.[0] ?? "",
   };
   const permCtx: PermissionContext = { workspaceRoot: opts.cwd ?? opts.writableRoots?.[0] ?? null };

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -378,11 +378,16 @@ export async function handleMessage(
   //   ★enforcement = gate 결과와 무관하게 그룹 전체 drop★ — capture→bus가 owner를 이미 처리하므로(runInjection이
   //   route targets 에만 주입) native 가 또 답하면 이중응답. gate는 shadow/audit(effective 권위 기록)용으로만.
   //   env flag 2개 분리, 둘 다 off 기본 = ★라이브 영향 0(byte-level 불변)★. shadow=drop 없이 audit만.
+  // ★이 브리지가 '누구' 인지는 한 곳에서만 정한다★ (빌 리뷰 2026-08-12).
+  //   같은 식이 아래 네 곳에 흩어져 있었다. 그중 하나라도 빠지면 ★남의 신원으로 도는데★
+  //   그게 승인 요청의 주인으로도 쓰인다 — 실제로 dex 요청 4건이 codex 앞으로 기록됐다.
+  const selfAgentId = deps.agentId ?? process.env.CODEX_AGENT_ID ?? "codex";
+
   if (chatId < 0 && messageId !== undefined) {
     const shadowOn = process.env.CODEX_GROUP_NATIVE_DENY_SHADOW === "true";
     const enforceOn = process.env.CODEX_GROUP_NATIVE_DENY === "true";
     if (shadowOn || enforceOn) {
-      const self = deps.agentId ?? process.env.CODEX_AGENT_ID ?? "codex";
+      const self = selfAgentId;
       const teamBaseUrl = deps.teamBaseUrl ?? process.env.TEAM_BASE_URL ?? "http://127.0.0.1:7878/team";
       const gate = deps.ownerGate
         ? await deps.ownerGate({ text, self, tgMessageId: String(messageId) })
@@ -437,7 +442,7 @@ export async function handleMessage(
   const toolAwareText = scheduleRequest
     ? scheduleToolPrompt({
         text,
-        agentId: deps.agentId ?? process.env.CODEX_AGENT_ID ?? "codex",
+        agentId: selfAgentId,
         teamBaseUrl: deps.teamBaseUrl ?? process.env.TEAM_BASE_URL ?? "http://127.0.0.1:7878/team",
         repoRoot: deps.repoRoot ?? process.env.B3OS_REPO_ROOT ?? REPO_ROOT,
       })
@@ -445,14 +450,14 @@ export async function handleMessage(
   // 첫 접촉(여태 한 번도 인사 안 한 신입) = 영입 후 첫 응답 → 인사 + OT 받은 것 언급하며 시작(GD 2026-07-01).
   //   판정은 ★영속 마커★(재시작에도 남음) — 인메모리 prior(세션 resume용)와 분리해, 이미 합류한 팀원이
   //   재시작 후 재소개하지 않게 한다(GD 2026-07-10 버그픽스). prior는 아래 resumeSessionId 로만 쓴다.
-  const greetAgentId = deps.agentId ?? process.env.CODEX_AGENT_ID ?? "codex";
+  const greetAgentId = selfAgentId;
   const greetedBefore = hasGreetedFirstContact(greetAgentId);
   const promptText = greetedBefore
     ? toolAwareText
     : `[이번이 이 대화의 첫 응답입니다. 먼저 짧게 인사하고, OT(팀 미션·규칙·역할·팀 스킬)를 받아 팀에 합류했음을 한 줄로 밝힌 뒤 본론에 답하세요.]\n\n${toolAwareText}`;
   const preflight = codexRuntimePreflight(
     {
-      id: deps.agentId ?? process.env.CODEX_AGENT_ID ?? "codex",
+      id: selfAgentId,
       workspace_path: deps.workdir ?? process.env.CODEX_WORKDIR ?? "",
     },
     deps.sandbox ?? "read-only",
@@ -467,6 +472,8 @@ export async function handleMessage(
   }
   const result = await runTurn({
     prompt: promptText,
+    agentId: selfAgentId, // ★필수★ — 승인 요청의 주인이 된다
+
     resumeSessionId: prior,
     codexHome: deps.codexHome,
     cwd: deps.workdir,
@@ -491,7 +498,7 @@ export async function handleMessage(
     const marker = extractScheduleMarker(result.reply);
     if (marker) {
       reply = await registerReminder(marker, {
-        agentId: deps.agentId ?? process.env.CODEX_AGENT_ID ?? "codex",
+        agentId: selfAgentId,
         teamBaseUrl: deps.teamBaseUrl ?? process.env.TEAM_BASE_URL ?? "http://127.0.0.1:7878/team",
       });
     }

--- a/src/server/runtimes/codex/runner.test.ts
+++ b/src/server/runtimes/codex/runner.test.ts
@@ -3,7 +3,7 @@ import { buildCodexArgs, extractSessionId, redactPromptArg } from "./runner";
 
 describe("codex runner args", () => {
   test("new turn uses read-only sandbox and terminates options before prompt", () => {
-    const args = buildCodexArgs({ prompt: "--dangerously-bypass-approvals-and-sandbox" }, "/tmp/last.txt");
+    const args = buildCodexArgs({ agentId: "t-agent", prompt: "--dangerously-bypass-approvals-and-sandbox" }, "/tmp/last.txt");
     expect(args.slice(0, 4)).toEqual(["exec", "--ignore-user-config", "-s", "read-only"]);
     expect(args).toContain("--json");
     expect(args).toContain("--skip-git-repo-check");
@@ -12,7 +12,7 @@ describe("codex runner args", () => {
 
   test("new turn preserves explicit sandbox and model", () => {
     const args = buildCodexArgs(
-      { prompt: "hi", sandbox: "workspace-write", model: "gpt-test" },
+      { agentId: "t-agent", prompt: "hi", sandbox: "workspace-write", model: "gpt-test" },
       "/tmp/last.txt",
     );
     expect(args.slice(0, 4)).toEqual(["exec", "--ignore-user-config", "-s", "workspace-write"]);
@@ -22,7 +22,7 @@ describe("codex runner args", () => {
 
   test("new workspace-write turn can enable network access", () => {
     const args = buildCodexArgs(
-      { prompt: "hi", sandbox: "workspace-write", networkAccess: true },
+      { agentId: "t-agent", prompt: "hi", sandbox: "workspace-write", networkAccess: true },
       "/tmp/last.txt",
     );
     expect(args.slice(0, 4)).toEqual(["exec", "--ignore-user-config", "-s", "workspace-write"]);
@@ -33,7 +33,7 @@ describe("codex runner args", () => {
 
   test("new workspace-write turn code-enforces writable roots from cwd", () => {
     const args = buildCodexArgs(
-      { prompt: "hi", sandbox: "workspace-write", cwd: "/tmp/codex-work" },
+      { agentId: "t-agent", prompt: "hi", sandbox: "workspace-write", cwd: "/tmp/codex-work" },
       "/tmp/last.txt",
     );
     expect(args).toContain('sandbox_workspace_write.writable_roots=["/tmp/codex-work"]');
@@ -41,7 +41,7 @@ describe("codex runner args", () => {
 
   test("resume does not pass -s, forces configured sandbox, and terminates options before prompt", () => {
     const args = buildCodexArgs(
-      { prompt: "-starts-with-dash", resumeSessionId: "sess-1", sandbox: "danger-full-access" },
+      { agentId: "t-agent", prompt: "-starts-with-dash", resumeSessionId: "sess-1", sandbox: "danger-full-access" },
       "/tmp/last.txt",
     );
     expect(args.slice(0, 3)).toEqual(["exec", "resume", "sess-1"]);
@@ -53,15 +53,14 @@ describe("codex runner args", () => {
   });
 
   test("resume defaults to read-only even though -s is unavailable for the resume subcommand", () => {
-    const args = buildCodexArgs({ prompt: "hi", resumeSessionId: "sess-1" }, "/tmp/last.txt");
+    const args = buildCodexArgs({ agentId: "t-agent", prompt: "hi", resumeSessionId: "sess-1" }, "/tmp/last.txt");
     expect(args).not.toContain("-s");
     expect(args[args.indexOf("-c") + 1]).toBe('sandbox_mode="read-only"');
   });
 
   test("resume workspace-write turn preserves network access override", () => {
     const args = buildCodexArgs(
-      {
-        prompt: "hi",
+      { agentId: "t-agent", prompt: "hi",
         resumeSessionId: "sess-1",
         sandbox: "workspace-write",
         networkAccess: true,
@@ -76,7 +75,7 @@ describe("codex runner args", () => {
   });
 
   test("spawn trace redacts prompt while preserving codex args", () => {
-    const args = buildCodexArgs({ prompt: "private message", sandbox: "workspace-write" }, "/tmp/last.txt");
+    const args = buildCodexArgs({ agentId: "t-agent", prompt: "private message", sandbox: "workspace-write" }, "/tmp/last.txt");
     expect(redactPromptArg(args)).toEqual([
       "exec",
       "--ignore-user-config",

--- a/src/server/runtimes/codex/runner.ts
+++ b/src/server/runtimes/codex/runner.ts
@@ -22,9 +22,15 @@ import type { CodexSandboxMode } from "../../types";
 export const CODEX_BIN = process.env.CODEX_BIN ?? "codex";
 
 export interface CodexTurnOptions {
-  /** ★이 턴이 '누구' 인가.★ 팀원 스크립트(_me.sh)가 tmux 세션으로 ★추측하지 않게★ 명시적으로 넘긴다.
-   *  (2026-07-13: hermes 가 구버전 _me.sh 의 tmux 폴백 때문에 ★전 발신이 'bill' 로 위장★됐다) */
-  agentId?: string;
+  /** ★이 턴이 '누구' 인가. 필수다.★ 팀원 스크립트(_me.sh)가 tmux 세션으로 ★추측하지 않게★ 명시적으로 넘긴다.
+   *  (2026-07-13: hermes 가 구버전 _me.sh 의 tmux 폴백 때문에 ★전 발신이 'bill' 로 위장★됐다)
+   *
+   *  ★선택 인자로 두지 않는다★ (빌 리뷰 2026-08-12): 이 값은 승인 요청의 주인으로도 쓰인다.
+   *  기본값을 두면 새 호출부가 빠뜨렸을 때 ★조용히 남의 신원으로 찍힌다★ — 실제로 그랬다
+   *  (appServerRunner 가 "codex" 를 박아둬서 dex 요청 4건이 codex 앞으로 기록됐다).
+   *  필수로 두면 빠뜨리는 순간 ★컴파일이 막는다.★ 런타임 예외보다 이르다 —
+   *  승인 경로는 자주 안 도는 길이라 예외는 한참 뒤에야 드러난다. */
+  agentId: string;
   /** 작업 디렉토리 = 페르소나(AGENTS.md) + 스킬 접근 루트. codex가 cwd의 AGENTS.md를 자동로드. */
   cwd?: string;
   /** 팀원별 정체성 격리(config/auth/session). 미지정 시 기본 ~/.codex. */


### PR DESCRIPTION
## 배경

팀 리드(2026-08-11): **"왜 op 방에 떠.. dex 방에 떠야지" · "팀원은 다 본인이 얘기하는 방에 뜨지"**
그리고: **"이 런타임으로 다른 팀원을 영입할 수도 있어. dex 전용이 아니라는 건 기본사항이야."**

## 무엇이 문제였나

`appServerRunner` 가 승인 판정용 id 를 **`"codex"` 로 박아놨습니다.** 그래서 `permission_request.agent_id` 가 **전부 `codex`** 로 남았고, **누구 요청인지 구분이 안 돼 팀원 방으로 라우팅할 수가 없었습니다.** 전부 op 방으로 갔습니다.

실측 (2026-08-11 flag on 중):

| agent_id | action | status | 실제 주인 |
|---|---|---|---|
| `codex` | shell | denied | **dex** 가 `send.sh` 를 실행하려던 것 |
| `codex` | write | denied | dex |
| `codex` | write | allowed_once | dex |

## 그리고 `codex` 는 실재하는 다른 팀원 id 입니다

명부에 **`codex`(openclaw 런타임)** 와 **`dex`(codex 런타임)** 가 따로 있습니다. 허가증(grant)도 이 id 로 저장되므로 **두 사람이 같은 서랍을 쓰고 있었습니다.**

## 앞 주석도 틀렸습니다

*"Tier-D는 id 불필요"* 라고 적혀 있었는데, `permissionGate.checkPermission` 은 **id 가 없으면 예외를 던지고** Tier-D 판정은 그 뒤에 있습니다. id 없이는 도달조차 못 합니다.

## 시험 — 처음 쓴 것은 장식이었습니다

`buildOperationFromApproval` 을 직접 부르는 시험을 먼저 썼는데 **뮤턴트가 살아남았습니다.** 그 함수는 원래 id 를 인자로 받으므로 이 결함을 못 잡습니다.

지금 시험은 **`runViaAppServer` 를 실제로 돌려 `permission_request` 행의 `agent_id` 를 읽습니다.**

- `dex` → `"dex"` · **대조군** `cody` → `"cody"` (한 값으로 고정돼 있지 않음)
- 승인 대기에 매달리지 않게, 행이 생기면 읽고 거절로 마감해 턴을 풂
- **뮤턴트**: id 를 `"codex"` 로 되돌리면 → **사망** ✓

## 이 PR 은 전제일 뿐입니다

방을 옮기는 것은 **다음 PR** — 그 팀원의 브리지가 **자기 요청만** 골라 자기 방에 렌더하고 콜백을 받게 합니다. 이 변경 없이는 그 라우팅이 불가능합니다.

**dex 전용이 아닙니다** — 그 턴을 도는 팀원 id 를 그대로 싣습니다. 이 런타임으로 다른 팀원을 영입해도 그대로 동작합니다.

## 검증

`tsc` 0 · 전체 **2585 pass / 0 fail** · **flag 는 꺼진 상태라 라이브 영향 없음**