### PR TITLE
fix(codex): 팀원이 시킨 일이 죽으면 요청자에게 알린다 — 체인 밖 모양으로

### DIFF
--- a/src/server/runtimes/codex/adapter.test.ts
+++ b/src/server/runtimes/codex/adapter.test.ts
@@ -306,10 +306,43 @@ describe("codex adapter — 핵심 정확성", () => {
     expect(repliesFrom(db, "system").length).toBe(1); // 같은 본문 → 60s 내 재통지 억제
   });
 
-  test("에이전트 요청(user 아님) + 실패 → 통지 안 함 (봇↔봇 루프 방지)", async () => {
+  test("★팀원 요청 + 실패 → 요청자에게 통지한다. 단 체인 밖 모양으로★ (봇↔봇 루프 방지)", async () => {
+    // ★계약이 바뀌었다★ — 전에는 '통지 안 함' 이었다. 그 가드가 막던 것은 "알리는 것" 이 아니라
+    //   ★"체인에 얹혀서 알리는 것"★ 이었다(in_reply_to + hop_count+1 → hop 한도 소모 → [전달 차단] 유발).
+    //   ★안 알리면 팀원이 시킨 일이 죽어도 아무도 모른다★ — 2026-08-13 실측: dex 위임 4건이 승인창 만료로
+    //   죽었는데 요청자 통지 0건이었고, 요청자는 "dex 가 실행을 안 한다" 로 오진했다.
     const db = setup();
     const fail: CodexCaller = async () => ({ ok: false, reply: "", detail: "boom", elapsedMs: 1 });
     await runTurn(db, agentsOf(db), codyOf(db), row({ from_agent_id: "bill" }), "", fail);
+    const notices = repliesFrom(db, "system");
+    expect(notices.length, "요청자에게 통지 1건").toBe(1);
+    const n = notices[0]!;
+    expect(n.to_agent_id, "방이 아니라 ★요청자에게만★").toBe("bill");
+    expect(n.type).toBe("dm");
+    expect(n.source, "pingpong 검사는 source==='agent' 일 때만 돈다").toBe("system");
+    expect(n.in_reply_to, "★parent 없음 = 체인 밖★").toBeNull();
+    expect(n.hop_count, "★hop 한도와 무관★").toBe(0);
+    expect(String(n.body), "실패 사유가 실려야 진단이 된다").toContain("boom");
+  });
+
+  test("팀원 통지: 같은 실패는 두 번 알리지 않는다 — 단 ★다른 위임은 각각 알린다★", async () => {
+    const db = setup();
+    const fail: CodexCaller = async () => ({ ok: false, reply: "", detail: "boom", elapsedMs: 1 });
+    const same = row({ from_agent_id: "bill", message_id: "same-msg" });
+    await runTurn(db, agentsOf(db), codyOf(db), same, "", fail);
+    await runTurn(db, agentsOf(db), codyOf(db), same, "", fail);
+    expect(repliesFrom(db, "system").length, "같은 message_id = 1건").toBe(1);
+    // ★본문 기준 60초 창이었다면 여기서 묻혔다★ — 서로 다른 위임의 실패는 각각 보여야 한다.
+    await runTurn(db, agentsOf(db), codyOf(db), row({ from_agent_id: "bill", message_id: "other-msg" }), "", fail);
+    expect(repliesFrom(db, "system").length, "다른 message_id = 추가 통지").toBe(2);
+  });
+
+  test("명부 밖·플랫폼 발신·자기 자신에게는 통지하지 않는다", async () => {
+    const db = setup();
+    const fail: CodexCaller = async () => ({ ok: false, reply: "", detail: "boom", elapsedMs: 1 });
+    await runTurn(db, agentsOf(db), codyOf(db), row({ from_agent_id: "system", message_id: "m-sys" }), "", fail);
+    await runTurn(db, agentsOf(db), codyOf(db), row({ from_agent_id: "ghost", message_id: "m-ghost" }), "", fail);
+    await runTurn(db, agentsOf(db), codyOf(db), row({ from_agent_id: "cody", message_id: "m-self" }), "", fail);
     expect(allMessages(db)).toEqual([]);
   });
 
@@ -447,7 +480,14 @@ describe("codex adapter — 핵심 정확성", () => {
         "★succeeded artifact 에 reply_message_id 가 있다 = 서버가 턴 본문을 게시했다★ ([A] 회귀)",
       ).toBeNull();
     }
-    expect(allMessages(db)).toEqual([]);
+    // ★[A] 계약은 "서버가 ★팀원 이름으로★ 게시하지 않는다" 다★ — "아무것도 안 들어간다" 가 아니다.
+    //   m3 실패에는 이제 요청자(bill)에게 가는 ★system 통지 1건★ 이 들어간다(실패가 보여야 하므로).
+    //   그 통지는 from="system" 이라 팀원을 사칭하지 않는다 = [A] 회귀가 아니다.
+    expect(repliesFrom(db, "cody").length, "★팀원 이름으로 게시된 것은 0건★ ([A] 회귀 가드)").toBe(0);
+    const msgs = allMessages(db);
+    expect(msgs.length, "실패 1건 → system 통지 1건").toBe(1);
+    expect(msgs[0]?.from_agent_id).toBe("system");
+    expect(msgs[0]?.to_agent_id, "요청자에게만").toBe("bill");
   });
 
   test("inflight marker: runTurn 정상 종료 후 marker를 삭제한다", async () => {

--- a/src/server/runtimes/codex/adapter.ts
+++ b/src/server/runtimes/codex/adapter.ts
@@ -101,7 +101,7 @@ export async function runTurn(
           permission: preflight,
         },
       });
