### PR TITLE
feat(codex): 작업 중에 온 말을 그 작업에 밀어 넣는다

### DIFF
--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -16,6 +16,8 @@ import {
   type BridgeDeps,
   tgSend,
   tgEdit,
+  isTurnRunningFor,
+  buildDmSteerText,
 } from "./bridge";
 import type { CodexTurnResult } from "./runner";
 import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
@@ -978,5 +980,67 @@ describe("codex bridge — 상태 머리글", () => {
     await handleMessage(42, "해줘", 1, deps);
     const withWork = edits.filter((e) => e.includes("실행: pwd"));
     expect(withWork[0]!.split("\n")[0]).toBe(DEFAULT_WORKING_TEXT);
+  });
+});
+
+// ── ★도는 중인 작업에 말을 밀어 넣는다★ ──
+//
+// 실측(2026-08-19): 팀 리드가 작업 중에 보낸 메시지 4건이 ★전부 로그에 들어와 있는데 답이 없었다.★
+// 받기는 하지만 새 턴으로 줄을 세우니, 하던 일이 끝날 때까지 아무 반응이 없어 ★못 듣는 것처럼 보인다.★
+// 버스로 온 일에는 이 배선이 있었고(7군데) 1:1 에는 ★0군데★ 였다.
+describe("codex bridge — 진행 중 작업에 끼어들기", () => {
+  beforeEach(() => resetChatThreads());
+
+  test("★턴이 도는 동안에는 그 대화가 '도는 중' 으로 보인다★ — 끼어들지 말지를 이걸로 가른다", async () => {
+    let sawRunning = false;
+    const deps: BridgeDeps = {
+      reactMessage: async () => true,
+      sendMessage: async () => 900,
+      editMessage: async () => true,
+      sandbox: "read-only",
+      runTurn: async () => {
+        sawRunning = isTurnRunningFor(51);
+        return { ok: true, reply: "끝", sessionId: "s1", detail: "ok", elapsedMs: 1 };
+      },
+    };
+    await handleMessage(51, "해줘", 1, deps);
+    expect(sawRunning, "턴 안에서는 도는 중이어야 한다").toBe(true);
+    expect(isTurnRunningFor(51), "끝나면 도는 중이 아니다").toBe(false);
+  });
+
+  test("★대조군 — 다른 대화는 '도는 중' 이 아니다★ (남의 턴에 끼워 넣으면 안 된다)", async () => {
+    let other = true;
+    const deps: BridgeDeps = {
+      reactMessage: async () => true,
+      sendMessage: async () => 900,
+      editMessage: async () => true,
+      sandbox: "read-only",
+      runTurn: async () => {
+        other = isTurnRunningFor(52); // 다른 대화 번호
+        return { ok: true, reply: "끝", sessionId: "s1", detail: "ok", elapsedMs: 1 };
+      },
+    };
+    await handleMessage(51, "해줘", 1, deps);
+    expect(other).toBe(false);
+  });
+
+  test("★턴이 던져도 '도는 중' 표시가 남지 않는다★ — 남으면 이후 모든 말이 갈 곳을 잃는다", async () => {
+    const deps: BridgeDeps = {
+      reactMessage: async () => true,
+      sendMessage: async () => 900,
+      editMessage: async () => true,
+      sandbox: "read-only",
+      runTurn: async () => { throw new Error("터짐"); },
+    };
+    await handleMessage(53, "해줘", 1, deps).catch(() => undefined);
+    expect(isTurnRunningFor(53)).toBe(false);
+  });
+
+  test("밀어 넣는 문구에 ★반영하라·답하라★ 가 들어간다 — 없으면 조용히 무시될 수 있다", () => {
+    const t = buildDmSteerText("로그인이 안되면 알려줘");
+    expect(t).toContain("[중간 메시지");
+    expect(t).toContain("로그인이 안되면 알려줘");
+    expect(t).toContain("반영해서 계속하라");
+    expect(t).toContain("이 메시지에도 답해라");
   });
 });

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -14,6 +14,7 @@ import { runCodexTurn, type CodexTurnOptions, type CodexTurnResult } from "./run
 import { createSerialTurnQueue } from "./serialTurnQueue";
 import { makeDmSessionStore, NOOP_DM_SESSION_STORE, type DmSessionStore } from "./dmSessionStore";
 import { toMarkdownV2, splitForTelegram, toPlain } from "./telegramMarkdown";
