### PR TITLE
fix(codex): 승인 결정을 status 와 decision_scope 두 칸으로 읽는다

### DIFF
--- a/src/server/runtimes/codex/appServerPopup.scope.test.ts
+++ b/src/server/runtimes/codex/appServerPopup.scope.test.ts
@@ -1,0 +1,102 @@
+/**
+ * pollDecision 은 status 와 decision_scope 를 ★같이★ 읽는다.
+ *
+ * '이 세션' 은 지속되는 허가를 남기지 않으므로 status 가 allowed_once 와 같다(permissionGate.ts).
+ * 둘을 가르는 것은 decision_scope 뿐이라, status 만 읽으면 사람이 세션을 골라도 런타임에는
+ * '한번' 이 간다. 아래 시험은 그 경계를 양쪽에서 잰다 — 세션이 세션으로 가는가, 그리고
+ * ★세션이 아닌 것이 세션으로 새지 않는가.★
+ */
+import { test, expect } from "bun:test";
+import { Database } from "bun:sqlite";
+import { migrate } from "../../db/migrate";
+import { decidePermissionRequest } from "../../lib/permissionGate";
+import { pollDecision } from "./appServerPopup";
+
+/** 결정 대기 중인 요청 하나를 만든다. */
+function pendingRequest(db: Database, id = "req_scope"): string {
+  db.prepare(
+    `INSERT INTO permission_request (id, scope_key, runtime, agent_id, action, target, status)
+     VALUES (?, ?, 'codex', 'dex', 'shell', '/tmp/x', 'pending')`,
+  ).run(id, `scope:${id}`);
+  return id;
+}
+
+function migrated(): Database {
+  const db = new Database(":memory:");
+  migrate(db);
+  return db;
+}
+
+test("★'이 세션' 을 고르면 세션으로 간다★ — status 는 allowed_once 지만 범위가 session 이다", async () => {
+  const db = migrated();
+  const id = pendingRequest(db);
+  expect(decidePermissionRequest(db, id, "allow_session", { approver: "team-lead" }).ok).toBe(true);
+
+  // 두 칸이 실제로 이 모양인지 먼저 고정한다 — 아니면 아래 기대값이 무엇을 재는지 알 수 없다.
+  const row = db.prepare("SELECT status, decision_scope FROM permission_request WHERE id = ?").get(id) as {
+    status: string; decision_scope: string | null;
+  };
+  expect(row.status).toBe("allowed_once");
+  expect(row.decision_scope).toBe("session");
+
+  expect(await pollDecision(db, id, 1_000, 5)).toBe("approved_for_session");
+});
+
+test("대조군 — '한번' 은 한번이다", async () => {
+  const db = migrated();
+  const id = pendingRequest(db);
+  decidePermissionRequest(db, id, "allow_once", { approver: "team-lead" });
+  expect(
+    (db.prepare("SELECT decision_scope AS s FROM permission_request WHERE id = ?").get(id) as { s: string }).s,
+  ).toBe("once");
+  expect(await pollDecision(db, id, 1_000, 5)).toBe("approved");
+});
+
+test("★옛 행의 decision_scope 는 NULL 이다 — 그걸 session 으로 읽지 않는다★", async () => {
+  const db = migrated();
+  const id = "req_legacy_row";
+  // #325 이전에 결정된 행: status 만 있고 범위 칸이 비어 있다.
+  db.prepare(
+    `INSERT INTO permission_request (id, scope_key, runtime, agent_id, action, target, status, decision_scope)
+     VALUES (?, 'scope:legacy', 'codex', 'dex', 'shell', '/tmp/x', 'allowed_once', NULL)`,
+  ).run(id);
+
+  // NULL 을 세션으로 읽으면 옛 '한번' 결정이 소급해서 세션 허용이 된다.
+  expect(await pollDecision(db, id, 1_000, 5)).toBe("approved");
+});
+
+test("칸 자체가 없는 옛 스키마에서도 '한번' 으로 떨어진다 — 조회 실패로 죽지 않는다", async () => {
+  const db = new Database(":memory:");
+  // decision_scope 가 붙기 전의 표(migrate 를 안 돌린 설치본).
+  db.run(
+    `CREATE TABLE permission_request (id TEXT PRIMARY KEY, scope_key TEXT, runtime TEXT, agent_id TEXT,
+     action TEXT, target TEXT, payload_json TEXT, status TEXT, requested_by TEXT, created_at TEXT,
+     decided_at TEXT, approver TEXT, provenance_json TEXT)`,
+  );
+  db.prepare(`INSERT INTO permission_request (id, status, runtime, action) VALUES ('req_old', 'allowed_once', 'codex', 'shell')`).run();
+
+  expect(await pollDecision(db, "req_old", 1_000, 5)).toBe("approved");
+});
+
+test("모르는 범위 값은 좁은 쪽으로 떨어진다 — 세션으로 넓히지 않는다", async () => {
+  const db = migrated();
+  const id = "req_unknown_scope";
+  db.prepare(
+    `INSERT INTO permission_request (id, scope_key, runtime, agent_id, action, target, status, decision_scope)
+     VALUES (?, 'scope:unknown', 'codex', 'dex', 'shell', '/tmp/x', 'allowed_once', 'everything')`,
+  ).run(id);
+
+  expect(await pollDecision(db, id, 1_000, 5)).toBe("approved");
+});
+
+test("회귀 — '항상 허용' 은 그대로 세션이다(범위 always)", async () => {
+  const db = migrated();
+  const id = pendingRequest(db, "req_always");
+  decidePermissionRequest(db, id, "allow_always", { approver: "team-lead" });
+  const row = db.prepare("SELECT status, decision_scope FROM permission_request WHERE id = ?").get(id) as {
+    status: string; decision_scope: string | null;
+  };
+  expect(row.status).toBe("allowed_always");
+  expect(row.decision_scope).toBe("always");
+  expect(await pollDecision(db, id, 1_000, 5)).toBe("approved_for_session");
+});

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -4,7 +4,8 @@
  * ★재빌드 아님:★ permissionGate.requestPermission(팝업 생성)+getPermissionRequest(상태) + telegramCapture(3버튼 렌더)
  * 를 재사용. onApproval이 ask면 여기서 팝업 띄우고 GD 결정을 폴링해 ReviewDecision으로 매핑한다.
  *
