### PR TITLE
feat(permission-gate): 사람이 고른 허용 범위를 기록한다 — decision_scope

### DIFF
--- a/src/server/db/migrate.permissionScope.test.ts
+++ b/src/server/db/migrate.permissionScope.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { migrate } from "./migrate";
+import { decidePermissionRequest, requestPermission, getPermissionRequest } from "../lib/permissionGate";
+
+// decision_scope 가 붙기 전의 표. 기존 설치본을 이 모양으로 재현한다.
+const OLD_TABLE = `CREATE TABLE permission_request (
+  id TEXT PRIMARY KEY,
+  scope_key TEXT NOT NULL,
+  runtime TEXT NOT NULL,
+  agent_id TEXT,
+  action TEXT NOT NULL,
+  target TEXT NOT NULL,
+  payload_json TEXT NOT NULL DEFAULT '{}',
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK(status IN ('pending','allowed_once','allowed_always','denied','expired')),
+  requested_by TEXT NOT NULL DEFAULT 'system',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  decided_at TEXT,
+  approver TEXT,
+  provenance_json TEXT
+)`;
+
+const cols = (db: Database): string[] =>
+  (db.prepare("PRAGMA table_info('permission_request')").all() as { name: string }[]).map((c) => c.name);
+
+const tableSql = (db: Database): string =>
+  (db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='permission_request'").get() as { sql: string }).sql;
+
+describe("permission_request.decision_scope — 표를 재작성하지 않고 범위를 적는다", () => {
+  test("기존 설치본에 칸만 붙는다 — 행도 CHECK 도 그대로", () => {
+    const db = new Database(":memory:");
+    db.exec(OLD_TABLE);
+    for (let i = 0; i < 26; i++) {
+      db.prepare(
+        `INSERT INTO permission_request (id, scope_key, runtime, action, target, status)
+         VALUES (?, ?, 'codex', 'exec', '/tmp/x', ?)`,
+      ).run(`p${i}`, `s${i}`, i < 12 ? "allowed_once" : i < 18 ? "denied" : "expired");
+    }
+    const checkBefore = tableSql(db).match(/CHECK\(status IN \([^)]*\)\)/)?.[0];
+
+    migrate(db);
+
+    expect(cols(db)).toContain("decision_scope");
+    expect((db.prepare("SELECT count(*) AS n FROM permission_request").get() as { n: number }).n).toBe(26);
+    // ★CHECK 는 손대지 않는다★ — 남의 DB 를 재작성하지 않는다는 것이 이 설계의 이유다.
+    expect(tableSql(db).match(/CHECK\(status IN \([^)]*\)\)/)?.[0]).toBe(checkBefore);
+    // 옛 행은 범위를 모른다. null 이어야 하고, '한번' 으로 채워지면 안 된다.
+    expect((db.prepare("SELECT count(*) AS n FROM permission_request WHERE decision_scope IS NULL").get() as { n: number }).n).toBe(26);
+  });
+
+  test("두 번 돌려도 칸이 한 번만 붙는다", () => {
+    const db = new Database(":memory:");
+    db.exec(OLD_TABLE);
+    migrate(db);
+    migrate(db);
+    expect(cols(db).filter((c) => c === "decision_scope")).toHaveLength(1);
+  });
+});
+
+describe("세션 결정이 기록에 남는다", () => {
+  function db(): Database {
+    const d = new Database(":memory:");
+    migrate(d);
+    return d;
+  }
+  const op = (target: string) => ({ runtime: "codex", agent_id: "dex", action: "exec", target });
+
+  test("★세션과 한번이 기록에서 갈린다★ — status 만 보면 같다", () => {
+    const d = db();
+    const once = requestPermission(d, op("/tmp/a")).request!;
+    const session = requestPermission(d, op("/tmp/b")).request!;
+
+    decidePermissionRequest(d, once.id, "allow_once", { approver: "gd" });
+    decidePermissionRequest(d, session.id, "allow_session", { approver: "gd" });
+
+    const a = getPermissionRequest(d, once.id)!;
+    const b = getPermissionRequest(d, session.id)!;
+
+    expect(a.status).toBe("allowed_once");
+    expect(b.status).toBe("allowed_once"); // 지속 허가를 안 남긴다는 점에서 같다
+    expect(a.decision_scope).toBe("once");
+    expect(b.decision_scope).toBe("session"); // ★고른 것은 여기 남는다★
+  });
+
+  test("세션은 grant 를 만들지 않는다 — 세션 범위는 런타임이 지킨다", () => {
+    const d = db();
+    const r = requestPermission(d, op("/tmp/c")).request!;
+    decidePermissionRequest(d, r.id, "allow_session", { approver: "gd" });
+    expect((d.prepare("SELECT count(*) AS n FROM permission_grant").get() as { n: number }).n).toBe(0);
+  });
+
+  test("항상 허용은 grant 를 만들고 범위도 always 로 남는다", () => {
+    const d = db();
+    const r = requestPermission(d, op("/tmp/d")).request!;
+    decidePermissionRequest(d, r.id, "allow_always", { approver: "gd" });
+    const row = getPermissionRequest(d, r.id)!;
+    expect(row.status).toBe("allowed_always");
+    expect(row.decision_scope).toBe("always");
+    expect((d.prepare("SELECT count(*) AS n FROM permission_grant").get() as { n: number }).n).toBe(1);
+  });
+
+  test("거절은 범위가 없다", () => {
+    const d = db();
+    const r = requestPermission(d, op("/tmp/e")).request!;
+    decidePermissionRequest(d, r.id, "deny", { approver: "gd" });
+    const row = getPermissionRequest(d, r.id)!;
+    expect(row.status).toBe("denied");
+    expect(row.decision_scope).toBeNull();
+  });
+});

