### PR TITLE
fix(rules): 룰을 고치면 기존 팀원 로딩파일도 되맞춘다

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -54,6 +54,7 @@ import { ensureDailyTaskReviewJobs, ensureWeeklySelfLearningJobs } from "./sched
 import { renderAndRepoint } from "./lib/teamOsRender";
 import { installProgressHook, repairProgressHook, repairReplyGuardHook, ensureOwnerGateHook } from "./runtimes/claude/launcher";
 import { writeMemberPersona, savePersonaFile } from "./lib/writeMemberPersona";
+import { refreshLoadingFiles } from "./lib/refreshLoadingFiles";
 import { persistOwnerChatIdIfEmpty } from "./runtimes/codex/launcher";
 import { createApprovalsApp } from "./routes/approvals";
 import { createPermissionGateRoutes } from "./routes/permissionGate";
@@ -177,6 +178,29 @@ try {
     try { repairReplyGuardHook(cid); } catch { /* best-effort */ }
     // ★owner-gate 만 "없으면 깐다" 다★ — 위 둘과 목적이 반대다(주석은 launcher 쪽에).
     try { ensureOwnerGateHook(cid); } catch { /* best-effort */ }
+  }
+  // ★이미 있는 로딩파일(CLAUDE.md/AGENTS.md) 되맞추기 — 게이트 밖★ (위 훅 수리와 같은 이유·같은 형태).
+  //   룰을 고쳐 배포·재시작해도 기존 팀원 파일은 그대로였다(2026-08-18 실측: 렌더 결과에는 새 문장이
+  //   있는데 팀원 AGENTS.md 는 6일 전 파일 그대로, 그 문장 0건). 정본 룰 파일은 심링크로 닿아서
+  //   이 간극이 드러나지 않았다 — ★핵심룰 요약만 조용히 낡는다.★
+  //   ★없는 파일은 만들지 않는다★(영입 절차의 몫) — 그래서 게이트가 지키려던 실멤버 보호가 유지된다.
+  //   렌더러는 SOUL.md 를 건드리지 않고 skip-if-unchanged 다.
+  {
+    const teamNameForRefresh = (db.query("SELECT value FROM setting WHERE key = 'team_name'").get() as { value: string } | null)?.value ?? undefined;
+    const r = refreshLoadingFiles(
+      agents
+        .filter((a) => a.runtime !== "b3os_native")
+        .map((a) => ({
+          id: a.id, display_name: a.display_name, role: a.role, runtime: a.runtime,
+          bot_username: a.telegram_bot_username ?? undefined,
+          workspace_path: a.workspace_path, persona_file: a.persona_file,
+          owner_name: ownerRow?.value ?? undefined, team_name: teamNameForRefresh,
+          team_collect_enabled: false,
+        })),
+    );
+    // ★결과를 로그로 남긴다★ — 조용한 성공은 조용한 실패와 구별되지 않는다.
+    if (r.updated.length > 0) console.log(`[teamos-render] 로딩파일 되맞춤: ${r.updated.join(", ")}`);
+    for (const s of r.skipped) console.warn(`[teamos-render] 로딩파일 되맞춤 실패(계속) ${s.id}: ${s.reason}`);
   }
   // ★옛 합류 깃발 정리 (일회성 전환, 전 환경)★ — 2026-08-05 이전 영입은 `.b3os-just-joined` 에
   //   지시 없이 `joined` 한 줄만 들어 있다. 지금 룰은 "있으면 읽고·따르고·지워라" 라

