### PR TITLE
test(rules): 룰 시험이 렌더 산출물 없이도 돌게 한다

### DIFF
--- a/src/server/lib/ruleDedupeSafety.test.ts
+++ b/src/server/lib/ruleDedupeSafety.test.ts
@@ -9,13 +9,28 @@
  * 이 테스트가 빨개지면: 핵심룰에서 뺀 것을 TEAM-OS 가 못 받고 있다는 뜻 → 되살리거나 되돌려라.
  */
 import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { buildAgentsMd, buildPersona } from "./personaTemplates";
 
 const rulesDir = join(import.meta.dir, "../../../rules");
-const teamOs = readFileSync(join(rulesDir, "TEAM-OS.md"), "utf8");
+
+/**
+ * ★룰 내용은 추적본(template)으로 잰다.★
+ *
+ * `TEAM-OS.md` 는 gitignore 된 ★렌더 산출물★ 이라 새 클론·워크트리에는 없다.
+ * 이 파일을 최상단에서 읽으면 그런 환경에서 ★모듈 로드가 ENOENT 로 실패해 이 파일의 검사가
+ * 하나도 돌지 않는다★ — 검사가 있는데 아무것도 지키지 않는 상태가 된다.
+ *
+ * 렌더는 `{{OWNER}}` 치환뿐이므로(`teamOsRender.renderTeamOs`) ★룰 문장 검사에는 템플릿으로 충분하다.★
+ * 렌더본이 필요한 검사는 아래 `teamOsRendered` 를 쓰고, 없으면 ★조건 미성립으로 건너뛴다★ —
+ * "검사했는데 통과" 와 "잴 수 없었다" 를 같은 초록으로 뭉개지 않기 위해 사유를 남긴다.
+ */
 const teamOsTemplate = readFileSync(join(rulesDir, "TEAM-OS.template.md"), "utf8");