--- a/src/server/db/migrate.ts
+++ b/src/server/db/migrate.ts
@@ -88,6 +88,16 @@ export function migrate(db: Database): void {
        provenance_json TEXT
      )`,
   );
+  // 사람이 고른 ★범위★ 를 그대로 적는 칸. once | session | always.
+  //
+  // status 는 CHECK 로 값이 고정돼 있고, ★CHECK 는 ALTER 로 못 바꾼다★ — 늘리려면 표를 재작성해야 한다.
+  // 이 표는 공개 코드가 무조건 만든다(PUBLIC_BUILD 분기 없음). 남의 설치본 DB 를 재작성하지 않는다.
+  // ADD COLUMN 은 메타데이터만 바꾸고 기존 행은 NULL 로 남으므로 어느 설치본에서도 안전하다.
+  //
+  // status 는 ★지속되는 허가를 남기는가★ 를 말한다(allowed_always 만 grant 를 쓴다).
+  // 세션 허용은 지속되지 않으므로 status 는 allowed_once 와 같고, 둘을 가르는 것은 이 칸이다.
+  // ★결정을 보고할 때는 두 칸을 같이 읽는다★ — status 만 읽으면 세션 선택이 '한번' 으로 보인다.
+  addColumnIfMissing(db, "permission_request", "decision_scope", "TEXT");
   db.exec("CREATE INDEX IF NOT EXISTS idx_permission_request_status ON permission_request(status, created_at DESC)");
   db.exec("CREATE INDEX IF NOT EXISTS idx_permission_request_scope ON permission_request(scope_key, status, created_at DESC)");
   db.exec(

--- a/src/server/lib/permissionGate.ts
+++ b/src/server/lib/permissionGate.ts
@@ -9,7 +9,19 @@ export type PermissionTier = "allow" | "ask" | "deny";
 export type PermissionAgent = Pick<AgentRecord, "id" | "workspace_path">;
 export type PermissionDecision = "allow" | "deny" | "approval_required";
 export type PermissionRequestStatus = "pending" | "allowed_once" | "allowed_always" | "denied" | "expired";
-export type PermissionDecisionInput = "allow_once" | "allow_always" | "deny";
+/**
+ * `allow_session` = 이 세션 동안만 허용.
+ *
+ * ★status 로는 allow_once 와 구분되지 않는다.★ status 는 CHECK 로 값이 고정돼 있고 그 표는
+ * 공개 코드가 모든 설치본에 만든다 — 값을 늘리려면 남의 DB 까지 재작성해야 해서 하지 않는다.
+ * 대신 `decision_scope` 칸에 사람이 고른 범위를 그대로 적는다. 결정을 읽을 때는 두 칸을 같이 본다.
+ *
+ * ★grant 는 만들지 않는다.★ 세션 범위를 실제로 지키는 것은 런타임이고(codex 의 acceptForSession),
+ * 우리 표는 사람이 무엇을 골랐는지를 적는 자리다.
+ */
+export type PermissionDecisionInput = "allow_once" | "allow_session" | "allow_always" | "deny";
+/** 사람이 고른 범위 — status 와 함께 읽어야 결정이 온전해진다. */
+export type PermissionDecisionScope = "once" | "session" | "always";
 
 export type PermissionAction =
   | { kind: "sandbox"; sandbox: CodexSandboxMode; writableRoot?: string }
@@ -52,6 +64,8 @@ export interface PermissionRequestRow {
   target: string;
   payload_json: string;
   status: PermissionRequestStatus;
+  /** 사람이 고른 범위. 이 칸이 생기기 전에 결정된 행은 null 이다 — 없음을 '한번' 으로 읽지 않는다. */
+  decision_scope: PermissionDecisionScope | null;
   requested_by: string;
   created_at: string;
   decided_at: string | null;
@@ -335,13 +349,20 @@ export function decidePermissionRequest(
     return { ok: false, status: row.status, error: `Tier D cannot be approved: ${tierD.join(",")}` };
   }
 
+  // 세션은 ★지속되는 허가를 남기지 않는다★ — 그 점에서 allowed_once 와 같다. 무엇을 골랐는지는
+  // decision_scope 가 말한다. 거절은 범위가 없으므로 null 이다.
   const status: PermissionRequestStatus =
-    decision === "allow_once" ? "allowed_once" : decision === "allow_always" ? "allowed_always" : "denied";
+    decision === "allow_always" ? "allowed_always" : decision === "deny" ? "denied" : "allowed_once";
+  const scope: PermissionDecisionScope | null =
+    decision === "allow_once" ? "once"
+    : decision === "allow_session" ? "session"
+    : decision === "allow_always" ? "always"
+    : null;
   const changed = db.prepare(
     `UPDATE permission_request