--- a/src/server/lib/refreshLoadingFiles.test.ts
+++ b/src/server/lib/refreshLoadingFiles.test.ts
@@ -1,0 +1,96 @@
+/**
+ * ★두 방향을 같은 무게로 건다.★
+ *   ① 있는 파일은 되맞춘다 — 이게 없으면 룰을 고쳐도 팀원에게 안 닿는다
+ *   ② ★없는 파일은 만들지 않는다★ — 이게 없으면 게이트가 지키려던 '실멤버 보호' 가 깨진다
+ * 한쪽만 재면 다음 사람이 반대쪽으로 고쳐도 초록이다.
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { refreshLoadingFiles } from "./refreshLoadingFiles";
+import type { WriteMemberPersonaInput } from "./writeMemberPersona";
+
+const ws = (): string => mkdtempSync(join(tmpdir(), "refresh-loading-"));
+
+const member = (id: string, runtime: string, workspace: string): WriteMemberPersonaInput => ({
+  id,
+  display_name: id,
+  role: "QA",
+  runtime,
+  workspace_path: workspace,
+  persona_file: `${workspace}/SOUL.md`,
+});
+
+describe("refreshLoadingFiles", () => {
+  test("★있는 로딩파일은 되맞춘다★ — 이게 없으면 룰을 고쳐도 팀원에게 안 닿는다", () => {
+    const w = ws();
+    writeFileSync(join(w, "AGENTS.md"), "옛 내용", "utf8");
+    const calls: string[] = [];
+    const r = refreshLoadingFiles([member("dex", "codex", w)], (m) => {
+      calls.push(m.id);
+      return { written: [join(w, "AGENTS.md")] };
+    });
+    expect(calls).toEqual(["dex"]);
+    expect(r.updated).toEqual(["dex"]);
+    expect(r.absent).toEqual([]);
+  });
+
+  test("★없는 로딩파일은 만들지 않는다★ — 게이트가 지키려던 실멤버 보호가 이것이다", () => {
+    const w = ws(); // AGENTS.md 를 만들지 않는다
+    const calls: string[] = [];
+    const r = refreshLoadingFiles([member("newbie", "codex", w)], (m) => {
+      calls.push(m.id);
+      return { written: [] };
+    });
+    expect(calls, "★파일이 없는데 렌더러를 불렀다★").toEqual([]);
+    expect(r.absent).toEqual(["newbie"]);
+    expect(r.updated).toEqual([]);
+    expect(existsSync(join(w, "AGENTS.md")), "★없던 파일이 생겼다★").toBe(false);
+  });
+
+  test("claude 런타임은 CLAUDE.md 를 본다 — 런타임마다 로딩파일이 다르다", () => {
+    const w = ws();
+    writeFileSync(join(w, "CLAUDE.md"), "옛 내용", "utf8");
+    const r = refreshLoadingFiles([member("steve", "claude_channel", w)], () => ({ written: [join(w, "CLAUDE.md")] }));
+    expect(r.updated).toEqual(["steve"]);
+
+    // 대조군 — 같은 런타임인데 AGENTS.md 만 있으면 대상이 아니다
+    const w2 = ws();
+    writeFileSync(join(w2, "AGENTS.md"), "옛 내용", "utf8");
+    const r2 = refreshLoadingFiles([member("steve2", "claude_channel", w2)], () => ({ written: ["x"] }));
+    expect(r2.absent).toEqual(["steve2"]);
+  });
+
+  test("내용이 같으면 갱신했다고 말하지 않는다 — skip-if-unchanged 를 그대로 전한다", () => {
+    const w = ws();
+    writeFileSync(join(w, "AGENTS.md"), "같은 내용", "utf8");
+    const r = refreshLoadingFiles([member("dex", "codex", w)], () => ({ written: [] }));
+    expect(r.updated).toEqual([]);
+    expect(r.absent).toEqual([]);
+  });
+
+  test("★렌더 대상이 아닌 런타임은 사유를 남긴다★ — 조용히 사라지면 왜 안 됐는지 아무도 모른다", () => {
+    const w = ws();
+    const r = refreshLoadingFiles([member("nat", "b3os_native", w)], () => ({ written: ["x"] }));
+    expect(r.skipped).toHaveLength(1);
+    expect(r.skipped[0]!.id).toBe("nat");
+    expect(r.skipped[0]!.reason).toContain("b3os_native");
+  });
+
+  test("★한 명이 실패해도 나머지는 계속한다★ + 실패는 사유와 함께 남는다", () => {
+    const w1 = ws();
+    const w2 = ws();
+    writeFileSync(join(w1, "AGENTS.md"), "옛 내용", "utf8");
+    writeFileSync(join(w2, "AGENTS.md"), "옛 내용", "utf8");
+    const r = refreshLoadingFiles(
+      [member("bad", "codex", w1), member("good", "codex", w2)],
+      (m) => {
+        if (m.id === "bad") throw new Error("디스크가 가득 찼다");
+        return { written: [join(w2, "AGENTS.md")] };
+      },
+    );
+    expect(r.updated).toEqual(["good"]);
+    expect(r.skipped).toEqual([{ id: "bad", reason: "디스크가 가득 찼다" }]);
+  });
+});

--- a/src/server/lib/refreshLoadingFiles.ts
+++ b/src/server/lib/refreshLoadingFiles.ts
@@ -1,0 +1,73 @@
+/**
+ * 이미 있는 팀원 로딩파일(CLAUDE.md / AGENTS.md)을 저장소 기준으로 되맞춘다.
+ *
+ * ═══ 왜 필요한가 ═══
+ * 부팅 시 로딩파일을 다시 만드는 백필이 `index.ts` 에 있는데 그 블록 전체가 `PUBLIC_BUILD` 게이트
+ * 뒤에 있다. 라이브는 `PUBLIC_BUILD=false` 라 **통째로 건너뛴다.** 그래서 룰을 고치고 배포·재시작해도
+ * **기존 팀원의 로딩파일은 그대로 남는다.**
+ *
+ * 실측(2026-08-18): 핵심룰에 판별 축을 추가하는 변경을 배포한 뒤, 렌더 결과에는 그 문장이 있는데
+ * 한 팀원의 `AGENTS.md` 는 08-12 파일 그대로였다(그 문장 0건). 렌더가 실패한 것이 아니라 **쓰지
+ * 않은 것**이다. 정본 룰 파일은 심링크로 닿아서 그동안 이 간극이 드러나지 않았다.
+ *
+ * ★같은 원인으로 이미 한 번 사고가 났다.★ `index.ts` 의 progress 훅 주석에 그대로 적혀 있다 —
+ * "위 백필은 PUBLIC_BUILD 뒤에 있어 라이브에서는 안 돈다. 그래서 이미 깔린 배선이 낡아도 아무도
+ * 안 고쳤고, 훅 커맨드가 옛것으로 남아 owner-skip 이 fail-open 으로 돌았다." 그때는 훅만 게이트
+ * 밖으로 뺐고 **로딩파일은 아직 안쪽에 있었다.**
+ *
+ * ═══ 왜 이 방식이 안전한가 ═══
+ * 게이트가 지키려던 것은 "실멤버 보호" 다. 그래서 훅 수리와 같은 형태를 쓴다 —
+ * ★파일이 이미 있는 팀원만★ 되맞추고 **새로 만들지 않는다.** 없는 팀원은 영입 절차가 만든다.
+ *
+ * 그리고 이 렌더러는 **`SOUL.md`(persona)를 아예 건드리지 않는다**(`writeMemberPersona` 주석 참조 —
+ * 2026-07-17 에 렌더가 persona 를 덮어 12명 중 7명이 어긋난 뒤 분리됐다). 로딩파일은 룰이라 코드
+ * 소유이고, persona 는 사람 소유다. `writeMemberPersona` 자체가 skip-if-unchanged 라 내용이 같으면
+ * 쓰지도 백업하지도 않는다.
+ */
+import { existsSync } from "node:fs";
+import { personaTargetsForRuntime } from "./personaTemplates";
+import { writeMemberPersona, type WriteMemberPersonaInput } from "./writeMemberPersona";
+
+export interface RefreshLoadingFilesResult {
+  /** 실제로 다시 쓴 팀원. */
+  updated: string[];
+  /** 로딩파일이 없어서 건드리지 않은 팀원(새로 만들지 않는다). */
+  absent: string[];
+  /** 렌더 대상이 아니거나 실패한 팀원 — 사유와 함께 남긴다. */
+  skipped: { id: string; reason: string }[];
+}
+
+/**
+ * @param members 재렌더 후보. `runtime` 이 로딩파일 정책을 정한다.
+ * @param write 주입용(시험). 기본값은 실제 렌더러.
+ */
+export function refreshLoadingFiles(
+  members: WriteMemberPersonaInput[],
+  write: (m: WriteMemberPersonaInput) => { written: string[] } = writeMemberPersona,
+): RefreshLoadingFilesResult {
+  const out: RefreshLoadingFilesResult = { updated: [], absent: [], skipped: [] };
+  for (const m of members) {
+    let loadingFile: string;
+    try {
+      // b3os_native 는 정책 미확정이라 여기서 예외가 난다 — 사유를 남기고 넘어간다.
+      loadingFile = personaTargetsForRuntime(m.runtime, m.workspace_path ?? "", m.persona_file).loadingFile;
+    } catch (e) {
+      out.skipped.push({ id: m.id, reason: e instanceof Error ? e.message : String(e) });
+      continue;
+    }
+    // ★없으면 만들지 않는다★ — 이 함수는 '되맞추기' 이지 '설치' 가 아니다.
+    if (!existsSync(loadingFile)) {
+      out.absent.push(m.id);
+      continue;
+    }
+    try {
+      const r = write(m);
+      // skip-if-unchanged 라 내용이 같으면 written 이 비어 있다 — 그때는 갱신했다고 말하지 않는다.
+      if (r.written.length > 0) out.updated.push(m.id);
+    } catch (e) {
+      // ★실패를 삼키지 않는다★ — 조용한 실패는 성공과 구별되지 않는다. 사유를 결과에 담아 부르는 쪽이 로그로 남긴다.
+      out.skipped.push({ id: m.id, reason: e instanceof Error ? e.message : String(e) });
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
룰을 고쳐 배포·재시작해도 **기존 팀원의 `CLAUDE.md`/`AGENTS.md` 는 그대로**였다. 부팅 백필이 `PUBLIC_BUILD` 게이트 뒤에 있고 라이브는 `PUBLIC_BUILD=false` 라 통째로 건너뛴다.

## 어떻게 드러났나

핵심룰에 판별 축을 넣는 변경(#330)을 배포한 뒤 확인해 보니:

| | 값 |
|---|---|
| 렌더 결과 | 10917자 · `who receives` **1건** |
| 팀원 `AGENTS.md` | 11098자 · `who receives` **0건** · mtime **6일 전** |

**렌더가 실패한 것이 아니라 쓰지 않은 것**이다. 정본 룰 파일은 심링크로 닿아서 이 간극이 드러나지 않았다 — **핵심룰 요약만 조용히 낡는다.**

## 같은 원인으로 이미 한 번 사고가 났다

`index.ts` 의 progress 훅 주석에 그대로 적혀 있다:

> 위 백필은 `PUBLIC_BUILD` 뒤에 있어 라이브에서는 안 돈다. 그래서 **이미 깔린 배선이 낡아도 아무도 안 고쳤고**, 훅 커맨드가 옛것으로 남아 owner-skip 이 fail-open 으로 돌았다.

그때는 훅만 게이트 밖으로 뺐고 **로딩파일은 안쪽에 남았다.**

## 고친 방법 — 그 수정과 같은 형태

- **파일이 이미 있는 팀원만** 되맞춘다. **새로 만들지 않는다**(없는 팀원은 영입 절차의 몫).
- 그래서 게이트가 지키려던 **실멤버 보호가 유지된다.**
- 렌더러는 `SOUL.md` 를 건드리지 않고(2026-07-17 분리) skip-if-unchanged 다.
- **결과를 로그로 남긴다** — 조용한 성공은 조용한 실패와 구별되지 않는다. 실패는 사유와 함께.

## 검증

- `refreshLoadingFiles` 시험 **6 pass / 0 fail** — 두 방향을 같은 무게로 건다(있으면 갱신 / **없으면 안 만든다**)
- **뮤턴트 3종 사망** — 뮤턴트가 실제로 적용됐는지 `diff` 로 확인한 뒤 셌다
  - 없는 파일 가드 제거 → 2 fail · skip-if-unchanged 전달 제거 → 1 fail · 실패 사유 삼키기 → 1 fail
- `tsc --noEmit` 통과 (이 워크트리는 `bun install` 을 해서 pre-push 타입체크도 실제로 돈다)
- 전체 수트 **2772 pass / 6 skip / 3 fail**

## 미검증 · 알려진 실패

- **전체 수트의 3 fail 은 이 변경과 무관하다.** 전부 `rules/TEAM-OS.md` 를 읽는 시험이고 그 파일은 gitignore 된 렌더 산출물이라 워크트리에 없다(ENOENT). 브랜치와 무관하며 **별건으로 낸다**(codex 와 담당 합의됨). CI 는 오늘 다른 PR 에서 verify 성공했으므로 CI 환경에는 그 파일이 있는 것으로 보이지만, **내가 확인한 범위는 워크트리다.**
- **이 PR 의 완료는 머지가 아니다** — 배포·재시작 후 팀원 로딩파일이 실제로 갱신되는지 확인하는 것까지다. 그때 `who receives` 가 팀원 파일에 들어오는지로 잰다.

Submitted-by: bill
