### PR TITLE
fix(scheduler): 봉투가 다른 job 의 결과를 단정하던 것 + 늦게 깨어난 사실을 싣는다

### DIFF
--- a/src/server/scheduler/core.test.ts
+++ b/src/server/scheduler/core.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { openDb, migrate } from "../db/migrate";
 import { seedKrHolidays } from "../db/migrate";
 import {
@@ -22,6 +25,8 @@ import {
   completeScheduledJob,
   skipScheduledJob,
   consecutiveFailures,
+  lateWakeBanner,
+  emitCapabilityWorkloop,
 } from "./core";
 import { nextCronRun } from "./cron";
 
@@ -898,5 +903,139 @@ describe("연속 실패 카운트는 성공에서만 끊긴다", () => {
     job = getScheduledJob(d, job.id)!;
     failScheduledJob(d, job, "2", { now: new Date(T0.getTime() + 120_000) });
     expect(consecutiveFailures(d, job.id, 5)).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 늦은 깨움 배너 + 봉투가 다른 job 의 결과를 단정하지 않는다 (prop_696c5d65b2d5)
+//
+// 실측 배경(2026-08-13): 맥이 자다 깨면 밀린 슬롯이 부팅 직후 한꺼번에 돈다.
+// 그날 23:52:05 UTC 한 초에 8개 job 이 실행됐고, 04:00 SHARED 정리와 05:00 self-learning 의
+// 1시간 간격이 0초가 됐다. 그 사실은 scheduled_job_run 에만 남고 ★깨어난 당사자에겐 안 갔다.★
+// ─────────────────────────────────────────────────────────────────────────────
+describe("늦은 깨움은 봉투에 사실로 실린다", () => {
+  // 2026-08-14 금 05:00 KST 예정 슬롯 = 2026-08-13 20:00 UTC.
+  const DUE = kst(2026, 8, 14, 5, 0);
+
+  // ★테스트가 라이브 agents.json 을 읽지 않게 격리한다★ — ambientAgents 의 기본 경로는
+  // <repo>/agents.json 이고, 그건 팀 전체의 런타임 상태다(b3os-infra-safety ④).
+  // 파일 하나를 tmp 에 새로 쓰고 TEAM_AGENT_REGISTRY 로 명시한다(캐시가 경로+mtime 키라 매번 새 파일).
+  let registryPath: string | undefined;
+  let prevRegistry: string | undefined;
+  beforeEach(() => {
+    prevRegistry = process.env.TEAM_AGENT_REGISTRY;
+    registryPath = join(mkdtempSync(join(tmpdir(), "b3os-sched-reg-")), "agents.json");
+    writeFileSync(registryPath, JSON.stringify([
+      { id: "dex", display_name: "Dex", role: "Codex runtime pilot", runtime: "codex",
+        capabilities: ["learning_loop_pm", "coordinator"], enabled: true },
+    ]));
+    process.env.TEAM_AGENT_REGISTRY = registryPath;
+  });
+  afterEach(() => {
+    if (prevRegistry === undefined) delete process.env.TEAM_AGENT_REGISTRY;
+    else process.env.TEAM_AGENT_REGISTRY = prevRegistry;
+  });
+
+  function workloopJob(d: ReturnType<typeof db>, id = "sched_late_probe") {
+    const j = createCronJob(d, {
+      id, title: "self-learning", cron: "0 5 * * 5", timezone: "Asia/Seoul",
+      createdBy: "system", payload: learningPayload, from: new Date(DUE.getTime() - 1000),
+    });
+    return getScheduledJob(d, j.id)!;
+  }
+
+  // ★정시일 때 봉투가 한 글자도 안 바뀌는지부터 고정한다.★ 이게 없으면 "항상 붙이는" 구현이
+  // 아래 지연 검사를 전부 통과한다 — 가짜가 통과하는 길을 먼저 막는다.
+  test("정시 깨움은 원문 그대로 — 배너 0자", () => {
+    const d = db();
+    const job = workloopJob(d);
+    expect(lateWakeBanner(job, DUE)).toBe("");
+    const out = emitCapabilityWorkloop(d, job, learningPayload, DUE);
+    const body = d.prepare(`SELECT body FROM message WHERE id = ?`).get(out.emittedMessageId!) as { body: string };
+    expect(body.body).toBe(learningPayload.body); // 부분일치가 아니라 완전일치
+  });
+
+  test("임계는 15분 — 14분은 조용하고 16분은 말한다", () => {
+    const d = db();
+    const job = workloopJob(d);
+    expect(lateWakeBanner(job, new Date(DUE.getTime() + 14 * 60_000))).toBe("");
+    expect(lateWakeBanner(job, new Date(DUE.getTime() + 16 * 60_000))).toContain("16분 늦게");
+  });
+
+  // 08-13 실측 재현: 예정 05:00 KST → 실제 08:52 KST = 232분 지연.
+  test("실제로 있었던 232분 지연이 시각·간격까지 그대로 찍힌다", () => {
+    const d = db();
+    const job = workloopJob(d);
+    const banner = lateWakeBanner(job, kst(2026, 8, 14, 8, 52));
+    // ★시간+분을 둘 다 읽는다★ — 분을 버리면 3시간 52분이 "3시간" 으로 반올림돼도 통과한다.
+    expect(banner).toContain("3시간 52분 늦게");
+    // ★프로세스 시간대에 의존하지 않는지 여기서 갈린다.★ bun test 는 TZ=UTC 로 도는데,
+    // 구현이 로컬 포맷을 쓰면 이 두 줄은 UTC(20:00 / 23:52)로 찍혀 실패한다.
+    expect(banner).toContain("예정 2026-08-14 05:00");
+    expect(banner).toContain("실제 2026-08-14 08:52");
+    expect(banner).toContain("Asia/Seoul");
+  });
+
+  test("60분 미만은 '시간' 을 안 쓴다", () => {
+    const d = db();
+    const job = workloopJob(d);
+    expect(lateWakeBanner(job, new Date(DUE.getTime() + 45 * 60_000))).toContain("45분 늦게");
+    expect(lateWakeBanner(job, new Date(DUE.getTime() + 45 * 60_000))).not.toContain("시간");
+  });
+
+  // ★두 경로 다 잰다.★ 한쪽만 고치고 "완료" 로 읽히는 것이 이 팀이 가장 자주 밟는 함정이다.
+  test("capability_workloop 봉투 — 배너가 맨 앞, 원문은 그대로", () => {
+    const d = db();
+    const job = workloopJob(d);
+    const late = kst(2026, 8, 14, 8, 52);
+    const out = emitCapabilityWorkloop(d, job, learningPayload, late);
+    const { body } = d.prepare(`SELECT body FROM message WHERE id = ?`).get(out.emittedMessageId!) as { body: string };
+    expect(body.startsWith("[늦은 깨움]")).toBe(true);
+    expect(body).toContain(learningPayload.body);
+  });
+
+  test("inbox 봉투도 같은 배너를 받는다 — 예약 알림도 늦게 깨어난다", async () => {
+    const d = db();
+    const now = kst(2026, 8, 14, 8, 52);
+    const job = scheduleReminder(d, {
+      targetAgentId: "dex",
+      body: "[예약 알림] 늦은 깨움 경로",
+      runAt: DUE,
+      createdBy: "dex",
+    });
+    const results = await runDueSchedulerJobsOnce(d, { now });
+    expect(results[0]?.status).toBe("succeeded");
+    const { body } = d.prepare(`SELECT body FROM message WHERE id = ?`).get(results[0]!.emittedMessageId!) as { body: string };
+    expect(body.startsWith("[늦은 깨움]")).toBe(true);
+    expect(body).toContain("3시간 52분 늦게");
+    expect(body).toContain("[예약 알림] 늦은 깨움 경로");
+    expect(getScheduledJob(d, job.id)!.status).toBe("succeeded");
+  });
+
+  // ★배너가 dedupe 를 바꾸면 같은 슬롯이 두 번 깨운다.★ 본문이 달라져도 키는 슬롯 기준이어야 한다.
+  test("배너가 붙어도 같은 슬롯은 여전히 한 번만 나간다", () => {
+    const d = db();
+    const job = workloopJob(d);
+    const late = kst(2026, 8, 14, 8, 52);
+    const first = emitCapabilityWorkloop(d, job, learningPayload, late);
+    const second = emitCapabilityWorkloop(d, job, learningPayload, new Date(late.getTime() + 30_000));
+    expect(second.emittedMessageId).toBe(first.emittedMessageId);
+    expect(d.prepare(`SELECT count(*) AS n FROM message`).get()).toEqual({ n: 1 });
+  });
+
+  // ★고친 본체.★ 봉투가 04:00 job 의 결과를 산문으로 단정하던 문장을 지웠는지 본다.
+  // 부재만 재면 문장을 통째로 날려도 통과하므로, 대체 지시가 실제로 들어왔는지 함께 잰다.
+  test("self-learning 봉투는 04:00 정리 결과를 단정하지 않고 직접 확인을 시킨다", () => {
+    const d = db();
+    const jobs = ensureWeeklySelfLearningJobs(d);
+    const body = JSON.parse(jobs[1]!.payload_json).body as string;
+    // 없어야 하는 것: 다른 job 이 이미 돌았다는 주장
+    expect(body).not.toContain("04:00에 정리된 것 포함");
+    // 있어야 하는 것: 읽는 시점에 직접 재라는 지시 + 아직일 때의 대안
+    expect(body).toContain("읽기 직전에 mtime 과 최신 항목 날짜를 직접 확인하세요");
+    expect(body).toContain("별개 job 이라 아직 안 돌았을 수 있습니다");
+    expect(body).toContain("원자료");
+    // 원래 목적은 그대로 남아 있어야 한다(문장을 지우다 과제까지 지우지 않았는지)
+    expect(body).toContain("POST /team/api/proposals");
   });
 });

--- a/src/server/scheduler/core.test.ts
+++ b/src/server/scheduler/core.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { openDb, migrate } from "../db/migrate";
@@ -920,11 +920,12 @@ describe("늦은 깨움은 봉투에 사실로 실린다", () => {
   // ★테스트가 라이브 agents.json 을 읽지 않게 격리한다★ — ambientAgents 의 기본 경로는
   // <repo>/agents.json 이고, 그건 팀 전체의 런타임 상태다(b3os-infra-safety ④).
   // 파일 하나를 tmp 에 새로 쓰고 TEAM_AGENT_REGISTRY 로 명시한다(캐시가 경로+mtime 키라 매번 새 파일).
-  let registryPath: string | undefined;
+  let registryDir: string | undefined;
   let prevRegistry: string | undefined;
   beforeEach(() => {
     prevRegistry = process.env.TEAM_AGENT_REGISTRY;
-    registryPath = join(mkdtempSync(join(tmpdir(), "b3os-sched-reg-")), "agents.json");
+    registryDir = mkdtempSync(join(tmpdir(), "b3os-sched-reg-"));
+    const registryPath = join(registryDir, "agents.json");
     writeFileSync(registryPath, JSON.stringify([
       { id: "dex", display_name: "Dex", role: "Codex runtime pilot", runtime: "codex",
         capabilities: ["learning_loop_pm", "coordinator"], enabled: true },
@@ -934,6 +935,10 @@ describe("늦은 깨움은 봉투에 사실로 실린다", () => {
   afterEach(() => {
     if (prevRegistry === undefined) delete process.env.TEAM_AGENT_REGISTRY;
     else process.env.TEAM_AGENT_REGISTRY = prevRegistry;
+    // ★만든 것은 지운다★ — 없으면 수트를 한 번 돌 때마다 tmpdir 에 이 describe 의 테스트 수만큼
+    // 디렉토리가 쌓인다(codex 리뷰 실측: 누적 80개). 검사가 남기는 쓰레기도 검사의 결함이다.
+    if (registryDir) rmSync(registryDir, { recursive: true, force: true });
+    registryDir = undefined;
   });
 
   function workloopJob(d: ReturnType<typeof db>, id = "sched_late_probe") {
@@ -969,11 +974,31 @@ describe("늦은 깨움은 봉투에 사실로 실린다", () => {
     const banner = lateWakeBanner(job, kst(2026, 8, 14, 8, 52));
     // ★시간+분을 둘 다 읽는다★ — 분을 버리면 3시간 52분이 "3시간" 으로 반올림돼도 통과한다.
     expect(banner).toContain("3시간 52분 늦게");
-    // ★프로세스 시간대에 의존하지 않는지 여기서 갈린다.★ bun test 는 TZ=UTC 로 도는데,
-    // 구현이 로컬 포맷을 쓰면 이 두 줄은 UTC(20:00 / 23:52)로 찍혀 실패한다.
+    // 이 두 줄은 job 시간대(Asia/Seoul) 기준이다. bun test 의 기본 TZ 는 UTC 라
+    // 구현이 로컬 포맷을 쓰면 UTC(20:00 / 23:52)로 찍혀 실패한다 — ★단 그건 기본 TZ 일 때만이다.★
+    // TZ=Asia/Seoul 로 돌리면 로컬 == job 시간대라 같은 문자열이 나온다(아래 별도 검사 참고).
     expect(banner).toContain("예정 2026-08-14 05:00");
     expect(banner).toContain("실제 2026-08-14 08:52");
     expect(banner).toContain("Asia/Seoul");
+  });
+
+  // ★위 검사만으로는 시간대 독립성을 못 잰다.★ job 시간대가 Asia/Seoul 이라, 프로세스도
+  // Asia/Seoul 이면 로컬 포맷과 결과가 같아진다 — 실제로 `timeZone` 을 지운 뮤턴트가
+  // TZ=Asia/Seoul 에서만 살아남았다(UTC·LA 에서는 죽음). 이미 보는 축으로 변이하면 안 잡힌다.
+  // 그래서 ★job 시간대를 프로세스와 겹치지 않을 값으로 둔 검사★ 를 따로 세운다.
+  // 예정 2026-08-13 20:00 UTC = 13:00 PDT, 232분 뒤 = 16:52 PDT.
+  test("배너 시각은 job 시간대를 따른다 — 프로세스 시간대가 무엇이든", () => {
+    const d = db();
+    const j = createCronJob(d, {
+      // LA 기준 목 13:00 = 서울 금 05:00 = DUE. 요일도 시간대를 따라 달라진다.
+      id: "sched_late_probe_la", title: "LA 예약", cron: "0 13 * * 4",
+      timezone: "America/Los_Angeles", createdBy: "system",
+      payload: learningPayload, from: new Date(DUE.getTime() - 1000),
+    });
+    const banner = lateWakeBanner(getScheduledJob(d, j.id)!, kst(2026, 8, 14, 8, 52));
+    expect(banner).toContain("예정 2026-08-13 13:00");
+    expect(banner).toContain("실제 2026-08-13 16:52");
+    expect(banner).toContain("America/Los_Angeles");
   });
 
   test("60분 미만은 '시간' 을 안 쓴다", () => {

--- a/src/server/scheduler/core.ts
+++ b/src/server/scheduler/core.ts
@@ -93,7 +93,14 @@ export const WEEKLY_SHARED_CURATION_BODY = [
 export const WEEKLY_SELF_LEARNING_BODY = [
   "[workloop: self-learning 세션 · 금 05:00 KST]",
   "b3os-task-loop의 scheduled workloop 계약으로 이번 세션을 오픈→검토→proposal 등록→보고→닫기까지 한 턴에 수행하세요.",
-  "목적: SHARED.md(04:00에 정리된 것 포함)와 지난 1주 팀 활동을 검토해, 팀에 필요한 (a)팀 룰 변경 (b)새로운 과제 (c)고쳐야 할 이슈를 뽑아 ★proposal 시스템에 등록★하세요.",
+  // 예전에는 "SHARED.md(04:00에 정리된 것 포함)" 였다. ★이 봉투가 다른 job 의 결과를 산문으로 단정하고 있었다.★
+  // 04:00 정리(codex)와 05:00 이 세션은 별개 job 이고, 맥이 자다 깨면 둘이 같은 초에 깨어난다
+  // (2026-08-13: 8개 job 이 23:52:05 UTC 한 초에 실행 — 1시간 간격이 0초). 그러면 이 문장은 거짓이 된다.
+  // ★대신 값을 박지도 않는다★ — 봉투는 wake 시점에 만들어지므로 "최종 수정: 08:52 기준" 같은 값은
+  // 몇 분 뒤 무효가 되고, 산문 거짓말이 기계가 서명한 거짓말로 바뀔 뿐이다(dbak 반대리뷰).
+  // 그래서 ★주장하지 말고 읽는 시점에 직접 확인하라고 지시한다.★ 지연 여부와 무관하게 성립한다.
+  "목적: rules/SHARED.md 와 지난 1주 팀 활동을 검토해, 팀에 필요한 (a)팀 룰 변경 (b)새로운 과제 (c)고쳐야 할 이슈를 뽑아 ★proposal 시스템에 등록★하세요.",
+  "★SHARED.md 를 읽기 직전에 mtime 과 최신 항목 날짜를 직접 확인하세요★ — 04:00 정리 세션은 별개 job 이라 아직 안 돌았을 수 있습니다. 아직이면 정리본을 기다리지 말고 원자료(team.db·git log·audit)로 보세요.",
   // 라우터가 /api 아래 마운트되고 그 전체가 /team 아래 붙는다 → 실제 경로는 /team/api/proposals.
   // "POST /api/proposals" 로 적혀 있어서 시킨 대로 하면 404 가 난다(2026-07-31 실측).
   "★등록 방법: POST /team/api/proposals★ (/api/proposals 는 404 입니다). 각 proposal 에 근거(왜)+예상효과 필수. 등록하면 리뷰 게이트로 올라갑니다(자동 적용 아님).",
@@ -828,11 +835,14 @@ export function skipScheduledJob(
   ).run(nextStatus, enabled, nextRun, nowSql, nowSql, job.id);
 }
 
-export function emitScheduledJob(db: Database, job: ScheduledJobRow): string {
+export function emitScheduledJob(db: Database, job: ScheduledJobRow, now: Date = new Date()): string {
   const payload = JSON.parse(job.payload_json) as SchedulePayload;
   if (payload.type !== "inbox") throw new Error(`unsupported_payload:${payload.type}`);
   const env = {
     ...payload.envelope,
+    // ★두 emit 경로 모두에 붙인다★ — inbox 도 capability_workloop 도 늦게 깨어난다.
+    // 한쪽만 고치면 "고쳤다" 로 읽히고 다른 쪽은 조용히 옛 동작을 유지한다.
+    body: withLateWakeBanner(payload.envelope.body, job, now),
     dedupe_key: scheduledDedupeKey(job.id, job.next_run_at),
   };
   const accepted = acceptInbound(db, env, { dedupeWindowSec: 60 });
@@ -861,6 +871,7 @@ export function emitCapabilityWorkloop(
   db: Database,
   job: ScheduledJobRow,
   payload: CapabilityWorkloopPayload,
+  now: Date = new Date(),
 ): { emittedMessageId?: string; skippedReason?: string; targetAgentId?: string } {
   const agents = ambientAgents();
   if (agents.filter((agent) => agent.enabled !== false && isTeamOfficialMember(agent) && !hasCapability(agent, "non_interactive")).length === 0) {
@@ -875,7 +886,7 @@ export function emitCapabilityWorkloop(
       from_agent_id: "system",
       to_agent_id: targetAgentId,
       type: "dm",
-      body: payload.body,
+      body: withLateWakeBanner(payload.body, job, now),
       source: "agent",
       hop_count: 0,
       priority: "normal",
@@ -1049,6 +1060,72 @@ function lateBySec(job: ScheduledJobRow, now: Date): number {
   return (now.getTime() - fromSqliteDate(job.next_run_at).getTime()) / 1000;
 }
 
+/**
+ * A wake this late gets a banner. 15분: 정시 tick 지터(초 단위)와 "맥이 자다 깼다"(수십 분~수 시간)
+ * 사이에 겹치는 구간이 없다. 30일 실측에서 이 선을 넘은 실행은 전부 부팅 직후 catch-up 이었다.
+ */
+export const LATE_WAKE_BANNER_THRESHOLD_SEC = 15 * 60;
+
+/**
+ * 시각을 job 의 시간대로 찍는다.
+ *
+ * ★프로세스 시간대에 의존하지 않는다★ — `bun test` 는 TZ=UTC 로 돌고 실서버는 Asia/Seoul 이라,
+ * 로컬 포맷을 쓰면 검사 환경에서만 통과하는 결함이 생긴다(SHARED.md 2026-07-30). timeZone 을
+ * 명시하면 어디서 돌든 같은 문자열이 나온다. sv-SE 로케일은 "YYYY-MM-DD HH:mm" 을 준다.
+ */
+function formatInZone(date: Date, tz: string): string {
+  try {
+    return new Intl.DateTimeFormat("sv-SE", {
+      timeZone: tz,
+      year: "numeric", month: "2-digit", day: "2-digit",
+      hour: "2-digit", minute: "2-digit", hour12: false,
+    }).format(date);
+  } catch {
+    // 알 수 없는 시간대면 UTC 로 떨어뜨린다 — 배너가 없는 것보다 UTC 라도 있는 게 낫다.
+    return `${toSqliteDate(date).slice(0, 16)} UTC`;
+  }
+}
+
+function formatLateness(sec: number): string {
+  const totalMin = Math.round(sec / 60);
+  if (totalMin < 60) return `${totalMin}분`;
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return m === 0 ? `${h}시간` : `${h}시간 ${m}분`;
+}
+
+/**
+ * 늦게 깨어난 wake 봉투 맨 앞에 붙는 배너. 정시면 빈 문자열(= 봉투 무변화).
+ *
+ * 왜 필요한가: 미스파이어 유예가 기본 OFF 라서(위 주석) 맥이 자는 동안 밀린 슬롯은 부팅 직후
+ * 한꺼번에 실행된다. 그때 04:00 job 과 05:00 job 이 같은 초에 깨어나 ★간격 계약이 0초가 된다.★
+ * 그 사실은 scheduled_job_run 에만 남고 ★깨어난 당사자에게는 안 간다★ — 그래서 후행 owner 가
+ * 선행 job 의 산출물이 아직 없는 상태에서 그것을 읽는다(2026-08-13 실측).
+ *
+ * ★배너는 동시 실행 자체를 막지 못한다.★ 막는 건 봉투 본문의 "읽기 직전에 직접 확인하라" 쪽이고,
+ * 배너는 owner 가 "이 세션의 입력이 신선한가" 를 판단할 사실을 주는 역할이다. 둘은 대체재가 아니다.
+ *
+ * ★선행 job 의 '완료' 는 싣지 않는다★ — scheduled_job_run.outcome='succeeded' 는 "깨움 메시지를
+ * 발송했다" 는 뜻이지 "그 일이 끝났다" 가 아니다(started_at == finished_at 같은 초). 그 값을
+ * "선행 완료" 로 실으면 지금 고치는 것과 똑같은 거짓을 한 세대 더 만든다(dbak 반대리뷰).
+ */
+export function lateWakeBanner(job: ScheduledJobRow, now: Date): string {
+  const lateSec = lateBySec(job, now);
+  if (lateSec < LATE_WAKE_BANNER_THRESHOLD_SEC) return "";
+  const tz = job.timezone || "Asia/Seoul";
+  return [
+    `[늦은 깨움] 이 세션은 예정보다 ★${formatLateness(lateSec)} 늦게★ 시작됐습니다.`,
+    `  예정 ${formatInZone(fromSqliteDate(job.next_run_at), tz)} · 실제 ${formatInZone(now, tz)} (${tz})`,
+    "  같은 시각에 다른 정기 작업도 함께 깨어났을 수 있습니다 — 앞선 작업의 산출물이 아직 없을 수 있으니, 파일·기록을 읽기 전에 실제 상태를 직접 확인하세요.",
+  ].join("\n");
+}
+
+/** 배너를 봉투 본문 앞에 붙인다. 정시면 원문 그대로(문자열 동일성 보장). */
+function withLateWakeBanner(body: string, job: ScheduledJobRow, now: Date): string {
+  const banner = lateWakeBanner(job, now);
+  return banner ? `${banner}\n\n${body}` : body;
+}
+
 export async function runDueSchedulerJobsOnce(
   db: Database,
   opts: {
@@ -1143,14 +1220,16 @@ export async function runDueSchedulerJobsOnce(
       } else if (payload.type === "inbox") {
         // inbox: emit + reschedule atomically so a crash can't double-emit.
         const emittedMessageId = db.transaction((j: ScheduledJobRow) => {
-          const id = emitScheduledJob(db, j);
+          // 배너의 "실제" 시각은 completeScheduledJob 이 기록하는 시각과 같아야 한다 —
+          // 여기서 새로 new Date() 를 부르면 봉투와 run 기록이 서로 다른 시각을 말한다.
+          const id = emitScheduledJob(db, j, now);
           completeScheduledJob(db, j, { emittedMessageId: id, now });
           return id;
         })(claimed);
         results.push({ jobId: job.id, status: "succeeded", emittedMessageId });
       } else {
         const outcome = db.transaction((j: ScheduledJobRow) => {
-          const emitted = emitCapabilityWorkloop(db, j, payload);
+          const emitted = emitCapabilityWorkloop(db, j, payload, now);
           if (emitted.skippedReason) {
             skipScheduledJob(db, j, emitted.skippedReason, { now });
             return emitted;


### PR DESCRIPTION
## 무엇이 문제인가

스케줄러는 미스파이어 유예가 기본 OFF 다(의도된 선택 — 켜면 금요일 학습 루프가 한 주를 통째로 건너뛴다). 그래서 맥이 자는 동안 밀린 슬롯은 부팅 직후 한꺼번에 실행된다.

실측(30일):

| 날짜(UTC) | 같은 초에 실행된 job | 최대 지연 |
|---|---|---|
| 2026-07-29 23:00:12 | 5 | 450분 |
| 2026-08-03 03:18:05 | 6 | 738분 |
| 2026-08-13 23:52:05 | 8 | 442분 |

2026-08-13 에는 `sched_weekly_shared_curation`(예정 19:00)과 `sched_weekly_self_learning_session`(예정 20:00)이 `23:52:05` 같은 초에 실행됐다. 1시간 간격이 0초가 됐다.

문제는 두 개다.

1. **그 사실이 깨어난 당사자에게 가지 않는다.** 지연은 `scheduled_job_run` 에만 남는다. 봉투를 받은 owner 는 자기가 정시에 깨어난 것으로 읽는다.
2. **봉투가 다른 job 의 결과를 산문으로 단정한다.** `WEEKLY_SELF_LEARNING_BODY` 에 `"SHARED.md(04:00에 정리된 것 포함)"` 이 상수로 박혀 있다. 04:00 정리는 별개 job 이므로 이 문장은 두 job 이 같은 초에 깨어나는 순간 거짓이 된다. 실제로 후행 세션이 정리 전 파일을 읽었다.

## 왜 그렇게 되나

`dueScheduledJobs` 는 `ORDER BY next_run_at ASC` 라 **발송 순서는 보존된다.** 무너지는 것은 순서가 아니라 **간격**이다. 두 job 사이의 1시간은 "앞 job 이 일을 끝낼 시간" 이었는데, catch-up 에서는 그 시간이 없다. 그리고 `scheduled_job` 에는 선행 job 개념이 없어 이 조건을 표현할 자리가 없다.

## 어떻게 고쳤나

**1. 봉투에서 단정을 뺀다** — `"SHARED.md(04:00에 정리된 것 포함)"` → 읽는 시점에 mtime 과 최신 항목 날짜를 직접 확인하고, 아직이면 원자료(`team.db`·git log·audit)로 보라는 지시로 교체.

값을 박는 방식(`"최종 수정: 08:52 기준"`)은 쓰지 않았다. 봉투는 wake 시점에 만들어지므로 그 값은 몇 분 뒤 무효가 된다 — 이번 사례에서도 정리는 wake 3분 뒤에 파일을 썼다. 산문 거짓말이 기계가 서명한 거짓말로 바뀔 뿐이다.

**2. 늦은 깨움 배너** — 15분 이상 밀리면 봉투 맨 앞에 예정·실제·지연을 싣는다.

```
[늦은 깨움] 이 세션은 예정보다 ★3시간 52분 늦게★ 시작됐습니다.
  예정 2026-08-14 05:00 · 실제 2026-08-14 08:52 (Asia/Seoul)
  같은 시각에 다른 정기 작업도 함께 깨어났을 수 있습니다 — …
```

`inbox` 와 `capability_workloop` **두 경로 모두**에 붙였다. 시각은 job 의 시간대로 명시 포맷하므로 프로세스 시간대에 의존하지 않는다(`bun test` 는 UTC, 실서버는 Asia/Seoul).

**범위에서 뺀 것 — 선행 job 의 "완료" 표시.** `scheduled_job_run.outcome='succeeded'` 는 "깨움 메시지를 발송했다" 는 뜻이지 "그 일이 끝났다" 가 아니다(`started_at == finished_at` 같은 초, `detail_json` 은 `targetAgentId` 하나). 이 값을 완료로 실으면 지금 고치는 것과 똑같은 거짓을 한 세대 더 만든다.

**한계** — 배너는 동시 실행 자체를 막지 못한다. 막는 것은 1번의 직접 확인 지시이고, 배너는 owner 가 입력 신선도를 판단할 사실을 주는 역할이다. 둘은 대체재가 아니다.

## 검증

- `scheduler/core.test.ts` **59 pass** (신규 8). 신규 검사: 정시 = 원문 완전일치 · 임계 14분/16분 · 232분 지연의 시각·간격 · 60분 미만 표기 · 두 emit 경로 · dedupe 불변 · 봉투 문구.
- **뮤턴트 6종 전부 잡힘**: ①capability 경로만 배너 제거 ②inbox 경로만 제거 ③배너 항상 붙임 ④로컬시간 포맷 ⑤분 버림 ⑥옛 단정 문장 복원.
- `tsc --noEmit` 통과.
- 전체 수트 **2597 pass**. 실패 3건은 이 브랜치 이전 커밋에서도 동일하게 실패한다(worktree 에 gitignore 대상 `rules/TEAM-OS.md` 가 없어서 나는 환경 문제).
- 테스트는 `TEAM_AGENT_REGISTRY` 를 tmp 로 격리한다 — 라이브 `agents.json` 을 읽지 않는다.

## 미검증 범위

실제 catch-by-boot 상황은 재현하지 않았다(맥 절전 필요). 배너 경로는 고정 시각 주입으로만 검증했다.

## 롤백

이 커밋 revert. 상태·스키마 변경 없음.

근거: proposal `prop_696c5d65b2d5` (accepted) · peer review `rev_7125de31964c` (dbak, 반대리뷰)

Submitted-by: bill
