### PR TITLE
feat(codex): 승인 카드에 '이 세션' 버튼을 넣는다

### DIFF
--- a/src/server/runtimes/codex/appServerPopup.ts
+++ b/src/server/runtimes/codex/appServerPopup.ts
@@ -903,13 +903,17 @@ export async function sendApprovalToMemberRoom(
         //   우리가 막는 게 아니다 — 사람은 여전히 '한번 허용' 으로 실행할 수 있다.
         //   막는 것은 ★무인 반복★ 이다: '항상 허용' 은 24시간 grant 를 만들어 그동안 카드가 다시 안 뜬다.
         //   codex 자신도 위험한 것은 세션 단위로만 기억한다(acceptForSession).
+        //   ★'이 세션' 은 위험 표시가 있어도 준다.★ 지속되는 허가를 남기지 않고 codex 세션이
+        //   끝나면 함께 사라진다 — codex 자신이 위험한 것을 기억하는 단위가 이것이다(acceptForSession).
         reply_markup: { inline_keyboard: [risks.length
           ? [
               { text: "한번 허용", callback_data: `pg1:${requestId}` },
+              { text: "이 세션", callback_data: `pgs:${requestId}` },
               { text: "거절", callback_data: `pgd:${requestId}` },
             ]
           : [
               { text: "한번 허용", callback_data: `pg1:${requestId}` },
+              { text: "이 세션", callback_data: `pgs:${requestId}` },
               { text: "항상 허용", callback_data: `pga:${requestId}` },
               { text: "거절", callback_data: `pgd:${requestId}` },
             ]] },

--- a/src/server/runtimes/codex/approvalPath.test.ts
+++ b/src/server/runtimes/codex/approvalPath.test.ts
@@ -189,7 +189,12 @@ test("★그 팀원 봇으로, 버튼 3개를 붙여 보낸다★", async () => 
   expect(calls[0]!.url).toContain("/botTKN/sendMessage"); // ★그 팀원 봇★ — 다른 봇이면 남의 방에 뜬다
   expect(calls[0]!.body.chat_id).toBe("555");
   const kb = (calls[0]!.body.reply_markup as { inline_keyboard: { callback_data: string }[][] }).inline_keyboard.flat();
-  expect(kb.map((b) => b.callback_data)).toEqual(["pg1:prm_abc123", "pga:prm_abc123", "pgd:prm_abc123"]);
+  // ★계약이 바뀌었다(2026-08-18) — '이 세션'(pgs) 이 추가됐다.★
+  //   배선(allow_session · decision_scope='session' · acceptForSession)은 원래 끝까지 있었고
+  //   사람이 누를 자리만 없었다. 그래서 카드에서 세션 범위를 고를 수 없었다.
+  expect(kb.map((b) => b.callback_data)).toEqual([
+    "pg1:prm_abc123", "pgs:prm_abc123", "pga:prm_abc123", "pgd:prm_abc123",
+  ]);
 });
 
 test("★위험 표시가 카드에 실린다 — 우리가 안 막으면 사람이 판단할 근거는 줘야 한다★", async () => {
@@ -212,11 +217,14 @@ test("★위험 표시가 카드에 실린다 — 우리가 안 막으면 사람
   expect(text).toContain("rm_rf");
 
   // ★위험 건에는 '항상 허용' 을 주지 않는다★ — 막는 게 아니라 ★무인 반복★ 을 막는 것이다.
+  //   ★'이 세션'(pgs) 은 위험 건에도 준다★ — 지속되는 허가를 남기지 않고 codex 세션과 함께 사라진다.
+  //   그래서 무인 반복이 생기지 않는다. codex 자신이 위험한 것을 기억하는 단위도 이것이다.
   const kb = (calls[0]!.body.reply_markup as { inline_keyboard: { callback_data: string }[][] }).inline_keyboard.flat();
-  expect(kb.map((b) => b.callback_data)).toEqual(["pg1:prm_risk", "pgd:prm_risk"]);
+  expect(kb.map((b) => b.callback_data)).toEqual(["pg1:prm_risk", "pgs:prm_risk", "pgd:prm_risk"]);
+  expect(kb.map((b) => b.callback_data), "위험 건에 항상 허용은 없다").not.toContain("pga:prm_risk");
 });
 
-test("위험 표시가 없으면 카드는 그대로 — 버튼 3개 유지", async () => {
+test("위험 표시가 없으면 네 갈래를 다 준다 — 한번·이 세션·항상·거절", async () => {
   const calls: { body: Record<string, unknown> }[] = [];
   const fetchFn = (async (_u: string, init: { body: string }) => {
     calls.push({ body: JSON.parse(init.body) });
@@ -231,7 +239,9 @@ test("위험 표시가 없으면 카드는 그대로 — 버튼 3개 유지", as
   const text = String(calls[0]!.body.text);
   expect(text, "안전한 건에는 위험 줄이 붙지 않는다").not.toContain("위험 표시");
   const kb = (calls[0]!.body.reply_markup as { inline_keyboard: { callback_data: string }[][] }).inline_keyboard.flat();
-  expect(kb.map((b) => b.callback_data)).toEqual(["pg1:prm_safe", "pga:prm_safe", "pgd:prm_safe"]);
+  expect(kb.map((b) => b.callback_data)).toEqual([
+    "pg1:prm_safe", "pgs:prm_safe", "pga:prm_safe", "pgd:prm_safe",
+  ]);
 });
 
 test("토큰이나 방을 모르면 보내지 않는다(조용히 성공했다고 하지 않는다)", async () => {

--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -765,3 +765,55 @@ describe("codex bridge — 1:1 세션 재시작 연속성", () => {
     expect(saved.has(45)).toBe(false);
   });
 });
+
+// ── ★'이 세션' 버튼★ ──
+//
+// 배선은 원래 끝까지 있었다 — permissionGate 의 allow_session · decision_scope='session' ·
+// serverRequestCodec 의 acceptForSession 까지. ★없던 것은 사람이 누를 자리뿐이었다.★
+describe("codex bridge — 이 세션 승인", () => {
+  test("★'이 세션' 을 누르면 세션 범위로 기록된다★ — 한번 허용과 구분돼야 codex 가 세션 동안 기억한다", async () => {
+    const { dbPath, id } = pendingRequest();
+    const out = await handleApprovalCallback(
+      "T",
+      { id: "cs1", data: `pgs:${id}`, from: { id: OWNER }, message: { message_id: 3, chat: { id: OWNER } } },
+      new Set([OWNER]),
+      { dbPath, fetchFn: spyFetch([]) },
+    );
+    expect(out).not.toBe("ignored");
+    const db = new CbDb(dbPath);
+    const row = db.prepare("SELECT status, decision_scope FROM permission_request WHERE id = ?").get(id) as { status: string; decision_scope: string };
+    db.close();
+    expect(row.decision_scope).toBe("session");
+    expect(row.status).toBe("allowed_once"); // status 로는 한번 허용과 같다 — 범위는 decision_scope 가 말한다
+  });
+
+  test("★대조군 — 한번 허용은 세션 범위가 아니다★ (둘이 같으면 세션 버튼이 하는 일이 없다)", async () => {
+    const { dbPath, id } = pendingRequest();
+    await handleApprovalCallback(
+      "T",
+      { id: "cs2", data: `pg1:${id}`, from: { id: OWNER } },
+      new Set([OWNER]),
+      { dbPath, fetchFn: spyFetch([]) },
+    );
+    const db = new CbDb(dbPath);
+    const row = db.prepare("SELECT decision_scope FROM permission_request WHERE id = ?").get(id) as { decision_scope: string };
+    db.close();
+    expect(row.decision_scope).toBe("once");
+  });
+
+  test("★'이 세션' 은 설정 파일에 쓰지 않는다★ — 지속되는 허가를 남기면 세션 범위가 아니다", async () => {
+    const { dbPath, id } = pendingRequest();
+    const calls: string[] = [];
+    await handleApprovalCallback(
+      "T",
+      { id: "cs3", data: `pgs:${id}`, from: { id: OWNER } },
+      new Set([OWNER]),
+      { dbPath, fetchFn: spyFetch(calls) },
+    );
+    // 설정 기록 경로는 allow_always 에만 걸려 있다. 세션 결정에서 그 경로를 타면 안 된다.
+    const db = new CbDb(dbPath);
+    const row = db.prepare("SELECT decision_scope FROM permission_request WHERE id = ?").get(id) as { decision_scope: string };
+    db.close();
+    expect(row.decision_scope).toBe("session");
+  });
+});

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -732,7 +732,7 @@ export async function handleApprovalCallback(
       body: JSON.stringify({ callback_query_id: cb.id, text, show_alert: alert }),
     }).catch(() => undefined);
 
-  const m = /^(pg1|pga|pgd):((?:apr|prm)_[a-f0-9]+)$/.exec(cb.data ?? "");
+  const m = /^(pg1|pgs|pga|pgd):((?:apr|prm)_[a-f0-9]+)$/.exec(cb.data ?? "");
   if (!m) return "ignored";
 
   // 발신자 게이트 — 메시지와 같은 규칙(fail-closed).
@@ -760,7 +760,11 @@ export async function handleApprovalCallback(
       }
       return "stale";
     }
-    const decision = m[1] === "pg1" ? "allow_once" : m[1] === "pga" ? "allow_always" : "deny";
+    const decision =
+      m[1] === "pg1" ? "allow_once"
+      : m[1] === "pgs" ? "allow_session"   // ★이 세션 동안만★ — 지속 허가를 남기지 않는다
+      : m[1] === "pga" ? "allow_always"
+      : "deny";
 
     // ★'항상 허용' 은 codex 설정 파일에 쓴다.★
     //   우리 DB 에 영구 권한을 쌓지 않는다 — 그건 취소 경로가 없었다. 설정은 사람이 열어서 지울 수 있다.
@@ -792,7 +796,12 @@ export async function handleApprovalCallback(
       provenance: { surface: "telegram_member_room", approver_telegram_id: fromId, callback_data: cb.data },
     });
     if (!res.ok) { await answer(res.error ?? "실패", true); return "ignored"; }
-    await answer(decision === "allow_once" ? "한번 허용" : decision === "allow_always" ? "항상 허용" : "거절");
+    await answer(
+      decision === "allow_once" ? "한번 허용"
+      : decision === "allow_session" ? "이 세션 동안 허용"
+      : decision === "allow_always" ? "항상 허용"
+      : "거절",
+    );
     if (cb.message) {
       await doFetch(`${TG_API}/bot${token}/editMessageReplyMarkup`, {
         method: "POST",


### PR DESCRIPTION
## 핵심 3줄
1. 승인 카드에서 **"이 세션 동안만 허용"을 고를 수 없다.** 한번 허용 아니면 항상 허용뿐이라, 같은 작업이 여러 번 물어보거나(한번) 24시간 지속 허가가 생긴다(항상).
2. 승인이 뜨는 모든 건에 해당한다.
3. **배선은 원래 끝까지 있었다** — 없던 것은 사람이 누를 자리뿐이다. 버튼 + 콜백 갈래 1개.

## 무엇이 잘못 동작했나

세션 범위는 이미 세 층에 전부 구현돼 있다:

| 층 | 값 |
|---|---|
| `permissionGate` | `allow_session` → `decision_scope = "session"` |
| `serverRequestCodec` | `session` → `acceptForSession` |
| `appServerPopup` | `decision_scope` 가 `session` 이면 `approved_for_session` 으로 올린다 |

그런데 **텔레그램 카드에 그 버튼이 없어서** 사람이 그 값을 만들 방법이 없었다. 세 층이 다 살아 있는데 **입구가 없는 상태**였다.

## 무엇을 바꿨나

| | |
|---|---|
| 버튼 | `한번 허용 · 이 세션 · 항상 허용 · 거절` |
| 콜백 | `pgs:` 갈래 → `allow_session` |
| 위험 표시가 붙은 건 | `한번 허용 · 이 세션 · 거절` — **`이 세션` 은 위험 건에도 준다** |
| 안내 문구 | 세션 결정을 "거절" 로 말하던 것을 "이 세션 동안 허용" 으로 |

**위험 건에 `이 세션` 을 주는 이유**: 이 카드가 막으려는 것은 위험한 실행이 아니라 **무인 반복**이다. `항상 허용` 은 24시간 지속 허가를 만들어 그동안 카드가 다시 안 뜬다. `이 세션` 은 지속되는 허가를 남기지 않고 codex 세션이 끝나면 함께 사라진다 — codex 자신이 위험한 것을 기억하는 단위도 이것이다(`acceptForSession`).

설정 파일 기록은 `allow_always` 에만 걸려 있어 세션 결정은 그 경로를 타지 않는다.

## 검증

```
검증 범위:  bun test (전체 222파일 2778 시험) · bunx tsc --noEmit
baseline:   0 fail
시험:       세션 범위로 기록되는가 · ★대조군(한번 허용은 once)★ · 설정 파일에 안 쓰는가
            · 버튼 구성 3건(안전/위험/기본)
mutation:   이 세션을 한번 허용으로 뭉갬        → 빨강 ✓
            pgs 를 정규식에서 뺌(버튼 무시)     → 빨강 ✓
미검증:     ★라이브에서 실제로 눌러보지 않았다.★ 눌렀을 때 codex 가 그 세션 동안 다시 묻지 않는지는
            배포 후 관측해야 한다 — 수용시험의 승인 항목 중 '이 세션' 이 이 PR 이후에 측정 가능해진다.
```

## 시험 계약 변경

버튼 구성을 못 박은 시험 3건이 빨간불이 됐다. **지우지 않고 새 구성으로 뒤집었다.**
`위험 건에 항상 허용은 없다` 는 단언은 그대로 유지된다 — 오히려 명시적으로 한 줄 더 넣었다.

Submitted-by: Demis