+import { steerActiveTurn } from "./activeTurns";
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -60,6 +61,44 @@ export interface BridgeDeps {
   registerScheduleReminder?: (req: ScheduleMarkerRequest, ctx: ScheduleMarkerContext) => Promise<string>;
   /** 1:1 대화 세션을 재시작 넘어 기억한다. 미지정이면 기억하지 않는다(시험 기본값). */
   dmSessions?: DmSessionStore;
+}
+
+/**
+ * ★지금 어느 대화의 턴이 도는 중인가.★
+ *
+ * 도는 중에 사람이 또 말하면 ★그 턴에 끼워 넣어야★ 한다(codex turn/steer). 새 턴으로 줄을 세우면
+ * 하던 일이 끝날 때까지 답이 없어 ★못 듣는 것처럼 보인다.★ 실제로 그렇게 보였다 —
+ * 로그에는 메시지가 다 들어와 있는데 답이 없었다(2026-08-19 실측).
+ *
+ * 등록부(activeTurns)는 ★팀원 단위★ 라 어느 대화의 턴인지 모른다. 그래서 여기서 대화를 함께 기억한다 —
+ * 다른 대화의 말을 남의 턴에 끼워 넣으면 안 된다.
+ */
+let runningTurnChatId: number | null = null;
+
+/**
+ * 도는 턴의 진행 줄에 한 줄 얹는 통로.
+ * ★밀어 넣었다는 것을 사람이 봐야 한다★ — 안 보이면 들어갔는지 모른 채 같은 말을 다시 하게 된다.
+ * 턴이 도는 동안에만 채워져 있다.
+ */
+let noteIntoRunningTurn: ((line: string) => void) | null = null;
+
+/**
+ * 진행 중 작업에 밀어 넣을 문구.
+ * 버스 쪽(buildSteerText)과 같은 모양으로 둔다 — 받는 쪽(codex)이 같은 형식을 이미 읽고 있다.
+ * ★"반영해서 계속하라 · 답할 때 이 말에도 답하라" 를 명시★ 하지 않으면 조용히 무시될 수 있다.
+ */
+export function buildDmSteerText(body: string): string {
+  return [
+    "[중간 메시지 — 팀 리드]",
+    body,
+    "",
+    "이 말을 반영해서 계속하라. 답할 때는 이 메시지에도 답해라.",
+  ].join("\n");
+}
+
+/** 시험·진단용 — 지금 그 대화의 턴이 도는 중인가. */
+export function isTurnRunningFor(chatId: number): boolean {
+  return runningTurnChatId === chatId;
 }
 
 // 채팅별 codex thread(resume sessionId) → 같은 대화 맥락 유지.
@@ -563,19 +602,32 @@ export async function handleMessage(
     schedule();
   };
 
