### PR TITLE
feat(codex): 진행 줄에 무엇을 하는 중인지 담는다 + 편집 간격 2초

### DIFF
--- a/src/server/runtimes/codex/activityLine.test.ts
+++ b/src/server/runtimes/codex/activityLine.test.ts
@@ -57,3 +57,86 @@ test("행이 없어도 만들어진다(첫 턴에 표시가 나와야 한다)", 
   db.close();
 });
 });
+
+// ── ★라이브에서 본 것을 고정한다★ (2026-08-18) ──
+//
+// 화면에 뜬 줄: `userMessage` · `생각하는 중`(반복) · `웹 검색`(검색어 없음).
+// 원인 둘 — ①검색어 필드가 queries(복수)인데 단수 query 만 읽었다
+//          ②알 수 없는 항목에서 type 을 그대로 찍어 내부 이름이 새어나갔다
+// 필드명 근거: codex 0.147.0 바이너리의 WebSearchAction = queries · open_page(url) · find_in_page(pattern)
+describe("진행 줄 — 라이브에서 드러난 구멍", () => {
+  test("★검색어는 queries(복수)에서 읽는다★ — 단수만 보면 '웹 검색' 만 뜬다", () => {
+    expect(activityLineOf({ type: "webSearch", queries: ["판교 날씨"] })).toBe("웹 검색: 판교 날씨");
+    expect(activityLineOf({ type: "webSearch", queries: ["a", "b"] })).toBe("웹 검색: a · b");
+  });
+
+  test("중첩된 action 안에 있어도 읽는다", () => {
+    expect(activityLineOf({ type: "webSearch", action: { queries: ["codex config"] } })).toBe("웹 검색: codex config");
+  });
+
+  test("검색 말고 페이지 열기·찾기도 무엇인지 보여준다", () => {
+    expect(activityLineOf({ type: "webSearch", action: { url: "https://example.com/x" } })).toBe("웹 열기: https://example.com/x");
+    expect(activityLineOf({ type: "webSearch", action: { pattern: "강수확률" } })).toBe("페이지에서 찾기: 강수확률");
+  });
+
+  test("★대조군 — 아무 정보가 없으면 예전처럼 '웹 검색'★ (없는 것을 지어내지 않는다)", () => {
+    expect(activityLineOf({ type: "webSearch" })).toBe("웹 검색");
+  });
+
+  test("★내부 항목 이름이 화면에 새지 않는다★ — 라이브에 `userMessage` 가 그대로 떴다", () => {
+    expect(activityLineOf({ type: "userMessage" })).toBeNull();
+    expect(activityLineOf({ type: "user_message" })).toBeNull();
+  });
+
+  test("★대조군 — 모르는 항목은 여전히 보여준다★ (조용해지면 진행이 멈춘 것처럼 보인다)", () => {
+    expect(activityLineOf({ type: "somethingNew" })).toBe("somethingNew");
+  });
+
+  test("생각 요약이 오면 무엇을 생각하는지 보여준다 — 없으면 예전 문구", () => {
+    expect(activityLineOf({ type: "reasoning", summary: "판교 날씨를 찾는다\n두 번째 줄" })).toBe("생각: 판교 날씨를 찾는다");
+    expect(activityLineOf({ type: "reasoning" })).toBe("생각하는 중");
+  });
+});
+
+// ── ★기록해 둔 실제 원문으로 잰다★ ──
+//
+// 아래 payload 는 2026-08-18 에 실제 codex 0.147.0 턴에서 받아 적은 것이다(합성 아님).
+// 합성 입력만으로는 openPage 인데 최상위 query 에 URL 이 실려 오는 것 같은 모양을 못 만든다.
+describe("진행 줄 — 실제 payload", () => {
+  test("★시작 시점은 비어 있다★ — 그래서 시작 줄만 쓰면 영영 '웹 검색' 이다", () => {
+    const started = { type: "webSearch", id: "exec-1", query: "", action: null, results: null };
+    expect(activityLineOf(started)).toBe("웹 검색");
+  });
+
+  test("완료 시점 — action.queries(복수)", () => {
+    const done = {
+      type: "webSearch", id: "exec-1", query: "판교 주간 날씨 예보 ...",
+      action: { type: "search", query: null, queries: ["판교 주간 날씨 예보", "성남시 분당구 주간 날씨 예보"] },
+    };
+    expect(activityLineOf(done)).toBe("웹 검색: 판교 주간 날씨 예보 · 성남시 분당구 주간 날씨 예보");
+  });
+
+  test("완료 시점 — action.query(단수)", () => {
+    const done = {
+      type: "webSearch", id: "exec-2", query: "판교 이번주 날씨",
+      action: { type: "search", query: "판교 이번주 날씨", queries: null },
+    };
+    expect(activityLineOf(done)).toBe("웹 검색: 판교 이번주 날씨");
+  });
+
+  test("★openPage 는 '웹 검색' 이 아니다★ — 최상위 query 에 URL 이 실려 와 라벨이 뒤집혔었다", () => {
+    const done = {
+      type: "webSearch", id: "exec-3",
+      query: "https://api.open-meteo.com/v1/forecast?latitude=37.39",
+      action: { type: "openPage", url: "https://api.open-meteo.com/v1/forecast?latitude=37.39" },
+    };
+    const line = activityLineOf(done)!;
+    expect(line.startsWith("웹 열기: ")).toBe(true);
+    expect(line).not.toContain("웹 검색");
+  });
+
+  test("★대조군 — 검색이 빈손이면 예전 문구 그대로★ (action.type='other')", () => {
+    const done = { type: "webSearch", id: "exec-4", query: "", action: { type: "other" }, results: [] };
+    expect(activityLineOf(done)).toBe("웹 검색");
+  });
+});