-      postFailureNotice(db, agent, row);
+      postFailureNotice(db, agents, agent, row, `permission_${preflight.tier}:${preflight.rule}`);
       return;
     }
     const envelope = stores.envelopeBuilder.buildForBus({
@@ -154,7 +154,7 @@ export async function runTurn(
           conversation_key: conversationKey,
         },
       });
-      postFailureNotice(db, agent, row);
+      postFailureNotice(db, agents, agent, row, result.detail);
       return;
     }
     if (result.sessionId) {
@@ -216,32 +216,77 @@ export async function runTurn(
       detail,
       artifact: { surface: CODEX_SURFACE_TEAM_BUS, conversation_key: conversationKey },
     });
-    postFailureNotice(db, agent, row);
+    postFailureNotice(db, agents, agent, row, detail);
   } finally {
     stores.inflightStore.clear(row.message_id, targetAgentId);
   }
 }
 
-/** 사용자 요청 실패 시에만 짧은 가시 통지 1회(에이전트 요청엔 안 보냄 — 루프 방지). dedupe로 스팸 차단. */
-function postFailureNotice(db: Database, agent: AgentRecord, row: PendingDispatchRow): void {
-  if (row.from_agent_id !== "user") return;
+/**
+ * 턴이 죽었다는 사실을 ★시킨 사람에게★ 알린다. (codex 런타임 전용 — 이 파일 안에서만 쓴다)
+ *
+ * ★전에는 팀 리드(user)가 시킨 것만 알렸다.★ 팀원이 시킨 일이 죽으면 아무 신호가 없었다.
+ *   2026-08-13 실측: dex 에게 위임한 4건이 승인창 5분 만료로 죽었는데 요청자에게 통지 0건이었고,
+ *   요청자는 ★"dex 가 실행을 안 한다" 로 오진했다.★ 실패가 안 보이면 팀원으로 쓸 수 없다.
+ *
+ * ★가드를 지운 게 아니다★ — 그 가드가 막던 것은 "알리는 것" 이 아니라 ★"체인에 얹혀서 알리는 것"★ 이었다.
+ *   예전 통지는 `in_reply_to` + `hop_count+1` 이라 체인 안에 들어갔고, 팀원 요청까지 열면
+ *   hop 한도를 먹고 그게 다시 [전달 차단] 을 부른다. 그래서 통지를 ★체인 밖 모양★ 으로 바꾼 뒤 조건을 넓힌다.
+ *   같은 4속성을 `wakeDispatcher.notifySenderOfBlock` 이 이미 쓰고 있다(그쪽은 루프가 안 난다):
+ *     ① `source:"system"` — pingpong 검사는 source==='agent' 일 때만 돈다
+ *     ② `in_reply_to` 없음 — parent 가 null = 체인 밖
+ *     ③ `hop_count: 0` — hop 한도와 무관
+ *     ④ dedupe 를 ★직접 SELECT★ 로 확인 — `insertMessage` 에 dedupe_key 만 넘기면 ★저장만 되고 안 막는다★
+ *
+ * 보내는 곳: 팀 리드가 시킨 것 → 그 방(기존 동작 유지) · 팀원이 시킨 것 → ★그 팀원에게만★ (방에 안 뿌린다)
+ */
+function postFailureNotice(
+  db: Database,
+  agents: () => AgentRecord[],
+  agent: AgentRecord,
+  row: PendingDispatchRow,
+  reason?: string,
+): void {
+  const sender = row.from_agent_id;
+  const fromLead = sender === "user";
+  if (!fromLead) {
+    // notifySenderOfBlock 과 같은 가드 — 자기 자신·플랫폼 발신·명부 밖에는 안 보낸다.
+    if (!sender || sender === agent.id) return;
+    if (sender === "system" || sender === "moderator") return;
+    if (!agents().some((a) => a.id === sender)) return;
+  }
   try {
     // ★플랫폼 공지는 팀원을 사칭하지 않는다★ (2026-07-13 — [B] 전환 중 발견)
     //   예전엔 from=<팀원>, source="agent" 로 넣어서 ★"그 팀원이 그렇게 말했다" 로 보였다.★
     //   ★그 팀원은 아무 말도 안 했다 — 턴이 죽은 것이다.★ 서버가 그의 입을 빌리면 안 된다.
-    //   (만료 통지·마감 알림이 이미 from="system" 인 것과 같은 원칙)
-    const body = `⚠️ ${agent.display_name ?? agent.id} 의 응답이 실패했습니다. 잠시 후 다시 시도해 주세요.`;
-    const dedupeKey = buildDedupeKey("system", "broadcast", body);
-    if (findRecentDuplicate(db, dedupeKey, 60)) return;
+    const why = reason ? ` (${reason.slice(0, 120)})` : "";
+    const body = `⚠️ ${agent.display_name ?? agent.id} 의 응답이 실패했습니다${why}. 잠시 후 다시 시도해 주세요.`;
+    // dedupe 는 ★받는 곳에 따라 기준이 다르다★ — 두 계약이 서로 다른 것을 막는다.
+    //   · 팀 리드 방(broadcast) = ★도배 방지★ 가 목적 → 본문 기준 60초 창(기존 계약 유지)
+    //   · 팀원 1:1 = ★같은 실패를 두 번 안 알리기★ 가 목적 → ★message_id 기준★
+    //     (본문 기준 60초를 쓰면 서로 다른 위임 두 건이 연속 실패했을 때 ★두 번째가 조용히 사라진다★)
+    let dedupeKey: string;
+    if (fromLead) {
+      dedupeKey = buildDedupeKey("system", "broadcast", body);
+      if (findRecentDuplicate(db, dedupeKey, 60)) return;
+    } else {
+      dedupeKey = `codex-fail-notice:${row.message_id}:${agent.id}`;
+      // ★직접 SELECT★ — insertMessage 에 dedupe_key 만 넘기면 저장만 되고 막지는 않는다.
+      if (db.prepare(`SELECT 1 FROM message WHERE dedupe_key = ? LIMIT 1`).get(dedupeKey)) return;
+    }
+    // ★모양도 받는 곳에 따라 다르다.★ 팀 리드 방은 기존 계약(hop 승계 · in_reply_to)을 그대로 둔다 —
+    //   그 방의 통지는 원 메시지의 답으로 읽혀야 하고, hop 을 리셋하면 루프 차단선이 풀린다.
+    //   팀원 1:1 은 ★체인 밖★ 이어야 한다(hop 0 · parent 없음). 그래야 통지가 hop 한도를 먹지 않고,
+    //   그게 다시 [전달 차단] 을 부르는 연쇄가 생기지 않는다 — 이것이 예전에 팀원 통지를 막아둔 이유다.
     insertMessage(db, {
       thread_id: row.thread_id,
       from_agent_id: "system",
-      to_agent_id: "broadcast",
-      type: "broadcast",
+      to_agent_id: fromLead ? "broadcast" : sender,
+      type: fromLead ? "broadcast" : "dm",
       body,
       source: "system",
-      hop_count: row.hop_count + 1,
-      in_reply_to: row.message_id,
+      hop_count: fromLead ? row.hop_count + 1 : 0,
+      ...(fromLead ? { in_reply_to: row.message_id } : {}),
       priority: "normal",
       dedupe_key: dedupeKey,
     });


### PR DESCRIPTION
## 문제

codex 턴이 실패해도 요청자가 팀원이면 통지가 없다. `postFailureNotice` 가 `from_agent_id !== "user"` 에서 조기 반환한다.

관측 (버스 로그·team.db):

| 턴 | 건수 | 결과 |
|---|---|---|
| 승인 요청 발생 | 4 | 승인창 만료·거절 직후 0~1초 내 `appserver_interrupted` |
| 승인 요청 없음 | 5 | 정상 완료 |
| 승인 허가 | 2 | 정상 완료 |

4건 모두 요청자 통지 0건.

## 원인

가드가 막던 것은 통지 자체가 아니라 **체인에 얹힌 통지**다.

기존 통지는 `in_reply_to` + `hop_count+1` 로 체인 안에 들어간다. 팀원 요청까지 열면 통지가 hop 한도를 소모하고, 한도 초과 시 그 스레드의 후속 메시지가 `pingpong_limit_exceeded` 로 차단된다.

`antiPingpong.ts`:
- `:83` 왕복 한도 — `source === "agent"` 일 때만 적용
- `:73` hop 한도 — source 무관, 전부 적용

`wakeDispatcher.notifySenderOfBlock` 은 `source:"system"` · parent 없음 · `hop_count:0` · 직접 SELECT dedupe 로 이 문제를 피한다.

## 변경

수신 대상에 따라 통지 모양과 dedupe 기준을 분리한다.

| | 팀 리드 방 (broadcast) | 팀원 1:1 (dm) |
|---|---|---|
| hop_count | `row.hop_count + 1` | `0` |
| in_reply_to | 유지 | 없음 |
| dedupe | 본문 기준 60초 창 | `message_id` 기준 직접 SELECT |
| 목적 | 도배 방지 | 같은 실패 1회, 다른 위임은 각각 |

- 가드는 `notifySenderOfBlock` 과 동일 집합: 자기 자신 · `system`/`moderator` · 명부 밖 제외
- `from="system"` 유지
- 실패 사유(`detail`)를 본문에 포함

## 시험

기존 `에이전트 요청(user 아님) + 실패 → 통지 안 함` 을 새 계약으로 교체:
- 팀원 요청 실패 → 통지 1건 · `to=요청자` · `type=dm` · `source=system` · parent null · `hop_count=0` · 사유 포함
- 같은 `message_id` 1건 / 다른 `message_id` 각각
- 명부 밖 · `system` · 자기 자신 → 통지 없음
- RunArtifact 시험의 `allMessages` 부재 단언 → `repliesFrom(db,"cody")===0` + 통지 정체 단언으로 교체

## 검증

| 항목 | 결과 |
|---|---|
| `tsc --noEmit` | exit 0 |
| `bun test src/server/runtimes/codex/` | 281 pass · 5 skip · 0 fail |
| `bun test src/server/runtimes/b3osNative/ src/server/bus/` | 408 pass · 0 fail |
| 변경 범위 | 1커밋 · 2파일 · +101/-16 · 공유 코드 0 |

`b3osNative` 는 동명 함수를 자체 사본으로 보유하므로 영향 없음.

## 미해결 (후속 PR)

1:1 dedupe 키에 시간 창이 없다. `wake_dispatched` 회복이 같은 `message_id` 를 재투입하면 재시도 실패 시 통지가 나가지 않는다. 회복 PR 에서 재시도·재실패를 별도 통지로 처리한다.

Submitted-by: Demis
Reviewed-by: Bill