### PR TITLE
fix(codex): 1:1 대화 맥락이 재시작을 넘어 이어지게 한다

### DIFF
--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -694,3 +694,74 @@ test("★대조군 — 대기열이 콜백 처리를 늦추지 않는다★ (턴
   expect(elapsed).toBeLessThan(1000); // 턴(1500ms)을 기다리지 않았다
   await turns.drain();
 });
+
+// ── ★재시작 넘어 맥락이 이어지는가 (배선)★ ──
+//
+// 순수 저장 로직은 dmSessionStore.test.ts 가 잰다. 여기서는 ★브리지가 그것을 실제로 쓰는지★ 를 잰다 —
+// 실제로 끊겨 있던 곳이 저장소가 아니라 배선이었다(브리지가 codex_session_map 을 참조하지 않았다).
+describe("codex bridge — 1:1 세션 재시작 연속성", () => {
+  beforeEach(() => resetChatThreads());
+
+  /** 인메모리 지도가 빈 상태 = 방금 재시작한 상황. */
+  function spiesWithSessions(store: { get: (c: number) => string | undefined; save: (c: number, s: string) => void; clear: (c: number) => void }) {
+    const seen: { resume?: string }[] = [];
+    const deps: BridgeDeps = {
+      reactMessage: async () => true,
+      sendMessage: async () => 900,
+      editMessage: async () => true,
+      sandbox: "read-only",
+      dmSessions: store,
+      runTurn: async (o) => {
+        seen.push({ resume: o.resumeSessionId });
+        return { ok: true, reply: "답", sessionId: "sess-new", detail: "ok", elapsedMs: 1 };
+      },
+    };
+    return { deps, seen };
+  }
+
+  test("★재시작 후에도 지난 세션으로 이어간다★ — 이 배선이 없으면 매 재시작마다 첫 대화가 된다", async () => {
+    const saved = new Map<number, string>([[42, "sess-before-restart"]]);
+    const { deps, seen } = spiesWithSessions({
+      get: (c) => saved.get(c),
+      save: (c, s) => { saved.set(c, s); },
+      clear: (c) => { saved.delete(c); },
+    });
+    await handleMessage(42, "이어서 하자", 1, deps);
+    expect(seen[0]!.resume).toBe("sess-before-restart");
+  });
+
+  test("★대조군 — 기억하는 곳이 없으면 새 대화로 시작한다★ (고치기 전 동작)", async () => {
+    const { deps, seen } = spiesWithSessions({ get: () => undefined, save: () => {}, clear: () => {} });
+    await handleMessage(43, "안녕", 1, deps);
+    expect(seen[0]!.resume).toBeUndefined();
+  });
+
+  test("턴이 끝나면 그 세션을 적는다 — 다음 재시작이 이어받을 수 있게", async () => {
+    const saved = new Map<number, string>();
+    const { deps } = spiesWithSessions({
+      get: (c) => saved.get(c),
+      save: (c, s) => { saved.set(c, s); },
+      clear: (c) => { saved.delete(c); },
+    });
+    await handleMessage(44, "해줘", 1, deps);
+    expect(saved.get(44)).toBe("sess-new");
+  });
+
+  test("★턴이 실패하면 저장된 세션을 지운다★ — 죽은 세션을 계속 resume 하면 매번 실패한다", async () => {
+    const saved = new Map<number, string>([[45, "sess-dead"]]);
+    const deps: BridgeDeps = {
+      reactMessage: async () => true,
+      sendMessage: async () => 900,
+      editMessage: async () => true,
+      sandbox: "read-only",
+      dmSessions: {
+        get: (c) => saved.get(c),
+        save: (c, s) => { saved.set(c, s); },
+        clear: (c) => { saved.delete(c); },
+      },
+      runTurn: async () => ({ ok: false, reply: "", detail: "boom", elapsedMs: 1 }),
+    };
+    await handleMessage(45, "해줘", 1, deps);
+    expect(saved.has(45)).toBe(false);
+  });
+});

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -12,6 +12,7 @@
  */
 import { runCodexTurn, type CodexTurnOptions, type CodexTurnResult } from "./runner";
 import { createSerialTurnQueue } from "./serialTurnQueue";
