### PR TITLE
feat(scheduler): workflow 회차 단위 skip을 추가한다

### DIFF
--- a/skills/b3os-scheduler/SKILL.md
+++ b/skills/b3os-scheduler/SKILL.md
@@ -60,7 +60,7 @@ assignScheduledJobToWorkflow(db, prepare.id, "weekly_self_learning", "shared_cur
 assignScheduledJobToWorkflow(db, session.id, "weekly_self_learning", "self_learning", 20);
 ```
 
-한 회차를 건너뛸 때 개별 `next_run_at`을 직접 수정하지 않는다. 팀장 인증 경로에서 아래 API를 호출하면 소속된 활성 잡 전체가 같은 로컬 날짜의 회차인지 검증한 뒤 한 트랜잭션으로 `skipped` 이력과 다음 슬롯을 기록한다. 일부 잡이 다른 회차를 가리키거나 실행 중이면 전체가 롤백된다.
+한 회차를 건너뛸 때 개별 `next_run_at`을 직접 수정하지 않는다. 팀장 인증 경로에서 아래 API를 호출하면 소속된 활성 잡 중 그 로컬 날짜에 남아 있는 단계를 한 트랜잭션으로 `skipped` 처리하고 다음 슬롯을 기록한다. 같은 날 이미 실행되어 다음 회차로 넘어간 단계는 `alreadyPassedJobIds`로 구분한다. 그 밖의 회차 불일치나 실행 중인 잡이 있으면 전체가 롤백된다.
 
 ```http
 POST /team/api/schedules/workflows/weekly_self_learning/occurrences/2026-08-21/skip
@@ -69,7 +69,9 @@ Content-Type: application/json
 {"reason":"이번 주 세션 휴무"}
 ```
 
-같은 회차 skip 재요청은 idempotent no-op이다. 현재 API는 **skip만 지원**한다. reschedule은 예외 스키마에 예약되어 있지만, 벽시계 시각·DST·선후행 의존을 함께 정의한 뒤 별도로 구현한다.
+같은 회차 skip 재요청은 idempotent no-op이다. 응답의 `ungroupedActiveJobIds`와 `warnings`는 같은 날짜에 활성 상태지만 워크플로 밖이라 건너뛰지 않은 잡을 알린다. 현재 API와 예외 스키마는 **skip만 지원**한다.
+
+회차 키는 워크플로 시간대의 로컬 날짜 하나다. 따라서 한 워크플로의 단계는 같은 로컬 날짜 안에 있어야 하며, 23:00 준비→다음 날 01:00 보고처럼 자정을 넘는 구성은 현재 모델로 묶지 않는다.
 
 **반복 cron 잡:**
 ```ts

--- a/skills/b3os-scheduler/SKILL.md
+++ b/skills/b3os-scheduler/SKILL.md
@@ -20,6 +20,7 @@ trigger: schedule recurring work
 
 ## 개념 (실제 구현)
 - **정본 저장**: `team.db`의 `scheduled_job` 테이블 (id·kind·schedule_kind·next_run_at(UTC)·schedule_expr·payload_json·enabled·lock_until…). 실행 이력=`scheduled_job_run`.
+- **여러 잡이 한 과제를 이루면** `scheduled_workflow`가 관계의 정본이다. 잡은 `workflow_id`·`workflow_step_key`·`workflow_step_order`로 소속되며, 제목이나 payload 문자열로 관계를 추론하지 않는다. 회차별 예외는 `scheduled_workflow_exception`에 남긴다.
 - **워커**: b3os 서버가 `startSchedulerWorker`로 틱마다(기본 60초, env `B3OS_SCHEDULER_INTERVAL_MS`로 조정·최소 5초) `next_run_at<=now`인 잡을 lease-claim → 발화 → 재계산. 코드=`src/server/scheduler/core.ts`(`runDueSchedulerJobsOnce`)·`workers/schedulerWorker.ts`.
 - **발화 = 2종 페이로드**: ①`inbox` — `payload_json`의 인박스 봉투를 `acceptInbound`로 삽입(실제 wake/라우팅은 wakeDispatcher, 신규 라우팅 0). ②`exec` — allowlist된 ops 스크립트를 spawn(에이전트 안 깨우고 결정적 작업 직접 수행, 옛 launchd 대체). inbox는 emit+재계산이 단일 트랜잭션(at-most-once), exec는 async라 실행 후 재계산(at-least-once).
 - **잡 종류(kind × schedule_kind)**: `recurring`×`cron`(시·분·요일·월) / `recurring`×`interval`(N분 간격) / `oneshot`×`once`(1회 리마인드).
@@ -44,6 +45,31 @@ trigger: schedule recurring work
 
 ## 등록 방법
 API = `src/server/scheduler/core.ts`. 서버 프로세스 안이나 team.db를 여는 스크립트에서 호출.
+
+### 여러 잡으로 구성된 워크플로
+
+준비→실행→보고처럼 여러 scheduled job이 한 과제를 이루면 먼저 `ensureScheduledWorkflow`로 불변 키를 만들고, 각 잡을 `assignScheduledJobToWorkflow`로 연결한다. `workflow_step_key`는 워크플로 안에서 유일해야 한다.
+
+```ts
+ensureScheduledWorkflow(db, {
+  id: "weekly_self_learning",
+  title: "주간 러닝 세션",
+  timezone: "Asia/Seoul",
+});
+assignScheduledJobToWorkflow(db, prepare.id, "weekly_self_learning", "shared_curation", 10);
+assignScheduledJobToWorkflow(db, session.id, "weekly_self_learning", "self_learning", 20);
+```
+
+한 회차를 건너뛸 때 개별 `next_run_at`을 직접 수정하지 않는다. 팀장 인증 경로에서 아래 API를 호출하면 소속된 활성 잡 전체가 같은 로컬 날짜의 회차인지 검증한 뒤 한 트랜잭션으로 `skipped` 이력과 다음 슬롯을 기록한다. 일부 잡이 다른 회차를 가리키거나 실행 중이면 전체가 롤백된다.
+
+```http
+POST /team/api/schedules/workflows/weekly_self_learning/occurrences/2026-08-21/skip
+Content-Type: application/json
+
+{"reason":"이번 주 세션 휴무"}
+```
+
+같은 회차 skip 재요청은 idempotent no-op이다. 현재 API는 **skip만 지원**한다. reschedule은 예외 스키마에 예약되어 있지만, 벽시계 시각·DST·선후행 의존을 함께 정의한 뒤 별도로 구현한다.
 
 **반복 cron 잡:**
 ```ts

--- a/skills/b3os-team-learning-loop/SKILL.md
+++ b/skills/b3os-team-learning-loop/SKILL.md
@@ -31,6 +31,8 @@ trigger: record a team lesson
 
 금요일 05:00 KST self-learning 세션에서 실행한다. 자동화가 있더라도 파일을 바로 고치는 것이 아니라 후보를 만들고, 필요한 경우 공동 리뷰와 {{OWNER}} 승인 gate를 거친다. 금요일 10:00 KST에는 learning-loop PM이 {{OWNER}}에게 정리된 결과를 메시지로 보낸다.
 
+스케줄 구성의 관계 정본은 `scheduled_workflow.id = weekly_self_learning`이다. 특정 주 회차를 쉬거나 조정할 때 잡 제목으로 검색해 개별 수정하지 말고 `b3os-scheduler`의 workflow occurrence 연산을 사용한다.
+
 1. 입력 수집
    - 지난 1주일 `rules/SHARED.md` 신규 항목과 stale(낡음)/중복 후보
    - Tasks 칸반에서 반복적으로 멈춘 과제, owner 혼선, handoff 실패, 완료 기준 누락

--- a/src/server/db/migrate.ts
+++ b/src/server/db/migrate.ts
@@ -355,13 +355,15 @@ export function migrateSchedulerState(db: Database): void {
   db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_scheduled_job_workflow_step
     ON scheduled_job(workflow_id, workflow_step_key)
     WHERE workflow_id IS NOT NULL AND workflow_step_key IS NOT NULL`);
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_scheduled_job_workflow_order
+    ON scheduled_job(workflow_id, workflow_step_order)
+    WHERE workflow_id IS NOT NULL AND workflow_step_order IS NOT NULL`);
   db.exec(
     `CREATE TABLE IF NOT EXISTS scheduled_workflow_exception (
        id TEXT PRIMARY KEY,
        workflow_id TEXT NOT NULL REFERENCES scheduled_workflow(id) ON DELETE CASCADE,
        occurrence_date TEXT NOT NULL,
-       action TEXT NOT NULL CHECK(action IN ('skip','reschedule')),
-       rescheduled_to_date TEXT,
+       action TEXT NOT NULL CHECK(action = 'skip'),
        reason TEXT NOT NULL,
        actor TEXT NOT NULL,
        created_at TEXT NOT NULL DEFAULT (datetime('now')),

--- a/src/server/db/migrate.ts
+++ b/src/server/db/migrate.ts
@@ -305,6 +305,18 @@ export function migrateCodexRuntimeState(db: Database): void {
 
 export function migrateSchedulerState(db: Database): void {
   db.exec(
+    `CREATE TABLE IF NOT EXISTS scheduled_workflow (
+       id TEXT PRIMARY KEY,
+       title TEXT NOT NULL,
+       timezone TEXT NOT NULL DEFAULT 'Asia/Seoul',
+       owner_agent_id TEXT,
+       description TEXT NOT NULL DEFAULT '',
+       enabled INTEGER NOT NULL DEFAULT 1,
+       created_at TEXT NOT NULL DEFAULT (datetime('now')),
+       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+     )`,
+  );
+  db.exec(
     `CREATE TABLE IF NOT EXISTS scheduled_job (
        id TEXT PRIMARY KEY,
        kind TEXT NOT NULL CHECK(kind IN ('oneshot','recurring')),
@@ -312,6 +324,9 @@ export function migrateSchedulerState(db: Database): void {
        status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','running','succeeded','failed','cancelled')),
        enabled INTEGER NOT NULL DEFAULT 1,
        title TEXT NOT NULL,
+       workflow_id TEXT REFERENCES scheduled_workflow(id),
+       workflow_step_key TEXT,
+       workflow_step_order INTEGER,
        owner_agent_id TEXT,
        target_agent_id TEXT,
        created_by TEXT NOT NULL DEFAULT 'system',
@@ -331,8 +346,28 @@ export function migrateSchedulerState(db: Database): void {
        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
      )`,
   );
+  addColumnIfMissing(db, "scheduled_job", "workflow_id", "TEXT REFERENCES scheduled_workflow(id)");
+  addColumnIfMissing(db, "scheduled_job", "workflow_step_key", "TEXT");
+  addColumnIfMissing(db, "scheduled_job", "workflow_step_order", "INTEGER");
   db.exec("CREATE INDEX IF NOT EXISTS idx_scheduled_job_due ON scheduled_job(enabled, status, next_run_at, lock_until)");
   db.exec("CREATE INDEX IF NOT EXISTS idx_scheduled_job_target ON scheduled_job(target_agent_id, next_run_at)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_scheduled_job_workflow ON scheduled_job(workflow_id, workflow_step_order)");
+  db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_scheduled_job_workflow_step
+    ON scheduled_job(workflow_id, workflow_step_key)
+    WHERE workflow_id IS NOT NULL AND workflow_step_key IS NOT NULL`);
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS scheduled_workflow_exception (
+       id TEXT PRIMARY KEY,
+       workflow_id TEXT NOT NULL REFERENCES scheduled_workflow(id) ON DELETE CASCADE,
+       occurrence_date TEXT NOT NULL,
+       action TEXT NOT NULL CHECK(action IN ('skip','reschedule')),
+       rescheduled_to_date TEXT,
+       reason TEXT NOT NULL,
+       actor TEXT NOT NULL,
+       created_at TEXT NOT NULL DEFAULT (datetime('now')),
+       UNIQUE(workflow_id, occurrence_date)
+     )`,
+  );
   db.exec(
     `CREATE TABLE IF NOT EXISTS scheduled_job_run (
        id TEXT PRIMARY KEY,

--- a/src/server/db/schema.sql
+++ b/src/server/db/schema.sql
@@ -226,13 +226,15 @@ CREATE INDEX IF NOT EXISTS idx_scheduled_job_workflow ON scheduled_job(workflow_
 CREATE UNIQUE INDEX IF NOT EXISTS idx_scheduled_job_workflow_step
   ON scheduled_job(workflow_id, workflow_step_key)
   WHERE workflow_id IS NOT NULL AND workflow_step_key IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_scheduled_job_workflow_order
+  ON scheduled_job(workflow_id, workflow_step_order)
+  WHERE workflow_id IS NOT NULL AND workflow_step_order IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS scheduled_workflow_exception (
   id TEXT PRIMARY KEY,
   workflow_id TEXT NOT NULL REFERENCES scheduled_workflow(id) ON DELETE CASCADE,
   occurrence_date TEXT NOT NULL,
-  action TEXT NOT NULL CHECK(action IN ('skip','reschedule')),
-  rescheduled_to_date TEXT,
+  action TEXT NOT NULL CHECK(action = 'skip'),
   reason TEXT NOT NULL,
   actor TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),

--- a/src/server/db/schema.sql
+++ b/src/server/db/schema.sql
@@ -181,6 +181,17 @@ CREATE TABLE IF NOT EXISTS codex_approval_correlation (
 CREATE INDEX IF NOT EXISTS idx_codex_approval_corr_state ON codex_approval_correlation(state, created_at);
 CREATE INDEX IF NOT EXISTS idx_codex_approval_corr_proc ON codex_approval_correlation(process_instance);
 
+CREATE TABLE IF NOT EXISTS scheduled_workflow (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  timezone TEXT NOT NULL DEFAULT 'Asia/Seoul',
+  owner_agent_id TEXT,
+  description TEXT NOT NULL DEFAULT '',
+  enabled INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 CREATE TABLE IF NOT EXISTS scheduled_job (
   id TEXT PRIMARY KEY,
   kind TEXT NOT NULL CHECK(kind IN ('oneshot','recurring')),
@@ -188,6 +199,9 @@ CREATE TABLE IF NOT EXISTS scheduled_job (
   status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','running','succeeded','failed','cancelled')),
   enabled INTEGER NOT NULL DEFAULT 1,
   title TEXT NOT NULL,
+  workflow_id TEXT REFERENCES scheduled_workflow(id),
+  workflow_step_key TEXT,
+  workflow_step_order INTEGER,
   owner_agent_id TEXT,
   target_agent_id TEXT,
   created_by TEXT NOT NULL DEFAULT 'system',
@@ -208,6 +222,22 @@ CREATE TABLE IF NOT EXISTS scheduled_job (
 );
 CREATE INDEX IF NOT EXISTS idx_scheduled_job_due ON scheduled_job(enabled, status, next_run_at, lock_until);
 CREATE INDEX IF NOT EXISTS idx_scheduled_job_target ON scheduled_job(target_agent_id, next_run_at);
+CREATE INDEX IF NOT EXISTS idx_scheduled_job_workflow ON scheduled_job(workflow_id, workflow_step_order);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_scheduled_job_workflow_step
+  ON scheduled_job(workflow_id, workflow_step_key)
+  WHERE workflow_id IS NOT NULL AND workflow_step_key IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS scheduled_workflow_exception (
+  id TEXT PRIMARY KEY,
+  workflow_id TEXT NOT NULL REFERENCES scheduled_workflow(id) ON DELETE CASCADE,
+  occurrence_date TEXT NOT NULL,
+  action TEXT NOT NULL CHECK(action IN ('skip','reschedule')),
+  rescheduled_to_date TEXT,
+  reason TEXT NOT NULL,
+  actor TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(workflow_id, occurrence_date)
+);
 
 CREATE TABLE IF NOT EXISTS scheduled_job_run (
   id TEXT PRIMARY KEY,

--- a/src/server/routes/scheduler.test.ts
+++ b/src/server/routes/scheduler.test.ts
@@ -232,6 +232,7 @@ describe("scheduler routes", () => {
     const payload = { type: "capability_workloop" as const, capability: "coordinator", threadId: "route-weekly", body: "route" };
     const a = createCronJob(db, { id: "route-weekly-a", title: "A", cron: "0 4 * * 5", timezone: "Asia/Seoul", from, payload });
     const b = createCronJob(db, { id: "route-weekly-b", title: "B", cron: "0 10 * * 5", timezone: "Asia/Seoul", from, payload });
+    const legacy = createCronJob(db, { id: "route-weekly-legacy", title: "Legacy", cron: "0 5 * * 5", timezone: "Asia/Seoul", from, payload });
     assignScheduledJobToWorkflow(db, a.id, "route-weekly", "a", 10);
     assignScheduledJobToWorkflow(db, b.id, "route-weekly", "b", 20);
 
@@ -244,8 +245,15 @@ describe("scheduler routes", () => {
       method: "POST", headers: authHeaders("gd"), body: JSON.stringify({ reason: "week off" }),
     });
     expect(skipped.status).toBe(200);
-    const json = (await skipped.json()) as { skippedJobIds: string[]; alreadySkipped: boolean };
+    const json = (await skipped.json()) as {
+      skippedJobIds: string[];
+      alreadySkipped: boolean;
+      ungroupedActiveJobIds: string[];
+      warnings: Array<{ code: string; job_ids: string[] }>;
+    };
     expect(json.skippedJobIds).toEqual([a.id, b.id]);
     expect(json.alreadySkipped).toBe(false);
+    expect(json.ungroupedActiveJobIds).toEqual([legacy.id]);
+    expect(json.warnings).toEqual([{ code: "ungrouped_active_jobs_in_occurrence", job_ids: [legacy.id] }]);
   });
 });

--- a/src/server/routes/scheduler.test.ts
+++ b/src/server/routes/scheduler.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { Hono } from "hono";
 import { openDb, migrate } from "../db/migrate";
 import { createSchedulerRoutes } from "./scheduler";
+import { assignScheduledJobToWorkflow, createCronJob, ensureScheduledWorkflow } from "../scheduler/core";
 
 function makeApp(opts: { acceptingJobs?: boolean } = {}) {
   process.env.OP_MESSAGE_TOKEN = "test-token";
@@ -222,5 +223,29 @@ describe("scheduler routes", () => {
       headers: authHeaders("gd"),
     });
     expect(leadCancel.status).toBe(200);
+  });
+
+  test("lead can skip a complete workflow occurrence but a member cannot", async () => {
+    const { app, db } = makeApp();
+    ensureScheduledWorkflow(db, { id: "route-weekly", title: "Route weekly", timezone: "Asia/Seoul" });
+    const from = new Date("2026-08-16T15:00:00Z");
+    const payload = { type: "capability_workloop" as const, capability: "coordinator", threadId: "route-weekly", body: "route" };
+    const a = createCronJob(db, { id: "route-weekly-a", title: "A", cron: "0 4 * * 5", timezone: "Asia/Seoul", from, payload });
+    const b = createCronJob(db, { id: "route-weekly-b", title: "B", cron: "0 10 * * 5", timezone: "Asia/Seoul", from, payload });
+    assignScheduledJobToWorkflow(db, a.id, "route-weekly", "a", 10);
+    assignScheduledJobToWorkflow(db, b.id, "route-weekly", "b", 20);
+
+    const blocked = await app.request("/api/schedules/workflows/route-weekly/occurrences/2026-08-21/skip", {
+      method: "POST", headers: authHeaders("dex"), body: JSON.stringify({ reason: "not lead" }),
+    });
+    expect(blocked.status).toBe(403);
+
+    const skipped = await app.request("/api/schedules/workflows/route-weekly/occurrences/2026-08-21/skip", {
+      method: "POST", headers: authHeaders("gd"), body: JSON.stringify({ reason: "week off" }),
+    });
+    expect(skipped.status).toBe(200);
+    const json = (await skipped.json()) as { skippedJobIds: string[]; alreadySkipped: boolean };
+    expect(json.skippedJobIds).toEqual([a.id, b.id]);
+    expect(json.alreadySkipped).toBe(false);
   });
 });

--- a/src/server/routes/scheduler.ts
+++ b/src/server/routes/scheduler.ts
@@ -1,7 +1,7 @@
 import { Hono, type Context } from "hono";
 import type { Database } from "bun:sqlite";
 import { z } from "zod";
-import { getScheduledJob, scheduleReminder } from "../scheduler/core";
+import { getScheduledJob, scheduleReminder, skipWorkflowOccurrence } from "../scheduler/core";
 import { appendAudit } from "../db/queries";
 import { leadActorId, trustedActorFromRequest } from "../lib/opAuth";
 
@@ -30,6 +30,10 @@ const reminderSchema = z
     message: "provide exactly one of run_at or delay_seconds",
     path: ["run_at"],
   });
+
+const workflowSkipSchema = z.object({
+  reason: z.string().trim().min(1).max(500),
+});
 
 function authError(c: Context, auth: ReturnType<typeof trustedActorFromRequest>) {
   const status = (auth.status ?? 401) as 401 | 403 | 503;
@@ -154,6 +158,37 @@ export function createSchedulerRoutes(deps: SchedulerRouteDeps): Hono {
       return c.json({ error: "schedule_forbidden", id }, 403);
     }
     return c.json({ job });
+  });
+
+  r.post("/schedules/workflows/:id/occurrences/:date/skip", async (c) => {
+    const auth = trustedActorFromRequest(c.req.raw, { loopbackDashboardActor: leadActorId(deps.db) });
+    if (!auth.ok || !auth.actor) return authError(c, auth);
+    const actor = auth.actor.actor;
+    if (!isLeadActor(deps.db, actor)) return c.json({ error: "workflow_schedule_forbidden" }, 403);
+    let raw: unknown;
+    try {
+      raw = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid_json" }, 400);
+    }
+    const parsed = workflowSkipSchema.safeParse(raw);
+    if (!parsed.success) return c.json({ error: "schema_validation", issues: parsed.error.issues }, 400);
+    try {
+      const result = skipWorkflowOccurrence(deps.db, {
+        workflowId: c.req.param("id"),
+        occurrenceDate: c.req.param("date"),
+        actor,
+        reason: parsed.data.reason,
+      });
+      return c.json({ ok: true, ...result });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      if (detail === "invalid_occurrence_date") return c.json({ error: detail }, 400);
+      if (detail.startsWith("scheduled_workflow_not_active:") || detail.startsWith("scheduled_workflow_has_no_jobs:")) {
+        return c.json({ error: detail }, 404);
+      }
+      return c.json({ error: "workflow_occurrence_not_skippable", detail }, 409);
+    }
   });
 
   r.post("/schedules/:id/cancel", (c) => {

--- a/src/server/routes/scheduler.ts
+++ b/src/server/routes/scheduler.ts
@@ -180,14 +180,25 @@ export function createSchedulerRoutes(deps: SchedulerRouteDeps): Hono {
         actor,
         reason: parsed.data.reason,
       });
-      return c.json({ ok: true, ...result });
+      return c.json({
+        ok: true,
+        ...result,
+        warnings: result.ungroupedActiveJobIds.length > 0
+          ? [{ code: "ungrouped_active_jobs_in_occurrence", job_ids: result.ungroupedActiveJobIds }]
+          : [],
+      });
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       if (detail === "invalid_occurrence_date") return c.json({ error: detail }, 400);
       if (detail.startsWith("scheduled_workflow_not_active:") || detail.startsWith("scheduled_workflow_has_no_jobs:")) {
         return c.json({ error: detail }, 404);
       }
-      return c.json({ error: "workflow_occurrence_not_skippable", detail }, 409);
+      if (
+        detail.startsWith("scheduled_workflow_job_not_pending:")
+        || detail.startsWith("scheduled_workflow_occurrence_mismatch:")
+        || detail.startsWith("scheduled_workflow_no_next_run:")
+      ) return c.json({ error: "workflow_occurrence_not_skippable", detail }, 409);
+      throw error;
     }
   });
 

--- a/src/server/scheduler/core.test.ts
+++ b/src/server/scheduler/core.test.ts
@@ -27,6 +27,10 @@ import {
   consecutiveFailures,
   lateWakeBanner,
   emitCapabilityWorkloop,
+  ensureScheduledWorkflow,
+  assignScheduledJobToWorkflow,
+  skipWorkflowOccurrence,
+  WEEKLY_SELF_LEARNING_WORKFLOW_ID,
 } from "./core";
 import { nextCronRun } from "./cron";
 
@@ -78,6 +82,11 @@ describe("b3os scheduler core", () => {
     const second = ensureWeeklySelfLearningJobs(d);
     expect(second.map((job) => job.id)).toEqual(first.map((job) => job.id));
     expect(d.prepare(`SELECT count(*) AS n FROM scheduled_job WHERE id IN (?, ?)`).get(first[0]!.id, first[1]!.id)).toEqual({ n: 2 });
+    expect(first.map((job) => [job.workflow_id, job.workflow_step_key, job.workflow_step_order])).toEqual([
+      [WEEKLY_SELF_LEARNING_WORKFLOW_ID, "shared_curation", 10],
+      [WEEKLY_SELF_LEARNING_WORKFLOW_ID, "self_learning", 20],
+    ]);
+    expect(d.prepare(`SELECT title FROM scheduled_workflow WHERE id = ?`).get(WEEKLY_SELF_LEARNING_WORKFLOW_ID)).toEqual({ title: "주간 러닝 세션" });
     expect(JSON.parse(first[0]!.schedule_expr!)).toMatchObject({ cron: "0 4 * * 5" });
     expect(JSON.parse(first[1]!.schedule_expr!)).toMatchObject({ cron: "0 5 * * 5" });
     expect(JSON.parse(first[0]!.payload_json)).toMatchObject({
@@ -157,8 +166,58 @@ describe("b3os scheduler core", () => {
 
   test("migration creates scheduler tables", () => {
     const d = db();
-    const tables = d.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name IN ('scheduled_job','scheduled_job_run')`).all() as Array<{ name: string }>;
-    expect(tables.map((t) => t.name).sort()).toEqual(["scheduled_job", "scheduled_job_run"]);
+    const tables = d.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name IN ('scheduled_workflow','scheduled_job','scheduled_job_run','scheduled_workflow_exception')`).all() as Array<{ name: string }>;
+    expect(tables.map((t) => t.name).sort()).toEqual(["scheduled_job", "scheduled_job_run", "scheduled_workflow", "scheduled_workflow_exception"]);
+  });
+
+  test("workflow occurrence skip consumes every step atomically and is idempotent", () => {
+    const d = db();
+    ensureScheduledWorkflow(d, { id: "weekly-test", title: "Weekly test", timezone: "Asia/Seoul" });
+    const a = createCronJob(d, {
+      id: "weekly-test-a", title: "A", cron: "0 4 * * 5", timezone: "Asia/Seoul",
+      from: kst(2026, 8, 17, 0, 0), payload: learningPayload,
+    });
+    const b = createCronJob(d, {
+      id: "weekly-test-b", title: "B", cron: "0 10 * * 5", timezone: "Asia/Seoul",
+      from: kst(2026, 8, 17, 0, 0), payload: learningPayload,
+    });
+    assignScheduledJobToWorkflow(d, a.id, "weekly-test", "prepare", 10);
+    assignScheduledJobToWorkflow(d, b.id, "weekly-test", "report", 20);
+
+    const result = skipWorkflowOccurrence(d, {
+      workflowId: "weekly-test", occurrenceDate: "2026-08-21", actor: "gd", reason: "week off",
+      now: kst(2026, 8, 18, 12, 0),
+    });
+    expect(result.skippedJobIds).toEqual([a.id, b.id]);
+    expect(result.alreadySkipped).toBe(false);
+    const rows = d.prepare(`SELECT id, next_run_at, run_count FROM scheduled_job WHERE workflow_id='weekly-test' ORDER BY workflow_step_order`).all() as Array<{ id: string; next_run_at: string; run_count: number }>;
+    expect(rows.map((row) => fromSqliteDate(row.next_run_at))).toEqual([
+      kst(2026, 8, 28, 4, 0),
+      kst(2026, 8, 28, 10, 0),
+    ]);
+    expect(rows.map((row) => row.run_count)).toEqual([1, 1]);
+    expect(d.prepare(`SELECT count(*) AS n FROM scheduled_job_run WHERE outcome='skipped' AND job_id IN (?, ?)`).get(a.id, b.id)).toEqual({ n: 2 });
+
+    const repeated = skipWorkflowOccurrence(d, {
+      workflowId: "weekly-test", occurrenceDate: "2026-08-21", actor: "gd", reason: "retry",
+    });
+    expect(repeated.alreadySkipped).toBe(true);
+    expect(d.prepare(`SELECT sum(run_count) AS n FROM scheduled_job WHERE workflow_id='weekly-test'`).get()).toEqual({ n: 2 });
+  });
+
+  test("workflow occurrence skip rolls back when one step is on another occurrence", () => {
+    const d = db();
+    ensureScheduledWorkflow(d, { id: "weekly-mismatch", title: "Mismatch", timezone: "Asia/Seoul" });
+    const a = createCronJob(d, { id: "mismatch-a", title: "A", cron: "0 4 * * 5", timezone: "Asia/Seoul", from: kst(2026, 8, 17, 0, 0), payload: learningPayload });
+    const b = createCronJob(d, { id: "mismatch-b", title: "B", cron: "0 10 * * 5", timezone: "Asia/Seoul", from: kst(2026, 8, 24, 0, 0), payload: learningPayload });
+    assignScheduledJobToWorkflow(d, a.id, "weekly-mismatch", "a", 10);
+    assignScheduledJobToWorkflow(d, b.id, "weekly-mismatch", "b", 20);
+
+    expect(() => skipWorkflowOccurrence(d, {
+      workflowId: "weekly-mismatch", occurrenceDate: "2026-08-21", actor: "gd", reason: "week off",
+    })).toThrow("scheduled_workflow_occurrence_mismatch:mismatch-b:2026-08-28");
+    expect(d.prepare(`SELECT count(*) AS n FROM scheduled_workflow_exception WHERE workflow_id='weekly-mismatch'`).get()).toEqual({ n: 0 });
+    expect(d.prepare(`SELECT sum(run_count) AS n FROM scheduled_job WHERE workflow_id='weekly-mismatch'`).get()).toEqual({ n: 0 });
   });
 
   test("scheduleReminder creates a one-shot scheduled inbox wake", () => {

--- a/src/server/scheduler/core.test.ts
+++ b/src/server/scheduler/core.test.ts
@@ -140,6 +140,37 @@ describe("b3os scheduler core", () => {
     expect(session.enabled).toBe(1);
   });
 
+  test("weekly learning backfills a fully skipped historical occurrence", () => {
+    const d = db();
+    const jobs = ensureWeeklySelfLearningJobs(d);
+    for (const job of jobs) {
+      d.prepare(
+        `INSERT INTO scheduled_job_run
+           (id, job_id, scheduled_for, started_at, finished_at, outcome, detail_json)
+         VALUES (?, ?, ?, ?, ?, 'skipped', ?)`,
+      ).run(
+        `historical-${job.id}`,
+        job.id,
+        job.id === jobs[0]!.id ? "2026-08-20 19:00:00" : "2026-08-20 20:00:00",
+        "2026-08-18 02:48:00",
+        "2026-08-18 02:48:00",
+        JSON.stringify({ reason: "lead_requested_week_skip", requested_local_date: "2026-08-18" }),
+      );
+    }
+
+    ensureWeeklySelfLearningJobs(d);
+    expect(d.prepare(
+      `SELECT occurrence_date, action, reason, actor
+         FROM scheduled_workflow_exception
+        WHERE workflow_id = ?`,
+    ).get(WEEKLY_SELF_LEARNING_WORKFLOW_ID)).toEqual({
+      occurrence_date: "2026-08-21",
+      action: "skip",
+      reason: "lead_requested_week_skip",
+      actor: "historical_backfill",
+    });
+  });
+
   test("daily task review seeds portable 06:00/06:20 jobs idempotently", () => {
     const d = db();
     const first = ensureDailyTaskReviewJobs(d);
@@ -218,6 +249,50 @@ describe("b3os scheduler core", () => {
     })).toThrow("scheduled_workflow_occurrence_mismatch:mismatch-b:2026-08-28");
     expect(d.prepare(`SELECT count(*) AS n FROM scheduled_workflow_exception WHERE workflow_id='weekly-mismatch'`).get()).toEqual({ n: 0 });
     expect(d.prepare(`SELECT sum(run_count) AS n FROM scheduled_job WHERE workflow_id='weekly-mismatch'`).get()).toEqual({ n: 0 });
+  });
+
+  test("workflow occurrence skip honors max_runs through the shared skip transition", () => {
+    const d = db();
+    ensureScheduledWorkflow(d, { id: "weekly-capped", title: "Capped", timezone: "Asia/Seoul" });
+    const job = createCronJob(d, {
+      id: "weekly-capped-a", title: "A", cron: "0 4 * * 5", timezone: "Asia/Seoul",
+      from: kst(2026, 8, 17, 0, 0), payload: learningPayload,
+    });
+    d.prepare(`UPDATE scheduled_job SET max_runs = 1 WHERE id = ?`).run(job.id);
+    assignScheduledJobToWorkflow(d, job.id, "weekly-capped", "a", 10);
+
+    skipWorkflowOccurrence(d, {
+      workflowId: "weekly-capped", occurrenceDate: "2026-08-21", actor: "gd", reason: "week off",
+      now: kst(2026, 8, 18, 12, 0),
+    });
+
+    expect(d.prepare(`SELECT status, enabled, run_count FROM scheduled_job WHERE id = ?`).get(job.id)).toEqual({
+      status: "succeeded", enabled: 0, run_count: 1,
+    });
+  });
+
+  test("workflow occurrence skip consumes only steps remaining in the current local date", () => {
+    const d = db();
+    ensureScheduledWorkflow(d, { id: "weekly-partial", title: "Partial", timezone: "Asia/Seoul" });
+    const a = createCronJob(d, { id: "partial-a", title: "A", cron: "0 4 * * 5", timezone: "Asia/Seoul", from: kst(2026, 8, 17, 0, 0), payload: learningPayload });
+    const b = createCronJob(d, { id: "partial-b", title: "B", cron: "0 5 * * 5", timezone: "Asia/Seoul", from: kst(2026, 8, 17, 0, 0), payload: learningPayload });
+    assignScheduledJobToWorkflow(d, a.id, "weekly-partial", "a", 10);
+    assignScheduledJobToWorkflow(d, b.id, "weekly-partial", "b", 20);
+    skipScheduledJob(d, a, "completed_probe", {
+      now: kst(2026, 8, 21, 4, 1),
+      nextRunFrom: new Date(fromSqliteDate(a.next_run_at).getTime() + 1),
+    });
+
+    const result = skipWorkflowOccurrence(d, {
+      workflowId: "weekly-partial", occurrenceDate: "2026-08-21", actor: "gd", reason: "stop remaining",
+      now: kst(2026, 8, 21, 4, 30),
+    });
+
+    expect(result.skippedJobIds).toEqual([b.id]);
+    expect(result.alreadyPassedJobIds).toEqual([a.id]);
+    expect(d.prepare(`SELECT run_count FROM scheduled_job WHERE id = ?`).get(a.id)).toEqual({ run_count: 1 });
+    expect(d.prepare(`SELECT run_count FROM scheduled_job WHERE id = ?`).get(b.id)).toEqual({ run_count: 1 });
+    expect(fromSqliteDate(getScheduledJob(d, b.id)!.next_run_at)).toEqual(kst(2026, 8, 28, 5, 0));
   });
 
   test("scheduleReminder creates a one-shot scheduled inbox wake", () => {

--- a/src/server/scheduler/core.test.ts
+++ b/src/server/scheduler/core.test.ts
@@ -201,7 +201,7 @@ describe("b3os scheduler core", () => {
     expect(tables.map((t) => t.name).sort()).toEqual(["scheduled_job", "scheduled_job_run", "scheduled_workflow", "scheduled_workflow_exception"]);
   });
 
-  test("workflow occurrence skip consumes every step atomically and is idempotent", () => {
+  test("future workflow occurrence skip advances every step past the skipped slot and is idempotent", () => {
     const d = db();
     ensureScheduledWorkflow(d, { id: "weekly-test", title: "Weekly test", timezone: "Asia/Seoul" });
     const a = createCronJob(d, {

--- a/src/server/scheduler/core.ts
+++ b/src/server/scheduler/core.ts
@@ -23,6 +23,9 @@ export interface ScheduledJobRow {
   status: ScheduledJobStatus;
   enabled: number;
   title: string;
+  workflow_id: string | null;
+  workflow_step_key: string | null;
+  workflow_step_order: number | null;
   owner_agent_id: string | null;
   target_agent_id: string | null;
   created_by: string;
@@ -63,6 +66,7 @@ export type SchedulePayload = InboxPayload | ExecPayload | CapabilityWorkloopPay
 
 export const WEEKLY_SHARED_CURATION_JOB_ID = "sched_weekly_shared_curation";
 export const WEEKLY_SELF_LEARNING_JOB_ID = "sched_weekly_self_learning_session";
+export const WEEKLY_SELF_LEARNING_WORKFLOW_ID = "weekly_self_learning";
 export const WEEKLY_SHARED_CURATION_CRON = "0 4 * * 5";
 export const WEEKLY_SELF_LEARNING_CRON = "0 5 * * 5";
 // 보고 경로 — 두 루프가 같은 문구를 쓴다.
@@ -454,8 +458,160 @@ function ensureCronJob(db: Database, input: CreateCronJobInput & { id: string })
   return getScheduledJob(db, input.id)!;
 }
 
+export interface ScheduledWorkflowInput {
+  id: string;
+  title: string;
+  timezone?: string;
+  ownerAgentId?: string | null;
+  description?: string;
+}
+
+export interface WorkflowOccurrenceSkipResult {
+  workflowId: string;
+  occurrenceDate: string;
+  skippedJobIds: string[];
+  alreadySkipped: boolean;
+}
+
+export function ensureScheduledWorkflow(db: Database, input: ScheduledWorkflowInput): void {
+  db.prepare(
+    `INSERT INTO scheduled_workflow
+       (id, title, timezone, owner_agent_id, description, enabled, updated_at)
+     VALUES (?, ?, ?, ?, ?, 1, datetime('now'))
+     ON CONFLICT(id) DO UPDATE SET
+       title = excluded.title,
+       timezone = excluded.timezone,
+       owner_agent_id = excluded.owner_agent_id,
+       description = excluded.description,
+       enabled = 1,
+       updated_at = datetime('now')`,
+  ).run(
+    input.id,
+    input.title,
+    input.timezone ?? "Asia/Seoul",
+    input.ownerAgentId ?? null,
+    input.description ?? "",
+  );
+}
+
+export function assignScheduledJobToWorkflow(
+  db: Database,
+  jobId: string,
+  workflowId: string,
+  stepKey: string,
+  stepOrder: number,
+): void {
+  const result = db.prepare(
+    `UPDATE scheduled_job
+       SET workflow_id = ?, workflow_step_key = ?, workflow_step_order = ?, updated_at = datetime('now')
+     WHERE id = ?`,
+  ).run(workflowId, stepKey, stepOrder, jobId);
+  if (result.changes !== 1) throw new Error(`scheduled_job_not_found:${jobId}`);
+}
+
+function localDateInZone(date: Date, timezone: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+}
+
+/**
+ * Consume every job in one workflow occurrence as a single transaction.
+ * The occurrence may be skipped before it is due; advancing from each scheduled
+ * slot (not from the request time) guarantees that the skipped slot cannot wake.
+ */
+export function skipWorkflowOccurrence(
+  db: Database,
+  input: { workflowId: string; occurrenceDate: string; actor: string; reason: string; now?: Date },
+): WorkflowOccurrenceSkipResult {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(input.occurrenceDate)) throw new Error("invalid_occurrence_date");
+  if (!input.actor.trim()) throw new Error("actor_required");
+  if (!input.reason.trim()) throw new Error("reason_required");
+
+  const run = db.transaction((): WorkflowOccurrenceSkipResult => {
+    const workflow = db.prepare(
+      `SELECT id, timezone, enabled FROM scheduled_workflow WHERE id = ?`,
+    ).get(input.workflowId) as { id: string; timezone: string; enabled: number } | null;
+    if (!workflow || workflow.enabled !== 1) throw new Error(`scheduled_workflow_not_active:${input.workflowId}`);
+
+    const existing = db.prepare(
+      `SELECT action FROM scheduled_workflow_exception WHERE workflow_id = ? AND occurrence_date = ?`,
+    ).get(input.workflowId, input.occurrenceDate) as { action: string } | null;
+    if (existing) {
+      if (existing.action !== "skip") throw new Error("workflow_occurrence_exception_conflict");
+      return { workflowId: input.workflowId, occurrenceDate: input.occurrenceDate, skippedJobIds: [], alreadySkipped: true };
+    }
+
+    const jobs = db.prepare(
+      `SELECT * FROM scheduled_job
+       WHERE workflow_id = ? AND enabled = 1
+       ORDER BY workflow_step_order, id`,
+    ).all(input.workflowId) as ScheduledJobRow[];
+    if (jobs.length === 0) throw new Error(`scheduled_workflow_has_no_jobs:${input.workflowId}`);
+    for (const job of jobs) {
+      if (job.status !== "pending") throw new Error(`scheduled_workflow_job_not_pending:${job.id}:${job.status}`);
+      const jobDate = localDateInZone(fromSqliteDate(job.next_run_at), job.timezone || workflow.timezone);
+      if (jobDate !== input.occurrenceDate) {
+        throw new Error(`scheduled_workflow_occurrence_mismatch:${job.id}:${jobDate}`);
+      }
+    }
+
+    const nowSql = toSqliteDate(input.now ?? new Date());
+    db.prepare(
+      `INSERT INTO scheduled_workflow_exception
+         (id, workflow_id, occurrence_date, action, reason, actor, created_at)
+       VALUES (?, ?, ?, 'skip', ?, ?, ?)`,
+    ).run(`swx_${nanoid(10)}`, input.workflowId, input.occurrenceDate, input.reason, input.actor, nowSql);
+
+    for (const job of jobs) {
+      const scheduledFor = fromSqliteDate(job.next_run_at);
+      const nextRun = computeNextRun(db, job, new Date(scheduledFor.getTime() + 1));
+      if (!nextRun) throw new Error(`scheduled_workflow_no_next_run:${job.id}`);
+      db.prepare(
+        `INSERT INTO scheduled_job_run
+           (id, job_id, scheduled_for, started_at, finished_at, outcome, detail_json)
+         VALUES (?, ?, ?, ?, ?, 'skipped', ?)`,
+      ).run(
+        `sjr_${nanoid(10)}`,
+        job.id,
+        job.next_run_at,
+        nowSql,
+        nowSql,
+        JSON.stringify({ reason: "workflow_occurrence_skip", workflow_id: input.workflowId, occurrence_date: input.occurrenceDate, requested_by: input.actor, request_reason: input.reason }),
+      );
+      db.prepare(
+        `UPDATE scheduled_job
+         SET next_run_at = ?, run_count = run_count + 1, last_run_at = ?,
+             lock_until = NULL, lock_owner = NULL, updated_at = ?
+         WHERE id = ? AND status = 'pending'`,
+      ).run(nextRun, nowSql, nowSql, job.id);
+    }
+    appendAudit(db, input.actor, "scheduled_workflow_occurrence_skipped", input.workflowId, {
+      occurrence_date: input.occurrenceDate,
+      job_ids: jobs.map((job) => job.id),
+      reason: input.reason,
+    });
+    return {
+      workflowId: input.workflowId,
+      occurrenceDate: input.occurrenceDate,
+      skippedJobIds: jobs.map((job) => job.id),
+      alreadySkipped: false,
+    };
+  });
+  return run();
+}
+
 /** Seed and reconcile the portable weekly learning triggers. */
 export function ensureWeeklySelfLearningJobs(db: Database): ScheduledJobRow[] {
+  ensureScheduledWorkflow(db, {
+    id: WEEKLY_SELF_LEARNING_WORKFLOW_ID,
+    title: "주간 러닝 세션",
+    timezone: "Asia/Seoul",
+    description: "SHARED.md 정리와 주간 self-learning proposal 검토를 한 회차로 묶는다.",
+  });
   const sharedCuration = ensureCronJob(db, {
     id: WEEKLY_SHARED_CURATION_JOB_ID,
     title: "SHARED.md 미팅 (금 04:00 KST)",
@@ -471,6 +627,7 @@ export function ensureWeeklySelfLearningJobs(db: Database): ScheduledJobRow[] {
       body: WEEKLY_SHARED_CURATION_BODY,
     },
   });
+  assignScheduledJobToWorkflow(db, sharedCuration.id, WEEKLY_SELF_LEARNING_WORKFLOW_ID, "shared_curation", 10);
   const selfLearning = ensureCronJob(db, {
     id: WEEKLY_SELF_LEARNING_JOB_ID,
     title: "self-learning 세션 (금 05:00 KST)",
@@ -486,7 +643,8 @@ export function ensureWeeklySelfLearningJobs(db: Database): ScheduledJobRow[] {
       body: WEEKLY_SELF_LEARNING_BODY,
     },
   });
-  return [sharedCuration, selfLearning];
+  assignScheduledJobToWorkflow(db, selfLearning.id, WEEKLY_SELF_LEARNING_WORKFLOW_ID, "self_learning", 20);
+  return [getScheduledJob(db, sharedCuration.id)!, getScheduledJob(db, selfLearning.id)!];
 }
 
 /** @deprecated Use ensureWeeklySelfLearningJobs so both weekly jobs are seeded. */

--- a/src/server/scheduler/core.ts
+++ b/src/server/scheduler/core.ts
@@ -470,6 +470,8 @@ export interface WorkflowOccurrenceSkipResult {
   workflowId: string;
   occurrenceDate: string;
   skippedJobIds: string[];
+  alreadyPassedJobIds: string[];
+  ungroupedActiveJobIds: string[];
   alreadySkipped: boolean;
 }
 
@@ -518,6 +520,43 @@ function localDateInZone(date: Date, timezone: string): string {
   }).format(date);
 }
 
+function backfillWorkflowSkipExceptions(db: Database, workflowId: string, timezone: string): void {
+  const jobIds = (db.prepare(
+    `SELECT id FROM scheduled_job WHERE workflow_id = ? ORDER BY id`,
+  ).all(workflowId) as Array<{ id: string }>).map((row) => row.id);
+  if (jobIds.length === 0) return;
+  const placeholders = jobIds.map(() => "?").join(",");
+  const historicalRuns = db.prepare(
+    `SELECT job_id, scheduled_for, finished_at, detail_json
+       FROM scheduled_job_run
+      WHERE job_id IN (${placeholders})
+        AND outcome = 'skipped'
+        AND json_valid(detail_json)
+        AND json_extract(detail_json, '$.reason') = 'lead_requested_week_skip'`,
+  ).all(...jobIds) as Array<{ job_id: string; scheduled_for: string; finished_at: string | null; detail_json: string }>;
+  const byOccurrence = new Map<string, { jobIds: Set<string>; createdAt: string; requestReason: string }>();
+  for (const run of historicalRuns) {
+    const occurrenceDate = localDateInZone(fromSqliteDate(run.scheduled_for), timezone);
+    const detail = JSON.parse(run.detail_json) as { request_reason?: unknown };
+    const current = byOccurrence.get(occurrenceDate) ?? {
+      jobIds: new Set<string>(),
+      createdAt: run.finished_at ?? run.scheduled_for,
+      requestReason: typeof detail.request_reason === "string" ? detail.request_reason : "lead_requested_week_skip",
+    };
+    current.jobIds.add(run.job_id);
+    if ((run.finished_at ?? run.scheduled_for) < current.createdAt) current.createdAt = run.finished_at ?? run.scheduled_for;
+    byOccurrence.set(occurrenceDate, current);
+  }
+  for (const [occurrenceDate, occurrence] of byOccurrence) {
+    if (occurrence.jobIds.size !== jobIds.length) continue;
+    db.prepare(
+      `INSERT OR IGNORE INTO scheduled_workflow_exception
+         (id, workflow_id, occurrence_date, action, reason, actor, created_at)
+       VALUES (?, ?, ?, 'skip', ?, 'historical_backfill', ?)`,
+    ).run(`swx_backfill_${workflowId}_${occurrenceDate}`, workflowId, occurrenceDate, occurrence.requestReason, occurrence.createdAt);
+  }
+}
+
 /**
  * Consume every job in one workflow occurrence as a single transaction.
  * The occurrence may be skipped before it is due; advancing from each scheduled
@@ -531,18 +570,34 @@ export function skipWorkflowOccurrence(
   if (!input.actor.trim()) throw new Error("actor_required");
   if (!input.reason.trim()) throw new Error("reason_required");
 
+  const requestedAt = input.now ?? new Date();
   const run = db.transaction((): WorkflowOccurrenceSkipResult => {
     const workflow = db.prepare(
       `SELECT id, timezone, enabled FROM scheduled_workflow WHERE id = ?`,
     ).get(input.workflowId) as { id: string; timezone: string; enabled: number } | null;
     if (!workflow || workflow.enabled !== 1) throw new Error(`scheduled_workflow_not_active:${input.workflowId}`);
 
+    const ungroupedJobs = db.prepare(
+      `SELECT * FROM scheduled_job
+       WHERE workflow_id IS NULL AND enabled = 1 AND status = 'pending'
+       ORDER BY next_run_at, id`,
+    ).all() as ScheduledJobRow[];
+    const ungroupedActiveJobIds = ungroupedJobs
+      .filter((job) => localDateInZone(fromSqliteDate(job.next_run_at), job.timezone || workflow.timezone) === input.occurrenceDate)
+      .map((job) => job.id);
+
     const existing = db.prepare(
       `SELECT action FROM scheduled_workflow_exception WHERE workflow_id = ? AND occurrence_date = ?`,
     ).get(input.workflowId, input.occurrenceDate) as { action: string } | null;
     if (existing) {
-      if (existing.action !== "skip") throw new Error("workflow_occurrence_exception_conflict");
-      return { workflowId: input.workflowId, occurrenceDate: input.occurrenceDate, skippedJobIds: [], alreadySkipped: true };
+      return {
+        workflowId: input.workflowId,
+        occurrenceDate: input.occurrenceDate,
+        skippedJobIds: [],
+        alreadyPassedJobIds: [],
+        ungroupedActiveJobIds,
+        alreadySkipped: true,
+      };
     }
 
     const jobs = db.prepare(
@@ -551,57 +606,61 @@ export function skipWorkflowOccurrence(
        ORDER BY workflow_step_order, id`,
     ).all(input.workflowId) as ScheduledJobRow[];
     if (jobs.length === 0) throw new Error(`scheduled_workflow_has_no_jobs:${input.workflowId}`);
+    const remainingJobs: ScheduledJobRow[] = [];
+    const alreadyPassedJobIds: string[] = [];
     for (const job of jobs) {
       if (job.status !== "pending") throw new Error(`scheduled_workflow_job_not_pending:${job.id}:${job.status}`);
-      const jobDate = localDateInZone(fromSqliteDate(job.next_run_at), job.timezone || workflow.timezone);
-      if (jobDate !== input.occurrenceDate) {
-        throw new Error(`scheduled_workflow_occurrence_mismatch:${job.id}:${jobDate}`);
+      const timezone = job.timezone || workflow.timezone;
+      const jobDate = localDateInZone(fromSqliteDate(job.next_run_at), timezone);
+      if (jobDate === input.occurrenceDate) {
+        remainingJobs.push(job);
+        continue;
       }
+      const requestDate = localDateInZone(requestedAt, timezone);
+      if (jobDate > input.occurrenceDate && requestDate === input.occurrenceDate) {
+        alreadyPassedJobIds.push(job.id);
+        continue;
+      }
+      throw new Error(`scheduled_workflow_occurrence_mismatch:${job.id}:${jobDate}`);
     }
 
-    const nowSql = toSqliteDate(input.now ?? new Date());
+    const nowSql = toSqliteDate(requestedAt);
     db.prepare(
       `INSERT INTO scheduled_workflow_exception
          (id, workflow_id, occurrence_date, action, reason, actor, created_at)
        VALUES (?, ?, ?, 'skip', ?, ?, ?)`,
     ).run(`swx_${nanoid(10)}`, input.workflowId, input.occurrenceDate, input.reason, input.actor, nowSql);
 
-    for (const job of jobs) {
+    for (const job of remainingJobs) {
       const scheduledFor = fromSqliteDate(job.next_run_at);
-      const nextRun = computeNextRun(db, job, new Date(scheduledFor.getTime() + 1));
-      if (!nextRun) throw new Error(`scheduled_workflow_no_next_run:${job.id}`);
-      db.prepare(
-        `INSERT INTO scheduled_job_run
-           (id, job_id, scheduled_for, started_at, finished_at, outcome, detail_json)
-         VALUES (?, ?, ?, ?, ?, 'skipped', ?)`,
-      ).run(
-        `sjr_${nanoid(10)}`,
-        job.id,
-        job.next_run_at,
-        nowSql,
-        nowSql,
-        JSON.stringify({ reason: "workflow_occurrence_skip", workflow_id: input.workflowId, occurrence_date: input.occurrenceDate, requested_by: input.actor, request_reason: input.reason }),
-      );
-      db.prepare(
-        `UPDATE scheduled_job
-         SET next_run_at = ?, run_count = run_count + 1, last_run_at = ?,
-             lock_until = NULL, lock_owner = NULL, updated_at = ?
-         WHERE id = ? AND status = 'pending'`,
-      ).run(nextRun, nowSql, nowSql, job.id);
+      skipScheduledJob(db, job, "workflow_occurrence_skip", {
+        now: requestedAt,
+        nextRunFrom: new Date(scheduledFor.getTime() + 1),
+        detail: {
+          workflow_id: input.workflowId,
+          occurrence_date: input.occurrenceDate,
+          requested_by: input.actor,
+          request_reason: input.reason,
+        },
+      });
     }
     appendAudit(db, input.actor, "scheduled_workflow_occurrence_skipped", input.workflowId, {
       occurrence_date: input.occurrenceDate,
-      job_ids: jobs.map((job) => job.id),
+      job_ids: remainingJobs.map((job) => job.id),
+      already_passed_job_ids: alreadyPassedJobIds,
+      ungrouped_active_job_ids: ungroupedActiveJobIds,
       reason: input.reason,
     });
     return {
       workflowId: input.workflowId,
       occurrenceDate: input.occurrenceDate,
-      skippedJobIds: jobs.map((job) => job.id),
+      skippedJobIds: remainingJobs.map((job) => job.id),
+      alreadyPassedJobIds,
+      ungroupedActiveJobIds,
       alreadySkipped: false,
     };
   });
-  return run();
+  return run.immediate();
 }
 
 /** Seed and reconcile the portable weekly learning triggers. */
