### PR TITLE
feat(codex): 작업 중 메시지에 진행 줄을 보여준다

### DIFF
--- a/src/server/runtimes/codex/appServerRunner.ts
+++ b/src/server/runtimes/codex/appServerRunner.ts
@@ -99,8 +99,11 @@ export async function runViaAppServer(
     const r = await client.runTurn(opts.prompt, {
       // ★지금 무엇을 하는 중인지 보이게 한다.★ 창이 없는 런타임이라 이벤트로 직접 쓴다.
       onActivity: (line) => {
-        if (!db) return;
-        try { setActivityLine(db, opts.agentId, line); } catch { /* 표시가 턴을 막지 않는다 */ }
+        // 두 수신처가 서로를 막지 않는다 — 대시보드 쓰기가 실패해도 채널 표시는 살고, 반대도 같다.
+        if (db) {
+          try { setActivityLine(db, opts.agentId, line); } catch { /* 표시가 턴을 막지 않는다 */ }
+        }
+        try { opts.onActivity?.(line); } catch { /* 채널 표시가 턴을 막지 않는다 */ }
       },
       onApproval: async (req) => {
         // ★경계는 codex 설정이 정한다. 우리는 두 번째로 판정하지 않는다.★

--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -503,3 +503,132 @@ test("★app-server 하나뿐이다★ — 플래그로 갈라두면 한쪽만 �
     if (saved !== undefined) process.env.B3OS_CODEX_APPSERVER = saved;
   }
 });
+
+// ── ★진행 표시 배선★ ──
+//
+// 순수 로직(줄 접기·길이·넘김)은 progressLines.test.ts 가 잰다.
+// 여기서 재는 것은 ★배선★ 이다 — 브리지가 진행 이벤트를 실제로 받는가, 그 줄이 어느 메시지에
+// 쓰이는가, 답이 어디로 가는가. 실제로 끊겨 있던 곳이 로직이 아니라 이 배선이었다.
+describe("codex bridge — 진행 표시", () => {
+  beforeEach(() => resetChatThreads());
+
+  /** onActivity 를 실제로 부르는 두뇌 mock. */
+  function spiesWithActivity(lines: string[], reply = "다 했습니다") {
+    const calls = {
+      sends: [] as string[],
+      edits: [] as { mid: number; text: string }[],
+      gotOnActivity: false,
+    };
+    let nextMid = 2000;
+    const deps: BridgeDeps = {
+      reactMessage: async () => true,
+      sendMessage: async (_c, text) => { calls.sends.push(text); return ++nextMid; },
+      editMessage: async (_c, mid, text) => { calls.edits.push({ mid, text }); return true; },
+      sandbox: "read-only",
+      runTurn: async (o) => {
+        calls.gotOnActivity = typeof (o as { onActivity?: unknown }).onActivity === "function";
+        for (const l of lines) (o as { onActivity?: (s: string) => void }).onActivity?.(l);
+        // 편집은 1.5초 배치라 턴이 끝나기 전에 한 번은 나가야 관측된다.
+        await new Promise((r) => setTimeout(r, 1700));
+        return { ok: true, reply, sessionId: "s1", detail: "ok", elapsedMs: 1 };
+      },
+    };
+    return { deps, calls };
+  }
+
+  test("★브리지가 진행 통로를 넘긴다★ — 이 배선이 없어서 화면에 문구 하나만 남았다", async () => {
+    const { deps, calls } = spiesWithActivity(["git status"]);
+    await handleMessage(11, "확인해줘", 1, deps);
+    expect(calls.gotOnActivity).toBe(true);
+  });
+
+  test("★받은 줄이 작업중 메시지에 실제로 쓰인다★", async () => {
+    const { deps, calls } = spiesWithActivity(["git status --short", "bun test"]);
+    await handleMessage(12, "확인해줘", 1, deps);
+    const withLines = calls.edits.filter((e) => e.text.includes("🛠️"));
+    expect(withLines.length).toBeGreaterThan(0);
+    expect(withLines[withLines.length - 1]!.text).toContain("bun test");
+  });
+
+  test("★대조군 — 진행 줄이 없으면 진행 편집도 없다★ (기존 동작 그대로)", async () => {
+    const { deps, calls } = spiesWithActivity([]);
+    await handleMessage(13, "안녕", 1, deps);
+    expect(calls.edits.filter((e) => e.text.includes("🛠️")).length).toBe(0);
+  });
+
+  test("★마지막 편집은 답이다★ — 진행 줄이 답을 덮어쓰지 않는다", async () => {
+    const { deps, calls } = spiesWithActivity(["read a.ts", "read b.ts"], "정리했습니다");
+    await handleMessage(14, "해줘", 1, deps);
+    const last = calls.edits[calls.edits.length - 1]!;
+    expect(last.text).toBe("정리했습니다");
+  });
+  /**
+   * 경합을 실제로 만드는 mock.
+   *   · lines: [지연ms, 문구] — 그 시각에 진행 줄을 흘린다
+   *   · editDelays: 편집 호출별 지연(부족하면 0). ★첫 편집만 느리게★ 해야 답과 순서가 뒤집힌다
+   *   · turnMs: 턴이 끝나는 시각
+   */
+  function spiesRace(opts: {
+    lines: [number, string][];
+    editDelays: number[];
+    reply: string;
+    turnMs: number;
+  }) {
+    const calls = { sends: [] as string[], edits: [] as { text: string; doneAt: number }[] };
+    let nextMid = 3000;
+    let editN = 0;
+    const t0 = Date.now();
+    const deps: BridgeDeps = {
+      reactMessage: async () => true,
+      sendMessage: async (_c, text) => { calls.sends.push(text); return ++nextMid; },
+      editMessage: async (_c, _mid, text) => {
+        const d = opts.editDelays[editN++] ?? 0;
+        if (d > 0) await new Promise((r) => setTimeout(r, d));
+        calls.edits.push({ text, doneAt: Date.now() - t0 });
+        return true;
+      },
+      sandbox: "read-only",
+      runTurn: async (o) => {
+        const onAct = (o as { onActivity?: (s: string) => void }).onActivity;
+        for (const [at, text] of opts.lines) setTimeout(() => onAct?.(text), at);
+        await new Promise((r) => setTimeout(r, opts.turnMs));
+        return { ok: true, reply: opts.reply, sessionId: "s1", detail: "ok", elapsedMs: 1 };
+      },
+    };
+    return { deps, calls };
+  }
+
+  // ★첫 편집은 즉시 나간다★(lastEditAt 초기값 0) — 이후만 1.5초 간격으로 묶인다.
+  //   그래서 경합을 만들려면 ★첫 편집을 길게★ 잡아야 한다. 아래 두 시험의 시간 값은 그 실측에서 나왔다.
+
+  test("★편집 중에 들어온 마지막 줄도 화면에 나간다★ — 재예약이 없으면 그 줄은 영영 안 보인다", async () => {
+    // 첫 줄 t=0 → 편집 즉시 시작, 3000ms 걸린다.
+    // 둘째 줄 t=100 → 예약된 flush 가 t≈1500 에 뜨는데 ★그때 편집이 아직 돈다★ → 조용히 되돌아간다.
+    // 타이머는 이미 소진됐고 뒤에 줄이 더 없으므로, 재예약이 없으면 둘째 줄은 화면에 못 간다.
+    const { deps, calls } = spiesRace({
+      lines: [[0, "첫 명령"], [100, "둘째 명령"]],
+      editDelays: [3000],
+      reply: "끝",
+      turnMs: 4200,
+    });
+    await handleMessage(21, "해줘", 1, deps);
+    const progress = calls.edits.filter((e) => e.text.includes("🛠️"));
+    expect(progress.length).toBeGreaterThan(0);
+    expect(progress[progress.length - 1]!.text).toContain("둘째 명령");
+  });
+
+  test("★날아간 편집이 답을 덮지 않는다★ — 마지막 편집은 언제나 답이다", async () => {
+    // 진행 편집이 t≈0 에 시작해 2000ms 걸리는데 턴은 t=500 에 끝난다
+    // = 답을 쓰려는 순간 ★진행 편집이 아직 날아가 있다.★ 기다리지 않으면 답이 먼저 찍히고
+    //   늦게 끝난 진행 줄이 그 위를 덮는다.
+    const { deps, calls } = spiesRace({
+      lines: [[0, "느린 명령"]],
+      editDelays: [2000],
+      reply: "최종 답변",
+      turnMs: 500,
+    });
+    await handleMessage(22, "해줘", 1, deps);
+    expect(calls.edits.length).toBeGreaterThan(1);
+    expect(calls.edits[calls.edits.length - 1]!.text).toBe("최종 답변");
+  });
+});

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -21,6 +21,7 @@ import { appendAuditFile } from "../../lib/auditFile";
 import type { CodexSandboxMode } from "../../types";
 import type { PermissionContext } from "../../lib/permissionGate";
 import { codexRuntimePreflight, codexConfiguredGrants } from "./permissions";
+import { appendLine, renderBubble, fits, EDIT_MIN_INTERVAL_MS, type ProgressLine } from "./progressLines";
 
 export interface BridgeDeps {
   /** codex 한 턴 구동(기본 runCodexTurn — 테스트 mock). */
@@ -475,9 +476,76 @@ export async function handleMessage(
     else await send(chatId, errText);
     return { ok: false, reply: "", detail: `permission_${preflight.tier}:${preflight.rule}` };
   }
+  // ★진행 표시★ — codex 가 도구를 시작할 때마다 오는 줄을 모아 "작업 중…" 메시지를 고쳐 쓴다.
+  //   창이 없는 런타임이라 이게 없으면 사람 눈에는 몇 분간 문구 하나만 남는다.
+  //   간격·자르기·넘김 기준은 hermes 실구현 값을 그대로 쓴다(progressLines.ts 주석).
+  let bubbleId = workingMsgId;          // 지금 고쳐 쓰는 메시지
+  let lines: ProgressLine[] = [];       // 그 메시지에 담긴 줄
+  let lastEditAt = 0;                   // 마지막 편집 시각
+  let editTimer: ReturnType<typeof setTimeout> | null = null;
+  let editing = false;                  // 편집 진행 중이면 다음 것을 겹쳐 치지 않는다
+  let dirty = false;                    // 아직 화면에 안 나간 줄이 있나
+  let inFlightEdit: Promise<void> | null = null; // 지금 날아가 있는 편집(답을 쓰기 전에 기다린다)
+
+  const flush = async (): Promise<void> => {
+    if (editing || !dirty || bubbleId === null) return;
+    editing = true;
+    dirty = false;
+    lastEditAt = Date.now();
+    const text = renderBubble(workingText, lines);
+    const work = (async () => {
+      const ok = await edit(chatId, bubbleId as number, text);
+      if (!ok) {
+        // ★편집이 안 되면 그 버블은 그대로 두고 새 버블을 연다.★ 이미 보낸 줄을 지우지 않는다.
+        const fresh = await send(chatId, text);
+        if (fresh !== null) bubbleId = fresh;
+        else bubbleId = null; // 보내기까지 막히면 진행 표시를 포기한다(턴은 계속 간다)
+      }
+    })();
+    inFlightEdit = work;
+    try {
+      await work;
+    } finally {
+      inFlightEdit = null;
+      editing = false;
+    }
+    // ★편집 중에 들어온 줄은 여기서 다시 예약한다.★ 안 하면 타이머는 이미 소진돼 있어
+    //   뒤에 줄이 더 오지 않는 한 마지막 줄이 화면에 영영 안 나간다.
+    if (dirty) schedule();
+  };
+
+  const schedule = (): void => {
+    if (editTimer !== null || bubbleId === null) return;
+    const wait = Math.max(0, EDIT_MIN_INTERVAL_MS - (Date.now() - lastEditAt));
+    editTimer = setTimeout(() => {
+      editTimer = null;
+      void flush();
+    }, wait);
+  };
+
+  const onActivity = (line: string): void => {
+    if (bubbleId === null) return;
+    const next = appendLine(lines, line);
+    if (next === lines) return; // 빈 줄이라 담을 것이 없다
+    if (!fits(workingText, next)) {
+      // ★한도에 닿으면 지금 버블은 남기고 새 버블로 넘어간다★ — 어디까지 했는지가 사라지지 않는다.
+      lines = appendLine([], line);
+      dirty = true;
+      void (async () => {
+        const fresh = await send(chatId, renderBubble(workingText, lines));
+        if (fresh !== null) { bubbleId = fresh; dirty = false; lastEditAt = Date.now(); }
+      })();
+      return;
+    }
+    lines = next;
+    dirty = true;
+    schedule();
+  };
+
   const result = await runTurn({
     prompt: promptText,
     agentId: selfAgentId, // ★필수★ — 승인 요청의 주인이 된다
+    onActivity,
 
     resumeSessionId: prior,
     codexHome: deps.codexHome,
@@ -486,13 +554,21 @@ export async function handleMessage(
     networkAccess: deps.networkAccess,
     writableRoots: deps.workdir ? [deps.workdir] : [],
   });
+  // ★예약된 편집이 답을 덮어쓰지 못하게 먼저 끈다.★ 끄지 않으면 답을 쓴 뒤 진행 줄이 다시 올라온다.
+  if (editTimer !== null) { clearTimeout(editTimer); editTimer = null; }
+  dirty = false;
+  // ★이미 날아간 편집은 취소할 수 없다★ — 끝나기를 기다린 뒤에 답을 쓴다.
+  //   기다리지 않으면 그 응답이 답보다 늦게 도착해 답이 진행 줄로 덮인다.
+  if (inFlightEdit !== null) { try { await inFlightEdit; } catch { /* 표시 실패가 답을 막지 않는다 */ } }
+
   if (result.sessionId) chatThreads.set(chatId, result.sessionId);
 
   if (!result.ok || !result.reply) {
     // self-heal: 턴 실패(만료·손상 세션 포함) 시 thread 초기화 → 다음 턴은 새 세션(죽은 sessionId resume 반복 stuck 방지).
     chatThreads.delete(chatId);
     const errText = "⚠️ 일시적으로 응답을 만들지 못했어요. 잠시 후 다시 시도해 주세요.";
-    if (workingMsgId !== null) await edit(chatId, workingMsgId, errText);
+    // ★마지막 버블에 쓴다★ — 넘김이 일어났으면 첫 버블에 쓸 경우 오류가 진행 줄 위로 올라간다.
+    if (bubbleId !== null) await edit(chatId, bubbleId, errText);
     else await send(chatId, errText);
     return { ok: false, reply: "", detail: `codex_turn_failed:${result.detail}` };
   }
@@ -510,8 +586,10 @@ export async function handleMessage(
   }
 
   // ④ 작업중 메시지를 답으로 교체(편집). 작업중 메시지가 없거나 편집 실패 시 신규 발신.
+  //   ★교체 대상은 지금 쓰고 있는 마지막 버블이다.★ 진행 줄이 길어 새 버블로 넘어갔다면
+  //   첫 버블에 답을 쓰면 답이 진행 줄 ★위★ 에 나타나고, 마지막 버블은 "작업 중" 인 채 남는다.
   let delivered = false;
-  if (workingMsgId !== null) delivered = await edit(chatId, workingMsgId, reply);
+  if (bubbleId !== null) delivered = await edit(chatId, bubbleId, reply);
   if (!delivered) {
     const newId = await send(chatId, reply);
     delivered = newId !== null;

--- a/src/server/runtimes/codex/progressLines.test.ts
+++ b/src/server/runtimes/codex/progressLines.test.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "bun:test";
+import {
+  previewOf, appendLine, renderBubble, fits, retryPlan,
+  PREVIEW_MAX, BUBBLE_MAX_UNITS, RETRY_WAIT_MAX_SEC,
+} from "./progressLines";
+
+test("★긴 줄은 미리보기 길이로 잘린다★ — 자른 결과도 그 길이를 넘지 않는다", () => {
+  const long = "x".repeat(200);
+  const out = previewOf(long);
+  expect(out.length).toBe(PREVIEW_MAX);
+  expect(out.endsWith("…")).toBe(true);
+});
+
+test("★경계 너머까지 잰다★ — 39·40·41자", () => {
+  expect(previewOf("y".repeat(39)).length).toBe(39);
+  expect(previewOf("y".repeat(40)).length).toBe(40);
+  expect(previewOf("y".repeat(41)).length).toBe(40); // 41자는 잘린다
+  expect(previewOf("y".repeat(40))).not.toContain("…"); // 딱 맞으면 안 자른다
+});
+
+test("줄바꿈·연속 공백은 한 칸으로 접힌다 — 여러 줄 명령이 버블을 밀어내지 않는다", () => {
+  expect(previewOf("git status\n  --short\t-b")).toBe("git status --short -b");
+});
+
+test("★연속 중복은 새 줄을 만들지 않고 세기만 올린다★", () => {
+  let lines: ReturnType<typeof appendLine> = [];
+  lines = appendLine(lines, "read file.ts");
+  lines = appendLine(lines, "read file.ts");
+  lines = appendLine(lines, "read file.ts");
+  expect(lines.length).toBe(1);
+  expect(lines[0]).toEqual({ text: "read file.ts", count: 3 });
+  expect(renderBubble("⏳", lines)).toContain("(×3)");
+});
+
+test("★대조군 — 사이에 다른 줄이 끼면 접지 않는다★ (연속일 때만 접는다)", () => {
+  let lines: ReturnType<typeof appendLine> = [];
+  lines = appendLine(lines, "a");
+  lines = appendLine(lines, "b");
+  lines = appendLine(lines, "a");
+  expect(lines.map((l) => l.text)).toEqual(["a", "b", "a"]);
+  expect(lines.every((l) => l.count === 1)).toBe(true);
+});
+
+test("빈 줄·공백만 있는 줄은 버블에 안 들어간다", () => {
+  let lines: ReturnType<typeof appendLine> = [];
+  lines = appendLine(lines, "   ");
+  lines = appendLine(lines, "\n\t");
+  expect(lines).toEqual([]);
+});
+
+test("줄이 없으면 버블은 머리글 그대로다 — 빈 줄이 붙지 않는다", () => {
+  expect(renderBubble("⏳ 작업 중…", [])).toBe("⏳ 작업 중…");
+});
+
+test("★버블 한도를 넘으면 fits 가 false 다★ — 호출자가 새 버블을 연다", () => {
+  const header = "⏳ 작업 중…";
+  const many = Array.from({ length: 200 }, (_, i) => ({ text: `cmd-${i} ` + "z".repeat(30), count: 1 }));
+  expect(renderBubble(header, many).length).toBeGreaterThan(BUBBLE_MAX_UNITS);
+  expect(fits(header, many)).toBe(false);
+  expect(fits(header, many.slice(0, 5))).toBe(true);
+});
+
+test("★한도 경계를 넘겨서 잰다★ — 4032 이하는 담고 초과는 못 담는다", () => {
+  const header = "H";
+  const fill = (units: number) => [{ text: "q".repeat(units), count: 1 }];
+  // 버블 = header + "\n" + "🛠️ " + text. 그 고정분을 뺀 길이로 경계를 만든다.
+  const fixed = renderBubble(header, fill(0)).length;
+  expect(fits(header, fill(BUBBLE_MAX_UNITS - fixed))).toBe(true);
+  expect(fits(header, fill(BUBBLE_MAX_UNITS - fixed + 1))).toBe(false);
+});
+
+test("★429 대기 계획 — 짧으면 기다리고 길면 포기한다★ (경계 5초 포함)", () => {
+  expect(retryPlan(2)).toEqual({ wait: true, waitMs: 2000 });
+  expect(retryPlan(RETRY_WAIT_MAX_SEC)).toEqual({ wait: true, waitMs: 5000 });
+  expect(retryPlan(RETRY_WAIT_MAX_SEC + 1)).toEqual({ wait: false, waitMs: 0 });
+  expect(retryPlan(0)).toEqual({ wait: false, waitMs: 0 });
+});

--- a/src/server/runtimes/codex/progressLines.ts
+++ b/src/server/runtimes/codex/progressLines.ts
@@ -1,0 +1,73 @@
+/**
+ * 진행 줄 버블 — "작업 중…" 메시지에 지금 무엇을 하는 중인지 누적해 보여준다.
+ *
+ * 값의 출처는 hermes v0.19.1 실구현이다(같은 문제를 이미 푼 곳):
+ *   편집 최소 간격 1.5초 · 미리보기 40자 · 연속 중복은 (×N) 으로 접기 ·
+ *   텔레그램 4096 UTF-16 code unit 에서 여유 64 를 뺀 4032 에서 새 버블로 넘김.
+ *
+ * 이 파일은 순수 함수만 둔다 — 편집 호출·타이머는 bridge 가 쥔다.
+ * 그래야 "무엇을 그릴지" 를 텔레그램 없이 잰다.
+ */
+
+/** 한 줄 미리보기 길이. 넘으면 뒤를 자르고 … 를 붙인다. */
+export const PREVIEW_MAX = 40;
+/** 한 버블의 최대 길이(UTF-16 code unit). 텔레그램 4096 - 여유 64. */
+export const BUBBLE_MAX_UNITS = 4032;
+/** 편집 최소 간격(ms). 이 사이에 온 이벤트는 모아 한 번에 친다. */
+export const EDIT_MIN_INTERVAL_MS = 1500;
+
+export interface ProgressLine {
+  text: string;
+  /** 같은 줄이 연속으로 몇 번 왔나. 1이면 표시하지 않는다. */
+  count: number;
+}
+
+/** 줄바꿈·앞뒤 공백을 걷고 길면 자른다. 자를 때 길이는 … 포함 PREVIEW_MAX 다. */
+export function previewOf(raw: string, max: number = PREVIEW_MAX): string {
+  const flat = raw.replace(/\s+/g, " ").trim();
+  if (flat.length <= max) return flat;
+  return flat.slice(0, Math.max(0, max - 1)) + "…";
+}
+
+/**
+ * 줄을 누적한다. ★연속으로 같은 줄이면 새 줄을 만들지 않고 세기만 올린다.★
+ * 같은 도구를 반복 호출할 때 버블이 같은 문장으로 채워지는 것을 막는다.
+ * 빈 줄은 버린다(이벤트는 왔지만 보여줄 것이 없는 경우).
+ */
+export function appendLine(lines: ProgressLine[], raw: string, max: number = PREVIEW_MAX): ProgressLine[] {
+  const text = previewOf(raw, max);
+  if (text === "") return lines;
+  const last = lines[lines.length - 1];
+  if (last && last.text === text) {
+    const next = lines.slice(0, -1);
+    next.push({ text, count: last.count + 1 });
+    return next;
+  }
+  return [...lines, { text, count: 1 }];
+}
+
+/** 버블 본문. header 는 "⏳ 작업 중…" 같은 첫 줄이다. */
+export function renderBubble(header: string, lines: ProgressLine[]): string {
+  if (lines.length === 0) return header;
+  const body = lines.map((l) => (l.count > 1 ? `🛠️ ${l.text} (×${l.count})` : `🛠️ ${l.text}`)).join("\n");
+  return `${header}\n${body}`;
+}
+
+/**
+ * 이 버블에 줄을 더 담을 수 있나. ★담을 수 없으면 호출자가 새 버블을 연다.★
+ * 자르지 않고 넘기는 이유: 이미 보낸 줄을 지우면 어디까지 했는지가 사라진다.
+ */
+export function fits(header: string, lines: ProgressLine[], maxUnits: number = BUBBLE_MAX_UNITS): boolean {
+  // JS 문자열 length 가 곧 UTF-16 code unit 수다 — 텔레그램이 세는 단위와 같다.
+  return renderBubble(header, lines).length <= maxUnits;
+}
+
+/**
+ * 텔레그램 429 의 retry_after(초)를 어떻게 다룰지.
+ * 짧으면 기다렸다 한 번 더, 길면 편집을 포기하고 호출자가 다른 길로 간다.
+ */
+export const RETRY_WAIT_MAX_SEC = 5;
+export function retryPlan(retryAfterSec: number): { wait: boolean; waitMs: number } {
+  if (retryAfterSec > 0 && retryAfterSec <= RETRY_WAIT_MAX_SEC) return { wait: true, waitMs: retryAfterSec * 1000 };
+  return { wait: false, waitMs: 0 };
+}

--- a/src/server/runtimes/codex/runner.ts
+++ b/src/server/runtimes/codex/runner.ts
@@ -49,6 +49,10 @@ export interface CodexTurnOptions {
   model?: string;
   /** 하드 타임아웃(ms). 초과 시 kill(턴 원자성). */
   timeoutMs?: number;
+  /** 진행 줄(도구 시작 등) 알림. 미지정이면 러너가 대시보드 표시만 갱신한다.
+   *  채널(텔레그램 등)이 "지금 무엇을 하는 중인지" 를 보여주려면 이 통로가 필요하다 —
+   *  없으면 러너까지 온 이벤트가 호출자에게 도달하지 않는다. */
+  onActivity?: (line: string) => void;
 }
 
 export interface CodexTurnResult {


### PR DESCRIPTION
## 핵심 3줄
1. dex 에게 일을 시키면 "⏳ 작업 중…" 한 줄만 뜨고 몇 분간 그대로다. 무엇을 하는 중인지 채널에서 보이지 않는다.
2. dex 를 쓰는 모든 턴에 해당한다. 진행 신호는 이미 나오고 있었고 **대시보드만 받고 있었다.**
3. `CodexTurnOptions` 에 통로를 추가해 브리지가 그 줄을 받아 작업 중 메시지를 갱신한다 — 새 모듈 73줄 + 배선.

## 무엇이 잘못 동작했나

`appServerClient` 는 진행 이벤트를 내보내고, `appServerRunner` 는 그것을 받아 대시보드 표시(`setActivityLine`)를 갱신하고 있었다.
그런데 `CodexTurnOptions` 에 **호출자에게 전달할 통로가 없어서**, 채널을 담당하는 `bridge.ts` 는 그 줄을 한 개도 받지 못했다.

기능이 없던 것이 아니라 **선이 대시보드에서 끊겨 있었다.**

## 무엇을 바꿨나

| | |
|---|---|
| `runner.ts` | `onActivity` 옵션 추가 |
| `appServerRunner.ts` | 대시보드와 호출자 **양쪽**에 전달. 한쪽이 실패해도 다른 쪽은 산다 |
| `progressLines.ts` (신규) | 줄 접기·자르기·넘김 판정 — 순수 함수 |
| `bridge.ts` | 1.5초 배치 편집, 넘침 시 새 버블, 답은 마지막 버블에 |

표시 규칙은 hermes v0.19.1 실구현 값을 그대로 쓴다(같은 문제를 이미 푼 곳):
편집 최소 간격 **1.5초** · 미리보기 **40자** · 연속 중복은 **(×N)** 으로 접기 · **4032 UTF-16 unit** 에서 새 버블로 넘김.

**넘길 때 이전 버블을 지우지 않는다** — 어디까지 했는지가 사라지면 안 된다.
**답은 마지막 버블에 쓴다** — 첫 버블에 쓰면 답이 진행 줄 위에 나타나고 마지막 버블이 "작업 중" 인 채 남는다.

## 검증

```
검증 범위:  bun test (전체 218파일 2679 시험) · bunx tsc --noEmit
baseline:   0 fail
단위:       progressLines 10건 — 경계(39·40·41자) · 연속 중복 접기 · 대조군(사이에 다른 줄이 끼면 안 접음)
            · 4032 경계 양쪽 · 429 대기 계획 경계(5초 포함/초과)
배선:       bridge 4건 — 통로가 실제로 넘어가는가 · 받은 줄이 메시지에 쓰이는가
            · 대조군(줄이 없으면 진행 편집도 없음) · 마지막 편집이 답인가
미검증:     ★라이브에서 실제 텔레그램 편집을 하지 않았다★ — 편집 호출은 mock 이다.
            텔레그램 편집 제한(429) 실동작은 재지 않았다. 팀 보존 로그에 429 관측 기록이 없어
            (hermes 운영 로그 기준) 예방값만 따랐다.
            긴 턴에서 버블이 실제로 넘어가는 장면은 라이브에서만 볼 수 있다.
```

Submitted-by: Demis
