### PR TITLE
feat(codex): 1:1 로 온 사진·문서를 dex 가 실제로 보게 한다

### DIFF
--- a/src/server/runtimes/codex/activeTurns.ts
+++ b/src/server/runtimes/codex/activeTurns.ts
@@ -11,7 +11,8 @@
  * 그 길을 쓰려면 ★지금 도는 클라이언트를 찾을 수 있어야★ 해서 이 등록부를 둔다.
  */
 export interface SteerableTurn {
-  steer(text: string): Promise<void>;
+  /** imagePaths 는 ★선택★ 이다 — 버스 경로는 안 넘기고 그대로 돈다(글자만 끼워 넣는다). */
+  steer(text: string, imagePaths?: readonly string[]): Promise<void>;
   readonly currentTurnId: string | null;
 }
 
@@ -31,11 +32,15 @@ export function unregisterActiveTurn(agentId: string, turn: SteerableTurn): void
  * 진행 중 턴에 말을 끼워 넣는다. 성공하면 true.
  * ★turnId 가 없으면 아직 턴이 안 붙은 것★ 이라 넣지 않는다(codex 가 expectedTurnId 를 요구한다).
  */
-export async function steerActiveTurn(agentId: string, text: string): Promise<boolean> {
+export async function steerActiveTurn(
+  agentId: string,
+  text: string,
+  imagePaths?: readonly string[],
+): Promise<boolean> {
   const turn = active.get(agentId);
   if (!turn || !turn.currentTurnId) return false;
   try {
-    await turn.steer(text);
+    await turn.steer(text, imagePaths);
     return true;
   } catch {
     return false; // 실패하면 기존 defer 경로로 되돌아간다(조용히 삼키지 않는다)

--- a/src/server/runtimes/codex/appServerClient.ts
+++ b/src/server/runtimes/codex/appServerClient.ts
@@ -196,6 +196,28 @@ export function activityLineOf(item: unknown): string | null {
   return type ? clip(type) : null;
 }
 
+/**
+ * ★턴에 실어 보낼 입력 아이템을 만든다.★
+ *
+ * 클래스 안에 두면 시험이 못 닿는다 — app-server 를 실제로 띄워야 하기 때문이다.
+ * 그런데 여기서 틀리면 ★그림이 조용히 빠진 채★ 글자만 간다(사람은 보냈는데 못 봤다는 답을 받는다).
+ * 그래서 판단을 밖으로 뺀다.
+ *
+ * 실측(CLI 0.147.0 · app-server): 입력 종류는 text | image | localImage | audio | localAudio |
+ * skill | mention. localImage 는 ★path 를 요구한다★ — imageUrl 로 주면
+ * `Invalid request: missing field \`path\`` 로 거부된다.
+ * ★그림이 글자보다 앞선다★ — 뒤에 두면 "이 그림" 이 앞 문장을 못 가리킨다.
+ */
+export function buildTurnInput(
+  text: string,
+  imagePaths?: readonly string[],
+): Array<Record<string, unknown>> {
+  return [
+    ...(imagePaths ?? []).map((path) => ({ type: "localImage", path })),
+    { type: "text", text, text_elements: [] },
+  ];
+}
+
 export class CodexAppServerClient {
   private proc: ChildProcessWithoutNullStreams | null = null;
   private buf = "";
@@ -293,7 +315,20 @@ export class CodexAppServerClient {
    * ★견고성: timeoutMs 내 turn/completed 없으면 interrupt 후 status="timeout"으로 정리(무응답 턴이 런타임 막지 않게).★
    * exec 폴백이 없으므로 예외는 여기서 정면 처리한다.
    */
-  runTurn(text: string, handlers: RunTurnHandlers = {}, timeoutMs = 300_000): Promise<TurnResult> {
+  /**
+   * ★그림은 경로만 넘기면 안 된다 — 입력 아이템으로 넣어야 codex 가 본다.★
+   *
+   * 실측(CLI 0.147.0 · app-server): 입력 아이템 종류는 text | image | localImage | audio | localAudio |
+   * skill | mention 이고, localImage 는 ★path 를 요구한다★ (imageUrl 로 주면
+   * `Invalid request: missing field \`path\`` 로 거부). 글자가 적힌 그림을 태워
+   * ★codex 가 그 글자를 읽어냈다★ — 경로를 본문에 적어주는 것과는 다른 길이다.
+   */
+  runTurn(
+    text: string,
+    handlers: RunTurnHandlers = {},
+    timeoutMs = 300_000,
+    imagePaths?: readonly string[],
+  ): Promise<TurnResult> {
     if (!this.threadId) throw new Error("startThread first");
     this.activeHandlers = handlers;
     this.currentTurnId = null;
@@ -316,7 +351,8 @@ export class CodexAppServerClient {
       this.turnResolve = finish;
       this.notify("turn/start", {
         threadId: this.threadId,
-        input: [{ type: "text", text, text_elements: [] }],
+        // ★그림이 글자보다 앞선다★ — 뒤에 두면 "이 그림" 이 앞 문장을 못 가리킨다(스파이크에서 앞에 두고 확인).
+        input: buildTurnInput(text, imagePaths),
         ...this.turnPolicy, // ★thread 에 준 실행 모드를 턴에도 그대로★ (openclaw 와 같은 모양)
       })
         .catch(() => finish({ finalText: "", status: "error", turnId: this.currentTurnId }));
@@ -334,9 +370,15 @@ export class CodexAppServerClient {
   }
 
   /** 진행 중 턴을 새 지시로 전환(중간 steer). expectedTurnId 필수(실측). */
-  async steer(text: string): Promise<void> {
+  async steer(text: string, imagePaths?: readonly string[]): Promise<void> {
     if (!this.threadId || !this.currentTurnId) throw new Error("no active turn to steer");
-    await this.notify("turn/steer", { threadId: this.threadId, expectedTurnId: this.currentTurnId, input: [{ type: "text", text, text_elements: [] }] });
+    await this.notify("turn/steer", {
+      threadId: this.threadId,
+      expectedTurnId: this.currentTurnId,
+      // ★중간에 보낸 그림도 봐야 한다★ — 턴 시작과 같은 모양이다. 안 실으면 사람이 도중에 붙인
+      //   화면 사진이 글자만 남고 사라진다(그게 이 결함의 원래 모습이었다).
+      input: buildTurnInput(text, imagePaths),
+    });
   }
 
   /** 진행 중 턴을 완전 중단(interrupt). */

--- a/src/server/runtimes/codex/appServerRunner.ts
+++ b/src/server/runtimes/codex/appServerRunner.ts
@@ -96,7 +96,7 @@ export async function runViaAppServer(
     // ★진행 중 턴에 끼어들 수 있게 등록★ — 이게 없으면 턴 도는 동안 온 메시지가 연기되다 사라진다
     //   (실측: 20번 연기 후 blocked. 턴도 답도 없었다.)
     registerActiveTurn(opts.agentId, client);
-    const r = await client.runTurn(opts.prompt, {
+    const r = await client.runTurn(opts.prompt, {  // 그림은 아래 4번째 인자로 간다
       // ★지금 무엇을 하는 중인지 보이게 한다.★ 창이 없는 런타임이라 이벤트로 직접 쓴다.
       onActivity: (line, itemId) => {
         // 두 수신처가 서로를 막지 않는다 — 대시보드 쓰기가 실패해도 채널 표시는 살고, 반대도 같다.
@@ -128,7 +128,7 @@ export async function runViaAppServer(
           ? await requestApprovalPopup(db, req, opts.agentId, opts.cwd)
           : "denied"; // db 없는 caller 는 띄울 곳이 없다(테스트·도구 경로)
       },
-    }, TURN_TIMEOUT_MS);
+    }, TURN_TIMEOUT_MS, opts.imagePaths);
     // ★Phase1 ③: 턴 종료 시 이 turn의 남은 pending/decided 팝업을 expire(cancel/interrupt/timeout 포함).
     //   늦게 도착한 승인은 finalizeApprovalDelivery의 CAS가 expired 상태를 보고 이미 거부하지만, 여기서 상태를
     //   확정 정리해 orphan 누적을 막는다. best-effort. (delivered/orphaned는 건드리지 않음.)★

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -12,7 +12,7 @@
  */
 import { runCodexTurn, type CodexTurnOptions, type CodexTurnResult } from "./runner";
 import {
-  attachmentNote, decideDmMessage, downloadDmAttachments,
+  attachmentNote, decideDmMessage, downloadDmAttachments, downloadDmAttachmentsSafe,
   type DmAttachments, type DmMessageMedia,
 } from "./dmMedia";
 import { createSerialTurnQueue } from "./serialTurnQueue";
@@ -91,6 +91,27 @@ let noteIntoRunningTurn: ((line: string) => void) | null = null;
  * 버스 쪽(buildSteerText)과 같은 모양으로 둔다 — 받는 쪽(codex)이 같은 형식을 이미 읽고 있다.
  * ★"반영해서 계속하라 · 답할 때 이 말에도 답하라" 를 명시★ 하지 않으면 조용히 무시될 수 있다.
  */
+/**
+ * ★중간 개입에 첨부를 실어 보낸다.★
+ *
+ * 폴 루프 안 클로저로 두면 시험이 못 닿는다 — 리뷰에서 ★첨부를 통째로 무시해도 초록★ 이었다.
+ * 실사용 경로다: 작업을 시켜놓고 도는 중에 사진을 보내면 여기로 온다.
+ * 여기서 그림이 빠지면 codex 는 글자만 받고 "무슨 그림?" 이라 답한다 —
+ * ★사람은 보냈는데, 못 봤다는 사실조차 안 남는다.★ 이 파일이 고치려던 결함과 같은 모양이다.
+ */
+export async function steerWithAttachments(
+  text: string,
+  d: {
+    fetchAttachments: (() => Promise<DmAttachments>) | null;
+    steer: (text: string, imagePaths?: readonly string[]) => Promise<boolean>;
+  },
+): Promise<boolean> {
+  const mid = d.fetchAttachments ? await d.fetchAttachments() : null;
+  const note = mid ? attachmentNote(mid) : "";
+  const body = note ? `${text}\n\n${note}` : text;
+  return d.steer(body, mid?.imagePaths);
+}
+
 export function buildDmSteerText(body: string): string {
   return [
     "[중간 메시지 — 팀 리드]",
@@ -568,11 +589,10 @@ export async function handleMessage(
   //   실패해도 턴을 죽이지 않는다 — 사람이 보낸 것을 말없이 없애지 않고, 무슨 일이 났는지 본문에 적는다.
   let attachments: DmAttachments | null = null;
   if (fetchAttachments) {
-    try {
-      attachments = await fetchAttachments();
-    } catch (e) {
-      attachments = { imagePaths: [], files: [], failed: [{ kind: "attachment", reason: e instanceof Error ? e.message : String(e) }] };
-    }
+    attachments = await fetchAttachments().catch((e) => ({
+      imagePaths: [], files: [],
+      failed: [{ kind: "attachment", reason: e instanceof Error ? e.message : String(e) }],
+    }));
   }
   const note = attachments ? attachmentNote(attachments) : "";
   const promptWithMedia = note ? `${promptText}\n\n${note}` : promptText;
@@ -1142,13 +1162,12 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
         // ★루프는 여기서도 기다리지 않는다★ — 기다리면 승인 버튼이 다시 막힌다.
         void routeIncoming(chatId, text, {
           isRunning: isTurnRunningFor,
-          steer: async (t) => {
-            // ★도중에 붙인 그림도 그 작업 안으로 넣는다.★ 여기서 내려받아도 폴 루프는 안 막힌다 —
-            //   위에서 routeIncoming 을 기다리지 않기 때문이다(await 를 붙이면 승인 버튼이 다시 막힌다).
-            const mid = hasMedia && msg ? await downloadDmAttachments(token, msg).catch(() => null) : null;
-            const withNote = mid && attachmentNote(mid) ? `${t}\n\n${attachmentNote(mid)}` : t;
-            return steerActiveTurn(liveAgentId, withNote, mid?.imagePaths);
-          },
+          // ★도중에 붙인 그림도 그 작업 안으로 넣는다.★ 여기서 내려받아도 폴 루프는 안 막힌다 —
+          //   위에서 routeIncoming 을 기다리지 않기 때문이다(await 를 붙이면 승인 버튼이 다시 막힌다).
+          steer: (t) => steerWithAttachments(t, {
+            fetchAttachments: hasMedia && msg ? () => downloadDmAttachmentsSafe(token, msg) : null,
+            steer: (body, imagePaths) => steerActiveTurn(liveAgentId, body, imagePaths),
+          }),
           note: (line) => {
             // 턴이 방금 끝났으면 통로가 닫혀 있다 — 그때는 남기지 않는다.
             //   ★닫힌 뒤에 남기면 답을 쓴 자리에 진행 줄이 덮인다.★ 유실이 아니라 안전 쪽이다.

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -11,6 +11,10 @@
  * 채팅별 codex thread(resume sessionId)로 멀티턴 맥락 유지.
  */
 import { runCodexTurn, type CodexTurnOptions, type CodexTurnResult } from "./runner";
+import {
+  attachmentNote, decideDmMessage, downloadDmAttachments,
+  type DmAttachments, type DmMessageMedia,
+} from "./dmMedia";
 import { createSerialTurnQueue } from "./serialTurnQueue";
 import { makeDmSessionStore, NOOP_DM_SESSION_STORE, type DmSessionStore } from "./dmSessionStore";
 import { toMarkdownV2, splitForTelegram, toPlain } from "./telegramMarkdown";
@@ -453,6 +457,12 @@ export async function handleMessage(
   text: string,
   messageId: number | undefined,
   deps: BridgeDeps = {},
+  /**
+   * ★첨부는 여기서 내려받는다 — 폴 루프가 아니다.★
+   * 루프에서 받으면 내려받는 동안 다음 업데이트를 못 읽어, #334 에서 고친 ★승인 버튼 막힘★ 이 되살아난다.
+   * 함수로 넘겨 이 턴 안에서 받게 한다(시험에서는 통신 없이 대신 넣는다).
+   */
+  fetchAttachments?: () => Promise<DmAttachments>,
 ): Promise<{ ok: boolean; reply: string; detail: string }> {
   // ★브리지도 app-server 로 간다.★
   //   전에는 브리지만 옛 exec 경로였다 — 그래서 ★사람이 직접 말 거는 길에만★ 그때까지의 개선
@@ -554,6 +564,19 @@ export async function handleMessage(
   const promptText = greetedBefore
     ? toolAwareText
     : `[이번이 이 대화의 첫 응답입니다. 먼저 짧게 인사하고, OT(팀 미션·규칙·역할·팀 스킬)를 받아 팀에 합류했음을 한 줄로 밝힌 뒤 본론에 답하세요.]\n\n${toolAwareText}`;
+  // ★첨부를 여기서 내려받는다.★ 진행 표시가 이미 떠 있는 자리라 사람은 기다리는 줄 안다.
+  //   실패해도 턴을 죽이지 않는다 — 사람이 보낸 것을 말없이 없애지 않고, 무슨 일이 났는지 본문에 적는다.
+  let attachments: DmAttachments | null = null;
+  if (fetchAttachments) {
+    try {
+      attachments = await fetchAttachments();
+    } catch (e) {
+      attachments = { imagePaths: [], files: [], failed: [{ kind: "attachment", reason: e instanceof Error ? e.message : String(e) }] };
+    }
+  }
+  const note = attachments ? attachmentNote(attachments) : "";
+  const promptWithMedia = note ? `${promptText}\n\n${note}` : promptText;
+
   const preflight = codexRuntimePreflight(
     {
       id: selfAgentId,
@@ -651,7 +674,9 @@ export async function handleMessage(
   let result: CodexTurnResult;
   try {
     result = await runTurn({
-      prompt: promptText,
+      prompt: promptWithMedia,
+      // ★그림은 본문이 아니라 입력으로 간다★ — 경로를 적어주면 codex 는 바이트로 읽을 뿐 보지 못한다.
+      imagePaths: attachments?.imagePaths,
       agentId: selfAgentId, // ★필수★ — 승인 요청의 주인이 된다
       onActivity,
       onStatus,
@@ -812,7 +837,16 @@ function tgReact(token: string): NonNullable<BridgeDeps["reactMessage"]> {
 
 interface TgUpdate {
   update_id: number;
-  message?: { message_id: number; chat: { id: number }; text?: string };
+  message?: {
+    message_id: number;
+    chat: { id: number };
+    text?: string;
+    /** ★사진에 달린 설명★ — 사진 메시지는 text 가 아니라 caption 으로 온다. */
+    caption?: string;
+    /** ★같은 그림의 여러 크기★ (썸네일·중간·원본). 장수가 아니다 — 여러 장은 메시지가 나뉘어 온다. */
+    photo?: DmMessageMedia["photo"];
+    document?: DmMessageMedia["document"];
+  };
   callback_query?: TgCallbackQuery;
 }
 
@@ -1080,10 +1114,15 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
           catch (e) { console.error(`[codex-bridge] 승인 콜백 처리 실패: ${e instanceof Error ? e.message : e}`); }
           continue;
         }
-        const text = u.message?.text;
-        const chatId = u.message?.chat.id;
-        const messageId = u.message?.message_id;
-        if (!text || chatId === undefined) continue;
+        const msg = u.message;
+        const chatId = msg?.chat.id;
+        const messageId = msg?.message_id;
+        // ★사진 메시지는 text 가 없다 — 설명은 caption 으로 온다.★
+        //   전에는 여기서 text 만 보고 걸렀다. 그래서 ★사진만 보낸 메시지는 통째로 버려졌다★ —
+        //   로그에도 안 남아 "무시당했다" 로 보였다(팀장님 관측: "이미지 첨부하면 못 읽는다").
+        const decided = decideDmMessage(msg);
+        if (chatId === undefined || !decided.handle) continue;
+        const { text, hasMedia } = decided;
 	        // 발신자 게이트(fail-closed): 허용 목록이 비어 있거나 미포함이면 무시한다.
 	        if (!isAllowedChat(allowFrom, chatId)) {
 	          if (allowFrom.size === 0 && !warnedNoAllowlist) {
@@ -1101,10 +1140,15 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
         //   turn/steer 는 turnId 를 요구하므로 ★막 시작해 번호가 아직 없으면 실패★ 한다. 그때는 아래로 내려가
         //   지금처럼 새 턴이 된다 — 실패를 조용히 삼키지 않는다.
         // ★루프는 여기서도 기다리지 않는다★ — 기다리면 승인 버튼이 다시 막힌다.
-        // ★루프는 여기서도 기다리지 않는다★ — 기다리면 승인 버튼이 다시 막힌다.
         void routeIncoming(chatId, text, {
           isRunning: isTurnRunningFor,
-          steer: (t) => steerActiveTurn(liveAgentId, t),
+          steer: async (t) => {
+            // ★도중에 붙인 그림도 그 작업 안으로 넣는다.★ 여기서 내려받아도 폴 루프는 안 막힌다 —
+            //   위에서 routeIncoming 을 기다리지 않기 때문이다(await 를 붙이면 승인 버튼이 다시 막힌다).
+            const mid = hasMedia && msg ? await downloadDmAttachments(token, msg).catch(() => null) : null;
+            const withNote = mid && attachmentNote(mid) ? `${t}\n\n${attachmentNote(mid)}` : t;
+            return steerActiveTurn(liveAgentId, withNote, mid?.imagePaths);
+          },
           note: (line) => {
             // 턴이 방금 끝났으면 통로가 닫혀 있다 — 그때는 남기지 않는다.
             //   ★닫힌 뒤에 남기면 답을 쓴 자리에 진행 줄이 덮인다.★ 유실이 아니라 안전 쪽이다.
@@ -1112,7 +1156,9 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
           },
           enqueue: (run) => turns.enqueue(run),
           runTurnFor: async () => {
-            const r = await handleMessage(chatId, text, messageId, live);
+            const r = await handleMessage(chatId, text, messageId, live, hasMedia && msg
+              ? () => downloadDmAttachments(token, msg)
+              : undefined);
             console.log(`[codex-bridge] → ${r.detail}: ${r.reply.slice(0, 60)}`);
           },
           react: () => { if (messageId !== undefined) void live.reactMessage?.(chatId, messageId, "👀"); },

--- a/src/server/runtimes/codex/bridgeMedia.test.ts
+++ b/src/server/runtimes/codex/bridgeMedia.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { handleMessage, resetChatThreads, type BridgeDeps } from "./bridge";
+import type { CodexTurnResult } from "./runner";
+import type { DmAttachments } from "./dmMedia";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+/**
+ * ★배선 — 첨부가 턴까지 실려 가는가.★
+ *
+ * 단위 시험(dmMedia.test)은 "무엇을 받고 무엇을 적나" 를 본다. 여기서 보는 것은 다른 사실이다:
+ * ★내려받은 그림이 codex 입력으로 실제로 넘어가는가.★ 둘은 같지 않다 —
+ * 어제(#346) 함수는 맞는데 그 함수를 부르는 분기가 한 번도 안 돌았던 일이 있었다.
+ */
+let prev: string | undefined;
+beforeEach(() => {
+  prev = process.env.B3OS_FIRST_CONTACT_DIR;
+  process.env.B3OS_FIRST_CONTACT_DIR = mkdtempSync(join(tmpdir(), "b3os-media-"));
+  resetChatThreads();
+});
+afterEach(() => {
+  if (prev === undefined) delete process.env.B3OS_FIRST_CONTACT_DIR;
+  else process.env.B3OS_FIRST_CONTACT_DIR = prev;
+});
+
+const ok = (reply: string): CodexTurnResult => ({ ok: true, reply, detail: "ok", elapsedMs: 1 });
+
+function spy() {
+  const calls: { prompt: string; imagePaths?: readonly string[] }[] = [];
+  let mid = 900;
+  const deps: BridgeDeps = {
+    reactMessage: async () => true,
+    sendMessage: async () => ++mid,
+    editMessage: async () => true,
+    sandbox: "read-only",
+    runTurn: async (o) => {
+      calls.push({ prompt: o.prompt, imagePaths: o.imagePaths });
+      return ok("답");
+    },
+  };
+  return { deps, calls };
+}
+
+const attach = (a: Partial<DmAttachments>): DmAttachments => ({ imagePaths: [], files: [], failed: [], ...a });
+
+describe("첨부 배선 — 그림이 codex 입력까지 간다", () => {
+  test("★그림 경로가 턴 옵션으로 넘어간다★ — 본문에 적어주는 것과 다르다(적어주면 못 본다)", async () => {
+    const { deps, calls } = spy();
+    await handleMessage(1, "이거 뭐야", 5, deps, async () => attach({ imagePaths: ["/m/shot.jpg"] }));
+    expect(calls[0]?.imagePaths, "그림은 입력 아이템으로 가야 한다").toEqual(["/m/shot.jpg"]);
+  });
+
+  test("★대조군 — 첨부가 없으면 그림도 없다★ (지어내지 않는다)", async () => {
+    const { deps, calls } = spy();
+    await handleMessage(1, "그냥 글", 5, deps);
+    expect(calls[0]?.imagePaths).toBeUndefined();
+  });
+
+  test("그림이 왔다는 것을 ★본문에도 적는다★ — 설명 없이 그림만 오면 뭘 하란 건지 모른다", async () => {
+    const { deps, calls } = spy();
+    await handleMessage(1, "이거 뭐야", 5, deps, async () => attach({ imagePaths: ["/m/shot.jpg"] }));
+    expect(calls[0]?.prompt).toContain("그림");
+    expect(calls[0]?.prompt).toContain("이거 뭐야"); // 사람 말은 그대로 남는다
+  });
+
+  test("★문서는 경로가 본문에 들어간다★ — 그림과 달리 그게 유일한 통로다", async () => {
+    const { deps, calls } = spy();
+    await handleMessage(1, "읽어봐", 5, deps, async () => attach({
+      files: [{ file_name: "spec.pdf", file_path: "/m/spec.pdf" } as never],
+    }));
+    expect(calls[0]?.prompt).toContain("/m/spec.pdf");
+    expect(calls[0]?.imagePaths, "pdf 를 그림으로 넣으면 codex 가 거부한다").toEqual([]);
+  });
+
+  test("★내려받기가 통째로 실패해도 턴은 돈다★ — 사람 말까지 같이 잃으면 안 된다", async () => {
+    const { deps, calls } = spy();
+    const r = await handleMessage(1, "이거 봐줘", 5, deps, async () => {
+      throw new Error("telegram getFile failed");
+    });
+    expect(r.ok, "첨부 실패가 대화를 끊으면 안 된다").toBe(true);
+    expect(calls[0]?.prompt).toContain("이거 봐줘");
+    expect(calls[0]?.prompt).toContain("실패"); // 무슨 일이 났는지 codex 가 안다
+  });
+
+  test("★부분 실패 — 받은 것은 가고 못 받은 것은 남는다★", async () => {
+    const { deps, calls } = spy();
+    await handleMessage(1, "둘 다 봐", 5, deps, async () => attach({
+      imagePaths: ["/m/a.jpg"],
+      failed: [{ kind: "document", reason: "20MB 초과" }],
+    }));
+    expect(calls[0]?.imagePaths).toEqual(["/m/a.jpg"]);
+    expect(calls[0]?.prompt).toContain("20MB 초과");
+  });
+});

--- a/src/server/runtimes/codex/bridgeMedia.test.ts
+++ b/src/server/runtimes/codex/bridgeMedia.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { handleMessage, resetChatThreads, type BridgeDeps } from "./bridge";
+import { handleMessage, resetChatThreads, steerWithAttachments, type BridgeDeps } from "./bridge";
 import type { CodexTurnResult } from "./runner";
 import type { DmAttachments } from "./dmMedia";
 import { mkdtempSync } from "node:fs";
@@ -91,5 +91,54 @@ describe("첨부 배선 — 그림이 codex 입력까지 간다", () => {
     }));
     expect(calls[0]?.imagePaths).toEqual(["/m/a.jpg"]);
     expect(calls[0]?.prompt).toContain("20MB 초과");
+  });
+});
+
+describe("★중간 개입 — 도는 작업에도 첨부가 실린다★ (리뷰에서 조용히 사라지던 자리)", () => {
+  const got = () => {
+    const calls: { text: string; imagePaths?: readonly string[] }[] = [];
+    return {
+      calls,
+      steer: async (text: string, imagePaths?: readonly string[]) => {
+        calls.push({ text, imagePaths });
+        return true;
+      },
+    };
+  };
+
+  test("★그림이 steer 까지 간다★ — 빠지면 codex 는 글자만 받고 '무슨 그림?' 이라 답한다", async () => {
+    const g = got();
+    await steerWithAttachments("이 화면 봐줘", {
+      fetchAttachments: async () => attach({ imagePaths: ["/m/a.jpg"] }),
+      steer: g.steer,
+    });
+    expect(g.calls[0]?.imagePaths, "중간에 보낸 그림도 그 작업에 들어가야 한다").toEqual(["/m/a.jpg"]);
+    expect(g.calls[0]?.text).toContain("이 화면 봐줘");
+    expect(g.calls[0]?.text).toContain("그림");
+  });
+
+  test("★대조군 — 첨부가 없으면 글자만 간다★ (빈 첨부를 지어내지 않는다)", async () => {
+    const g = got();
+    await steerWithAttachments("잠시만", { fetchAttachments: null, steer: g.steer });
+    expect(g.calls[0]).toEqual({ text: "잠시만", imagePaths: undefined });
+  });
+
+  test("★내려받기 실패도 새 턴 경로와 같은 모양으로 남는다★ — 조용히 사라지면 안 됐다", async () => {
+    const g = got();
+    await steerWithAttachments("이거 봐", {
+      fetchAttachments: async () => attach({ failed: [{ kind: "photo", reason: "20MB 초과" }] }),
+      steer: g.steer,
+    });
+    expect(g.calls[0]?.text).toContain("20MB 초과");
+    expect(g.calls[0]?.text).toContain("이거 봐"); // 사람 말은 그대로
+  });
+
+  test("문서는 중간 개입에서도 경로로 실린다", async () => {
+    const g = got();
+    await steerWithAttachments("읽어봐", {
+      fetchAttachments: async () => attach({ files: [{ file_name: "spec.pdf", file_path: "/m/spec.pdf" } as never] }),
+      steer: g.steer,
+    });
+    expect(g.calls[0]?.text).toContain("/m/spec.pdf");
   });
 });

--- a/src/server/runtimes/codex/dmMedia.test.ts
+++ b/src/server/runtimes/codex/dmMedia.test.ts
@@ -1,0 +1,180 @@
+import { test, expect, describe } from "bun:test";
+import {
+  attachmentNote, decideDmMessage, dmBodyText, dmMediaRefs, downloadDmAttachments,
+  isImageMedia, largestPhotoVariant, MEDIA_ONLY_PROMPT,
+} from "./dmMedia";
+import type { StoredMedia } from "../../lib/mediaStore";
+
+/**
+ * ★1:1 로 온 첨부를 dex 가 실제로 보는가.★
+ *
+ * 원래 결함: 브리지가 받는 항목이 글자 하나뿐이라 ★사진만 보낸 메시지는 통째로 버려졌다.★
+ * 사진에 달린 설명(caption)도 안 왔다.
+ */
+const saved = (o: Partial<StoredMedia>): StoredMedia => ({
+  media_id: "tg_x", kind: "photo", file_id: "f", file_path: "/m/tg_x.jpg", url_path: "/media/tg_x.jpg", ...o,
+} as StoredMedia);
+
+describe("사진 크기 변형 — 장수가 아니라 화질을 고른다", () => {
+  test("★같은 그림의 여러 크기 중 가장 큰 것을 고른다★", () => {
+    const pick = largestPhotoVariant([
+      { file_id: "s", file_size: 1000 },
+      { file_id: "l", file_size: 90_000 },
+      { file_id: "m", file_size: 20_000 },
+    ]);
+    expect(pick?.file_id).toBe("l");
+  });
+
+  test("file_size 가 없으면 넓이로 고른다 — 텔레그램이 일부 변형에만 크기를 준다", () => {
+    const pick = largestPhotoVariant([
+      { file_id: "s", width: 90, height: 90 },
+      { file_id: "l", width: 1280, height: 960 },
+    ]);
+    expect(pick?.file_id).toBe("l");
+  });
+
+  test("★대조군 — 사진이 없으면 없다고 한다★ (지어내지 않는다)", () => {
+    expect(largestPhotoVariant(undefined)).toBeUndefined();
+    expect(largestPhotoVariant([])).toBeUndefined();
+  });
+});
+
+describe("무엇을 내려받나", () => {
+  test("사진 한 장은 ★한 건★ 이다 — 크기 변형마다 받지 않는다", () => {
+    const refs = dmMediaRefs({ photo: [{ file_id: "s", file_size: 10 }, { file_id: "l", file_size: 900 }] });
+    expect(refs).toHaveLength(1);
+    expect(refs[0]!.file_id).toBe("l");
+  });
+
+  test("사진과 문서가 같이 오면 ★둘 다★ 받는다", () => {
+    const refs = dmMediaRefs({
+      photo: [{ file_id: "p", file_size: 10 }],
+      document: { file_id: "d", file_name: "spec.pdf", mime_type: "application/pdf" },
+    });
+    expect(refs.map((r) => r.kind)).toEqual(["photo", "document"]);
+  });
+
+  test("★대조군 — 첨부가 없으면 빈 목록★", () => {
+    expect(dmMediaRefs({})).toHaveLength(0);
+  });
+});
+
+describe("그림인가 아닌가 — 그림만 입력 아이템으로 간다", () => {
+  test("photo 는 그림이다", () => {
+    expect(isImageMedia({ kind: "photo", mime_type: undefined, file_name: undefined })).toBe(true);
+  });
+  test("★파일로 보낸 png 도 그림이다★ — 텔레그램의 '파일로 보내기' 로 오면 document 다", () => {
+    expect(isImageMedia({ kind: "document", mime_type: "image/png", file_name: "shot.png" })).toBe(true);
+    expect(isImageMedia({ kind: "document", mime_type: undefined, file_name: "shot.PNG" })).toBe(true);
+  });
+  test("★대조군 — pdf 는 그림이 아니다★ (입력 아이템으로 넣으면 codex 가 거부한다)", () => {
+    expect(isImageMedia({ kind: "document", mime_type: "application/pdf", file_name: "a.pdf" })).toBe(false);
+  });
+});
+
+describe("내려받기 — 한 건이 실패해도 나머지는 간다", () => {
+  test("그림은 경로로, 문서는 파일로 갈린다", async () => {
+    const a = await downloadDmAttachments("tok", {
+      photo: [{ file_id: "p", file_size: 100 }],
+      document: { file_id: "d", file_name: "spec.pdf", mime_type: "application/pdf" },
+    }, {
+      store: (async (_t: string, ref: { kind: string }) =>
+        ref.kind === "photo"
+          ? saved({ kind: "photo", file_path: "/m/shot.jpg" })
+          : saved({ kind: "document", mime_type: "application/pdf", file_name: "spec.pdf", file_path: "/m/spec.pdf" })) as never,
+    });
+    expect(a.imagePaths).toEqual(["/m/shot.jpg"]);
+    expect(a.files.map((f) => f.file_name)).toEqual(["spec.pdf"]);
+    expect(a.failed).toHaveLength(0);
+  });
+
+  test("★한 건이 실패해도 나머지는 살고, 실패는 남는다★ — 조용히 없애지 않는다", async () => {
+    let n = 0;
+    const a = await downloadDmAttachments("tok", {
+      photo: [{ file_id: "p" }],
+      document: { file_id: "d", file_name: "spec.pdf", mime_type: "application/pdf" },
+    }, {
+      store: (async () => {
+        n += 1;
+        if (n === 1) throw new Error("telegram getFile failed");
+        return saved({ kind: "document", mime_type: "application/pdf", file_name: "spec.pdf", file_path: "/m/spec.pdf" });
+      }) as never,
+    });
+    expect(a.imagePaths).toHaveLength(0);
+    expect(a.files).toHaveLength(1);
+    expect(a.failed).toHaveLength(1);
+    expect(a.failed[0]!.reason).toContain("getFile");
+  });
+});
+
+describe("본문에 무엇을 적나", () => {
+  test("★그림이 있으면 그렇다고 적는다★ — 설명 없이 그림만 오면 codex 가 뭘 하란 건지 모른다", () => {
+    const note = attachmentNote({ imagePaths: ["/m/a.jpg"], files: [], failed: [] });
+    expect(note).toContain("그림");
+    expect(note).toContain("보이는 대로");
+  });
+
+  test("문서는 ★경로★ 를 적는다 — 그림과 달리 그게 유일한 통로다", () => {
+    const note = attachmentNote({
+      imagePaths: [], failed: [],
+      files: [saved({ kind: "document", file_name: "spec.pdf", file_path: "/m/spec.pdf" })],
+    });
+    expect(note).toContain("/m/spec.pdf");
+    expect(note).toContain("spec.pdf");
+  });
+
+  test("★실패도 적는다★ — 사람은 보냈는데 아무 말이 없으면 봤는지 못 봤는지 모른다", () => {
+    const note = attachmentNote({ imagePaths: [], files: [], failed: [{ kind: "photo", reason: "20MB 초과" }] });
+    expect(note).toContain("실패");
+    expect(note).toContain("20MB 초과");
+  });
+
+  test("★대조군 — 첨부가 없으면 아무것도 안 붙인다★", () => {
+    expect(attachmentNote({ imagePaths: [], files: [], failed: [] })).toBe("");
+  });
+});
+
+describe("본문 고르기 — 사진 설명은 caption 으로 온다", () => {
+  test("★caption 이 본문이 된다★ — 사진 메시지에는 text 가 없다", () => {
+    expect(dmBodyText(undefined, "이 화면 뭐가 문제야?")).toBe("이 화면 뭐가 문제야?");
+  });
+  test("글자가 있으면 글자가 우선", () => {
+    expect(dmBodyText("본문", "캡션")).toBe("본문");
+  });
+  test("★둘 다 없으면 없다고 한다★ — 그때만 첨부만 온 것이다", () => {
+    expect(dmBodyText(undefined, undefined)).toBeUndefined();
+    expect(dmBodyText("   ", "")).toBeUndefined();
+  });
+  test("첨부만 왔을 때 쓸 문구가 ★비어 있지 않다★ — 빈 턴이면 codex 가 아무것도 안 한다", () => {
+    expect(MEDIA_ONLY_PROMPT.trim().length).toBeGreaterThan(0);
+  });
+});
+
+describe("★이 메시지를 처리할 것인가★ — 원래 결함이 살던 자리", () => {
+  test("★사진만 보낸 메시지도 처리한다★ — 전에는 글자가 없다고 통째로 버렸다", () => {
+    const d = decideDmMessage({ photo: [{ file_id: "p", file_size: 100 }] });
+    expect(d.handle, "사진만 와도 처리해야 한다").toBe(true);
+    expect(d.hasMedia).toBe(true);
+    expect(d.text.trim().length, "빈 턴이면 codex 가 아무것도 안 한다").toBeGreaterThan(0);
+  });
+
+  test("★사진 설명(caption)이 본문이 된다★ — 사진 메시지엔 text 가 없다", () => {
+    const d = decideDmMessage({ photo: [{ file_id: "p" }], caption: "이 화면 왜 이래?" });
+    expect(d.text).toBe("이 화면 왜 이래?");
+  });
+
+  test("문서만 보내도 처리한다", () => {
+    expect(decideDmMessage({ document: { file_id: "d", file_name: "a.pdf" } }).handle).toBe(true);
+  });
+
+  test("글자만 오면 지금까지대로 간다", () => {
+    const d = decideDmMessage({ text: "안녕" });
+    expect(d).toEqual({ handle: true, text: "안녕", hasMedia: false });
+  });
+
+  test("★대조군 — 글도 첨부도 없으면 처리하지 않는다★ (아무 업데이트나 턴으로 만들지 않는다)", () => {
+    expect(decideDmMessage({}).handle).toBe(false);
+    expect(decideDmMessage(undefined).handle).toBe(false);
+    expect(decideDmMessage({ photo: [] }).handle).toBe(false);
+  });
+});

--- a/src/server/runtimes/codex/dmMedia.test.ts
+++ b/src/server/runtimes/codex/dmMedia.test.ts
@@ -180,11 +180,20 @@ describe("★이 메시지를 처리할 것인가★ — 원래 결함이 살던
 });
 
 describe("★안전 내려받기 — 어떤 식으로 실패해도 결과를 돌려준다★", () => {
-  test("던지지 않고 실패로 담는다 — 두 경로가 같은 방어를 쓰게 한다", async () => {
+  test("★건별 실패는 안쪽에서 잡힌다★ — 여기까지 오지 않는다(대조군)", async () => {
     const a = await downloadDmAttachmentsSafe("tok", { photo: [{ file_id: "p" }] }, {
       store: (async () => { throw new Error("망가진 응답"); }) as never,
     });
     expect(a.failed).toHaveLength(1);
-    expect(a.failed[0]!.reason).toContain("망가진 응답");
+    expect(a.failed[0]!.kind, "건별 실패는 그 첨부 종류로 기록된다").toBe("photo");
+  });
+
+  test("★건별 처리 바깥에서 터져도 던지지 않는다★ — 이 분기가 없으면 중간 개입이 통째로 죽는다", async () => {
+    // 텔레그램이 보낸 모양이 예상과 다르면 목록을 만드는 단계에서 터진다(건별 try 밖이다).
+    // 전에는 중간 개입 쪽이 이걸 .catch(() => null) 로 삼켜 ★첨부가 조용히 사라졌다.★
+    const a = await downloadDmAttachmentsSafe("tok", { photo: {} as never });
+    expect(a.failed, "던지지 않고 실패로 담아야 한다").toHaveLength(1);
+    expect(a.failed[0]!.kind).toBe("attachment");
+    expect(a.imagePaths).toHaveLength(0);
   });
 });

--- a/src/server/runtimes/codex/dmMedia.test.ts
+++ b/src/server/runtimes/codex/dmMedia.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe } from "bun:test";
 import {
-  attachmentNote, decideDmMessage, dmBodyText, dmMediaRefs, downloadDmAttachments,
+  attachmentNote, decideDmMessage, dmBodyText, dmMediaRefs, downloadDmAttachments, downloadDmAttachmentsSafe,
   isImageMedia, largestPhotoVariant, MEDIA_ONLY_PROMPT,
 } from "./dmMedia";
 import type { StoredMedia } from "../../lib/mediaStore";
@@ -176,5 +176,15 @@ describe("★이 메시지를 처리할 것인가★ — 원래 결함이 살던
     expect(decideDmMessage({}).handle).toBe(false);
     expect(decideDmMessage(undefined).handle).toBe(false);
     expect(decideDmMessage({ photo: [] }).handle).toBe(false);
+  });
+});
+
+describe("★안전 내려받기 — 어떤 식으로 실패해도 결과를 돌려준다★", () => {
+  test("던지지 않고 실패로 담는다 — 두 경로가 같은 방어를 쓰게 한다", async () => {
+    const a = await downloadDmAttachmentsSafe("tok", { photo: [{ file_id: "p" }] }, {
+      store: (async () => { throw new Error("망가진 응답"); }) as never,
+    });
+    expect(a.failed).toHaveLength(1);
+    expect(a.failed[0]!.reason).toContain("망가진 응답");
   });
 });

--- a/src/server/runtimes/codex/dmMedia.ts
+++ b/src/server/runtimes/codex/dmMedia.ts
@@ -1,0 +1,170 @@
+/**
+ * ★1:1 대화로 온 첨부를 dex 가 실제로 보게 한다.★
+ *
+ * 무엇이 문제였나 — 브리지가 받는 항목이 ★글자 하나뿐★ 이었다(TgUpdate.message.text).
+ * 그래서 사진만 보낸 메시지는 통째로 버려지고, 사진에 달린 설명(caption)도 안 왔다.
+ * 팀장님 관측: "dex 한테 이미지 첨부하면 못 읽는다" · "다른 팀원은 다 되는데".
+ * 다른 팀원(그룹방 capture 경로)은 이미 내려받아 저장하고 있었다 — ★1:1 만 안 이어져 있었다.★
+ *
+ * 사진은 버려지지 않는다: 텔레그램은 ★사진 한 장을 여러 크기로★ 보낸다(photo[] = 같은 그림의 썸네일·
+ * 중간·원본). 그중 가장 큰 것을 고르는 것은 ★장수를 고르는 게 아니라 화질을 고르는 것★ 이다.
+ * 여러 장을 보내면 텔레그램이 ★한 장씩 따로★ 보내므로 각 메시지가 각자 처리된다.
+ */
+import { storeTelegramMedia, type StoredMedia, type TelegramMediaRef } from "../../lib/mediaStore";
+
+/** 텔레그램 메시지에서 우리가 읽는 부분만. (브리지의 TgUpdate 와 같은 모양) */
+export interface DmMessageMedia {
+  photo?: Array<{
+    file_id: string;
+    file_unique_id?: string;
+    file_size?: number;
+    width?: number;
+    height?: number;
+  }>;
+  document?: {
+    file_id: string;
+    file_unique_id?: string;
+    file_name?: string;
+    mime_type?: string;
+    file_size?: number;
+  };
+}
+
+/**
+ * 같은 그림의 여러 크기 중 ★가장 큰 것★ 을 고른다.
+ * file_size 가 없는 변형이 섞여 있어 넓이로 보조 판정한다(둘 다 없으면 0 — 맨 뒤로 간다).
+ */
+export function largestPhotoVariant(
+  photo: DmMessageMedia["photo"],
+): NonNullable<DmMessageMedia["photo"]>[number] | undefined {
+  return photo?.slice().sort((a, b) => {
+    const as = a.file_size ?? (a.width ?? 0) * (a.height ?? 0);
+    const bs = b.file_size ?? (b.width ?? 0) * (b.height ?? 0);
+    return bs - as;
+  })[0];
+}
+
+/** 내려받을 대상을 뽑는다 — 순수 함수라 통신 없이 잴 수 있다. */
+export function dmMediaRefs(msg: DmMessageMedia): TelegramMediaRef[] {
+  const refs: TelegramMediaRef[] = [];
+  const photo = largestPhotoVariant(msg.photo);
+  if (photo) {
+    refs.push({
+      kind: "photo",
+      file_id: photo.file_id,
+      file_unique_id: photo.file_unique_id,
+      file_size: photo.file_size,
+      width: photo.width,
+      height: photo.height,
+      mime_type: "image/jpeg",
+    });
+  }
+  const doc = msg.document;
+  if (doc) {
+    refs.push({
+      kind: "document",
+      file_id: doc.file_id,
+      file_unique_id: doc.file_unique_id,
+      file_name: doc.file_name,
+      mime_type: doc.mime_type,
+      file_size: doc.file_size,
+    });
+  }
+  return refs;
+}
+
+/** 문서가 그림인가 — .png 를 문서로 보내는 사람이 많다(텔레그램의 "파일로 보내기"). */
+export function isImageMedia(m: Pick<StoredMedia, "kind" | "mime_type" | "file_name">): boolean {
+  if (m.kind === "photo") return true;
+  if (m.mime_type?.startsWith("image/")) return true;
+  return /\.(jpe?g|png|webp|gif)$/i.test(m.file_name ?? "");
+}
+
+export interface DmAttachments {
+  /** codex 에 ★입력 아이템★ 으로 넣을 그림 경로. 본문에 경로만 적는 것과 다르다 — 이래야 본다. */
+  imagePaths: string[];
+  /** 그림이 아닌 첨부(pdf·zip 등) — 본문에 경로를 적어 필요하면 열게 한다. */
+  files: StoredMedia[];
+  /** 내려받기에 실패한 것. ★조용히 지우지 않는다★ — 사람이 보낸 것이 사라지면 안 된다. */
+  failed: Array<{ kind: string; reason: string }>;
+}
+
+/**
+ * 첨부를 내려받아 로컬 경로로 만든다.
+ *
+ * ★한 건이 실패해도 나머지는 간다.★ 그리고 실패는 남긴다 — 사람은 보냈는데 아무 말이 없으면
+ * 봤는지 못 봤는지 알 수 없다(그게 이 결함의 원래 모습이었다).
+ */
+export async function downloadDmAttachments(
+  token: string,
+  msg: DmMessageMedia,
+  opts: { store?: typeof storeTelegramMedia; mediaDir?: string } = {},
+): Promise<DmAttachments> {
+  const store = opts.store ?? storeTelegramMedia;
+  const out: DmAttachments = { imagePaths: [], files: [], failed: [] };
+  for (const ref of dmMediaRefs(msg)) {
+    try {
+      const saved = await store(token, ref, opts.mediaDir ? { mediaDir: opts.mediaDir } : {});
+      if (isImageMedia(saved)) out.imagePaths.push(saved.file_path);
+      else out.files.push(saved);
+    } catch (e) {
+      out.failed.push({ kind: ref.kind, reason: e instanceof Error ? e.message : String(e) });
+    }
+  }
+  return out;
+}
+
+/**
+ * 첨부 사실을 본문에 덧붙인다.
+ *
+ * 그림은 ★입력 아이템으로 따로 들어가지만★ 본문에도 한 줄 적는다 — 안 적으면 사람이 설명 없이
+ * 그림만 보냈을 때 codex 가 무엇을 해달라는 건지 모른다. 문서는 경로가 유일한 통로다.
+ */
+export function attachmentNote(a: DmAttachments): string {
+  const lines: string[] = [];
+  if (a.imagePaths.length) {
+    lines.push(
+      a.imagePaths.length === 1
+        ? "[첨부: 그림 1장 — 위 입력으로 함께 보냈다. 보이는 대로 답하라.]"
+        : `[첨부: 그림 ${a.imagePaths.length}장 — 위 입력으로 함께 보냈다. 보이는 대로 답하라.]`,
+    );
+  }
+  for (const f of a.files) {
+    lines.push(`[첨부 파일: ${f.file_name ?? f.media_id} — ${f.file_path} (필요하면 직접 열어라)]`);
+  }
+  for (const f of a.failed) {
+    lines.push(`[첨부(${f.kind}) 내려받기 실패: ${f.reason} — 사람에게 다시 보내달라고 하라.]`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * 첨부만 있고 글이 없을 때 쓸 본문.
+ * ★빈 문자열로 두면 안 된다★ — codex 는 할 말이 없는 턴으로 받아 아무것도 안 한다.
+ */
+export const MEDIA_ONLY_PROMPT = "(설명 없이 첨부만 보냈다. 첨부를 보고 무엇인지 짧게 말하고, 필요한 것을 물어라.)";
+
+/**
+ * ★이 메시지를 처리할 것인가, 그리고 codex 에 무슨 말을 줄 것인가.★
+ *
+ * 이 판단이 원래 폴 루프 안에 `if (!text) continue` 한 줄로 있었다. 그래서
+ * ★사진만 보낸 메시지가 통째로 버려졌다★ — 로그에도 안 남아 무시당한 것처럼 보였다.
+ * 판단을 밖으로 빼서 시험이 지키게 한다(같은 실수를 오늘 steer 쪽에서도 했다).
+ */
+export function decideDmMessage(msg: {
+  text?: string;
+  caption?: string;
+  photo?: DmMessageMedia["photo"];
+  document?: DmMessageMedia["document"];
+} | undefined): { handle: boolean; text: string; hasMedia: boolean } {
+  const body = dmBodyText(msg?.text, msg?.caption);
+  const hasMedia = Boolean(msg?.photo?.length || msg?.document);
+  if (!body && !hasMedia) return { handle: false, text: "", hasMedia };
+  return { handle: true, text: body ?? MEDIA_ONLY_PROMPT, hasMedia };
+}
+
+/** 본문 = 글 또는 캡션. 둘 다 없으면 첨부만 온 것이다. */
+export function dmBodyText(text: string | undefined, caption: string | undefined): string | undefined {
+  const body = (text ?? caption ?? "").trim();
+  return body.length ? body : undefined;
+}

--- a/src/server/runtimes/codex/dmMedia.ts
+++ b/src/server/runtimes/codex/dmMedia.ts
@@ -115,6 +115,26 @@ export async function downloadDmAttachments(
 }
 
 /**
+ * ★내려받기를 시도하되, 어떤 식으로 실패해도 결과를 돌려준다.★
+ *
+ * 두 경로(새 턴 · 중간 개입)가 ★같은 방어★ 를 쓰게 하려고 여기 둔다.
+ * 전에는 중간 개입 쪽만 `.catch(() => null)` 이라 ★첨부가 조용히 사라졌다★ —
+ * 사람은 보냈는데 못 봤다는 사실조차 안 남는다. 이 파일이 고치려는 결함과 같은 모양이다.
+ * ★문을 두 개 만들었으면 그 둘도 같아야 한다.★
+ */
+export async function downloadDmAttachmentsSafe(
+  token: string,
+  msg: DmMessageMedia,
+  opts: { store?: typeof storeTelegramMedia; mediaDir?: string } = {},
+): Promise<DmAttachments> {
+  try {
+    return await downloadDmAttachments(token, msg, opts);
+  } catch (e) {
+    return { imagePaths: [], files: [], failed: [{ kind: "attachment", reason: e instanceof Error ? e.message : String(e) }] };
+  }
+}
+
+/**
  * 첨부 사실을 본문에 덧붙인다.
  *
  * 그림은 ★입력 아이템으로 따로 들어가지만★ 본문에도 한 줄 적는다 — 안 적으면 사람이 설명 없이

--- a/src/server/runtimes/codex/runner.ts
+++ b/src/server/runtimes/codex/runner.ts
@@ -55,6 +55,13 @@ export interface CodexTurnOptions {
   onActivity?: (line: string, itemId?: string) => void;
   /** 지금 어느 단계인가 — 맨 윗줄에서 교체된다(쌓이지 않는다). */
   onStatus?: (line: string) => void;
+  /**
+   * ★사람이 붙인 그림의 로컬 경로.★ 본문에 경로를 적어주는 것과 다르다 —
+   * 적어주면 codex 는 파일을 ★바이트로 읽을 뿐★ 이고, 입력 아이템으로 넣어야 ★본다.★
+   * 실측(CLI 0.147.0): 글자가 든 그림을 태워 codex 가 그 글자를 읽어냈고,
+   * 같은 질문을 그림 없이 주면 "안보임" 이 나왔다.
+   */
+  imagePaths?: readonly string[];
 }
 
 export interface CodexTurnResult {

--- a/src/server/runtimes/codex/turnInput.test.ts
+++ b/src/server/runtimes/codex/turnInput.test.ts
@@ -1,0 +1,37 @@
+import { test, expect, describe } from "bun:test";
+import { buildTurnInput } from "./appServerClient";
+
+/**
+ * ★codex 에 보낼 입력 아이템 조립.★
+ *
+ * 여기서 틀리면 ★그림이 조용히 빠진 채★ 글자만 간다 — 사람은 보냈는데 "안 보인다" 는 답을 받는다.
+ * 모양은 실측으로 고정했다(CLI 0.147.0 app-server):
+ *   · localImage 는 ★path 를 요구★ 한다 — imageUrl 로 주면 `missing field \`path\`` 로 거부
+ *   · 글자가 든 그림을 태워 codex 가 그 글자를 읽었고, 같은 질문을 그림 없이 주면 "안보임" 이 나왔다
+ */
+describe("턴 입력 조립", () => {
+  test("★그림이 글자보다 앞선다★ — 뒤에 두면 '이 그림' 이 앞 문장을 못 가리킨다", () => {
+    const input = buildTurnInput("이거 뭐야", ["/m/a.jpg"]);
+    expect(input.map((i) => i.type)).toEqual(["localImage", "text"]);
+  });
+
+  test("★localImage 는 path 로 준다★ — imageUrl 로 주면 codex 가 거부한다(실측)", () => {
+    const [img] = buildTurnInput("q", ["/m/a.jpg"]);
+    expect(img).toEqual({ type: "localImage", path: "/m/a.jpg" });
+  });
+
+  test("여러 장이면 ★순서대로 전부★ 실린다 — 하나만 보내면 나머지를 못 본다", () => {
+    const input = buildTurnInput("q", ["/m/a.jpg", "/m/b.png"]);
+    expect(input.filter((i) => i.type === "localImage").map((i) => i.path)).toEqual(["/m/a.jpg", "/m/b.png"]);
+  });
+
+  test("★대조군 — 그림이 없으면 글자 하나뿐★ (빈 아이템을 지어내지 않는다)", () => {
+    expect(buildTurnInput("안녕")).toEqual([{ type: "text", text: "안녕", text_elements: [] }]);
+    expect(buildTurnInput("안녕", [])).toHaveLength(1);
+  });
+
+  test("글자는 그림이 있어도 그대로 간다 — 사람 말이 첨부에 밀리면 안 된다", () => {
+    const input = buildTurnInput("이 화면 왜 이래?", ["/m/a.jpg"]);
+    expect(input.at(-1)).toEqual({ type: "text", text: "이 화면 왜 이래?", text_elements: [] });
+  });
+});


### PR DESCRIPTION
## 핵심 3줄
1. **1:1 로 보낸 사진을 dex 가 못 본다.** 브리지가 받는 항목이 **글자 하나뿐**이라, 사진만 보낸 메시지는 **통째로 버려졌고** 사진에 달린 설명(caption)도 안 왔다.
2. 그룹방 capture 경로는 **이미 내려받아 저장하고 있었다** — 1:1 만 안 이어져 있었다. **들어온 문이 다르면 동작이 달랐다**(어제 재시작 연속성, 오늘 중간 개입과 같은 자리다).
3. 경로를 본문에 적어주는 걸로는 **안 된다.** 그러면 codex 는 파일을 **바이트로 읽을 뿐 보지 못한다.** 입력 아이템으로 넣어야 본다.

## 무엇이 잘못 동작했나

```ts
message?: { message_id: number; chat: { id: number }; text?: string };
                                                      // ↑ 이게 전부였다
const text = u.message?.text;
if (!text || chatId === undefined) continue;          // ← 사진만 온 메시지는 여기서 사라진다
```

`photo` · `caption` · `document` 를 참조하는 곳이 **0군데**였다. 로그에도 안 남아 사람 눈에는 **무시당한 것**으로 보인다.

| 들어온 문 | 첨부 |
|---|---|
| 그룹방(capture) | 내려받아 저장 |
| 1:1 대화 | **0군데** |

## 그림은 버려지지 않았다 — 내 설명이 틀렸었다

팀장님이 "사진은 다 받아야지" 라고 하셨다. 확인하니 **코드는 맞고 내 설명이 틀렸다**:

텔레그램은 **사진 한 장을 여러 크기로** 보낸다(`photo[]` = 같은 그림의 썸네일·중간·원본). 가장 큰 것을 고르는 건 **장수를 고르는 게 아니라 화질을 고르는 것**이다. **여러 장은 메시지가 나뉘어** 오므로 각자 처리된다.

## 그림을 넣는 모양 — 추정 대신 실측

`localImage` 는 **`path` 를 요구한다**. `imageUrl` 로 주면 ``Invalid request: missing field `path` `` 로 거부된다. 입력 종류는 `text | image | localImage | audio | localAudio | skill | mention` 이다 (CLI 0.147.0 app-server).

```
[그림 있음]      status=completed → MANDARIN
[★대조군★ 그림 없음] status=completed → 안보임
```
같은 질문, 같은 경로. **그림이 있을 때만 그림 속 글자가 나온다.** 파일 이름은 `probe.png` 라 이름으로는 못 맞힌다.

## 무엇을 바꿨나

| | |
|---|---|
| 수신 형태 | `photo` · `caption` · `document` 를 받는다 |
| 그림 | **입력 아이템**(`localImage`)으로 넣는다 — 그림이 글자보다 **앞** |
| 문서 | 내려받아 **경로를 본문에** 적는다(그게 유일한 통로) |
| 실패 | **본문에 남긴다** — 사람이 보낸 것을 말없이 없애지 않는다 |
| 중간 개입 | 도중에 붙인 그림도 그 작업 안으로(`turn/steer` 도 같은 모양) |

**내려받기는 폴 루프가 아니라 턴 안에서 한다.** 루프에서 받으면 받는 동안 다음 업데이트를 못 읽어 **#334 의 승인 버튼 막힘이 되살아난다.**

**판단 두 개를 시험이 닿는 자리로 뺐다** — 오늘 #354 리뷰에서 배운 그대로다:
- `decideDmMessage` — **원래 결함이 살던 폴 루프 한 줄**
- `buildTurnInput` — 여기서 틀리면 **그림이 조용히 빠진 채** 글자만 간다

## 검증

```
검증 범위:  bun test (전체 229파일 2906 시험) · bunx tsc --noEmit
baseline:   0 fail
시험:       dmMedia 24건 — 크기 변형 · 무엇을 받나 · 그림 판별 · 부분 실패 · 본문 표기
            · ★이 메시지를 처리할 것인가(원래 결함이 살던 자리)★
            turnInput 5건 — 순서 · path 모양 · 여러 장 · ★대조군(그림 없으면 글자 하나)★
            bridgeMedia 6건(배선) — ★그림이 턴 옵션까지 가는가★ · 문서는 본문으로
            · 내려받기 통째 실패에도 턴은 돈다 · 부분 실패
mutation:   10종 ★전부 사망★ —
            그림을 입력에 안 실음 · 그림을 글자 뒤로 · path 대신 imageUrl
            · ★옛 동작(글자 없으면 버림)★ · 첨부만일 때 빈 본문 · 실패를 조용히 버림
            · 문서도 그림으로 넣음 · 그림을 턴까지 안 넘김 · 첨부 설명 안 붙임
            · 첨부 실패가 턴을 죽임
라이브:     ★우리 클라이언트 경로로 실제 codex 에 태워 확인했다★ —
            글자가 든 그림 → "MANDARIN" · ★같은 질문 그림 없이 → "안보임"★
            (scripts/dev/img-live-check.ts 로 다시 잴 수 있다)
미검증:     ★텔레그램으로 실제 사진을 보내보지는 않았다★ — 라이브 확인은 codex 쪽 경로다.
            텔레그램 수신부(getFile→내려받기)는 그룹방에서 이미 도는 코드를 그대로 쓴다.
            ★20MB 초과·손상 파일 같은 실패는 실제로 밟아본 적이 없다★ — 본문에 적히는 것은 시험으로만 봤다.
            ★배포 시 bridge 프로세스를 따로 재시작해야 한다★ (오늘 #354 에서 서버 재배포로는
            안 내려간 것이 확인됐다 — launchctl kickstart 필요).
```

Submitted-by: Demis