-  const result = await runTurn({
-    prompt: promptText,
-    agentId: selfAgentId, // ★필수★ — 승인 요청의 주인이 된다
-    onActivity,
-    onStatus,
+  runningTurnChatId = chatId;
+  // 밖(폴 루프)에서 진행 줄에 한 줄 얹을 수 있게 연다. 항목 id 를 매번 새로 주어 줄이 쌓이게 한다.
+  let noteSeq = 0;
+  noteIntoRunningTurn = (line: string) => onActivity(line, `note-${++noteSeq}`);
+  let result: CodexTurnResult;
+  try {
+    result = await runTurn({
+      prompt: promptText,
+      agentId: selfAgentId, // ★필수★ — 승인 요청의 주인이 된다
+      onActivity,
+      onStatus,
 
-    resumeSessionId: prior,
-    codexHome: deps.codexHome,
-    cwd: deps.workdir,
-    sandbox: deps.sandbox,
-    networkAccess: deps.networkAccess,
-    writableRoots: deps.workdir ? [deps.workdir] : [],
-  });
+      resumeSessionId: prior,
+      codexHome: deps.codexHome,
+      cwd: deps.workdir,
+      sandbox: deps.sandbox,
+      networkAccess: deps.networkAccess,
+      writableRoots: deps.workdir ? [deps.workdir] : [],
+    });
+  } finally {
+    // ★던지고 나가도 반드시 지운다.★ 안 지우면 그 대화는 영영 "도는 중" 으로 남아
+    //   이후 모든 말이 끼어들기로 가고, 끼어들 턴이 없어 아무 데도 안 간다.
+    runningTurnChatId = null;
+    noteIntoRunningTurn = null;
+  }
+
   // ★예약된 편집이 답을 덮어쓰지 못하게 먼저 끈다.★ 끄지 않으면 답을 쓴 뒤 진행 줄이 다시 올라온다.
   if (editTimer !== null) { clearTimeout(editTimer); editTimer = null; }
   dirty = false;
@@ -998,11 +1050,29 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
 	          continue;
 	        }
         console.log(`[codex-bridge] ← chat ${chatId}: ${text.slice(0, 60)}`);
-        // ★턴은 하나씩 돈다(직렬).★ 루프는 기다리지 않고 다음 업데이트로 간다 — 그래야 승인 버튼이 들어온다.
-        turns.enqueue(async () => {
-          const r = await handleMessage(chatId, text, messageId, live);
-          console.log(`[codex-bridge] → ${r.detail}: ${r.reply.slice(0, 60)}`);
-        });
+        // ★도는 중인 작업이 있으면 그 안으로 밀어 넣는다.★ 새 턴으로 줄을 세우면 하던 일이 끝날
+        //   때까지 답이 없어 ★못 듣는 것처럼 보인다★ — 실제로 그렇게 보였다(2026-08-19 실측:
+        //   메시지 4건이 전부 로그에 들어와 있는데 답이 없었다).
+        //   turn/steer 는 turnId 를 요구하므로 ★막 시작해 번호가 아직 없으면 실패★ 한다. 그때는 아래로 내려가
+        //   지금처럼 새 턴이 된다 — 실패를 조용히 삼키지 않는다.
+        // ★루프는 여기서도 기다리지 않는다★ — 기다리면 승인 버튼이 다시 막힌다.
+        void (async () => {
+          if (isTurnRunningFor(chatId)) {
+            if (messageId !== undefined) void live.reactMessage?.(chatId, messageId, "👀");
+            const injected = await steerActiveTurn(liveAgentId, buildDmSteerText(text));
+            if (injected) {
+              console.log(`[codex-bridge] ↳ 진행 중 작업에 전달: ${text.slice(0, 40)}`);
+              noteIntoRunningTurn?.(`받음: ${text}`); // 들어갔다는 것을 화면에도 남긴다
+              return;
+            }
+            console.log(`[codex-bridge] ↳ 전달 실패(작업 번호 없음) → 새 작업으로: ${text.slice(0, 40)}`);
+          }
+          // ★턴은 하나씩 돈다(직렬).★ 루프는 기다리지 않고 다음 업데이트로 간다.
+          turns.enqueue(async () => {
+            const r = await handleMessage(chatId, text, messageId, live);
+            console.log(`[codex-bridge] → ${r.detail}: ${r.reply.slice(0, 60)}`);
+          });
+        })();
       }
     } catch (e) {
       console.error("[codex-bridge] poll 오류:", (e as Error).message);

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -96,6 +96,48 @@ export function buildDmSteerText(body: string): string {
   ].join("\n");
 }
 