+import { makeDmSessionStore, NOOP_DM_SESSION_STORE, type DmSessionStore } from "./dmSessionStore";
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -56,6 +57,8 @@ export interface BridgeDeps {
   scheduleToolEnabled?: boolean;
   /** Host-side executor for structured schedule requests emitted by the Codex turn. */
   registerScheduleReminder?: (req: ScheduleMarkerRequest, ctx: ScheduleMarkerContext) => Promise<string>;
+  /** 1:1 대화 세션을 재시작 넘어 기억한다. 미지정이면 기억하지 않는다(시험 기본값). */
+  dmSessions?: DmSessionStore;
 }
 
 // 채팅별 codex thread(resume sessionId) → 같은 대화 맥락 유지.
@@ -444,7 +447,15 @@ export async function handleMessage(
   const workingMsgId = await send(chatId, workingText);
 
   // ③ 두뇌 호출(채팅별 thread resume로 맥락 유지)
-  const prior = chatThreads.get(chatId);
+  //   ★인메모리 지도가 비어 있으면 저장된 것을 본다★ — 그 지도는 재시작마다 비고,
+  //   그때 사람 쪽에서는 앞 대화를 잊은 것으로 보인다(2026-08-18 실측: 브리지가 codex_session_map 을
+  //   참조하지 않아 1:1 대화만 맥락이 끊겼다. 버스로 온 일은 그 표를 써서 이어졌다).
+  const sessions = deps.dmSessions ?? NOOP_DM_SESSION_STORE;
+  let prior = chatThreads.get(chatId);
+  if (prior === undefined) {
+    prior = sessions.get(chatId);
+    if (prior !== undefined) chatThreads.set(chatId, prior); // 다음 턴부터는 메모리에서 바로
+  }
   const toolAwareText = scheduleRequest
     ? scheduleToolPrompt({
         text,
@@ -561,11 +572,15 @@ export async function handleMessage(
   //   기다리지 않으면 그 응답이 답보다 늦게 도착해 답이 진행 줄로 덮인다.
   if (inFlightEdit !== null) { try { await inFlightEdit; } catch { /* 표시 실패가 답을 막지 않는다 */ } }
 
-  if (result.sessionId) chatThreads.set(chatId, result.sessionId);
+  if (result.sessionId) {
+    chatThreads.set(chatId, result.sessionId);
+    sessions.save(chatId, result.sessionId); // 재시작 넘어 기억한다
+  }
 
   if (!result.ok || !result.reply) {
     // self-heal: 턴 실패(만료·손상 세션 포함) 시 thread 초기화 → 다음 턴은 새 세션(죽은 sessionId resume 반복 stuck 방지).
     chatThreads.delete(chatId);
+    sessions.clear(chatId); // ★죽은 세션을 저장해두면 재시작 후에도 계속 그것으로 resume 한다★
     const errText = "⚠️ 일시적으로 응답을 만들지 못했어요. 잠시 후 다시 시도해 주세요.";
     // ★마지막 버블에 쓴다★ — 넘김이 일어났으면 첫 버블에 쓸 경우 오류가 진행 줄 위로 올라간다.
     if (bubbleId !== null) await edit(chatId, bubbleId, errText);
@@ -863,6 +878,8 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
       workspaceRoot: liveWorkspaceRoot,
       grants: codexConfiguredGrants(liveAgentId, liveSandbox, liveNetwork, liveWorkspaceRoot),
     },
+    // 라이브에서는 1:1 세션을 team.db 에 기억한다(재시작 넘어 맥락 유지).
+    dmSessions: deps.dmSessions ?? makeDmSessionStore(liveAgentId, defaultTeamDbPath()),
     sendMessage: deps.sendMessage ?? tgSend(token),
     editMessage: deps.editMessage ?? tgEdit(token),
     reactMessage: deps.reactMessage ?? tgReact(token),

--- a/src/server/runtimes/codex/dmSessionStore.test.ts
+++ b/src/server/runtimes/codex/dmSessionStore.test.ts
@@ -1,0 +1,93 @@
+import { test, expect, describe } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { migrate } from "../../db/migrate";
+import { makeDmSessionStore, NOOP_DM_SESSION_STORE, DM_SURFACE } from "./dmSessionStore";
+import { CodexSessionStore } from "./state";
+
+function freshDbPath(): string {
+  const p = join(mkdtempSync(join(tmpdir(), "dmsess-")), "team.db");
+  const db = new Database(p);
+  migrate(db);
+  db.prepare(
+    `INSERT OR IGNORE INTO agent(id, display_name, role, runtime, status_provider, workspace_path, persona_file)
+     VALUES('dex','Dex','runtime','codex','codex_cli','/tmp/dex','AGENTS.md')`,
+  ).run();
+  db.close();
+  return p;
+}
+
+describe("1:1 세션 기억 — 재시작 연속성", () => {
+  test("★재시작을 넘어 기억한다★ — 이게 없으면 재시작마다 앞 대화를 잊는다", () => {
+    const dbPath = freshDbPath();
+
+    // 재시작 전: 턴이 끝나 세션을 적는다
+    const before = makeDmSessionStore("dex", dbPath);
+    before.save(7066867819, "sess-abc");
+
+    // ★재시작★ — 새 프로세스가 뜬 상황(인메모리 지도는 비어 있다)
+    const after = makeDmSessionStore("dex", dbPath);
+    expect(after.get(7066867819)).toBe("sess-abc");
+  });
+
+  test("★대조군 — 기억하지 않는 구현에서는 끊긴다★ (고치기 전 동작)", () => {
+    NOOP_DM_SESSION_STORE.save(7066867819, "sess-abc");
+    expect(NOOP_DM_SESSION_STORE.get(7066867819)).toBeUndefined();
+  });
+
+  test("대화별로 따로 기억한다 — 다른 방의 맥락이 섞이면 안 된다", () => {
+    const dbPath = freshDbPath();
+    const s = makeDmSessionStore("dex", dbPath);
+    s.save(111, "sess-a");
+    s.save(222, "sess-b");
+    expect(s.get(111)).toBe("sess-a");
+    expect(s.get(222)).toBe("sess-b");
+  });
+
+  test("같은 대화를 다시 적으면 최신으로 덮는다 — 옛 세션으로 resume 하면 안 된다", () => {
+    const dbPath = freshDbPath();
+    const s = makeDmSessionStore("dex", dbPath);
+    s.save(111, "sess-old");
+    s.save(111, "sess-new");
+    expect(s.get(111)).toBe("sess-new");
+  });
+
+  test("★죽은 세션은 지운다★ — 안 지우면 재시작 후에도 계속 그것으로 resume 해 매번 실패한다", () => {
+    const dbPath = freshDbPath();
+    const s = makeDmSessionStore("dex", dbPath);
+    s.save(111, "sess-dead");
+    s.clear(111);
+    expect(s.get(111)).toBeUndefined();
+    expect(makeDmSessionStore("dex", dbPath).get(111)).toBeUndefined(); // 재시작 후에도
+  });
+
+  test("★버스 기록과 섞이지 않는다★ — 같은 표를 쓰되 surface 로 가른다", () => {
+    const dbPath = freshDbPath();
+    const db = new Database(dbPath);
+    new CodexSessionStore(db).save({
+      agentId: "dex", surface: "team_bus", conversationKey: "111", codexSessionId: "bus-sess",
+    });
+    db.close();
+
+    const s = makeDmSessionStore("dex", dbPath);
+    expect(s.get(111)).toBeUndefined();  // 버스 행을 1:1 세션으로 읽지 않는다
+    s.save(111, "dm-sess");
+
+    const check = new Database(dbPath);
+    const rows = check.prepare("SELECT surface, codex_session_id FROM codex_session_map WHERE conversation_key='111' ORDER BY surface").all() as { surface: string; codex_session_id: string }[];
+    check.close();
+    expect(rows).toEqual([
+      { surface: "team_bus", codex_session_id: "bus-sess" },
+      { surface: DM_SURFACE, codex_session_id: "dm-sess" },
+    ]);
+  });
+
+  test("★DB 를 못 열어도 대화는 계속된다★ — 기억 실패는 불편이지 고장이 아니다", () => {
+    const s = makeDmSessionStore("dex", "/nonexistent-dir/nope/team.db");
+    expect(() => s.save(111, "x")).not.toThrow();
+    expect(s.get(111)).toBeUndefined();
+    expect(() => s.clear(111)).not.toThrow();
+  });
+});

--- a/src/server/runtimes/codex/dmSessionStore.ts
+++ b/src/server/runtimes/codex/dmSessionStore.ts
@@ -1,0 +1,82 @@
+/**
+ * 1:1 대화의 codex 세션을 ★재시작 넘어★ 기억한다.
+ *
+ * 왜 필요한가(실측 2026-08-18): 브리지는 대화→세션 지도를 ★메모리에만★ 들고 있었다
+ * (`chatThreads` Map). 그래서 브리지가 재시작될 때마다 그 지도가 비고, 다음 턴은
+ * `resumeSessionId` 없이 시작한다 = ★사람 쪽에서는 앞 대화를 잊은 것으로 보인다.★
+ *
+ * 저장 자리는 이미 있었다 — `codex_session_map`. 다만 전 52행이 전부 `surface=team_bus` 였고
+ * 브리지는 그 표를 ★한 번도 참조하지 않았다★(브리지 파일 내 참조 0건).
+ * 버스로 온 일은 맥락이 이어지고 사람이 직접 건 대화는 안 이어지던 것이 그 차이다.
+ *
+ * 여기서는 그 표에 `surface="telegram_dm"` 으로 같이 적는다. 버스 쪽 행과 섞이지 않는다.
+ */
+import { Database } from "bun:sqlite";
+import { CodexSessionStore } from "./state";
+
+/** 이 표에서 1:1 대화가 쓰는 surface. 버스(team_bus)와 갈라 둔다. */
+export const DM_SURFACE = "telegram_dm";
+
+export interface DmSessionStore {
+  /** 이 대화의 지난 세션. 없으면 undefined(새 대화로 시작). */
+  get: (chatId: number) => string | undefined;
+  /** 턴이 성공하면 그 세션을 적는다. */
+  save: (chatId: number, sessionId: string) => void;
+  /** 세션이 죽었을 때 지운다 — 죽은 세션을 계속 resume 하면 매번 실패한다. */
+  clear: (chatId: number) => void;
+}
+
+/** 아무것도 저장하지 않는 구현(시험·주입용 기본값). */
+export const NOOP_DM_SESSION_STORE: DmSessionStore = {
+  get: () => undefined,
+  save: () => {},
+  clear: () => {},
+};
+
+/**
+ * team.db 를 여는 실제 구현.
+ * ★DB 문제가 대화를 막지 않는다★ — 읽기 실패는 '지난 세션 없음', 쓰기 실패는 조용히 넘긴다.
+ * 맥락이 끊기는 것은 불편이지만, 답을 못 하는 것은 고장이다.
+ */
+export function makeDmSessionStore(agentId: string, dbPath: string): DmSessionStore {
+  let db: Database | null = null;
+  const open = (): Database | null => {
+    if (db) return db;
+    try {
+      db = new Database(dbPath);
+      return db;
+    } catch {
+      return null;
+    }
+  };
+  const store = (): CodexSessionStore | null => {
+    const d = open();
+    return d ? new CodexSessionStore(d) : null;
+  };
+  return {
+    get: (chatId) => {
+      try {
+        return store()?.get(agentId, DM_SURFACE, String(chatId));
+      } catch {
+        return undefined;
+      }
+    },
+    save: (chatId, sessionId) => {
+      try {
+        store()?.save({
+          agentId,
+          surface: DM_SURFACE,
+          conversationKey: String(chatId),
+          codexSessionId: sessionId,
+        });
+      } catch { /* 기억 실패가 답을 막지 않는다 */ }
+    },
+    clear: (chatId) => {
+      try {
+        open()?.prepare(
+          `DELETE FROM codex_session_map WHERE agent_id = ? AND surface = ? AND conversation_key = ?`,
+        ).run(agentId, DM_SURFACE, String(chatId));
+      } catch { /* 지우기 실패가 답을 막지 않는다 */ }
+    },
+  };
+}


### PR DESCRIPTION
## 핵심 3줄
1. dex 와 1:1 로 나눈 대화는 **브리지가 재시작될 때마다 맥락이 끊긴다.** 사람 쪽에서는 앞 대화를 잊은 것으로 보인다.
2. 재시작마다 해당한다 — 오늘만 세 번 재시작했다. 버스로 들어온 일은 안 끊긴다. **사람이 직접 건 대화만 끊긴다.**
3. 이미 있는 `codex_session_map` 에 `surface="telegram_dm"` 으로 함께 적는다 — 새 모듈 80줄 + 배선 3곳.

## 무엇이 잘못 동작했나

브리지는 대화→세션 지도를 **메모리에만** 들고 있었다.

```
const chatThreads = new Map<number, string>();   // 프로세스와 함께 사라진다
const prior = chatThreads.get(chatId);           // 재시작 후에는 언제나 undefined
```

`resumeSessionId` 가 없으면 codex 는 **새 대화**로 시작한다.

**저장할 자리는 이미 있었다.** `codex_session_map` — 그런데 실측하면:

| | |
|---|---|
| 표의 행 수 | 52건 |
| 그중 `surface` | **전부 `team_bus`** |
| 브리지 파일의 그 표 참조 | **0건** |

버스로 온 일은 그 표를 써서 맥락이 이어지고, 1:1 대화만 안 이어지던 것이 이 차이다. 같은 런타임인데 들어온 문이 다르면 기억이 달랐다.

## 어떻게 고쳤나

| | |
|---|---|
| 읽기 | 인메모리 지도가 비어 있을 때만 저장된 값을 본다(지도는 캐시) |
| 쓰기 | 턴이 성공하면 저장한다 |
| 지우기 | 턴이 실패하면 저장된 세션도 지운다 — **죽은 세션을 남기면 재시작 후에도 계속 그것으로 resume 해 매번 실패한다** |
| 분리 | `surface="telegram_dm"` — 버스 행과 섞이지 않는다 |
| 실패 처리 | DB 를 못 열어도 대화는 계속된다. **맥락이 끊기는 것은 불편이지만 답을 못 하는 것은 고장이다** |

## 검증

```
검증 범위:  bun test (전체 221파일 2713 시험) · bunx tsc --noEmit
baseline:   0 fail
단위:       dmSessionStore 7건 — ★재시작을 흉내 내서 잰다★(저장 후 새 인스턴스로 읽기)
            · 대조군(기억 안 하는 구현에서는 끊긴다) · 대화별 분리 · 최신으로 덮기
            · 죽은 세션 지우기 · 버스 행과 섞이지 않음 · DB 못 열 때
배선:       bridge 4건 — 재시작 후 지난 세션으로 resume · 대조군 · 성공 시 저장 · 실패 시 삭제
mutation:   surface 를 버스와 같게        → 빨강 ✓
            clear 가 아무것도 안 지움      → 빨강 ✓
            저장된 세션을 안 읽음          → 빨강 ✓
            성공해도 저장 안 함            → 빨강 ✓
            실패해도 죽은 세션을 안 지움   → 빨강 ✓
미검증:     ★라이브에서 실제로 재시작해 이어지는지는 배포 후에만 관측된다.★
            수용시험의 '재시작 연속성' 항목이 이 PR 이후에 측정 가능해진다 —
            배포 → 대화 → 재시작 → 같은 대화 이어가기 순으로 재야 한다.
```

## 수용시험 항목과의 관계

`docs/RUNTIME_ACCEPTANCE.md` 의 **재시작 연속성**은 지금까지 "서버 재시작 필요" 로 미측정이었다.
이번에 코드를 읽어 **측정 전에 이미 답이 나왔다** — 그 경로에 저장이 없으니 이어질 수 없다.
이 PR 은 그 항목을 "측정 가능" 으로 바꾼다.

Submitted-by: Demis