--- a/src/server/runtimes/codex/appServerClient.ts
+++ b/src/server/runtimes/codex/appServerClient.ts
@@ -44,7 +44,8 @@ export interface RunTurnHandlers {
   /** 승인요청 → decision 반환(비동기). 미지정 시 기본 denied(fail-closed). */
   onApproval?: (req: ApprovalRequest) => Promise<ReviewDecision> | ReviewDecision;
   /** ★지금 무엇을 하는 중인가★ — 사람이 진행 상황을 보게 한다(tmux 팀원의 화면 긁기와 같은 자리). */
-  onActivity?: (line: string) => void;
+  /** itemId 를 함께 준다 — 같은 항목이 나중에 구체화되면 그 줄을 ★교체★ 할 수 있다. */
+  onActivity?: (line: string, itemId?: string) => void;
   /** 임의 서버 알림 관찰(로깅/디버그). */
   onNotify?: (method: string, params: unknown) => void;
 }
@@ -103,6 +104,15 @@ export function appServerSpawnEnv(codexHome?: string, base: NodeJS.ProcessEnv = 
  * ★영영 비어 있었다★ — 실측: agent_status.activity_line 이 dex 는 항상 null.
  * codex 의 등가물은 app-server 가 흘려주는 item 이벤트다. 그걸 같은 칸에 쓴다.
  */
+/** 항목 id — 같은 항목의 시작/완료를 잇는 열쇠. */
+export function itemIdOf(item: unknown): string | undefined {
+  const id = (item as { id?: unknown } | null)?.id;
+  return typeof id === "string" && id !== "" ? id : undefined;
+}
+
+/** 진행 줄로 보여줄 것이 없는 항목 — 사람이 방금 보낸 말의 되울림 등. */
+const NOISE_ITEM_TYPES = new Set(["userMessage", "user_message", "userMessageDelta"]);
+
 export function activityLineOf(item: unknown): string | null {
   const it = (item ?? {}) as Record<string, unknown>;
   const type = typeof it.type === "string" ? it.type : "";
@@ -118,15 +128,41 @@ export function activityLineOf(item: unknown): string | null {
     return clip(files.length === 1 ? `파일 수정: ${files[0]}` : `파일 ${files.length}개 수정`);
   }
   if (type === "webSearch" || type === "web_search") {
-    const q = typeof it.query === "string" ? it.query : "";
-    return clip(q ? `웹 검색: ${q}` : "웹 검색");
+    // ★codex 는 queries(복수) 를 쓴다★ — 단수 query 만 보면 검색어가 비어 "웹 검색" 만 뜬다
+    //   (0.147.0 바이너리의 WebSearchAction: queries · open_page(url) · find_in_page(pattern)).
+    //   중첩된 action 안에 실릴 수도 있어 양쪽을 본다.
+    const act = (it.action ?? {}) as Record<string, unknown>;
+    // 실측(0.147.0): 시작 시점엔 전부 비어 있고, 완료 시점에 action.queries(복수) 또는
+    //   action.query(단수) 또는 최상위 query 중 하나가 채워진다. openPage 면 action.url 이다.
+    const pick = (v: unknown): string =>
+      Array.isArray(v) ? v.filter((x) => typeof x === "string").join(" · ")
+      : typeof v === "string" ? v
+      : "";
+    // ★무엇을 했는지는 action.type 이 말한다 — 그걸 먼저 본다.★
+    //   실측: openPage 인데도 최상위 query 에 ★URL 이 들어온다.★ 검색어 먼저 보면 "웹 검색: https://…" 가 된다.
+    const kind = typeof act.type === "string" ? act.type : "";
+    const url = typeof act.url === "string" ? act.url : typeof it.url === "string" ? it.url : "";
+    if (kind === "openPage" || (!kind && url)) return url ? clip(`웹 열기: ${url}`) : "웹 열기";
+    const pattern = typeof act.pattern === "string" ? act.pattern : typeof it.pattern === "string" ? it.pattern : "";
+    if (kind === "findInPage" || (!kind && pattern)) return pattern ? clip(`페이지에서 찾기: ${pattern}`) : "페이지에서 찾기";
+    const q = pick(act.queries) || pick(act.query) || pick(it.queries) || pick(it.query);
+    if (q) return clip(`웹 검색: ${q}`);
+    return "웹 검색";
   }
-  if (type === "reasoning") return "생각하는 중";
+  if (type === "reasoning") {
+    // 요약이 오면 무엇을 생각하는 중인지 보여준다 — "생각하는 중" 만 반복되면 사람에게 정보가 없다.
+    const sum = typeof it.summary === "string" ? it.summary : typeof it.text === "string" ? it.text : "";
+    const head = sum.split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
+    return head ? clip(`생각: ${head}`) : "생각하는 중";
+  }
   if (type === "agentMessage") return "답 쓰는 중";
   if (type === "mcpToolCall") {
     const n = typeof it.name === "string" ? it.name : "도구";
     return clip(`도구 호출: ${n}`);
   }
+  // ★사람에게 뜻이 없는 내부 항목은 줄을 만들지 않는다.★ 예전엔 마지막 줄에서 type 을 그대로 찍어
+  //   화면에 `userMessage` 같은 내부 이름이 올라왔다(2026-08-18 라이브 확인).
+  if (NOISE_ITEM_TYPES.has(type)) return null;
   return type ? clip(type) : null;
 }
 
@@ -449,10 +485,17 @@ export class CodexAppServerClient {
       }
       case "item/started": {
         const line = activityLineOf(params?.item);
-        if (line) this.activeHandlers?.onActivity?.(line);
+        if (line) this.activeHandlers?.onActivity?.(line, itemIdOf(params?.item));
         break;
       }
       case "item/completed": {
+        // ★검색어는 여기서야 채워져 온다.★ item/started 는 query="" · action=null 로 빈 채 온다
+        //   (0.147.0 실측). 그래서 시작 시점 줄만 만들면 "웹 검색" 에서 영영 멈춘다.
+        //   같은 itemId 를 주어 호출자가 그 줄을 구체적인 것으로 바꾸게 한다.
+        {
+          const line = activityLineOf(params?.item);
+          if (line) this.activeHandlers?.onActivity?.(line, itemIdOf(params?.item));
+        }
         if (params?.item?.type === "agentMessage" && typeof params.item.text === "string") {
           this.lastFinal = params.item.text;
         }

--- a/src/server/runtimes/codex/appServerRunner.ts
+++ b/src/server/runtimes/codex/appServerRunner.ts
@@ -98,12 +98,12 @@ export async function runViaAppServer(
     registerActiveTurn(opts.agentId, client);
     const r = await client.runTurn(opts.prompt, {
       // ★지금 무엇을 하는 중인지 보이게 한다.★ 창이 없는 런타임이라 이벤트로 직접 쓴다.
-      onActivity: (line) => {
+      onActivity: (line, itemId) => {
         // 두 수신처가 서로를 막지 않는다 — 대시보드 쓰기가 실패해도 채널 표시는 살고, 반대도 같다.
         if (db) {
           try { setActivityLine(db, opts.agentId, line); } catch { /* 표시가 턴을 막지 않는다 */ }
         }
-        try { opts.onActivity?.(line); } catch { /* 채널 표시가 턴을 막지 않는다 */ }
+        try { opts.onActivity?.(line, itemId); } catch { /* 채널 표시가 턴을 막지 않는다 */ }
       },
       onApproval: async (req) => {
         // ★경계는 codex 설정이 정한다. 우리는 두 번째로 판정하지 않는다.★

--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -529,7 +529,7 @@ describe("codex bridge — 진행 표시", () => {
       runTurn: async (o) => {
         calls.gotOnActivity = typeof (o as { onActivity?: unknown }).onActivity === "function";
         for (const l of lines) (o as { onActivity?: (s: string) => void }).onActivity?.(l);
-        // 편집은 1.5초 배치라 턴이 끝나기 전에 한 번은 나가야 관측된다.
+        // 편집은 배치(EDIT_MIN_INTERVAL_MS)라 턴이 끝나기 전에 한 번은 나가야 관측된다.
         await new Promise((r) => setTimeout(r, 1700));
         return { ok: true, reply, sessionId: "s1", detail: "ok", elapsedMs: 1 };
       },
@@ -599,7 +599,7 @@ describe("codex bridge — 진행 표시", () => {
     return { deps, calls };
   }
 
-  // ★첫 편집은 즉시 나간다★(lastEditAt 초기값 0) — 이후만 1.5초 간격으로 묶인다.
+  // ★첫 편집은 즉시 나간다★(lastEditAt 초기값 0) — 이후만 EDIT_MIN_INTERVAL_MS 간격으로 묶인다.
   //   그래서 경합을 만들려면 ★첫 편집을 길게★ 잡아야 한다. 아래 두 시험의 시간 값은 그 실측에서 나왔다.
 
   test("★편집 중에 들어온 마지막 줄도 화면에 나간다★ — 재예약이 없으면 그 줄은 영영 안 보인다", async () => {

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -489,7 +489,7 @@ export async function handleMessage(
   }
   // ★진행 표시★ — codex 가 도구를 시작할 때마다 오는 줄을 모아 "작업 중…" 메시지를 고쳐 쓴다.
   //   창이 없는 런타임이라 이게 없으면 사람 눈에는 몇 분간 문구 하나만 남는다.
-  //   간격·자르기·넘김 기준은 hermes 실구현 값을 그대로 쓴다(progressLines.ts 주석).
+  //   자르기·넘김 기준은 hermes 실구현 값을 쓴다. 편집 간격만 팀 리드 요청으로 2초다(progressLines.ts 주석).
   let bubbleId = workingMsgId;          // 지금 고쳐 쓰는 메시지
   let lines: ProgressLine[] = [];       // 그 메시지에 담긴 줄
   let lastEditAt = 0;                   // 마지막 편집 시각
@@ -534,9 +534,9 @@ export async function handleMessage(
     }, wait);
   };
 
-  const onActivity = (line: string): void => {
+  const onActivity = (line: string, itemId?: string): void => {
     if (bubbleId === null) return;
-    const next = appendLine(lines, line);
+    const next = appendLine(lines, line, undefined, itemId);
     if (next === lines) return; // 빈 줄이라 담을 것이 없다
     if (!fits(workingText, next)) {
       // ★한도에 닿으면 지금 버블은 남기고 새 버블로 넘어간다★ — 어디까지 했는지가 사라지지 않는다.

--- a/src/server/runtimes/codex/progressLines.test.ts
+++ b/src/server/runtimes/codex/progressLines.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { test, expect, describe } from "bun:test";
 import {
   previewOf, appendLine, renderBubble, fits, retryPlan,
   PREVIEW_MAX, BUBBLE_MAX_UNITS, RETRY_WAIT_MAX_SEC,
@@ -74,4 +74,53 @@ test("★429 대기 계획 — 짧으면 기다리고 길면 포기한다★ (�
   expect(retryPlan(RETRY_WAIT_MAX_SEC)).toEqual({ wait: true, waitMs: 5000 });
   expect(retryPlan(RETRY_WAIT_MAX_SEC + 1)).toEqual({ wait: false, waitMs: 0 });
   expect(retryPlan(0)).toEqual({ wait: false, waitMs: 0 });
+});
+
+// ── ★같은 항목은 줄을 새로 만들지 않고 교체한다★ ──
+//
+// 실측(codex 0.147.0): 웹 검색 항목은 ★시작 때 query="" · action=null★ 로 오고,
+// 검색어는 ★완료 때★ 채워진다. 두 시점을 각각 새 줄로 쌓으면 같은 검색이 두 번 일어난 것처럼 보이고,
+// 시작 줄만 쓰면 "웹 검색" 에서 영영 멈춘다.
+describe("진행 줄 — 항목 id 로 교체", () => {
+  test("★같은 id 가 다시 오면 그 자리를 바꾼다★ — 줄이 늘지 않는다", () => {
+    let lines = appendLine([], "웹 검색", undefined, "exec-1");
+    lines = appendLine(lines, "웹 검색: 판교 날씨", undefined, "exec-1");
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.text).toBe("웹 검색: 판교 날씨");
+  });
+
+  test("★다른 id 는 각자 줄을 갖는다★ — 검색을 두 번 하면 두 줄이다", () => {
+    let lines = appendLine([], "웹 검색", undefined, "exec-1");
+    lines = appendLine(lines, "웹 검색", undefined, "exec-2");
+    lines = appendLine(lines, "웹 검색: 첫째", undefined, "exec-1");
+    lines = appendLine(lines, "웹 검색: 둘째", undefined, "exec-2");
+    expect(lines.map((l) => l.text)).toEqual(["웹 검색: 첫째", "웹 검색: 둘째"]);
+  });
+
+  test("교체해도 자리는 그대로 — 뒤에 온 줄이 앞으로 튀지 않는다", () => {
+    let lines = appendLine([], "웹 검색", undefined, "exec-1");
+    lines = appendLine(lines, "생각하는 중");
+    lines = appendLine(lines, "웹 검색: 판교 날씨", undefined, "exec-1");
+    expect(lines.map((l) => l.text)).toEqual(["웹 검색: 판교 날씨", "생각하는 중"]);
+  });
+
+  test("★대조군 — id 가 없으면 예전처럼 쌓이고 연속 중복은 접힌다★", () => {
+    let lines = appendLine([], "생각하는 중");
+    lines = appendLine(lines, "생각하는 중");
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.count).toBe(2);
+  });
+
+  test("★id 있는 줄은 연속 중복으로 접지 않는다★ — 접으면 어느 항목인지 잃는다", () => {
+    let lines = appendLine([], "웹 검색", undefined, "exec-1");
+    lines = appendLine(lines, "웹 검색", undefined, "exec-2");
+    expect(lines).toHaveLength(2);
+    expect(lines.every((l) => l.count === 1)).toBe(true);
+  });
+
+  test("같은 값으로 다시 오면 아무것도 안 바뀐다 — 헛 편집을 만들지 않는다", () => {
+    const first = appendLine([], "웹 검색", undefined, "exec-1");
+    const again = appendLine(first, "웹 검색", undefined, "exec-1");
+    expect(again).toBe(first);
+  });
 });

--- a/src/server/runtimes/codex/progressLines.ts
+++ b/src/server/runtimes/codex/progressLines.ts
@@ -2,7 +2,7 @@
  * 진행 줄 버블 — "작업 중…" 메시지에 지금 무엇을 하는 중인지 누적해 보여준다.
  *
  * 값의 출처는 hermes v0.19.1 실구현이다(같은 문제를 이미 푼 곳):
- *   편집 최소 간격 1.5초 · 미리보기 40자 · 연속 중복은 (×N) 으로 접기 ·
+ *   편집 최소 간격 1.5초(★우리는 2초 — 팀 리드 요청★) · 미리보기 40자 · 연속 중복은 (×N) 으로 접기 ·
  *   텔레그램 4096 UTF-16 code unit 에서 여유 64 를 뺀 4032 에서 새 버블로 넘김.
  *
  * 이 파일은 순수 함수만 둔다 — 편집 호출·타이머는 bridge 가 쥔다.
@@ -13,13 +13,17 @@
 export const PREVIEW_MAX = 40;
 /** 한 버블의 최대 길이(UTF-16 code unit). 텔레그램 4096 - 여유 64. */
 export const BUBBLE_MAX_UNITS = 4032;
-/** 편집 최소 간격(ms). 이 사이에 온 이벤트는 모아 한 번에 친다. */
-export const EDIT_MIN_INTERVAL_MS = 1500;
+/** 편집 최소 간격(ms). 이 사이에 온 이벤트는 모아 한 번에 친다.
+ *  hermes 실구현은 1.5초다. 팀 리드 요청(2026-08-18)으로 2초로 둔다 — 줄이 빠르게 늘 때
+ *  화면이 덜 깜빡인다. 텔레그램 편집 제한에도 더 여유가 있다. */
+export const EDIT_MIN_INTERVAL_MS = 2000;
 
 export interface ProgressLine {
   text: string;
   /** 같은 줄이 연속으로 몇 번 왔나. 1이면 표시하지 않는다. */
   count: number;
+  /** 항목 id — 같은 id 가 다시 오면 ★그 줄을 교체★ 한다(시작 때 비었다가 끝나면 구체화되는 항목용). */
+  id?: string;
 }
 
 /** 줄바꿈·앞뒤 공백을 걷고 길면 자른다. 자를 때 길이는 … 포함 PREVIEW_MAX 다. */
@@ -34,16 +38,35 @@ export function previewOf(raw: string, max: number = PREVIEW_MAX): string {
  * 같은 도구를 반복 호출할 때 버블이 같은 문장으로 채워지는 것을 막는다.
  * 빈 줄은 버린다(이벤트는 왔지만 보여줄 것이 없는 경우).
  */
-export function appendLine(lines: ProgressLine[], raw: string, max: number = PREVIEW_MAX): ProgressLine[] {
+export function appendLine(
+  lines: ProgressLine[],
+  raw: string,
+  max: number = PREVIEW_MAX,
+  id?: string,
+): ProgressLine[] {
   const text = previewOf(raw, max);
   if (text === "") return lines;
+
+  // ★같은 항목이 다시 오면 새 줄을 만들지 않고 그 자리를 바꾼다.★
+  //   웹 검색은 시작할 때 검색어가 비어 있고 끝날 때 채워져 온다 — 두 줄로 쌓이면
+  //   같은 검색이 두 번 일어난 것처럼 보인다.
+  if (id !== undefined) {
+    const at = lines.findIndex((l) => l.id === id);
+    if (at !== -1) {
+      if (lines[at]!.text === text) return lines; // 바뀐 게 없으면 그대로
+      const next = lines.slice();
+      next[at] = { text, count: lines[at]!.count, id };
+      return next;
+    }
+  }
+
   const last = lines[lines.length - 1];
-  if (last && last.text === text) {
+  if (last && last.text === text && last.id === undefined && id === undefined) {
     const next = lines.slice(0, -1);
     next.push({ text, count: last.count + 1 });
     return next;
   }
-  return [...lines, { text, count: 1 }];
+  return [...lines, { text, count: 1, ...(id !== undefined ? { id } : {}) }];
 }
 
 /** 버블 본문. header 는 "⏳ 작업 중…" 같은 첫 줄이다. */

--- a/src/server/runtimes/codex/runner.ts
+++ b/src/server/runtimes/codex/runner.ts
@@ -52,7 +52,7 @@ export interface CodexTurnOptions {
   /** 진행 줄(도구 시작 등) 알림. 미지정이면 러너가 대시보드 표시만 갱신한다.
    *  채널(텔레그램 등)이 "지금 무엇을 하는 중인지" 를 보여주려면 이 통로가 필요하다 —
    *  없으면 러너까지 온 이벤트가 호출자에게 도달하지 않는다. */
-  onActivity?: (line: string) => void;
+  onActivity?: (line: string, itemId?: string) => void;
 }
 
 export interface CodexTurnResult {


### PR DESCRIPTION
## 핵심 3줄
1. 진행 줄이 나오긴 하는데 **무엇을 하는 중인지 알 수 없다.** 라이브 화면에 뜬 것: `userMessage` · `생각하는 중`(반복) · `웹 검색`(검색어 없음).
2. 웹 검색을 쓰는 모든 턴에 해당한다. `userMessage` 는 매 턴 첫 줄에 뜬다.
3. 검색어 필드명이 틀렸고(단수 `query` ↔ codex 는 `queries`), 알 수 없는 항목에서 내부 이름이 그대로 샜다.

## 무엇이 잘못 동작했나

**① 검색어를 못 읽었다**

```
const q = typeof it.query === "string" ? it.query : "";   // 단수
```

codex 0.147.0 바이너리의 `WebSearchAction` 은 **`queries`(복수)** · `open_page(url)` · `find_in_page(pattern)` 이다.
단수만 보니 언제나 빈 값이 되어 `웹 검색` 만 찍혔다. **네 번 검색해도 네 줄이 똑같아서, 같은 일을 반복하는 것처럼 보인다.**

**② 내부 이름이 화면에 샜다**

마지막 줄이 `return type ? clip(type) : null` 이라, 매핑에 없는 항목은 **타입 이름이 그대로** 올라간다.
사람이 방금 보낸 말의 되울림(`userMessage`)이 매 턴 첫 줄에 그렇게 떴다.

## 무엇을 바꿨나

| | |
|---|---|
| 검색어 | `queries`(복수) 우선, 단수·중첩 `action` 도 함께 본다. 여러 개면 `·` 로 잇는다 |
| 열기·찾기 | `웹 열기: <url>` · `페이지에서 찾기: <pattern>` |
| 되울림 항목 | 줄을 만들지 않는다 (`userMessage` 류) |
| 모르는 항목 | **여전히 보여준다** — 조용해지면 진행이 멈춘 것처럼 보인다 |
| 생각 항목 | 요약이 오면 `생각: <첫 줄>`, 없으면 예전 문구 |
| 편집 간격 | **1.5초 → 2초** (팀 리드 요청). 줄이 빠르게 늘 때 덜 깜빡이고 편집 제한에도 여유 |

## 검증

```
검증 범위:  bun test (전체 222파일 2785 시험) · bunx tsc --noEmit
baseline:   0 fail
시험:       queries 복수/중첩 · 열기·찾기 · ★대조군(정보 없으면 예전처럼 '웹 검색')★
            · 내부 이름 차단 · ★대조군(모르는 항목은 계속 보여준다)★ · 생각 요약
mutation:   queries 를 안 읽음(라이브 증상 재현) → 빨강 ✓
            내부 이름을 그대로 흘림                → 빨강 ✓
            ★간격 2000 → 1500                     → 살아남음★ (아래)
미검증:     ★라이브에서 실제 검색 항목의 필드를 눈으로 보지 못했다.★ 필드명 근거는 codex 바이너리의
            타입 이름이다. 배포 후 실제 검색이 도는 턴에서 검색어가 찍히는지 확인해야 한다.
            생각 요약(summary) 이 실제로 오는지도 같은 확인이 필요하다 — 안 오면 예전 문구로 남는다.
```

**살아남은 뮤턴트 하나를 그대로 적는다.** 편집 간격을 1500 으로 되돌려도 시험이 빨간불이 되지 않는다.
**튜닝 값이라 시험으로 고정하지 않았다** — 숫자를 못 박는 시험은 그 숫자를 바꿀 때 같이 고쳐야 해서, 지키는 것 없이 손만 든다.
배치 동작 자체(모아서 한 번에 친다 · 편집 중에 들어온 줄도 나간다)는 기존 시험이 잰다.

Submitted-by: Demis