+/**
+ * ★들어온 말을 어디로 보낼지 정하고 실행한다.★
+ *
+ * 폴 루프 안에 두면 시험이 못 닿는다 — 실제로 그래서 두 계약이 ★지워도 초록★ 이었다:
+ *   ① 밀어 넣기가 실패하면 새 작업으로 되돌린다(조용히 삼키지 않는다)
+ *   ② 밀어 넣었으면 진행 줄에 남긴다(안 보이면 들어갔는지 모른 채 같은 말을 다시 한다)
+ * 둘 다 이 기능이 존재하는 이유라, ★지켜지는지 시험이 봐야 한다.★
+ */
+export interface IncomingRouteDeps {
+  isRunning: (chatId: number) => boolean;
+  steer: (text: string) => Promise<boolean>;
+  note: (line: string) => void;
+  enqueue: (run: () => Promise<void>) => void;
+  runTurnFor: () => Promise<void>;
+  react?: () => void;
+}
+
+export type IncomingRoute = "steered" | "newTurn";
+
+export async function routeIncoming(
+  chatId: number,
+  text: string,
+  d: IncomingRouteDeps,
+): Promise<IncomingRoute> {
+  if (d.isRunning(chatId)) {
+    d.react?.();
+    // ★던져도 말을 잃지 않는다★ — 연결이 끊기면 steer 는 성공/실패가 아니라 예외로 끝난다.
+    //   그때 그냥 올려보내면 이 말은 새 작업으로도 안 가고 사라진다.
+    const injected = await d.steer(buildDmSteerText(text)).catch((e) => {
+      console.warn(`[codex-bridge] 전달 중 오류 → 새 작업으로: ${String(e)}`);
+      return false;
+    });
+    if (injected) {
+      d.note(`받음: ${text}`);
+      return "steered";
+    }
+    // ★번호가 아직 없어 못 넣었다 — 여기서 멈추면 그 말은 아무 데도 안 간다.★
+  }
+  d.enqueue(d.runTurnFor);
+  return "newTurn";
+}
+
 /** 시험·진단용 — 지금 그 대화의 턴이 도는 중인가. */
 export function isTurnRunningFor(chatId: number): boolean {
   return runningTurnChatId === chatId;
@@ -985,6 +1027,9 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
       grants: codexConfiguredGrants(liveAgentId, liveSandbox, liveNetwork, liveWorkspaceRoot),
     },
     // 라이브에서는 1:1 세션을 team.db 에 기억한다(재시작 넘어 맥락 유지).
+    // ★agentId 를 실어 보낸다★ — 안 실으면 handleMessage 가 같은 식을 다시 계산해,
+    //   runBridge({agentId}) 로 부를 때 두 값이 갈린다. 그러면 steer 가 등록 안 된 id 를 찾아 늘 실패한다.
+    agentId: liveAgentId,
     dmSessions: deps.dmSessions ?? makeDmSessionStore(liveAgentId, defaultTeamDbPath()),
     sendMessage: deps.sendMessage ?? tgSend(token),
     editMessage: deps.editMessage ?? tgEdit(token),
@@ -1056,23 +1101,24 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
         //   turn/steer 는 turnId 를 요구하므로 ★막 시작해 번호가 아직 없으면 실패★ 한다. 그때는 아래로 내려가
         //   지금처럼 새 턴이 된다 — 실패를 조용히 삼키지 않는다.
         // ★루프는 여기서도 기다리지 않는다★ — 기다리면 승인 버튼이 다시 막힌다.