@@ -644,6 +703,7 @@ export function ensureWeeklySelfLearningJobs(db: Database): ScheduledJobRow[] {
     },
   });
   assignScheduledJobToWorkflow(db, selfLearning.id, WEEKLY_SELF_LEARNING_WORKFLOW_ID, "self_learning", 20);
+  backfillWorkflowSkipExceptions(db, WEEKLY_SELF_LEARNING_WORKFLOW_ID, "Asia/Seoul");
   return [getScheduledJob(db, sharedCuration.id)!, getScheduledJob(db, selfLearning.id)!];
 }
 
@@ -958,7 +1018,7 @@ export function skipScheduledJob(
   db: Database,
   job: ScheduledJobRow,
   reason: string,
-  opts: { now?: Date; detail?: Record<string, unknown> } = {},
+  opts: { now?: Date; nextRunFrom?: Date; detail?: Record<string, unknown> } = {},
 ): void {
   const now = opts.now ?? new Date();
   const nowSql = toSqliteDate(now);
@@ -968,11 +1028,10 @@ export function skipScheduledJob(
        (id, job_id, scheduled_for, started_at, finished_at, outcome, detail_json)
      VALUES (?, ?, ?, ?, ?, 'skipped', ?)`,
   ).run(runId, job.id, job.next_run_at, nowSql, nowSql, JSON.stringify({ reason, ...(opts.detail ?? {}) }));
-  const nextRun = job.kind === "recurring" ? computeNextRun(db, job, now) : null;
+  const nextRun = job.kind === "recurring" ? computeNextRun(db, job, opts.nextRunFrom ?? now) : null;
   // A skip is still a consumed occurrence — it bumps run_count. So it must honor max_runs
   // exactly like completeScheduledJob does, or the last allowed slot being skipped lets
-  // the job run one MORE time and overshoot its cap. (codex review; latent since dry-run,
-  // reachable in practice now that misfire skipping exists.)
+  // the job run one more time and overshoot its cap.
   const exhausted = job.max_runs != null && job.run_count + 1 >= job.max_runs;
   // Leaving a one-shot pending with its past next_run_at makes every worker tick claim
   // and record it forever.


### PR DESCRIPTION
## 핵심 3줄
1. 여러 scheduler job으로 구성된 한 workflow 회차를 개별 cancel만으로는 일관되게 건너뛸 수 없습니다.
2. 같은 회차의 일부 step만 남거나 다음 회차까지 잘못 소비되면 후속 작업 순서와 실행 한도가 어긋납니다.
3. workflow group/occurrence 식별자와 원자적 회차 skip 전이를 추가하고, core·route·migration·문서를 포함해 8개 파일을 변경했습니다.

## 무엇을 바꿨나

| 문제 | 고친 방법 |
|---|---|
| 연관 job의 회차 경계가 저장되지 않음 | `workflow_group`과 `workflow_occurrence`를 scheduler job에 저장 |
| 회차의 일부 step만 skip될 수 있음 | 동일 occurrence 전체를 한 트랜잭션에서 검증하고 skip |
| 다른 회차 혼합·실행 한도 초과 위험 | occurrence 일치, 로컬 날짜 경계, `max_runs`를 공통 전이에서 검증 |
| 임의 사용자가 workflow를 건너뛸 수 있음 | HTTP route를 팀 리드 권한으로 제한 |

## 검증

- 관련 범위: `bun test src/server/scheduler/core.test.ts src/server/routes/scheduler.test.ts`
  - 75 pass, 0 fail
- 전체 범위: `bun test`
  - 2,851 pass, 8 skip, 0 fail
- 정적 확인: `git diff --check origin/main...HEAD`
  - 문제 없음
- worktree: clean

## 미검증 범위

- 라이브 `team.db` 마이그레이션과 운영 worker 발화는 실행하지 않았습니다.
- merge·deploy는 이 PR 범위에 포함하지 않습니다.

Submitted-by: Codex