-       SET status = ?, decided_at = datetime('now'), approver = ?, provenance_json = ?
+       SET status = ?, decision_scope = ?, decided_at = datetime('now'), approver = ?, provenance_json = ?
      WHERE id = ? AND status = 'pending'`,
-  ).run(status, opts.approver, JSON.stringify(opts.provenance ?? {}), id).changes;
+  ).run(status, scope, opts.approver, JSON.stringify(opts.provenance ?? {}), id).changes;
   if (changed !== 1) return { ok: false, error: "permission request changed concurrently" };
 
   if (decision === "allow_always") {


### PR DESCRIPTION
## 요구사항

승인 카드에 "이 세션" 버튼을 둔다. codex 는 그 결정을 이미 끝까지 처리하는데(`session` → `acceptForSession`) 우리 표에 적을 자리가 없어, 기록과 실제가 갈릴 참이었다.

## 표를 재작성하지 않는다

`status` 의 허용값은 CHECK 로 고정돼 있고 **SQLite 는 CHECK 를 ALTER 로 못 바꾼다**. 값을 늘리려면 표를 새로 만들어 옮기고 바꿔치기해야 한다.

그런데 이 표는 **공개 코드가 조건 없이 모든 설치본에 만든다** — `permission_request` 생성에 `PUBLIC_BUILD` 분기가 없다. 재작성 코드를 넣으면 우리가 내용을 모르는 남의 DB 에서도 돈다.

`ADD COLUMN` 은 메타데이터만 바꾸고 기존 행은 NULL 로 남는다. 이 저장소에 이미 있는 `addColumnIfMissing` 패턴을 그대로 쓴다.

## 무엇이 어디에 적히나

| 칸 | 뜻 |
|---|---|
| `status` | **지속되는 허가를 남기는가** — `allowed_always` 만 `permission_grant` 를 쓴다 |
| `decision_scope` | **사람이 고른 범위** — `once` · `session` · `always` |

세션은 지속 허가를 남기지 않으므로 `status` 는 `allowed_once` 와 같다. **둘을 가르는 것은 `decision_scope` 다.**

→ 결정을 보고·표시할 때는 **두 칸을 같이 읽는다.** `status` 만 읽으면 세션 선택이 "한번" 으로 보인다.

칸이 생기기 전에 결정된 행은 `null` 이다. **없음을 "한번" 으로 채우지 않는다.**

## 세션은 grant 를 만들지 않는다

세션 범위를 실제로 지키는 것은 런타임이다(codex 의 `acceptForSession`). 여기서 grant 를 쓰면 세션이 끝나도 남아 `allow_always` 와 구분이 사라진다.

## 검증

신규 6개:

- 기존 26행 보존 · **CHECK 무변경**(재작성하지 않았다는 증거) · 옛 행 `decision_scope IS NULL`
- `migrate` 두 번 실행해도 칸이 한 번만 붙는다
- **세션과 한번이 기록에서 갈린다** — `status` 는 같고 `decision_scope` 가 다르다
- 세션은 `permission_grant` 0건 · 항상 허용은 1건 · 거절은 범위 `null`

뮤턴트 2종으로 검사가 실제로 잡는지 확인:

| 뮤턴트 | 결과 |
|---|---|
| `decision_scope` 기록 제거 | 2 fail |
| 세션에도 grant 생성 | 1 fail |

`tsc --noEmit` 통과 · 전체 **2610 pass / 0 fail**

## 범위 밖

텔레그램 "이 세션" 버튼과 codex 연결은 별건이다. 이 PR 은 그 값을 적을 자리만 만든다.

## 위험

`ADD COLUMN` 한 칸. 기존 행·CHECK·인덱스 무변경. 롤백은 이 커밋 revert(칸은 남지만 아무도 읽지 않는다).

Submitted-by: bill