+const teamOs = teamOsTemplate; // 룰 문장 검사의 기준 — 치환 전/후가 같은 문장을 본다
+const renderedPath = join(rulesDir, "TEAM-OS.md");
+/** 렌더 산출물. 이 환경에 없으면 null — 있을 때만 재는 검사가 있다. */
+const teamOsRendered: string | null = existsSync(renderedPath) ? readFileSync(renderedPath, "utf8") : null;
 
 /** 핵심룰에서 뺀 5개의 ★실행 세부★ — 주제어가 아니라 그 결정을 쓸 수 있게 만드는 문구다. */
 const MOVED_DETAILS = [
@@ -42,8 +57,13 @@ describe("★핵심룰에서 뺀 절차는 TEAM-OS 가 '실행 가능한 형태�
   //   워크트리·새 클론·CI 에는 없다 — 모듈 로드가 통째로 실패해 ★이 파일의 검사가 하나도 안 돈다.★
   //   여기 두면 검사가 있는 것처럼 보이지만 실제로는 아무것도 지키지 않는다. 별건으로 고칠 자리다.
 
-  it("템플릿과 렌더본이 같다 — 한쪽만 고치면 다음 렌더에 되돌아간다", () => {
-    expect(teamOsTemplate).toBe(teamOs);
+  /**
+   * ★이 검사만 렌더 산출물이 필요하다★ — 없는 환경에서는 ★건너뛴다(skip)★.
+   * 통과로 세면 "잴 수 없었다" 가 "확인했다" 로 읽힌다. skip 은 결과에 그대로 남는다.
+   * (렌더본이 없다는 것 자체는 결함이 아니다 — gitignore 산출물이라 새 클론에는 원래 없다.)
+   */
+  it.skipIf(teamOsRendered === null)("템플릿과 렌더본이 같다 — 한쪽만 고치면 다음 렌더에 되돌아간다", () => {
+    expect(teamOsRendered).toBe(teamOsTemplate);
   });
 
   it("★claude 는 @TEAM-OS.md 를 반드시 싣는다★ — 이게 이번 중복 제거의 전제다 (lui 지적: 단일 실패점)", () => {

--- a/src/server/lib/tmuxInject.test.ts
+++ b/src/server/lib/tmuxInject.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { ensureRenderedTeamOs } from "./testSupport";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { buildTmuxInjectionPrompt } from "./tmuxInject";
 
@@ -153,7 +153,9 @@ describe("Korean runtime loading templates", () => {
 
   test("CLAUDE template delegates owner and safety rules to TEAM-OS canonical text", () => {
     const claude = readFileSync(join(rulesDir, "CLAUDE.template.ko.md"), "utf8");
-    const teamOsEn = readFileSync(join(rulesDir, "TEAM-OS.md"), "utf8");
+    // ★룰 문장은 추적본으로 잰다★ — `TEAM-OS.md` 는 gitignore 된 렌더 산출물이라 새 클론·워크트리·CI 에 없다.
+    //   렌더는 `{{OWNER}}` 치환뿐이므로(`teamOsRender.renderTeamOs`) 문장 검사에는 템플릿으로 충분하다.
+    const teamOsEn = readFileSync(join(rulesDir, "TEAM-OS.template.md"), "utf8");
     const teamOs = readFileSync(join(rulesDir, "TEAM-OS.template.ko.md"), "utf8");
 
     expect(claude).toContain("@TEAM-OS.md");
@@ -170,18 +172,37 @@ describe("Korean runtime loading templates", () => {
     expect(teamOs).toContain("SECTION_CORE_RULE");
   });
 
+  /**
+   * ★렌더본이 있을 때만 재는 검사★ — 여기만 `rules/TEAM-OS.md`(gitignore 산출물)가 필요하다.
+   *
+   * 룰 문장 검사가 이 파일을 직접 읽으면 없는 환경에서 ★브랜치와 무관하게 빨간불★ 이 된다(ENOENT).
+   * 그래서 문장 검사는 추적본 기준이고 ★동일성 검사만 여기 남는다.★
+   *
+   * ★없을 때 통과로 세지 않는다★ — skip 은 결과에 그대로 남아 "확인했다" 와 구별된다.
+   * (렌더본이 없다는 것 자체는 결함이 아니다. 새 클론에는 원래 없다.)
+   */
+  test.skipIf(!existsSync(join(rulesDir, "TEAM-OS.md")))(
+    "렌더본이 템플릿과 일치한다 — 한쪽만 고치면 다음 렌더에 되돌아간다",
+    () => {
+      const teamOsTemplate = readFileSync(join(rulesDir, "TEAM-OS.template.md"), "utf8");
+      const rendered = readFileSync(join(rulesDir, "TEAM-OS.md"), "utf8");
+      // 렌더는 `{{OWNER}}` 치환뿐이라 같은 값으로 정규화해 비교한다.
+      expect(teamOsTemplate.replaceAll("{{OWNER}}", "the team lead")).toBe(
+        rendered.replaceAll("{{OWNER}}", "the team lead"),
+      );
+    },
+  );
+
   test("TEAM-OS section 4 keeps compacted behavior and safety invariants", () => {
-    const teamOsEn = readFileSync(join(rulesDir, "TEAM-OS.md"), "utf8");
+    // ★룰 문장은 추적본으로 잰다★ (위 시험과 같은 이유 — 렌더 산출물은 이 환경에 없을 수 있다).
     const teamOsTemplate = readFileSync(join(rulesDir, "TEAM-OS.template.md"), "utf8");
+    const teamOsEn = teamOsTemplate;
     const teamOsKo = readFileSync(join(rulesDir, "TEAM-OS.template.ko.md"), "utf8");
     const en = section(teamOsEn, "## 4. Shared Response Rules", "## 5. Collaboration Rules");
     const sourceEn = section(teamOsTemplate, "## 4. Shared Response Rules", "## 5. Collaboration Rules");
     const ko = section(teamOsKo, "## 4. 공통 응답 규칙", "## 5. 협업 규칙");
 
     expect(teamOsTemplate).not.toContain("Superseded compact template");
-    expect(teamOsTemplate.replaceAll("{{OWNER}}", "the team lead")).toBe(
-      teamOsEn.replaceAll("{{OWNER}}", "the team lead"),
-    );
 
     for (const token of [
       "ack or react first",


### PR DESCRIPTION
두 시험 파일이 `rules/TEAM-OS.md` 를 읽는다. 그 파일은 **gitignore 된 렌더 산출물**이라 새 클론·워크트리에 없고, 그 환경에서 다음이 일어난다.

- `ruleDedupeSafety.test.ts` — 최상단에서 읽으므로 **모듈 로드가 ENOENT 로 실패한다.** 그 파일의 검사가 하나도 실행되지 않는다. 검사가 있는데 아무것도 지키지 않는다.
- `tmuxInject.test.ts` — 두 시험이 **브랜치와 무관하게 실패한다.**

## 고친 방법

- **룰 문장 검사는 추적본**(`TEAM-OS.template.md`)으로 읽는다. 렌더는 `{{OWNER}}` 치환뿐이므로(`teamOsRender.renderTeamOs`) 문장 검사에는 템플릿으로 충분하다.
- **렌더본이 필요한 검사(템플릿과 렌더본이 일치하는가)는 조건부로 남긴다.** 없으면 `skip` 이다. 통과로 세면 **"잴 수 없었다" 가 "확인했다" 로 읽힌다.** 렌더본의 부재 자체는 결함이 아니다.

## 검증 — 조건부가 조건을 실제로 보는지 세 상태로 갈랐다

| 상태 | 결과 | |
|---|---|---|
| 렌더본 없음 | 10 pass / **2 skip** / 0 fail | |
| 렌더본 있고 동일 | **12 pass** / 0 fail | skip 이 아니라 실행된다 |
| 렌더본 어긋남 | 10 pass / **2 fail** | 있을 때 실패를 잡는다 |

세 번째가 없으면 그 검사가 무엇을 잡는지 모른 채 넘어간다.

- 전체 수트 **2771 pass / 8 skip / 0 fail** (같은 워크트리에서 이 변경 없이는 3 fail)
- `tsc --noEmit` 통과

## 미검증

CI 환경에 렌더 산출물이 있는지는 확인하지 않았다. 있으면 조건부 검사가 실행되고, 없으면 skip 이다. **어느 쪽이든 실패로 남지 않는다.**

Submitted-by: bill