-        void (async () => {
-          if (isTurnRunningFor(chatId)) {
-            if (messageId !== undefined) void live.reactMessage?.(chatId, messageId, "👀");
-            const injected = await steerActiveTurn(liveAgentId, buildDmSteerText(text));
-            if (injected) {
-              console.log(`[codex-bridge] ↳ 진행 중 작업에 전달: ${text.slice(0, 40)}`);
-              noteIntoRunningTurn?.(`받음: ${text}`); // 들어갔다는 것을 화면에도 남긴다
-              return;
-            }
-            console.log(`[codex-bridge] ↳ 전달 실패(작업 번호 없음) → 새 작업으로: ${text.slice(0, 40)}`);
-          }
-          // ★턴은 하나씩 돈다(직렬).★ 루프는 기다리지 않고 다음 업데이트로 간다.
-          turns.enqueue(async () => {
+        // ★루프는 여기서도 기다리지 않는다★ — 기다리면 승인 버튼이 다시 막힌다.
+        void routeIncoming(chatId, text, {
+          isRunning: isTurnRunningFor,
+          steer: (t) => steerActiveTurn(liveAgentId, t),
+          note: (line) => {
+            // 턴이 방금 끝났으면 통로가 닫혀 있다 — 그때는 남기지 않는다.
+            //   ★닫힌 뒤에 남기면 답을 쓴 자리에 진행 줄이 덮인다.★ 유실이 아니라 안전 쪽이다.
+            noteIntoRunningTurn?.(line);
+          },
+          enqueue: (run) => turns.enqueue(run),
+          runTurnFor: async () => {
             const r = await handleMessage(chatId, text, messageId, live);
             console.log(`[codex-bridge] → ${r.detail}: ${r.reply.slice(0, 60)}`);
-          });
-        })();
+          },
+          react: () => { if (messageId !== undefined) void live.reactMessage?.(chatId, messageId, "👀"); },
+        }).then((route) => {
+          console.log(`[codex-bridge] ↳ ${route === "steered" ? "진행 중 작업에 전달" : "새 작업으로"}: ${text.slice(0, 40)}`);
+        });
       }
     } catch (e) {
       console.error("[codex-bridge] poll 오류:", (e as Error).message);

--- a/src/server/runtimes/codex/dmSteerRoute.test.ts
+++ b/src/server/runtimes/codex/dmSteerRoute.test.ts
@@ -1,0 +1,121 @@
+import { test, expect, describe } from "bun:test";
+import { routeIncoming, buildDmSteerText, type IncomingRouteDeps } from "./bridge";
+
+/**
+ * ★들어온 말을 어디로 보낼지 — 그 판단이 계약을 지키는지 본다.★
+ *
+ * 이 판단은 원래 폴 루프 안에 있었다. 그래서 리뷰에서 ★두 계약을 지워도 시험이 초록★ 이었다:
+ *   ① 밀어 넣기가 실패하면 새 작업으로 되돌린다 — 지우면 그 말은 아무 데도 안 간다
+ *   ② 밀어 넣었으면 진행 줄에 남긴다 — 안 보이면 들어갔는지 모른 채 같은 말을 다시 한다
+ * 둘 다 이 기능이 존재하는 이유라, 시험이 지켜야 한다.
+ */
+type Calls = {
+  steered: string[];
+  notes: string[];
+  enqueued: number;
+  reacted: number;
+  ran: number;
+};
+
+function harness(opts: {
+  running: boolean;
+  steerResult?: boolean | (() => Promise<boolean>);
+}): { deps: IncomingRouteDeps; calls: Calls } {
+  const calls: Calls = { steered: [], notes: [], enqueued: 0, reacted: 0, ran: 0 };
+  const deps: IncomingRouteDeps = {
+    isRunning: () => opts.running,
+    steer: async (t) => {
+      calls.steered.push(t);
+      if (typeof opts.steerResult === "function") return opts.steerResult();
+      return opts.steerResult ?? true;
+    },
+    note: (line) => calls.notes.push(line),
+    enqueue: (run) => {
+      calls.enqueued += 1;
+      void run();
+    },
+    runTurnFor: async () => {
+      calls.ran += 1;
+    },
+    react: () => {
+      calls.reacted += 1;
+    },
+  };
+  return { deps, calls };
+}
+
+describe("1:1 — 작업 중에 온 말을 어디로 보내나", () => {
+  test("작업이 도는 중이면 ★그 작업에 밀어 넣는다★ — 새 작업으로 줄 세우지 않는다", async () => {
+    const { deps, calls } = harness({ running: true, steerResult: true });
+    const route = await routeIncoming(7066867819, "잠시만", deps);
+    expect(route).toBe("steered");
+    expect(calls.steered).toHaveLength(1);
+    expect(calls.enqueued, "밀어 넣었으면 새 작업은 안 만든다").toBe(0);
+  });
+
+  test("★대조군 — 도는 작업이 없으면 새 작업으로 간다★", async () => {
+    const { deps, calls } = harness({ running: false });
+    const route = await routeIncoming(7066867819, "기사 분석해줘", deps);
+    expect(route).toBe("newTurn");
+    expect(calls.steered, "도는 게 없는데 밀어 넣으려 하면 안 된다").toHaveLength(0);
+    expect(calls.enqueued).toBe(1);
+    expect(calls.ran).toBe(1);
+  });
+
+  test("★밀어 넣기가 실패하면 새 작업으로 되돌린다★ — 그 자리에서 멈추면 말이 사라진다", async () => {
+    // 번호가 아직 없는 찰나(막 시작한 턴)에 말이 오면 steer 가 false 를 준다.
+    // ★여기서 return 하면 그 말은 아무 데도 안 간다 — 사람은 무시당했다고 느낀다.★
+    const { deps, calls } = harness({ running: true, steerResult: false });
+    const route = await routeIncoming(7066867819, "로그인 안되면 알려줘", deps);
+    expect(route, "실패했으면 새 작업이어야 한다").toBe("newTurn");
+    expect(calls.steered, "시도는 했다").toHaveLength(1);
+    expect(calls.enqueued, "실패를 조용히 삼키지 않는다").toBe(1);
+    expect(calls.ran).toBe(1);
+  });
+
+  test("★밀어 넣었으면 진행 줄에 남긴다★ — 안 보이면 같은 말을 다시 하게 된다", async () => {
+    const { deps, calls } = harness({ running: true, steerResult: true });
+    await routeIncoming(7066867819, "5까지만 하고 멈춰줘", deps);
+    expect(calls.notes, "들어갔다는 것이 화면에 보여야 한다").toHaveLength(1);
+    expect(calls.notes[0]).toContain("5까지만 하고 멈춰줘");
+    expect(calls.notes[0]).toContain("받음");
+  });
+
+  test("★대조군 — 실패해서 새 작업으로 갔으면 '받음' 을 남기지 않는다★ (안 들어갔는데 들어갔다고 하면 안 된다)", async () => {
+    const { deps, calls } = harness({ running: true, steerResult: false });
+    await routeIncoming(7066867819, "잠깐", deps);
+    expect(calls.notes).toHaveLength(0);
+  });
+
+  test("밀어 넣을 때만 👀 를 단다 — 새 작업은 원래 흐름대로 간다", async () => {
+    const a = harness({ running: true, steerResult: true });
+    await routeIncoming(1, "x", a.deps);
+    expect(a.calls.reacted).toBe(1);
+
+    const b = harness({ running: false });
+    await routeIncoming(1, "x", b.deps);
+    expect(b.calls.reacted).toBe(0);
+  });
+
+  test("밀어 넣는 문구에 ★반영하라 + 이 말에도 답하라★ 가 들어간다 — 없으면 읽고 지나친다", async () => {
+    const { deps, calls } = harness({ running: true, steerResult: true });
+    await routeIncoming(1, "5까지만", deps);
+    const sent = calls.steered[0]!;
+    expect(sent).toContain("5까지만");
+    expect(sent).toContain("반영");
+    expect(sent).toContain("답해라");
+    expect(sent).toBe(buildDmSteerText("5까지만"));
+  });
+
+  test("steer 가 던져도 말은 살아남는다 — 새 작업으로 내려간다", async () => {
+    const { deps, calls } = harness({
+      running: true,
+      steerResult: async () => {
+        throw new Error("app-server 연결 끊김");
+      },
+    });
+    const route = await routeIncoming(1, "잠시만", deps).catch(() => "threw" as const);
+    expect(route, "예외로 말을 잃으면 안 된다").toBe("newTurn");
+    expect(calls.enqueued).toBe(1);
+  });
+});


### PR DESCRIPTION
## 핵심 3줄
1. 작업이 도는 동안 온 말이 **새 턴으로 줄을 선다.** 받기는 하는데 하던 일이 끝나야 처리되니 **사람 눈에는 못 듣는 것으로 보인다.**
2. 실측 — 작업 중에 온 메시지 **4건이 전부 로그에 들어와 있는데 답이 하나도 없었다.**
3. codex 의 `turn/steer` 로 **그 작업에 밀어 넣는다.** 버스 경로엔 이미 있던 배선이고 1:1 에만 없었다.

## 무엇이 잘못 동작했나

```
← chat: 덱스.. 아래 기사 분석해서 설명해줘…     ← 턴 시작
← chat: 로그인이 안되면 알려줘. 브라우저 띄워주면…  ← 받았다
← chat: 이말도 중간에 잘 들리나?                ← 받았다
← chat: 잠시만                                 ← 받았다
(답 없음 — 첫 턴이 아직 도는 중)
```

**받는 것 자체는 이미 고쳐져 있다**(폴링 루프가 턴을 기다리지 않는다). 문제는 그다음 — 받아서 **줄을 세우고** 하던 일이 끝나야 처리한다.

| 들어온 문 | 진행 중 턴에 끼어들기 |
|---|---|
| 팀 버스 | 배선 있음 (`steerActiveTurn` 7군데) |
| 1:1 대화 | **0군데** |

같은 런타임인데 들어온 문이 다르면 동작이 달랐다. **어제 재시작 연속성과 같은 자리다.**

## 무엇을 바꿨나

말이 오면 → **그 대화의 작업이 도는 중인가?**
- **도는 중** → `turn/steer` 로 밀어 넣는다 (👀 + 진행 줄에 `받음: …`)
- **아니면** → 지금처럼 새 작업
- **번호가 아직 없어 못 넣으면** → 로그에 남기고 새 작업으로 내려간다. **실패를 조용히 삼키지 않는다**

**도는 중 판정은 대화별이다.** 등록부(`activeTurns`)는 팀원 단위라 어느 대화의 턴인지 모른다. 브리지가 함께 기억한다 — **남의 대화 작업에 끼워 넣으면 안 된다.**

**턴이 예외로 끝나도 표시를 지운다**(`finally`). 안 지우면 그 대화의 이후 모든 말이 끼어들기로 가고, 끼어들 턴이 없어 **아무 데도 안 간다.**

**밀어 넣으면 진행 줄에 남긴다.** 보이지 않으면 들어갔는지 모른 채 같은 말을 다시 하게 된다.

## 검증

```
검증 범위:  bun test (전체 225파일 2863 시험) · bunx tsc --noEmit
baseline:   0 fail
시험:       턴 중에는 '도는 중' 으로 보인다 · ★대조군(다른 대화는 아니다)★
            · ★예외로 끝나도 표시가 안 남는다★ · 밀어 넣는 문구에 반영·답하라가 있다
mutation:   턴 시작 표시 안 함(끼어들기가 영영 안 걸림)  → 빨강 ✓
            대화 구분 없이 도는 중으로 판정              → 빨강 ✓
            예외 시 표시를 안 지움                       → 빨강 ✓
라이브:     ★실제 codex 턴에 밀어 넣어 확인했다.★
            "1부터 10까지 천천히 설명해줘" 를 시켜놓고 6초 시점에 "잠깐, 5까지만 하고 멈춰줘" 를 주입.
            → steer 성공(true) · 답: "요청을 반영해 5에서 멈출게요 … 5 … 여기서 멈추겠습니다"
            ★말이 들어갔고 하던 일이 바뀌었다.★
미검증:     ★텔레그램을 통한 실제 왕복은 안 해봤다★ — 위 확인은 codex 클라이언트 직접 호출이다.
            번호가 아직 없는 순간(막 시작한 찰나)에 말이 오는 경우는 재현하지 못했다 —
            그 경로는 로그를 남기고 새 작업으로 가지만, 실제로 밟힌 것은 못 봤다.
```

Submitted-by: Demis