- * 매핑: allowed_once→approved · allowed_always→approved_for_session · denied/expired/timeout→denied.
+ * 매핑: allowed_once→approved(★decision_scope 가 session 이면 approved_for_session★) ·
+ * allowed_always→approved_for_session · denied/expired/timeout→denied.
  * ★안전: Tier-D는 여기 도달 전 judgeApproval에서 이미 denied(팝업 안 뜸). fail-closed: 에러/무응답→denied.★
  */
 import { createHash, randomUUID } from "node:crypto";

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -756,13 +756,22 @@ export async function pollDecision(db: Database, requestId: string, ttlMs = POPU
   const deadline = Date.now() + ttlMs;
   for (;;) {
     let status: string | undefined;
+    let scope: string | null | undefined;
     try {
-      status = getPermissionRequest(db, requestId)?.status;
+      const row = getPermissionRequest(db, requestId);
+      status = row?.status;
+      // ★status 와 decision_scope 를 같이 읽는다.★ '이 세션' 은 지속되는 허가를 남기지 않아
+      //   status 가 allowed_once 와 같다(permissionGate.ts) — 둘을 가르는 것은 이 칸뿐이다.
+      //   status 만 읽으면 사람이 세션을 골라도 런타임에는 '한번' 이 간다.
+      scope = row?.decision_scope ?? null;
     } catch {
       return "denied"; // ★fail-closed: 조회 에러 → 거절★
     }
     switch (status) {
-      case "allowed_once": return "approved";
+      // ★decision_scope 가 'session' 일 때만 세션으로 올린다.★ #325 이전에 결정된 행은 이 칸이
+      //   NULL 이다 — NULL 을 session 으로 읽으면 옛 '한번' 결정이 소급해서 세션 허용이 된다.
+      //   모르는 값도 같다: 좁은 쪽(approved)으로 떨어뜨린다.
+      case "allowed_once": return scope === "session" ? "approved_for_session" : "approved";
       case "allowed_always": return "approved_for_session";
       case "denied":
       case "expired": return "denied";


### PR DESCRIPTION
## 문제 (사실)

승인창에서 사람이 **'이 세션'** 을 골라도 codex 에는 **'한번'** 이 간다. 다음 같은 작업에서 다시 물어본다.

## 왜 그런가 (인과)

`decidePermissionRequest` 는 세션 결정을 이렇게 적는다(`permissionGate.ts:391~398`):

| 사람이 고른 것 | `status` | `decision_scope` |
|---|---|---|
| 한번 허용 | `allowed_once` | `once` |
| **이 세션** | **`allowed_once`** | **`session`** |
| 항상 허용 | `allowed_always` | `always` |

세션은 **지속되는 허가를 남기지 않으므로** status 가 `allowed_once` 와 같다. status 는 CHECK 로 값이 고정돼 있어 늘릴 수 없고(#325), 둘을 가르는 것은 `decision_scope` 뿐이다.

그런데 `pollDecision` 은 **status 만 읽는다** — 그래서 session 이 once 로 뭉개진다.

## 고친 것

status 와 `decision_scope` 를 같이 읽어, scope 가 `session` 일 때만 `approved_for_session` 으로 올린다.

**넓히는 쪽이 아니라 좁히는 쪽이 기본이다.**

- #325 이전에 결정된 행은 `decision_scope` 가 **NULL** 이다. NULL 을 session 으로 읽으면 옛 '한번' 결정이 소급해서 세션 허용이 된다.
- 칸이 아직 없는 설치본(`SELECT *` 에 안 나옴)과 모르는 값도 같은 자리(`approved`)로 떨어진다.
- `allowed_always` → `approved_for_session` 은 그대로다.

## 시험

6개. 경계를 **양쪽에서** 잰다 — 세션이 세션으로 가는가, 그리고 **세션이 아닌 것이 세션으로 새지 않는가.**

| 입력 | 기대 |
|---|---|
| `allow_session` 결정 | `approved_for_session` |
| `allow_once` 결정 (대조군) | `approved` |
| 옛 행 — status `allowed_once` · scope **NULL** | `approved` |
| 칸 자체가 없는 옛 스키마 | `approved` |
| 모르는 값 (`everything`) | `approved` |
| `allow_always` (회귀) | `approved_for_session` |

## 검증

- `tsc --noEmit` 통과.
- **뮤턴트 2종 사망**: status 만 읽게 되돌리면 **1 fail** · NULL 과 모르는 값도 세션으로 읽게 넓히면 **3 fail**.
- 전체 2622개 중 **2616 pass · 0 fail** (6 skip).
- **대조군**: 같은 워크트리에서 `origin/main` 도 돌렸다 — 2616개 중 2609 pass. 대조군에서 1건이 한 번 깨졌다가 재실행에서 재현되지 않았다. **변경 전 코드에서 난 것이고 이 변경과 무관하다.**

## 라이브 반영 조건

`decision_scope` 칸은 서버가 다시 뜨면서 migrate 가 돌아야 생긴다. 라이브 재현은 그 재시작이 선행이고, 재시작은 승인 게이트 대상이라 이 PR 범위 밖이다.

## 시험 환경 의존

이 저장소의 시험 일부는 `rules/TEAM-OS.md`(git 미추적)와 저장소 루트 `team.db` 가 워크트리에 있어야 통과한다. 클론 직후 환경에서는 그 2건이 실패한다 — 이 PR 과 무관한 별건이다.

Submitted-by: demis
