### PR TITLE
fix(codex): 턴이 도는 동안에도 승인 버튼을 받는다

### DIFF
--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -11,6 +11,7 @@
  * 채팅별 codex thread(resume sessionId)로 멀티턴 맥락 유지.
  */
 import { runCodexTurn, type CodexTurnOptions, type CodexTurnResult } from "./runner";
+import { createSerialTurnQueue } from "./serialTurnQueue";
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -806,6 +807,14 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
   } catch (e) {
     console.error(`[codex-bridge] getMe 실패(토큰/네트워크?) — getUpdates 후 marker 폴백: ${e instanceof Error ? e.message : e}`);
   }
+  // ★턴을 여기서 기다리지 않는다★ — 기다리면 턴이 도는 동안 getUpdates 를 못 부르고,
+  //   승인 팝업은 턴 도중에만 뜨므로 버튼 입력이 영영 안 들어온다(실측 2026-08-18: 승인 6건 중
+  //   5건이 생성 후 300~302초에 만료 = 턴 하드 타임아웃 300초. 사람이 눌러 처리된 건 0건).
+  //   ★직렬이다★ — 겹쳐 돌리면 app-server 클라이언트(팀원 단위 공유)의 turn 상태가 덮어써진다.
+  const turns = createSerialTurnQueue((e) => {
+    console.error(`[codex-bridge] 턴 처리 실패: ${e instanceof Error ? e.message : e}`);
+  });
+
   for (;;) {
     try {
       const res = await fetch(`${TG_API}/bot${token}/getUpdates?timeout=30&offset=${offset}&allowed_updates=["message","callback_query"]`);
@@ -839,8 +848,11 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
 	          continue;
 	        }
         console.log(`[codex-bridge] ← chat ${chatId}: ${text.slice(0, 60)}`);
-        const r = await handleMessage(chatId, text, messageId, live);
-        console.log(`[codex-bridge] → ${r.detail}: ${r.reply.slice(0, 60)}`);
+        // ★턴은 하나씩 돈다(직렬).★ 루프는 기다리지 않고 다음 업데이트로 간다 — 그래야 승인 버튼이 들어온다.
+        turns.enqueue(async () => {
+          const r = await handleMessage(chatId, text, messageId, live);
+          console.log(`[codex-bridge] → ${r.detail}: ${r.reply.slice(0, 60)}`);
+        });
       }
     } catch (e) {
       console.error("[codex-bridge] poll 오류:", (e as Error).message);

--- a/src/server/runtimes/codex/serialTurnQueue.test.ts
+++ b/src/server/runtimes/codex/serialTurnQueue.test.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "bun:test";
+import { createSerialTurnQueue } from "./serialTurnQueue";
+
+const tick = (ms = 0) => new Promise((r) => setTimeout(r, ms));
+
+test("★enqueue 는 기다리지 않고 즉시 돌아온다★ — 이게 없으면 폴링이 턴에 막힌다(교착)", () => {
+  const q = createSerialTurnQueue();
+  const t0 = Date.now();
+  q.enqueue(async () => { await tick(50); });
+  expect(Date.now() - t0).toBeLessThan(20);
+});
+
+test("★두 턴이 절대 겹치지 않는다★ — app-server 클라이언트가 팀원 단위 공유라 겹치면 첫 턴이 죽는다", async () => {
+  const q = createSerialTurnQueue();
+  let running = 0;
+  let maxConcurrent = 0;
+  const task = async () => {
+    running += 1;
+    maxConcurrent = Math.max(maxConcurrent, running);
+    await tick(20);
+    running -= 1;
+  };
+  // 서로 다른 대화에서 온 것처럼 여러 개를 한꺼번에 넣는다.
+  q.enqueue(task); q.enqueue(task); q.enqueue(task);
+  await q.drain();
+  expect(maxConcurrent).toBe(1);
+});
+
+test("★넣은 순서대로 돈다★ — 답이 뒤섞이면 안 된다", async () => {
+  const q = createSerialTurnQueue();
+  const order: string[] = [];
+  q.enqueue(async () => { await tick(30); order.push("첫째"); });
+  q.enqueue(async () => { await tick(1); order.push("둘째"); });
+  q.enqueue(async () => { order.push("셋째"); });
+  await q.drain();
+  expect(order).toEqual(["첫째", "둘째", "셋째"]);
+});
+
+test("★앞 턴이 터져도 다음 턴은 돈다★ — 예외 하나가 대기열을 영구히 막지 않는다", async () => {
+  const errs: unknown[] = [];
+  const q = createSerialTurnQueue((e) => errs.push(e));
+  const order: string[] = [];
+  q.enqueue(async () => { throw new Error("터짐"); });
+  q.enqueue(async () => { order.push("다음"); });
+  await q.drain();
+  expect(order).toEqual(["다음"]);
+  expect(errs.length).toBe(1);
+});
+
+test("★보고 함수가 터져도 다음 턴은 돈다★ — 오류 보고가 대기열을 막으면 안 된다", async () => {
+  const q = createSerialTurnQueue(() => { throw new Error("보고까지 터짐"); });
+  const order: string[] = [];
+  q.enqueue(async () => { throw new Error("턴 터짐"); });
+  q.enqueue(async () => { order.push("다음"); });
+  await q.drain();
+  expect(order).toEqual(["다음"]);
+});
+
+test("사슬이 끝나면 비었다고 보고한다 — 진단용", async () => {
+  const q = createSerialTurnQueue();
+  q.enqueue(async () => { await tick(1); });
+  expect(q.idle()).toBe(false);
+  await q.drain();
+  expect(q.idle()).toBe(true);
+});

--- a/src/server/runtimes/codex/serialTurnQueue.ts
+++ b/src/server/runtimes/codex/serialTurnQueue.ts
@@ -1,0 +1,51 @@
+/**
+ * 턴 직렬 대기열 — ★받는 창구를 막지 않으면서, 턴은 한 번에 하나만★ 돌린다.
+ *
+ * 왜 필요한가(교착): 폴링 루프가 턴을 그 자리에서 기다리면 그동안 getUpdates 를 다시 부르지 못한다.
+ * 그런데 ★승인 팝업은 턴이 도는 중에만 뜬다.★ 그래서 사람이 버튼을 눌러도 그 입력은 턴이 끝날
+ * 때까지 가져와지지 않고, 턴은 승인을 기다리다 제한시간에 죽는다.
+ * 실측(2026-08-18): 승인 6건 중 5건이 생성 후 300~302초에 만료 — 턴 하드 타임아웃 300초와 같다.
+ * 사람이 눌러서 처리된 건은 0건이었다.
+ *
+ * 왜 ★직렬★ 인가: 교착을 푸는 데 필요한 것은 "루프가 턴을 기다리지 않는 것" 이지 "턴을 겹쳐
+ * 돌리는 것" 이 아니다. app-server 클라이언트는 ★팀원 단위★ 로 공유되고(clientPool.acquireClient),
+ * `CodexAppServerClient.runTurn` 에는 ★동시 진입 가드가 없다★ — 두 번째 턴이 첫 턴의 resolve 와
+ * 타이머를 덮어써 첫 턴이 끝나지 않는다. 턴 실패 시 dropClient 도 팀원 단위라 한 대화의 실패가
+ * 다른 대화의 프로세스를 닫는다. ★지금까지 그 가정을 지켜준 것이 폴링 루프의 인라인 await 였다.★
+ * 그 잠금을 걷어내는 대신 여기로 옮긴다.
+ *
+ * 대화별 병렬은 클라이언트를 대화별로 만들거나 runTurn 에 가드를 넣은 다음의 일이다.
+ */
+
+export interface SerialTurnQueue {
+  /** 사슬 뒤에 붙여 실행한다. 즉시 반환한다(기다리지 않는다). */
+  enqueue: (run: () => Promise<void>) => void;
+  /** 사슬이 비어 있나(시험·진단용). */
+  idle: () => boolean;
+  /** 지금 사슬이 끝날 때까지(시험용). */
+  drain: () => Promise<void>;
+}
+
+export function createSerialTurnQueue(onError?: (err: unknown) => void): SerialTurnQueue {
+  let chain: Promise<void> = Promise.resolve();
+  let pending = 0;
+
+  // 보고가 터져도 사슬은 이어져야 한다 — 그러지 않으면 이 catch 자체가 대기열을 막는다.
+  const report = (err: unknown): void => {
+    try { onError?.(err); } catch { /* 보고 실패가 대기열을 막지 않는다 */ }
+  };
+
+  const enqueue = (run: () => Promise<void>): void => {
+    pending += 1;
+    // ★실패를 사슬에 흘리지 않는다★ — 한 턴의 예외가 뒤의 모든 턴을 막으면 안 된다.
+    chain = chain
+      .then(() => run().catch(report))
+      .then(() => { pending -= 1; });
+  };
+
+  return {
+    enqueue,
+    idle: () => pending === 0,
+    drain: async () => { await chain; },
+  };
+}


### PR DESCRIPTION
## 핵심 3줄
1. dex 에게 뭔가 시키면, codex 가 허락을 물어보는 순간 **버튼을 눌러도 아무 일도 일어나지 않는다.** 턴은 5분 뒤 타임아웃으로 죽는다.
2. **지금 라이브에서 매번 일어난다.** 승인 요청 6건 중 5건이 생성 후 300~302초에 만료됐고(턴 하드 타임아웃 300초), **사람이 눌러 처리된 건은 0건**이다.
3. 폴링 루프가 턴을 인라인으로 기다리던 것을 방별 대기열로 바꾼다 — 루프 1곳 + 새 모듈 45줄.

## 무엇이 잘못 동작했나

`runBridge` 의 폴링 루프는 업데이트를 하나씩 처리하며 `await handleMessage(...)` 로 턴이 끝나기를 기다렸다.
그동안 `getUpdates` 를 다시 부르지 못한다.

그런데 **codex 의 승인 요청은 턴이 도는 중에만 발생한다.** 그래서:

```
턴 시작 → codex 가 승인을 물음 → 팝업 전송 → 사람이 버튼 누름
                                              ↓
                          그 callback_query 는 getUpdates 로만 들어온다
                                              ↓
                     루프는 턴을 기다리는 중이라 getUpdates 를 못 부른다
                                              ↓
                턴은 승인을 기다림 → 300초 하드 타임아웃 → 요청 expired
```

턴은 승인을 기다리고, 승인은 턴이 끝나기를 기다린다.

## 관측값

| request_id | created | expired | 간격 |
|---|---|---|---|
| prm_6a24f07f… | 2026-08-18 02:18:17 | 02:23:18 | **300초** |
| prm_8eac31f7… | 2026-08-14 07:04:17 | 07:09:18 | **301초** |
| prm_3930ccdd… | 2026-08-13 12:28:41 | 12:33:43 | **302초** |
| prm_12e09579… | 2026-08-13 08:39:45 | 08:44:47 | **302초** |
| prm_942b3311… | 2026-08-13 07:18:42 | 07:23:43 | **300초** |

`TURN_TIMEOUT_MS` 기본값이 300_000ms 다. 만료 간격이 그 값에 붙어 있다 — 사람이 누른 시점과 무관하다.

## 어떻게 고쳤나

턴을 **직렬 대기열**에 넣고 루프는 즉시 다음 업데이트로 간다.

| 지켜야 하는 것 | 어떻게 |
|---|---|
| 승인 버튼이 들어온다 | 루프가 턴을 기다리지 않는다 — 이것이 이 PR 의 목적이다 |
| 두 턴이 겹치지 않는다 | 사슬 하나로 직렬 실행 |
| 순서 | 넣은 순서대로 |
| 한 턴의 예외 | 사슬에 흘리지 않는다 — 예외 하나가 대기열을 영구히 막지 않는다 |
| 오류 보고 자체의 예외 | 감싼다 — 보고가 터져도 다음 턴은 돈다 |

**왜 대화별 병렬이 아니라 직렬인가.** 교착을 푸는 데 필요한 것은 "루프가 턴을 기다리지 않는 것" 이지 "턴을 겹쳐 돌리는 것" 이 아니다.
app-server 클라이언트는 **팀원 단위**로 공유되고(`clientPool.acquireClient`), `CodexAppServerClient.runTurn` 에는 **동시 진입 가드가 없다** — 두 번째 턴이 첫 턴의 `turnResolve` 와 타이머를 덮어써 첫 턴이 끝나지 않는다. 턴 실패 시 `dropClient` 도 팀원 단위라 한 대화의 실패가 다른 대화의 프로세스를 닫는다.
지금까지 그 가정을 지켜준 것이 **폴링 루프의 인라인 `await`** 였다. 그 잠금을 없애는 대신 대기열로 옮긴다.
대화별 병렬은 클라이언트를 대화별로 만들거나 `runTurn` 에 가드를 넣은 다음의 일이다 — 이 PR 에서 같이 하지 않는다.

## 검증

```
검증 범위:  bun test (전체 218파일 2669 시험) · bunx tsc --noEmit · serialTurnQueue 단위 6건
baseline:   0 fail
mutation:   직렬을 깨고 병렬로                → 빨강 ✓ (동시 실행 0건 계약이 지켜진다)
            턴 실패를 사슬로 흘림              → 빨강 ✓
            보고 예외를 그대로 던짐            → 빨강 ✓
미검증:     ★라이브에서 실제 버튼을 눌러 확인하지 않았다★ — 재시작 후 팀 리드가 한 번 눌러야
            "눌러서 처리됨" 이 처음 관측된다. 단위 시험은 대기열의 순서·격리만 잰다.
            텔레그램 편집 제한(429)은 이 PR 범위 밖이다 — 팀 보존 로그에 관측 기록이 없다.
```

Submitted-by: Demis
