### PR TITLE
test(codex): team.db 경로 시험이 비추적 파일에 기대지 않게 한다

### DIFF
--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -463,8 +463,8 @@ test("승인과 무관한 콜백은 건드리지 않는다", async () => {
 // ★답을 못 보내서 사람 화면엔 로딩중만 돌았다.★
 
 import { defaultTeamDbPath } from "./bridge";
-import { existsSync as dbExists } from "node:fs";
-import { isAbsolute } from "node:path";
+import { existsSync as pathExists } from "node:fs";
+import { isAbsolute, dirname, join as joinPath } from "node:path";
 
 test("★cwd·환경변수와 무관하게 저장소의 team.db 를 가리킨다★", () => {
   const before = process.cwd();
@@ -476,7 +476,11 @@ test("★cwd·환경변수와 무관하게 저장소의 team.db 를 가리킨다
     expect(isAbsolute(p)).toBe(true);
     expect(p.endsWith("/team.db")).toBe(true);
     expect(p.startsWith("/tmp/")).toBe(false); // cwd 를 따라가면 안 된다
-    expect(dbExists(p)).toBe(true);            // 실제로 열 수 있는 파일이어야 한다
+    // ★가리키는 폴더가 실제 저장소 루트여야 한다.★
+    //   전에는 team.db 자체의 존재를 봤는데, 그 파일은 ★git 이 추적하지 않는다★ —
+    //   worktree·새 클론·CI 에는 없어서 시험이 브랜치와 무관하게 빨간불이 났다(2026-08-18 실측).
+    //   추적되는 파일로 같은 것을 잰다: 경로가 엉뚱하면 여기서 걸린다.
+    expect(pathExists(joinPath(dirname(p), "package.json"))).toBe(true);
   } finally {
     process.chdir(before);
     if (saved !== undefined) process.env.B3OS_REPO_ROOT = saved;


### PR DESCRIPTION
## 핵심 3줄
1. `bridge.test.ts` 의 team.db 경로 시험이 **git 이 추적하지 않는 `team.db` 파일이 있어야만 통과**한다. worktree·새 클론·CI 에는 그 파일이 없어 **브랜치와 무관하게 빨간불**이 난다.
2. 같은 트리에서 다시 돌리면 재현되지 않아, 오늘 세 번 관측하고도 원인을 못 잡았다 — 브랜치 쪽을 뒤지게 만든다.
3. 의도(경로가 엉뚱하면 잡는다)는 그대로 두고, **추적되는 파일**로 같은 것을 잰다.

## 무엇이 잘못 동작했나

```
expect(dbExists(p)).toBe(true);   // 실제로 열 수 있는 파일이어야 한다
```

`team.db` 는 팀 상태 파일이라 gitignore 대상이다. 즉 이 시험은 **"이 체크아웃에 팀 DB 가 있는가"** 를 재고 있었고, 그건 코드의 성질이 아니라 **환경의 성질**이다.

증상: 격리 worktree 에서 `1 fail`, 같은 트리 재실행은 `0 fail`. `origin/main` 에서도 동일하게 실패한다.

## 어떻게 고쳤나

```
expect(pathExists(joinPath(dirname(p), "package.json"))).toBe(true);
```

가리키는 **폴더가 저장소 루트인지**를 본다. `package.json` 은 추적되는 파일이라 어느 체크아웃에나 있다.

## 검증

```
검증 범위:  bun test (전체) · bridge.test.ts 33건
baseline:   0 fail  ← ★worktree 에서도 0 fail★ (고치기 전에는 이 트리에서 1 fail)
mutation:   경로를 한 단계 얕게(엉뚱한 폴더)      → 빨강 ✓
            cwd 를 따라가게(원래 버그 재현)        → 빨강 ✓
            = 느슨해져서 통과한 것이 아니다. 이 시험이 막으려던 결함은 그대로 잡는다.
미검증:     CI 환경에서 직접 돌려보지 않았다(로컬 worktree 로만 확인).
```

Submitted-by: Demis
