### PR TITLE
feat(codex): 진행 표시를 상태 한 자리 + 실제 작업 누적으로 나눈다

### DIFF
--- a/src/server/runtimes/codex/activityLine.test.ts
+++ b/src/server/runtimes/codex/activityLine.test.ts
@@ -7,7 +7,7 @@ import { describe, test, expect } from "bun:test";
 import { Database } from "bun:sqlite";
 import { migrate } from "../../db/migrate";
 import { setActivityLine } from "../../db/queries";
-import { activityLineOf } from "./appServerClient";
+import { activityLineOf, statusLineOf } from "./appServerClient";
 
 describe("codex 활동 한 줄 — 무엇을 하는지 보여준다", () => {
 
@@ -92,9 +92,32 @@ describe("진행 줄 — 라이브에서 드러난 구멍", () => {
     expect(activityLineOf({ type: "somethingNew" })).toBe("somethingNew");
   });
 
-  test("생각 요약이 오면 무엇을 생각하는지 보여준다 — 없으면 예전 문구", () => {
-    expect(activityLineOf({ type: "reasoning", summary: "판교 날씨를 찾는다\n두 번째 줄" })).toBe("생각: 판교 날씨를 찾는다");
-    expect(activityLineOf({ type: "reasoning" })).toBe("생각하는 중");
+  // ★계약이 바뀌었다(2026-08-18 팀 리드 지적) — 매번 나오는 상태 줄은 빼고 실제 작업만 보여준다.★
+  //   "생각하는 중" · "답 쓰는 중" 은 어느 턴에나 여러 번 나와 줄만 차지하고 무엇을 하는 중인지는 안 알려준다.
+  // ★설계가 바뀌었다(팀 리드 2026-08-18) — 매 턴 반복되는 상태는 ★맨 윗줄 한 자리★ 에서 교체한다.
+  //   지우는 게 아니라 쌓지 않는 것이다. 실제 작업만 그 아래에 누적된다.
+  test("★반복되는 상태는 작업 줄로 쌓이지 않는다★", () => {
+    expect(activityLineOf({ type: "reasoning" })).toBeNull();
+    expect(activityLineOf({ type: "reasoning", summary: "판교 날씨를 찾는다" })).toBeNull();
+    expect(activityLineOf({ type: "agentMessage" })).toBeNull();
+  });
+
+  test("★그 상태는 머리글로 간다★ — 요약이 실리면 무엇을 생각하는 중인지까지", () => {
+    expect(statusLineOf({ type: "reasoning" })).toBe("🧠 생각하는 중…");
+    expect(statusLineOf({ type: "reasoning", summary: "판교 날씨를 찾는다\n둘째 줄" })).toBe("🧠 판교 날씨를 찾는다");
+    expect(statusLineOf({ type: "agentMessage" })).toBe("✍️ 대답하는 중…");
+  });
+
+  test("★대조군 — 실제 작업은 머리글이 아니다★ (그러면 앞 작업을 덮어쓴다)", () => {
+    expect(statusLineOf({ type: "commandExecution", command: "ls" })).toBeNull();
+    expect(statusLineOf({ type: "webSearch", action: { queries: ["x"] } })).toBeNull();
+  });
+
+  test("★대조군 — 실제 작업은 그대로 보여준다★ (다 걸러내면 화면이 빈다)", () => {
+    expect(activityLineOf({ type: "commandExecution", command: "bun test" })).toBe("실행: bun test");
+    expect(activityLineOf({ type: "webSearch", action: { queries: ["판교 날씨"] } })).toBe("웹 검색: 판교 날씨");
+    expect(activityLineOf({ type: "mcpToolCall", name: "team_status" })).toBe("도구 호출: team_status");
+    expect(activityLineOf({ type: "fileChange", fileChanges: { "a.ts": {} } })).toBe("파일 수정: a.ts");
   });
 });
 
@@ -138,5 +161,35 @@ describe("진행 줄 — 실제 payload", () => {
   test("★대조군 — 검색이 빈손이면 예전 문구 그대로★ (action.type='other')", () => {
     const done = { type: "webSearch", id: "exec-4", query: "", action: { type: "other" }, results: [] };
     expect(activityLineOf(done)).toBe("웹 검색");
+  });
+});
+
+describe("진행 줄 — 파일 변경(실제 payload)", () => {
+  // 아래 payload 는 2026-08-18 실제 턴에서 받아 적은 것이다.
+  // 예전 코드는 fileChanges 라는 ★객체★ 를 찾았는데 실제로는 changes ★배열★ 이라,
+  // 못 만나고 마지막 줄로 떨어져 화면에 ★내부 이름 fileChange★ 가 그대로 떴다.
+  const mk = (kind: string, paths: string[]) => ({
+    type: "fileChange",
+    id: "exec-1",
+    changes: paths.map((p) => ({ path: p, kind: { type: kind }, diff: "\n" })),
+    status: "completed",
+  });
+
+  test("★파일 하나면 이름과 무엇을 했는지 보여준다★", () => {
+    expect(activityLineOf(mk("add", ["/tmp/ws/note2.txt"]))).toBe("파일 생성: note2.txt");
+    expect(activityLineOf(mk("delete", ["/tmp/ws/old.md"]))).toBe("파일 삭제: old.md");
+    expect(activityLineOf(mk("update", ["/tmp/ws/a.ts"]))).toBe("파일 수정: a.ts");
+  });
+
+  test("여러 개면 개수로 줄인다 — 경로가 길어 화면을 다 먹는다", () => {
+    expect(activityLineOf(mk("add", ["/tmp/a", "/tmp/b", "/tmp/c"]))).toBe("파일 3개 생성");
+  });
+
+  test("★내부 이름이 새지 않는다★ — 이 항목에서 fileChange 라는 글자가 화면에 뜨면 안 된다", () => {
+    expect(activityLineOf(mk("add", ["/tmp/ws/x.txt"]))).not.toContain("fileChange");
+  });
+
+  test("★대조군 — 변경 목록이 비면 예전 경로로 떨어진다★ (지어내지 않는다)", () => {
+    expect(activityLineOf({ type: "fileChange", changes: [] })).toBe("fileChange");
   });
 });

--- a/src/server/runtimes/codex/appServerClient.ts
+++ b/src/server/runtimes/codex/appServerClient.ts
@@ -46,6 +46,8 @@ export interface RunTurnHandlers {
   /** ★지금 무엇을 하는 중인가★ — 사람이 진행 상황을 보게 한다(tmux 팀원의 화면 긁기와 같은 자리). */
   /** itemId 를 함께 준다 — 같은 항목이 나중에 구체화되면 그 줄을 ★교체★ 할 수 있다. */
   onActivity?: (line: string, itemId?: string) => void;
+  /** ★지금 어느 단계인가★ — 맨 윗줄에서 교체된다. 쌓이지 않는다. */
+  onStatus?: (line: string) => void;
   /** 임의 서버 알림 관찰(로깅/디버그). */
   onNotify?: (method: string, params: unknown) => void;
 }
@@ -104,6 +106,23 @@ export function appServerSpawnEnv(codexHome?: string, base: NodeJS.ProcessEnv = 
  * ★영영 비어 있었다★ — 실측: agent_status.activity_line 이 dex 는 항상 null.
  * codex 의 등가물은 app-server 가 흘려주는 item 이벤트다. 그걸 같은 칸에 쓴다.
  */
+/**
+ * ★지금 어느 단계인가★ — 맨 윗줄에서 교체되는 상태. 작업 줄과 달리 쌓이지 않는다.
+ * 매 턴 여러 번 오는 것이라 쌓으면 화면이 그것으로 찬다(팀 리드 지적 2026-08-18).
+ */
+export function statusLineOf(item: unknown): string | null {
+  const it = (item ?? {}) as Record<string, unknown>;
+  const type = typeof it.type === "string" ? it.type : "";
+  if (type === "reasoning") {
+    // 요약이 실려 오면 무엇을 생각하는 중인지까지 보여준다.
+    const sum = typeof it.summary === "string" ? it.summary : typeof it.text === "string" ? it.text : "";
+    const head = sum.split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
+    return head ? `🧠 ${head.length > 60 ? head.slice(0, 59) + "…" : head}` : "🧠 생각하는 중…";
+  }
+  if (type === "agentMessage") return "✍️ 대답하는 중…";
+  return null;
+}
+
 /** 항목 id — 같은 항목의 시작/완료를 잇는 열쇠. */
 export function itemIdOf(item: unknown): string | undefined {
   const id = (item as { id?: unknown } | null)?.id;
@@ -122,9 +141,24 @@ export function activityLineOf(item: unknown): string | null {
   const cmdText = typeof cmd === "string" ? cmd : Array.isArray(cmd) ? cmd.join(" ") : null;
   if (cmdText) return clip(`실행: ${cmdText}`);
 
-  const changes = it.fileChanges;
-  if (changes && typeof changes === "object") {
-    const files = Object.keys(changes as Record<string, unknown>);
+  // ★실측(0.147.0): 파일 변경은 changes 배열로 온다★ — [{ path, kind:{type:"add"|…}, diff }].
+  //   예전 코드는 fileChanges 라는 객체를 찾아서 못 만났고, 그 결과 화면에 ★내부 이름 fileChange 가 그대로★ 떴다.
+  const changeList = Array.isArray(it.changes) ? (it.changes as Record<string, unknown>[]) : null;
+  if (changeList && changeList.length > 0) {
+    const verb = (k: unknown): string => {
+      const t = (k as { type?: unknown } | null)?.type;
+      return t === "add" ? "생성" : t === "delete" ? "삭제" : "수정";
+    };
+    if (changeList.length === 1) {
+      const c = changeList[0]!;
+      const path = typeof c.path === "string" ? c.path.split("/").pop() ?? String(c.path) : "파일";
+      return clip(`파일 ${verb(c.kind)}: ${path}`);
+    }
+    return clip(`파일 ${changeList.length}개 ${verb(changeList[0]!.kind)}`);
+  }
+  const legacy = it.fileChanges;
+  if (legacy && typeof legacy === "object") {
+    const files = Object.keys(legacy as Record<string, unknown>);
     return clip(files.length === 1 ? `파일 수정: ${files[0]}` : `파일 ${files.length}개 수정`);
   }
   if (type === "webSearch" || type === "web_search") {
@@ -149,13 +183,9 @@ export function activityLineOf(item: unknown): string | null {
     if (q) return clip(`웹 검색: ${q}`);
     return "웹 검색";
   }
-  if (type === "reasoning") {
-    // 요약이 오면 무엇을 생각하는 중인지 보여준다 — "생각하는 중" 만 반복되면 사람에게 정보가 없다.
-    const sum = typeof it.summary === "string" ? it.summary : typeof it.text === "string" ? it.text : "";
-    const head = sum.split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
-    return head ? clip(`생각: ${head}`) : "생각하는 중";
-  }
-  if (type === "agentMessage") return "답 쓰는 중";
+  // ★상태 줄은 쌓지 않고 맨 위에서 교체된다★(팀 리드 설계 2026-08-18) — statusLineOf 가 돌려준다.
+  //   여기서는 null 을 내서 ★작업 줄로 쌓이지 않게★ 한다. 매 턴 여러 번 오는 것들이다.
+  if (type === "reasoning" || type === "agentMessage") return null;
   if (type === "mcpToolCall") {
     const n = typeof it.name === "string" ? it.name : "도구";
     return clip(`도구 호출: ${n}`);
@@ -484,6 +514,8 @@ export class CodexAppServerClient {
         break;
       }
       case "item/started": {
+        const status = statusLineOf(params?.item);
+        if (status) { this.activeHandlers?.onStatus?.(status); break; }
         const line = activityLineOf(params?.item);
         if (line) this.activeHandlers?.onActivity?.(line, itemIdOf(params?.item));
         break;
@@ -493,8 +525,12 @@ export class CodexAppServerClient {
         //   (0.147.0 실측). 그래서 시작 시점 줄만 만들면 "웹 검색" 에서 영영 멈춘다.
         //   같은 itemId 를 주어 호출자가 그 줄을 구체적인 것으로 바꾸게 한다.
         {
-          const line = activityLineOf(params?.item);
-          if (line) this.activeHandlers?.onActivity?.(line, itemIdOf(params?.item));
+          const status = statusLineOf(params?.item);
+          if (status) this.activeHandlers?.onStatus?.(status);
+          else {
+            const line = activityLineOf(params?.item);
+            if (line) this.activeHandlers?.onActivity?.(line, itemIdOf(params?.item));
+          }
         }
         if (params?.item?.type === "agentMessage" && typeof params.item.text === "string") {
           this.lastFinal = params.item.text;

--- a/src/server/runtimes/codex/appServerRunner.ts
+++ b/src/server/runtimes/codex/appServerRunner.ts
@@ -105,6 +105,9 @@ export async function runViaAppServer(
         }
         try { opts.onActivity?.(line, itemId); } catch { /* 채널 표시가 턴을 막지 않는다 */ }
       },
+      onStatus: (line) => {
+        try { opts.onStatus?.(line); } catch { /* 채널 표시가 턴을 막지 않는다 */ }
+      },
       onApproval: async (req) => {
         // ★경계는 codex 설정이 정한다. 우리는 두 번째로 판정하지 않는다.★
         //   codex 가 물으면 그 물음을 ★그 팀원의 방★ 으로 옮기고, 사람이 누른 대로 돌려준다.

--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -933,3 +933,50 @@ describe("텔레그램 전송 — MarkdownV2 거부 시 폴백", () => {
     expect(bodies).toHaveLength(1);
   });
 });
+
+// ── ★상태는 한 자리, 작업은 그 아래★ ──
+describe("codex bridge — 상태 머리글", () => {
+  beforeEach(() => resetChatThreads());
+
+  function spiesWithStatus(steps: Array<{ status?: string; work?: string; id?: string }>) {
+    const edits: string[] = [];
+    const deps: BridgeDeps = {
+      reactMessage: async () => true,
+      sendMessage: async () => 800,
+      editMessage: async (_c, _m, text) => { edits.push(text); return true; },
+      sandbox: "read-only",
+      runTurn: async (o) => {
+        const oa = (o as { onActivity?: (l: string, id?: string) => void }).onActivity;
+        const os = (o as { onStatus?: (l: string) => void }).onStatus;
+        for (const s of steps) {
+          if (s.status) os?.(s.status);
+          if (s.work) oa?.(s.work, s.id);
+          await new Promise((r) => setTimeout(r, 2100)); // 배치 간격을 넘긴다
+        }
+        return { ok: true, reply: "끝", sessionId: "s1", detail: "ok", elapsedMs: 1 };
+      },
+    };
+    return { deps, edits };
+  }
+
+  test("★상태는 쌓이지 않고 맨 윗줄에서 바뀐다★ — 작업은 아래에 남는다", async () => {
+    const { deps, edits } = spiesWithStatus([
+      { status: "🧠 생각하는 중…", work: "실행: ls", id: "e1" },
+      { status: "✍️ 대답하는 중…" },
+    ]);
+    await handleMessage(41, "해줘", 1, deps);
+    const withWork = edits.filter((e) => e.includes("실행: ls"));
+    expect(withWork.length).toBeGreaterThan(0);
+    const last = withWork[withWork.length - 1]!;
+    expect(last.split("\n")[0]).toBe("✍️ 대답하는 중…"); // 머리글은 최신 상태 하나
+    expect(last).toContain("실행: ls");                   // 작업은 남아 있다
+    expect((last.match(/생각하는 중/g) ?? []).length).toBe(0); // 옛 상태는 안 쌓인다
+  });
+
+  test("★대조군 — 상태가 안 오면 머리글은 처음 그대로★", async () => {
+    const { deps, edits } = spiesWithStatus([{ work: "실행: pwd", id: "e1" }]);
+    await handleMessage(42, "해줘", 1, deps);
+    const withWork = edits.filter((e) => e.includes("실행: pwd"));
+    expect(withWork[0]!.split("\n")[0]).toBe(DEFAULT_WORKING_TEXT);
+  });
+});

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -504,7 +504,7 @@ export async function handleMessage(
     editing = true;
     dirty = false;
     lastEditAt = Date.now();
-    const text = renderBubble(workingText, lines);
+    const text = renderBubble(headLine, lines);
     const work = (async () => {
       const ok = await edit(chatId, bubbleId as number, text);
       if (!ok) {
@@ -535,16 +535,25 @@ export async function handleMessage(
     }, wait);
   };
 
+  // ★상태는 한 자리에서 교체된다★ — 쌓지 않는다. 실제 작업만 아래에 쌓인다.
+  let headLine = workingText;
+  const onStatus = (line: string): void => {
+    if (bubbleId === null || line === headLine) return;
+    headLine = line;
+    dirty = true;
+    schedule();
+  };
+
   const onActivity = (line: string, itemId?: string): void => {
     if (bubbleId === null) return;
     const next = appendLine(lines, line, undefined, itemId);
     if (next === lines) return; // 빈 줄이라 담을 것이 없다
-    if (!fits(workingText, next)) {
+    if (!fits(headLine, next)) {
       // ★한도에 닿으면 지금 버블은 남기고 새 버블로 넘어간다★ — 어디까지 했는지가 사라지지 않는다.
       lines = appendLine([], line);
       dirty = true;
       void (async () => {
-        const fresh = await send(chatId, renderBubble(workingText, lines));
+        const fresh = await send(chatId, renderBubble(headLine, lines));
         if (fresh !== null) { bubbleId = fresh; dirty = false; lastEditAt = Date.now(); }
       })();
       return;
@@ -558,6 +567,7 @@ export async function handleMessage(
     prompt: promptText,
     agentId: selfAgentId, // ★필수★ — 승인 요청의 주인이 된다
     onActivity,
+    onStatus,
 
     resumeSessionId: prior,
     codexHome: deps.codexHome,

--- a/src/server/runtimes/codex/progressLines.test.ts
+++ b/src/server/runtimes/codex/progressLines.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe } from "bun:test";
 import {
-  previewOf, appendLine, renderBubble, fits, retryPlan,
+  previewOf, appendLine, renderBubble, fits, retryPlan, iconFor, WORK_ICONS,
   PREVIEW_MAX, BUBBLE_MAX_UNITS, RETRY_WAIT_MAX_SEC,
 } from "./progressLines";
 
@@ -122,5 +122,38 @@ describe("진행 줄 — 항목 id 로 교체", () => {
     const first = appendLine([], "웹 검색", undefined, "exec-1");
     const again = appendLine(first, "웹 검색", undefined, "exec-1");
     expect(again).toBe(first);
+  });
+});
+
+describe("버블 — 머리글은 상태 한 자리, 작업은 그 아래 누적", () => {
+  test("★머리글은 남고 작업은 아래에 쌓인다★ — 상태는 거기서 교체된다", () => {
+    let lines = appendLine([], "실행: a");
+    lines = appendLine(lines, "웹 검색: b");
+    const out = renderBubble("🧠 생각하는 중…", lines);
+    expect(out.split("\n")[0]).toBe("🧠 생각하는 중…");
+    expect(out).toContain("실행: a");
+    expect(out).toContain("웹 검색: b");
+  });
+
+  test("★대조군 — 아직 작업이 없으면 머리글만★ (빈 메시지는 못 보낸다)", () => {
+    expect(renderBubble("⏳ 작업 중…", [])).toBe("⏳ 작업 중…");
+  });
+
+  test("★아이콘은 줄마다 돌아간다★ — 같은 그림이 세로로 반복되면 줄 수를 눈으로 못 센다", () => {
+    let lines = appendLine([], "a");
+    lines = appendLine(lines, "b");
+    lines = appendLine(lines, "c");
+    const icons = renderBubble("H", lines).split("\n").slice(1).map((l) => l.split(" ")[0]);
+    expect(new Set(icons).size).toBe(3);
+    expect(icons[0]).toBe(iconFor(0));
+  });
+
+  test("★아이콘은 자리 기준이라 다시 그려도 같다★ — 편집마다 바뀌면 화면이 요동친다", () => {
+    const lines = appendLine(appendLine([], "a"), "b");
+    expect(renderBubble("H", lines)).toBe(renderBubble("H", lines));
+  });
+
+  test("아이콘 목록보다 줄이 많으면 처음부터 다시 쓴다", () => {
+    expect(iconFor(0)).toBe(iconFor(WORK_ICONS.length));
   });
 });

--- a/src/server/runtimes/codex/progressLines.ts
+++ b/src/server/runtimes/codex/progressLines.ts
@@ -70,9 +70,25 @@ export function appendLine(
 }
 
 /** 버블 본문. header 는 "⏳ 작업 중…" 같은 첫 줄이다. */
+/**
+ * 작업 줄 아이콘 — 줄마다 돌려 쓴다.
+ * ★같은 그림이 세로로 반복되면 줄 수를 눈으로 못 센다★(팀 리드 요청 2026-08-18).
+ * 무작위가 아니라 ★자리 기준★ 으로 고른다 — 편집할 때마다 그림이 바뀌면 화면이 요동친다.
+ */
+export const WORK_ICONS = ["🛠️", "⚙️", "🔧", "📎", "🧩", "📐"] as const;
+
+export function iconFor(index: number): string {
+  return WORK_ICONS[index % WORK_ICONS.length] as string;
+}
+
 export function renderBubble(header: string, lines: ProgressLine[]): string {
+  // ★머리글은 '지금 어느 단계인가' 한 자리다★ — 매 턴 여러 번 오는 상태(생각·대답 준비)를
+  //   여기서 교체한다. 쌓지 않으므로 화면이 그것으로 차지 않는다(팀 리드 설계 2026-08-18).
+  //   실제 작업은 그 아래에 계속 쌓인다.
   if (lines.length === 0) return header;
-  const body = lines.map((l) => (l.count > 1 ? `🛠️ ${l.text} (×${l.count})` : `🛠️ ${l.text}`)).join("\n");
+  const body = lines
+    .map((l, i) => (l.count > 1 ? `${iconFor(i)} ${l.text} (×${l.count})` : `${iconFor(i)} ${l.text}`))
+    .join("\n");
   return `${header}\n${body}`;
 }
 

--- a/src/server/runtimes/codex/runner.ts
+++ b/src/server/runtimes/codex/runner.ts
@@ -53,6 +53,8 @@ export interface CodexTurnOptions {
    *  채널(텔레그램 등)이 "지금 무엇을 하는 중인지" 를 보여주려면 이 통로가 필요하다 —
    *  없으면 러너까지 온 이벤트가 호출자에게 도달하지 않는다. */
   onActivity?: (line: string, itemId?: string) => void;
+  /** 지금 어느 단계인가 — 맨 윗줄에서 교체된다(쌓이지 않는다). */
+  onStatus?: (line: string) => void;
 }
 
 export interface CodexTurnResult {


### PR DESCRIPTION
## 핵심 3줄
1. 진행 표시가 **`작업 중…` · `생각하는 중` · `답 쓰는 중` 으로 채워진다.** 매 턴 여러 번 나오는 줄이라 **실제로 한 일이 그 사이에 묻힌다.**
2. dex 를 쓰는 모든 턴에 해당한다. 게다가 파일 작업은 **`fileChange` 라는 내부 이름**으로 떴다.
3. 상태는 **맨 윗줄 한 자리에서 교체**하고, 실제 작업만 **그 아래 누적**한다.

## 바뀌는 모습

**전**
```
⏳ 작업 중…
🛠️ 생각하는 중
🛠️ 답 쓰는 중
🛠️ 웹 검색
🛠️ 생각하는 중
🛠️ fileChange
```

**후** (실제 턴을 태워 찍은 화면)
```
✍️ 대답하는 중…
🛠️ 파일 생성: memo.txt
⚙️ 실행: /bin/zsh -lc "sed -n '1,20p' memo.t…
🔧 웹 검색
📎 웹 검색: 판교 현재 날씨 성남시 2026년 8월 18일
```
맨 윗줄은 `⏳ 작업 중…` → `🧠 생각하는 중…` → `✍️ 대답하는 중…` 으로 **교체**되고, 마지막에 답이 그 자리를 대신하는 것은 그대로다.

## 무엇을 바꿨나

| | |
|---|---|
| 상태(`reasoning` · `agentMessage`) | 작업 줄로 **쌓지 않는다**. `statusLineOf` 가 머리글로 돌려준다 |
| 실제 작업 | 그 아래 누적 — 파일·명령·검색·도구 |
| `onStatus` 통로 | 클라이언트 → 러너 → 브리지까지 새로 잇는다 |
| 파일 변경 | **`changes` 배열**을 읽는다 — 파일 이름과 생성/삭제/수정을 보여준다 |
| 아이콘 | 줄마다 돌려 쓴다 |

**파일 변경이 내부 이름으로 뜬 이유**: 실측하니 codex 는 `changes` **배열**로 보낸다 — `[{ path, kind:{type:"add"}, diff }]`. 예전 코드는 `fileChanges` 라는 **객체**를 찾다가 못 만나고 마지막 줄(타입 이름 그대로 출력)로 떨어졌다.

**아이콘을 자리 기준으로 고른 이유**: 무작위면 편집할 때마다 같은 줄의 그림이 바뀌어 **화면이 요동친다.** 자리 기준이면 다시 그려도 같은 줄은 같은 그림이다.

## 검증

```
검증 범위:  bun test (전체 224파일 2845 시험) · bunx tsc --noEmit
baseline:   0 fail
시험:       상태는 쌓이지 않고 머리글로 간다 · ★대조군(실제 작업은 머리글이 아니다)★
            · 파일 변경 4건(생성/삭제/수정 · 여러 개 · 내부 이름 안 샘 · ★대조군: 목록이 비면 지어내지 않는다★)
            · 아이콘 순환 · ★다시 그려도 같은 그림★ · 머리글 유지
배선:       bridge 2건 — 상태가 맨 윗줄에서 교체되고 작업은 남는가 · ★대조군(상태가 없으면 머리글 그대로)★
mutation:   상태를 작업 줄로 쌓음(옛 동작)     → 빨강 ✓
            상태 줄을 안 만듦(머리글 안 바뀜)   → 빨강 ✓
            아이콘을 하나로 고정                → 빨강 ✓
라이브:     ★실제 codex 턴을 태워 화면을 눈으로 확인했다★ — 위 "후" 블록이 그 출력이다
            (파일 생성 → 명령 실행 → 웹 검색 두 번 → 답, 상태는 한 자리에서 교체)
미검증:     ★실제 텔레그램에 보내보지는 않았다★ — 전송은 mock 이다.
            아이콘이 기기·글꼴에 따라 어떻게 보이는지는 확인하지 않았다.
```

## 시험 계약 변경

같은 날 내가 쓴 시험 3건이 빨간불이 됐다(상태 줄을 아예 빼는 앞 설계). **지우지 않고 새 설계로 뒤집었다** — 상태는 지우는 게 아니라 **쌓지 않는 것**이다.

Submitted-by: Demis
