### PR TITLE
chore(tests): 시험 고정값을 테스트 전용 값으로 통일한다

### DIFF
--- a/src/server/lib/livenessMonitor.test.ts
+++ b/src/server/lib/livenessMonitor.test.ts
@@ -84,7 +84,10 @@ describe("bot liveness monitor shared defaults", () => {
       const xml = renderBotLivenessMonitorPlist();
       expect(xml).toContain("<key>GD_CHAT_ID</key><string>1000000001</string>");
       expect(xml).not.toContain("9999999999");
-      expect(xml).not.toContain("7066867819");
+      // 하드코딩 방지는 값 하나를 이름으로 막지 않는다 — 긴 자릿수 자체를 막는다.
+      // 특정 값만 적으면 ★그 값이 아닌 다른 값이 박힐 때 통과한다.★
+      const longDigits = [...new Set(xml.match(/\d{9,}/g) ?? [])];
+      expect(longDigits).toEqual(["1000000001"]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/server/runtimes/claude/ownerGateHook.test.ts
+++ b/src/server/runtimes/claude/ownerGateHook.test.ts
@@ -19,7 +19,7 @@ import { createServer, type Server } from "node:http";
 
 const HOOK = join(import.meta.dir, "../../../../hooks/telegram-owner-gate.py");
 const GROUP = "-1009999999999"; // 테스트 전용 가짜 값
-const DM = "7066867819";
+const DM = "9999999999";
 
 let dirs: string[] = [];
 let servers: Server[] = [];

--- a/src/server/runtimes/claude/ownerGateSelfAndRoom.test.ts
+++ b/src/server/runtimes/claude/ownerGateSelfAndRoom.test.ts
@@ -21,7 +21,7 @@ const execFileAsync = promisify(execFile);
 const HOOK = join(import.meta.dir, "../../../../hooks/telegram-owner-gate.py");
 const GROUP = "-1009999999999";
 const OTHER_GROUP = "-1008888888888"; // 리사팀·공개 설치의 두 번째 방
-const DM = "7066867819";
+const DM = "9999999999";
 
 let dirs: string[] = [];
 let servers: Server[] = [];

--- a/src/server/runtimes/claude/replyGuardScope.test.ts
+++ b/src/server/runtimes/claude/replyGuardScope.test.ts
@@ -17,7 +17,7 @@ import { join } from "node:path";
 
 const HOOK = join(import.meta.dir, "reply-guard.py");
 const GROUP_CHAT = "-1009999999999"; // 텔레그램 그룹은 음수
-const DM_CHAT = "7066867819";        // 1:1 은 양수
+const DM_CHAT = "9999999999";        // 1:1 은 양수
 
 let dirs: string[] = [];
 afterEach(() => {


### PR DESCRIPTION
시험 4개가 들고 있던 고정값 하나가 테스트 전용 값이 아니었다. 같은 파일들이 이미 쓰던 방식(테스트 전용 가짜 값)으로 맞춘다.

판정은 그대로다 — 그 시험들은 값 자체가 아니라 멤버십과 주입 경로를 본다.

`livenessMonitor` 의 '하드코딩 금지' 가드도 함께 바꿨다. 값 하나를 이름으로 막고 있어서 **다른 값이 박히면 통과한다.** 자릿수 모양으로 막게 바꿨다.

```text
검증 범위:  대상 4파일 (37 tests) · tsc --noEmit
baseline:   0 fail
mutation:   plist 템플릿에 다른 긴 숫자값을 박음 → 새 가드 1 fail · 옛 가드 0 fail
미검증:     전체 시험 수트는 이 브랜치에서 돌리지 않았다 (대상 4파일만 돌렸다)
            워크트리 환경 의존 시험 2건(rules/TEAM-OS.md · 루트 team.db)은 이 브랜치와 무관하게
            클론 직후 환경에서 실패한다 — 별건이다
```
