### PR TITLE
chore(permission-gate): 없는 방어선을 말하는 주석과 도달 불가 분기를 걷는다

### DIFF
--- a/src/server/lib/permissionGate.ts
+++ b/src/server/lib/permissionGate.ts
@@ -276,19 +276,6 @@ export function requestPermission(db: Database, op: PermissionOperation): { deci
   const evalResult = evaluatePermission(db, op);
   const scope_key = scopeKeyForOperation(op);
   const target = targetForOperation(op);
-  if (evalResult.decision === "deny") {
-    appendPermissionAudit(db, {
-      request_id: null,
-      scope_key,
-      op,
-      target,
-      decision: `tier_d_denied:${evalResult.reasons.join(",")}`,
-      approver: null,
-      provenance: { ...(op.provenance ?? {}), reasons: evalResult.reasons },
-    });
-    appendAuditFile("permission_gate", "tier_d_denied", scope_key, { runtime: op.runtime, agent_id: op.agent_id ?? null, action: op.action, reasons: evalResult.reasons });
-    return evalResult;
-  }
   if (evalResult.decision === "allow") return evalResult;
 
   const id = `prm_${randomUUID().replace(/-/g, "").slice(0, 18)}`;

--- a/src/server/runtimes/codex/adapter.ts
+++ b/src/server/runtimes/codex/adapter.ts
@@ -442,7 +442,8 @@ export function makeCodexAdapter(
       // ★관리자 설정(agents.json)을 grant로 seed(per-agent)★ — 미주입 시 preflight가 workspace-write/network를
       // 매 턴 tier-a "ask"로 차단해 버스 경로 Dex도 구조적 실행불가(2026-07-05 fix, 브릿지와 동일 근본).
       // ctx.workspaceRoot 미설정 → preflight가 agent.workspace_path 사용(per-agent 정확) + grant scope도 그에 맞춤.
-      // deps.permissionContext 명시 시엔 그대로 존중. Tier-D는 이 grant로도 통과 못 함(hardDeny 우선).
+      // deps.permissionContext 명시 시엔 그대로 존중.
+      // ★이 grant 위에 놓인 상위 거부 등급은 없다★ — Tier-D 판정은 경로에서 빠졌다(#316·#318).
       const turnStores = deps.permissionContext
         ? stores
         : {

--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -6,9 +6,10 @@
  *
  * 매핑: allowed_once→approved(★decision_scope 가 session 이면 approved_for_session★) ·
  * allowed_always→approved_for_session · denied/expired/timeout→denied.
- * ★안전: Tier-D는 requestPermission(permissionGate)이 ★팝업을 만들기 전에★ deny 로 반환한다("이중 안전" 지점).
- *   전에는 이 자리에 judgeApproval(우리 승인 판정)이 있었다. #316 에서 경계를 codex 설정으로 넘기며 그 판정을
- *   경로에서 뺐고, 함수는 아무도 부르지 않는 채 남아 있다가 삭제됐다. ★주석만 남으면 없는 방어선을 있다고 읽는다.★
+ * ★이 경로에 우리 쪽 자동 거부는 없다.★ requestPermission 은 allow 아니면 approval_required 만 낸다 —
+ *   팝업을 만들기 전에 걸러지는 요청은 없고, 위험한 요청도 ★사람 앞까지 올라온다.★
+ *   경계는 codex 설정이 정하고, 그 밖은 사람이 승인창에서 정한다(#316·#318).
+ *   Tier-D 사유는 판정이 아니라 ★팝업 본문 표시용★ 으로만 남는다 — 사람이 보고 고를 근거다.
  *   fail-closed(에러/무응답→denied)는 그대로다.
  */
 import { createHash, randomUUID } from "node:crypto";
@@ -679,12 +680,11 @@ function unparsedOperation(req: ApprovalRequest, agentId: string, provenance: Re
     //  ★해석에 실패했다고 위험 검사까지 건너뛰지 않는다.★
     //   해석 실패로 보내는 것은 ★열쇠를 좁히려는 것★ 이지 ★검사를 면제하려는 것★ 이 아니다.
     //   payload 를 안 실으면 이 요청의 Tier-D 스캔 입력이 ★0★ 이 되고, 그러면
-    //   `[1, "; sudo rm -rf /tmp/x"]` 같은 규격 밖 요청이 ★사람이 누를 수 있는 평범한 팝업★ 으로 내려온다
-    //   (Tier-D 는 사람도 승인 못 하는 등급인데, 스캔이 비면 그 등급이 붙을 근거가 없어진다 — 루이 실측).
-    //   ★알아볼 수 없는 것을 넓게 통과시키지 않는다★ 는 이 경로의 원래 취지와도 맞다.
+    //   `[1, "; sudo rm -rf /tmp/x"]` 같은 규격 밖 요청이 ★위험 표시가 하나도 없는 팝업★ 으로 내려온다.
+    //   판정은 이제 사람이 한다 — 그러니 ★사람이 볼 근거를 비워서 내리지 않는다.★
     //
-    //   ★부작용은 명시한다★: 거대 payload 안에 'sudo' 같은 문자열이 ★우연히★ 들어 있으면 hard-deny 가 된다.
-    //   해석조차 못 한 payload 에 대해서는 fail-closed 가 맞는 방향이라고 봤다.
+    //   ★부작용은 명시한다★: 거대 payload 안에 'sudo' 같은 문자열이 ★우연히★ 들어 있으면
+    //   팝업에 위험 사유가 붙는다. 거부되지는 않고, 사람이 보고 판단한다.
     //
     //   붙이는 자리는 ★맨 뒤★ 다 — 앞은 사람이 읽는 안내문이어야 한다(팝업 첫 줄).
     //   ★주의: 이 op 은 command·path·egress 가 없어서 text 가 곧 target(=열쇠) 이다.★

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -778,8 +778,8 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
     networkAccess: liveNetwork,
     // ★관리자 설정(agents.json codex_sandbox/network)을 permissionGate grant로 seed★.
     // 미주입 시 preflight가 workspace-write/network를 매 턴 tier-a "ask"로 차단 → Dex 구조적 실행불가
-    // (2026-07-05 GD 테스트에서 "덱스 있어?"조차 dead-end로 발견). Tier-D(danger-full-access)는 이 grant로도
-    // 통과 못 함(hardDeny가 grant보다 우선). scope는 preflight의 workspaceRoot 산출과 동일 값으로 맞춤.
+    // (2026-07-05 실측: "덱스 있어?"조차 dead-end). scope는 preflight의 workspaceRoot 산출과 동일 값으로 맞춤.
+    // ★이 grant 위에 놓인 상위 거부 등급은 없다★ — Tier-D 판정은 경로에서 빠졌다(#316·#318).
     permissionContext: deps.permissionContext ?? {
       workspaceRoot: liveWorkspaceRoot,
       grants: codexConfiguredGrants(liveAgentId, liveSandbox, liveNetwork, liveWorkspaceRoot),

--- a/src/server/runtimes/codex/permissions.ts
+++ b/src/server/runtimes/codex/permissions.ts
@@ -3,7 +3,6 @@ import type { CodexSandboxMode } from "../../types";
 import {
   grantKey,
   requestPermission,
-  safeCheckPermission,
   type PermissionAgent,
   type PermissionCheck,
   type PermissionContext,
@@ -16,7 +15,9 @@ import {
  * 이 grants 를 permissionContext 에 실어야 preflight 가 통과한다(미주입 시 tier-a "ask"로 매 턴 차단 → 구조적 실행불가).
  * grant scope 는 askRule 이 만드는 것과 ★정확히 동일★해야 매칭된다: sandbox=`workspace-write:${root}`, network=`net:*`.
  * (root 는 preflight 의 workspaceRoot 와 같은 값을 넘겨야 함 — 아래 codexRuntimePreflight 의 workspaceRoot 산출과 일치.)
- * Tier-D(danger-full-access 등)는 grant 로 부여 불가라 이 헬퍼로도 통과 못 한다(hardDeny 가 grant 이전에 deny).
+ *
+ * ★이 grant 를 막아 세우는 상위 등급은 없다.★ 전에는 Tier-D 가 grant 보다 먼저 deny 했지만
+ * 그 판정은 경로에서 빠졌다 — 지금 경계를 정하는 것은 codex 설정이고, 그 밖은 승인창에서 사람이 정한다.
  */
 export function codexConfiguredGrants(
   agentId: string,


### PR DESCRIPTION
## 핵심 3줄
1. 주석 5곳이 "Tier-D 가 먼저 막는다" 고 말하지만 그 판정은 #316·#318 에서 경로에서 빠졌다 — **없는 방어선을 있다고 읽게 된다.**
2. 라이브 영향 0. 동작 변경 없음 — 걷어낸 코드는 실행될 수 없던 분기와 호출되지 않는 import 다. codex 런타임 팀원은 현재 0명이다.
3. 주석 5곳 정정 + 도달 불가 코드 제거. **+15 / −26 (5파일)**, 실코드 삭제는 13줄.

## 무엇을 바꿨나

| 문제 | 고친 방법 |
|---|---|
| `appServerPopup.ts` 머리말이 "Tier-D 는 팝업을 만들기 전에 deny 로 반환한다" 고 말한다 | 걸러지는 요청은 없고 위험한 요청도 사람 앞까지 올라온다고 적는다 |
| 같은 파일 payload 스캔 주석이 "hard-deny 가 된다" · "사람도 승인 못 하는 등급" 이라고 말한다 | 팝업에 위험 사유가 붙을 뿐 거부되지 않는다. 스캔 입력을 비우지 않는 이유가 **판정에서 표시로** 바뀐 것을 반영 |
| `bridge.ts` · `adapter.ts` · `permissions.ts` 가 "Tier-D 는 이 grant 로도 통과 못 함(hardDeny 우선)" 이라고 말한다 | grant 위에 놓인 상위 거부 등급은 없다고 적는다 |
| `requestPermission` 의 deny 분기가 실행될 수 없다 | 제거 (13줄) |
| `permissions.ts` 가 `safeCheckPermission` 을 import 만 하고 호출하지 않는다 | import 제거 |

`tierDReasons` 는 그대로 둔다 — 팝업 본문에 위험 사유를 적는 입력이라 값이 있다.

---

## 왜 도달 불가인가 (실측)

`evaluatePermission` 의 return 은 두 개뿐이다:

```
if (grant) return { decision: "allow", ... };
return { decision: "approval_required", reasons: [] };
```

`deny` 를 반환하지 않는다. 따라서 `requestPermission` 의 `if (evalResult.decision === "deny")` 는 실행되지 않고, 그 안의 감사기록 `tier_d_denied` 는 **남을 수 없었다.**

`safeCheckPermission` 은 `permissions.ts` 의 import 문이 유일한 등장이다(호출 0회).

## 검증

```
검증 범위:  bun test 전체 (216파일) · bunx tsc --noEmit
base  6ff990a: 2652 pass / 1 fail
PR    615c17e: 2652 pass / 1 fail  (같은 시험)  → 신규 실패 0
tsc:          통과 (종료코드 0)
mutation:     evaluatePermission 에 Tier-D deny 를 되돌림
              → permissionGate.test.ts "★위험 명령도 우리가 미리 막지 않는다★" 실패 (14 pass / 1 fail)
              = 이 커밋이 의존하는 불변식은 기존 시험이 지키고 있다
미검증:       실물 동작 확인 불가 — codex 런타임 팀원이 현재 0명이라 승인창을 띄울 대상이 없다.
              걷어낸 것이 도달 불가 코드와 주석뿐이라 동작 검증 대상이 없다는 판단.
```

### 워크트리에서 잴 때의 잡음 (측정 조건)

이 저장소를 새 워크트리에서 재면 **변경과 무관한 실패 4건**이 먼저 깔린다. 둘 다 gitignore 대상이라 워크트리에 없기 때문이다.

| 없는 파일 | 실패 | 채우면 |
|---|---|---|
| `rules/TEAM-OS.md` (생성물) | 3건 | 사라짐 |
| `team.db` (런타임 상태) | 1건 — `bridge.test.ts` "cwd·환경변수와 무관하게 저장소의 team.db 를 가리킨다" | 사라짐 |

`team.db` 는 런타임 상태 파일이라 심링크하지 않는다.

**★이 저장소의 시험은 실행이 상태를 남긴다.★** 첫 실행이 워크트리에 `team.db` 를 만들어 두므로, **두 번째 실행부터는 위 1건이 통과한다.** 즉 base 와 PR 을 연속으로 재면 순서가 결과를 바꾼다 — 먼저 돈 쪽이 실패하고 나중에 돈 쪽이 통과해 회귀로 오독된다. 실측:

```
team.db 없는 상태 → bridge.test.ts:  32 pass / 1 fail   (이 실행이 team.db 를 생성)
지우지 않고 재실행 → bridge.test.ts:  33 pass / 0 fail
```

위 base/PR 숫자는 **매 실행 전에 `team.db` 를 지우고 각각 따로** 잰 값이다.

## 이 PR 에 넣지 않은 것

리뷰에서 `hardDeny` 제거가 함께 제안됐으나 범위에서 뺐다. 근거:

1. **기존 시험이 명시적으로 반대 계약을 건다.** `permissionGate.test.ts` 는 `checkPermission(...)` 이 `tier: "deny"` 를 반환할 것을 단언하고, "판정 함수 자체는 남아 있다 — 없어진 것은 그것으로 우리가 대신 결정하던 자리" 라고 적는다. 제거하려면 이 단언부터 지워야 하고, 그건 정리가 아니라 계약 변경이다.
2. **삭제 범위가 주석 정리보다 훨씬 넓다.** `codexRuntimePreflight` 는 현재 인자를 전부 `void` 처리하고 `null` 만 반환하는 stub 이다. 그래서 이 아래가 전부 함께 죽어 있다:
   - `persistCodexPermissionRequest` — 호출 0회
   - `adapter.ts:139` · `bridge.ts:470` · `runtimeSubscription.ts:62` 의 `if (preflight)` 세 블록 — 항상 거짓
   - `codexConfiguredGrants` → `permissionContext.grants` 배선 — 소비처가 그 stub 뿐

   이 중 두 곳은 사용자에게 보이는 실패 경로(텔레그램 안내문·런타임 차단 기록)를 지우는 일이라, 별도 PR 에서 따로 판단받는 것이 맞다고 봤다.

Submitted-by: Jane
