### PR TITLE
fix(runtime): 턴 상한을 '조용한 시간' 으로 재고, 예약을 생존신호로 연장한다

### DIFF
--- a/src/server/bus/inFlightLiveness.test.ts
+++ b/src/server/bus/inFlightLiveness.test.ts
@@ -1,0 +1,75 @@
+/**
+ * ★in-flight 잠금은 '시작한 지 오래' 가 아니라 '조용한 지 오래' 로 푼다.★
+ *
+ * ★이 파일이 있는 이유★ — 이 판정을 되돌려도(quietSince → startedAt) 수트가 ★전부 초록★ 이었다.
+ * 지금 코드가 맞는 것과, 다음 사람이 깨뜨렸을 때 알아차리는 것은 다른 문제다. 여기서 그 축을 고정한다.
+ *
+ * ★키가 맞물리는지도 함께 잰다★ — 생존신호를 쓰는 키와 자가치유가 읽는 키가 어긋나면
+ * ★오류 없이 조용히 옛 동작★ 이 된다(신호가 영영 안 보이므로 '시작 시각' 만으로 판정).
+ */
+import { describe, expect, test } from "bun:test";
+import { noteTurnAlive, forgetTurnAlive, inFlightKey, shouldReleaseInFlight } from "./wakeDispatcher";
+
+const GRACE = 60_000;
+
+describe("in-flight 해제 판정", () => {
+  test("★대조군 — 신호가 없으면 시작 시각 기준으로 grace 를 넘길 때 푼다★ (상한을 없앤 게 아니다)", () => {
+    const key = inFlightKey("m-quiet", "hermes");
+    forgetTurnAlive(key);
+    const now = 1_000_000;
+    expect(shouldReleaseInFlight(key, now - GRACE - 1, GRACE, now), "조용한 턴은 푼다").toBe(true);
+    expect(shouldReleaseInFlight(key, now - GRACE + 1, GRACE, now), "아직 grace 안이면 안 푼다").toBe(false);
+  });
+
+  test("★살아 있다는 신호가 오면 시작한 지 아무리 오래돼도 안 푼다★ (핵심 한 줄)", () => {
+    const key = inFlightKey("m-alive", "hermes");
+    forgetTurnAlive(key);
+    noteTurnAlive("m-alive", "hermes"); // 방금 살아 있다고 알림
+    const now = Date.now();
+    const startedLongAgo = now - GRACE * 10; // 시작한 지 grace 의 10배
+
+    expect(
+      shouldReleaseInFlight(key, startedLongAgo, GRACE, now),
+      "★신호가 방금 왔는데 풀면, 일하는 중인 턴의 잠금을 놓는 것이다★",
+    ).toBe(false);
+  });
+
+  test("★신호가 끊기면 그때부터 다시 센다★ — 한 번 살아있었다고 영원히 잡고 있지 않는다", () => {
+    const key = inFlightKey("m-stopped", "hermes");
+    forgetTurnAlive(key);
+    noteTurnAlive("m-stopped", "hermes");
+    const aliveAt = Date.now();
+
+    expect(shouldReleaseInFlight(key, 0, GRACE, aliveAt + GRACE - 1), "아직 조용한 지 얼마 안 됐다").toBe(false);
+    expect(shouldReleaseInFlight(key, 0, GRACE, aliveAt + GRACE + 1000), "★신호 이후로 grace 를 넘겼다★").toBe(true);
+  });
+
+  test("★생존신호와 자가치유가 같은 키를 쓴다★ (어긋나면 오류 없이 옛 동작이 된다)", () => {
+    forgetTurnAlive(inFlightKey("m-key", "hermes"));
+    noteTurnAlive("m-key", "hermes");
+    const now = Date.now();
+    const startedLongAgo = now - GRACE * 10;
+
+    expect(
+      shouldReleaseInFlight(inFlightKey("m-key", "hermes"), startedLongAgo, GRACE, now),
+      "★같은 (메시지, 팀원) 으로 물어보면 방금 온 신호가 보여야 한다★",
+    ).toBe(false);
+    expect(
+      shouldReleaseInFlight(inFlightKey("m-key", "steve"), startedLongAgo, GRACE, now),
+      "다른 팀원의 키에는 그 신호가 없다 — 키가 실제로 구분된다",
+    ).toBe(true);
+  });
+
+  test("★턴이 끝나면 신호 기록을 버린다★ (안 버리면 프로세스 수명 내내 자란다)", () => {
+    const key = inFlightKey("m-done", "hermes");
+    noteTurnAlive("m-done", "hermes");
+    const now = Date.now();
+    expect(shouldReleaseInFlight(key, now - GRACE * 10, GRACE, now), "버리기 전에는 신호가 산다").toBe(false);
+
+    forgetTurnAlive(key);
+    expect(
+      shouldReleaseInFlight(key, now - GRACE * 10, GRACE, now),
+      "★버린 뒤에는 시작 시각 기준으로 돌아간다★",
+    ).toBe(true);
+  });
+});

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -159,9 +159,30 @@ const MAX_RETRIES = 3;
  */
 const lastAliveAt = new Map<string, number>();
 
+/** in-flight 키 — 자가치유·생존신호가 ★같은 모양★ 을 써야 맞물린다(어긋나면 오류 없이 옛 동작이 된다). */
+export function inFlightKey(messageId: string, agentId: string): string {
+  return `${messageId}:${agentId}`;
+}
+
 /** 살아 있다는 신호를 기록한다. 런타임 어댑터가 부른다(hermes = 자식이 출력을 흘릴 때마다). */
 export function noteTurnAlive(messageId: string, agentId: string): void {
-  lastAliveAt.set(`${messageId}:${agentId}`, Date.now());
+  lastAliveAt.set(inFlightKey(messageId, agentId), Date.now());
+}
+
+/** 턴이 끝났다 — 생존신호 기록을 버린다(안 지우면 이 Map 이 프로세스 수명 내내 자란다). */
+export function forgetTurnAlive(key: string): void {
+  lastAliveAt.delete(key);
+}
+
+/**
+ * ★이 in-flight 잠금을 풀어도 되나 — 기준은 '시작한 지 오래' 가 아니라 '조용한 지 오래' 다.★
+ *
+ * 순수 함수로 뽑아둔 이유: 이 판정이 ★이 변경의 핵심 한 줄★ 인데 tick 루프 안에 있으면 시험이 못 잡는다.
+ * (되돌려도 수트가 전부 초록이면 다음 사람이 깨뜨린 걸 아무도 모른다)
+ */
+export function shouldReleaseInFlight(key: string, startedAt: number, graceMs: number, now: number): boolean {
+  const quietSince = Math.max(startedAt, lastAliveAt.get(key) ?? 0);
+  return now - quietSince > graceMs;
 }
 
 /**
@@ -746,8 +767,12 @@ function makeHermesAdapter(db: Database, agents: () => AgentRecord[]): WakeAdapt
           agent,
           // ★살아 있는 동안 예약을 민다★ — blocking 런타임이라 이 행은 턴 내내 `dispatching` 이고,
           //   예약이 만료되면 recoverStaleClaims 가 `pending` 으로 되돌려 ★같은 메시지가 다시 나간다.★
-          //   DB 예약(extendLease)과 프로세스 내 잠금(noteTurnAlive) ★둘 다★ 밀어야 한다 — 한쪽만 밀면
-          //   다른 쪽이 먼저 풀려서 중복이 그대로 난다.
+          //
+          // ★둘을 미는 이유는 서로 다르다 — 같은 것을 이중으로 막는 게 아니다.★
+          //   · ★DB 예약(extendLease)★ = ★같은 메시지의 재디스패치★ 를 막는다. 폴러는 `pending` 행만 집고
+          //     `dispatching` → `pending` 은 recoverStaleClaims(lease 만료) ★한 경로뿐★ 이라, 여기가 유일한 방어다.
+          //   · ★프로세스 내 잠금(noteTurnAlive)★ = ★같은 팀원에게 온 '다른' 메시지★ 가 턴 도중 겹쳐 드는 것을 막는다.
+          //   그래서 한쪽만 밀면 ★막지 못하는 것이 서로 다르다.★ 둘 다 밀어야 둘 다 막힌다.
           onAlive: () => {
             extendLease(db, row.message_id, targetAgentId, HERMES_LEASE_SEC);
             noteTurnAlive(row.message_id, targetAgentId);
@@ -1822,12 +1847,13 @@ export function startWakeDispatcher(deps: WakeDispatcherDeps): () => void {
       for (const [key, entry] of inFlight) {
         // 잠금 해제 = dispatchRow 완료(턴 종료) 시 finally 에서. 여기는 hang 백스톱(self-heal)만.
         // ★기준은 "언제 시작했나" 가 아니라 "마지막으로 살아 있다고 한 게 언제냐" 다.★
-        //   살아 있다는 신호가 오는 동안은 잠금을 풀지 않는다 — 풀면 같은 메시지가 다시 나가 ★중복 실행★ 된다.
+        //   살아 있다는 신호가 오는 동안은 잠금을 풀지 않는다 — 풀면 ★같은 팀원에게 온 다음 메시지★ 가
+        //   턴이 도는 중에 겹쳐 들어간다(이 잠금이 막는 것이 그것이다. 같은 메시지의 재디스패치는 DB 예약이 막는다).
         const aliveAt = lastAliveAt.get(key) ?? 0;
-        const quietSince = Math.max(entry.startedAt, aliveAt);
-        if (now - quietSince > entry.graceMs) {
+        if (shouldReleaseInFlight(key, entry.startedAt, entry.graceMs, now)) {
+          const quietSince = Math.max(entry.startedAt, aliveAt);
           inFlight.delete(key);
-          lastAliveAt.delete(key);
+          forgetTurnAlive(key);
           appendAuditFile("bus_dispatcher", "inflight_self_heal", null, {
             key,
             age_ms: now - entry.startedAt,
@@ -1945,7 +1971,7 @@ export function startWakeDispatcher(deps: WakeDispatcherDeps): () => void {
             //   → 여기 도달 = 턴 종료. 모든 런타임 동일하게 잠금 해제. (mid-turn 주입 방지는 busy-defer 가 담당)
             inFlight.delete(key);
             // ★생존신호도 같이 지운다★ — 안 지우면 이 Map 이 프로세스 수명 내내 자란다(키가 메시지마다 하나).
-            lastAliveAt.delete(key);
+            forgetTurnAlive(key);
           }
         })();
       }

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -27,6 +27,7 @@ import {
   markFailed,
   markDeferred,
   recoverStaleClaims,
+  extendLease,
   recentThreadMessages,
 } from "../db/inboxQueries";
 import { appendAudit } from "../db/queries";
@@ -132,7 +133,7 @@ const POLL_INTERVAL_MS = Number(process.env.BUS_POLL_INTERVAL_MS ?? 1500);
 //   timeout cannot break the ladder.
 export const ADAPTER_TIMEOUT_MS = 10_000; // tmux prepare/session check timeout (10s)
 export const OPENCLAW_ADAPTER_TIMEOUT_MS = Number(process.env.OPENCLAW_ADAPTER_TIMEOUT_MS ?? 240_000);
-const DEFAULT_LEASE_SEC = 60; // fast runtimes (tmux/claude/hermes/codex/b3os_native) claim lease
+const DEFAULT_LEASE_SEC = 60; // fast runtimes (tmux/claude/codex/b3os_native) claim lease — ★hermes 는 아래에서 자기 turn cap 으로 파생한다(HERMES_LEASE_SEC)★
 const IN_FLIGHT_GRACE_MS = 120_000; // default inFlight eviction: lease 60 + buffer 60
 // openclaw-only long lease/grace, derived from the adapter timeout so adapter < lease < grace always holds.
 const OPENCLAW_LEASE_MS = OPENCLAW_ADAPTER_TIMEOUT_MS + 60_000;
@@ -146,6 +147,22 @@ const HERMES_LEASE_MS = HERMES_TURN_TIMEOUT_MS + 60_000;
 const HERMES_LEASE_SEC = Math.ceil(HERMES_LEASE_MS / 1000);
 const HERMES_IN_FLIGHT_GRACE_MS = HERMES_LEASE_MS + 60_000;
 const MAX_RETRIES = 3;
+
+/**
+ * ★턴이 마지막으로 '살아 있다' 고 알린 시각★ (key = `${message_id}:${agent_id}`).
+ *
+ * ★왜 있나★ — self-heal(아래 tick)은 `startedAt` 하나로 나이를 재서, ★일하는 중인 턴도★ grace 를 넘으면
+ * 잠금을 푼다. 잠금이 풀리면 같은 메시지가 다시 디스패치돼 ★같은 일이 두 번★ 돈다.
+ * blocking 런타임(hermes)의 강제 종료를 없애려면 ★"오래됐다" 가 아니라 "조용하다" 로 재야 한다.★
+ * 그래서 생존신호가 오면 여기 시각을 갱신하고, self-heal 은 ★startedAt 과 이 값 중 나중 것★ 을 기준으로 잰다.
+ * (DB 쪽 예약은 `extendLease` 가 따로 연장한다 — 이건 ★같은 프로세스 안의 잠금★ 용이다)
+ */
+const lastAliveAt = new Map<string, number>();
+
+/** 살아 있다는 신호를 기록한다. 런타임 어댑터가 부른다(hermes = 자식이 출력을 흘릴 때마다). */
+export function noteTurnAlive(messageId: string, agentId: string): void {
+  lastAliveAt.set(`${messageId}:${agentId}`, Date.now());
+}
 
 /**
  * Per-runtime claim lease (seconds). ★Blocking-wake runtimes (openclaw, hermes) hold their claim
@@ -727,6 +744,14 @@ function makeHermesAdapter(db: Database, agents: () => AgentRecord[]): WakeAdapt
             : ({ kind: "teammate", to: row.from_agent_id } as const);
         await runHermesTeamTurn({
           agent,
+          // ★살아 있는 동안 예약을 민다★ — blocking 런타임이라 이 행은 턴 내내 `dispatching` 이고,
+          //   예약이 만료되면 recoverStaleClaims 가 `pending` 으로 되돌려 ★같은 메시지가 다시 나간다.★
+          //   DB 예약(extendLease)과 프로세스 내 잠금(noteTurnAlive) ★둘 다★ 밀어야 한다 — 한쪽만 밀면
+          //   다른 쪽이 먼저 풀려서 중복이 그대로 난다.
+          onAlive: () => {
+            extendLease(db, row.message_id, targetAgentId, HERMES_LEASE_SEC);
+            noteTurnAlive(row.message_id, targetAgentId);
+          },
           threadId: row.thread_id,
           messageId: row.message_id,
           body: row.body,
@@ -1796,9 +1821,20 @@ export function startWakeDispatcher(deps: WakeDispatcherDeps): () => void {
 
       for (const [key, entry] of inFlight) {
         // 잠금 해제 = dispatchRow 완료(턴 종료) 시 finally 에서. 여기는 hang 백스톱(self-heal)만.
-        if (now - entry.startedAt > entry.graceMs) {
+        // ★기준은 "언제 시작했나" 가 아니라 "마지막으로 살아 있다고 한 게 언제냐" 다.★
+        //   살아 있다는 신호가 오는 동안은 잠금을 풀지 않는다 — 풀면 같은 메시지가 다시 나가 ★중복 실행★ 된다.
+        const aliveAt = lastAliveAt.get(key) ?? 0;
+        const quietSince = Math.max(entry.startedAt, aliveAt);
+        if (now - quietSince > entry.graceMs) {
           inFlight.delete(key);
-          appendAuditFile("bus_dispatcher", "inflight_self_heal", null, { key, age_ms: now - entry.startedAt });
+          lastAliveAt.delete(key);
+          appendAuditFile("bus_dispatcher", "inflight_self_heal", null, {
+            key,
+            age_ms: now - entry.startedAt,
+            // ★"오래 걸려서" 와 "조용해서" 는 다른 사건이다 — 무엇을 재서 풀었는지 남긴다.★
+            quiet_ms: now - quietSince,
+            had_alive_signal: aliveAt > 0,
+          });
         }
       }
 
@@ -1908,6 +1944,8 @@ export function startWakeDispatcher(deps: WakeDispatcherDeps): () => void {
             // dispatchRow 가 턴 끝까지 블록한다(openclaw=agent.wait / hermes=stdout / claude=inject).
             //   → 여기 도달 = 턴 종료. 모든 런타임 동일하게 잠금 해제. (mid-turn 주입 방지는 busy-defer 가 담당)
             inFlight.delete(key);
+            // ★생존신호도 같이 지운다★ — 안 지우면 이 Map 이 프로세스 수명 내내 자란다(키가 메시지마다 하나).
+            lastAliveAt.delete(key);
           }
         })();
       }

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -1877,7 +1877,9 @@ export function startWakeDispatcher(deps: WakeDispatcherDeps): () => void {
       const agentsNow = deps.agents();
       const rows = pendingDispatch(db, 10);
       for (const row of rows) {
-        const key = `${row.message_id}:${row.agent_id}`;
+        // ★키는 한 곳에서만 만든다★ — 여기서 따로 조립하면 생존신호(noteTurnAlive)와 모양이 갈려도
+        //   오류 없이 조용히 어긋난다(신호가 판정부에 영영 안 닿는다).
+        const key = inFlightKey(row.message_id, row.agent_id);
         if (inFlight.has(key)) continue;
 
         // Per-runtime claim lease: openclaw wakes run up to ~240s, so they need a lease that

--- a/src/server/db/inbox/dispatch.ts
+++ b/src/server/db/inbox/dispatch.ts
@@ -173,6 +173,36 @@ export function markDispatching(
 }
 
 /**
+ * ★예약(lease)을 '살아 있는 동안' 연장한다 — 시간이 아니라 생존신호로.★
+ *
+ * ★왜 필요한가★ — hermes 처럼 ★턴 내내 붙잡는(blocking)★ 런타임은 `markWakeDispatched` 가
+ * 턴이 끝난 뒤에야 찍히므로(wakeDispatcher) 그 행이 ★턴 내내 `dispatching` 에 머문다.★
+ * 그런데 `recoverStaleClaims` 는 ★`dispatching` + lease 만료★ 를 죽은 워커로 보고 `pending` 으로 되돌린다
+ * → 폴러가 ★같은 메시지를 다시 집어간다★ → ★같은 일이 두 번 돈다(중복 발신·중복 side effect).★
+ *
+ * 지금까지 이 길이 안 열린 이유는 ★hermes 를 turn cap 에서 강제 종료★ 해서 lease 만료 전에 끝냈기 때문이다.
+ * ★그 강제 종료를 없애려면 이 함수가 먼저 있어야 한다★ — 순서를 뒤집으면 중복 경로가 그대로 열린다.
+ *
+ * ★`dispatching` 인 행만 연장한다★ — 이미 끝났거나(`wake_dispatched`·완료) 다른 워커가 가져간 행을
+ * 되살리지 않는다. 그래서 반환값이 false 면 ★"연장 실패" 가 아니라 "연장할 필요가 없어졌다" 는 뜻일 수 있다.
+ */
+export function extendLease(
+  db: Database,
+  messageId: string,
+  agentId: string,
+  leaseSec: number,
+): boolean {
+  const result = db
+    .prepare(
+      `UPDATE message_recipient
+       SET lease_until = datetime('now', '+${leaseSec} seconds')
+       WHERE message_id = ? AND agent_id = ? AND delivery_state = 'dispatching'`,
+    )
+    .run(messageId, agentId);
+  return result.changes === 1;
+}
+
+/**
  * Mark a row as wake_dispatched (adapter was called, waiting for ack).
  */
 export function markWakeDispatched(

--- a/src/server/lib/hermesBridge.ts
+++ b/src/server/lib/hermesBridge.ts
@@ -52,6 +52,15 @@ export interface HermesTurnOptions {
   directReport?: boolean;
   /** anti-pingpong hop 체인: 받은 메시지의 hop_count. 봉투에 hop_count = (hopCount ?? 0)+1 로 실어 openclaw/claude 봉투와 대칭. */
   hopCount?: number;
+  /**
+   * ★이 턴이 아직 살아 있다는 신호.★ hermes 자식이 stdout/stderr 를 흘릴 때마다 불린다.
+   *
+   * 부르는 쪽(버스)이 이걸로 ★예약(lease)을 연장★ 한다 — 그래야 ★일하는 중인 턴이 죽은 것으로
+   * 오인돼 같은 메시지가 다시 디스패치되는 일★ 이 없다. (`extendLease` 주석에 경위)
+   * ★버스 밖 호출부(단톡방·슬랙)는 안 넘겨도 된다★ — 그쪽은 lease 가 없다.
+   * ★던지지 마라★ — 여기서 난 예외는 아래에서 삼킨다(갱신 실패가 턴을 죽이면 안 된다).
+   */
+  onAlive?: () => void;
 }
 
 function hermesCommand(agent: AgentRecord): string {
@@ -278,6 +287,21 @@ export function buildPrompt(opts: HermesTurnOptions): string {
  *   openclaw 와 동일한 600s 로 맞춘다. ★lease/grace 는 wakeDispatcher 가 이 값에서 자동 파생★ 하므로
  * 여기 하나만 바꾸면 사다리(turnCap<lease<grace)가 따라온다 — 빼먹을 일 없음.
  */
+/** 생존신호를 부르는 ★최소 간격★ — 출력 청크마다 DB 를 쓰지 않기 위한 것. lease(660s)보다 훨씬 짧아야 한다. */
+const ALIVE_NOTIFY_MIN_INTERVAL_MS = 30_000;
+/** SIGTERM 뒤 ★이만큼 기다렸다 SIGKILL★ 로 승격한다. 정리할 틈은 주되 무한정 기다리지 않는다. */
+const KILL_ESCALATION_MS = 5_000;
+
+/**
+ * ★시험용 spawn 주입★ — `openclawBridge.__setOpenclawBridgeTestDeps` 와 같은 관례다.
+ * ★왜 필요한가★: 이 파일에서 제일 위험한 것은 ★무응답 시계★ 다(잘못되면 일하는 턴이 죽거나,
+ * 매달린 턴이 안 죽어 중복 실행이 난다). 실제 hermes 를 띄우지 않고 그 시계만 재려면 이 이음매가 있어야 한다.
+ */
+type SpawnFn = typeof spawn;
+let spawnForBridge: SpawnFn = spawn;
+export function __setHermesBridgeTestDeps(deps?: { spawn?: SpawnFn }): void {
+  spawnForBridge = deps?.spawn ?? spawn;
+}
 export const HERMES_TURN_TIMEOUT_MS = Number(process.env.HERMES_TURN_TIMEOUT_MS ?? 600_000);
 
 export async function runHermesTeamTurn(opts: HermesTurnOptions): Promise<string> {
@@ -298,7 +322,7 @@ export async function runHermesTeamTurn(opts: HermesTurnOptions): Promise<string
   //   `--usage-file` 은 실행 후 JSON 을 쓴다. ★실패해도 쓴다.★ 실패 분기 24개가 전부 completed:false 다.
   const usagePath = join(tmpdir(), `hermes-usage-${opts.agent.id}-${opts.messageId}-${process.pid}.json`);
   return new Promise((resolve, reject) => {
-    const proc = spawn(cmd, ["-z", prompt, "--usage-file", usagePath], {
+    const proc = spawnForBridge(cmd, ["-z", prompt, "--usage-file", usagePath], {
       cwd: runtimeCwd,
       // ★팀원의 정체를 ★명시적으로★ 알려준다 — 추측하게 두지 않는다.★ (2026-07-13 실측 사고)
       //
@@ -322,18 +346,54 @@ export async function runHermesTeamTurn(opts: HermesTurnOptions): Promise<string
     });
     let stdout = "";
     let stderr = "";
-    const timer = setTimeout(() => {
+    // ★이 상한이 재는 것은 '일한 시간' 이 아니라 '조용한 시간' 이다.★
+    //   전에는 턴 시작에 한 번 걸고 끝이라, ★출력이 계속 나오는 멀쩡한 턴도★ 상한에서 죽었다
+    //   (실측: 12건이 90초에 죽었다. 그 90초는 상수가 아니라 호출부 하드코딩이었다 — 아무도 정한 적 없는 값이다).
+    //   ★살아 있으면 안 끊고, 진짜 조용할 때만 끊는다.★
+    //
+    // ★그래도 '안 끊기'로 갈 수는 없다★ — 자식이 매달리면 출력이 없고, 출력이 없으면 예약(lease)도 안 밀린다.
+    //   그럼 예약이 만료돼 ★같은 메시지가 다시 디스패치된다★(중복 실행). 그때 옛 자식은 살아 있다.
+    //   그래서 ★무응답일 때는 확실히 끝낸다★ — 이게 turn cap 을 대신하는 유일한 조치다.
+    let idleTimer: ReturnType<typeof setTimeout>;
+    let killEscalation: ReturnType<typeof setTimeout> | undefined;
+    const onIdle = (): void => {
+      // ★SIGTERM 만으로는 종료가 보장되지 않는다★ — 무시하거나 syscall 에 걸려 있으면 그대로 산다.
+      //   유예를 주고 ★SIGKILL 로 승격★ 한다. (승격이 없으면 위 '중복 실행 방지' 가 보장이 아니라 희망이 된다)
       proc.kill();
-      reject(new Error("hermes_timeout"));
-    }, timeoutMs);
-    proc.stdout.on("data", (c) => (stdout += c.toString()));
-    proc.stderr.on("data", (c) => (stderr += c.toString()));
+      killEscalation = setTimeout(() => { try { proc.kill("SIGKILL"); } catch { /* 이미 죽음 */ } }, KILL_ESCALATION_MS);
+      killEscalation.unref?.();
+      reject(new Error(`hermes_timeout (idle ${Math.round(timeoutMs / 1000)}s)`));
+    };
+    const bumpIdle = (): void => {
+      clearTimeout(idleTimer);
+      idleTimer = setTimeout(onIdle, timeoutMs);
+    };
+    idleTimer = setTimeout(onIdle, timeoutMs);
+    // 턴이 끝나면(error·close) 시계와 승격 예약을 함께 지운다 — 둘 중 하나만 지우면 승격이 뒤늦게 터진다.
+    const clearIdle = (): void => {
+      clearTimeout(idleTimer);
+      if (killEscalation) clearTimeout(killEscalation);
+    };
+    // ★생존신호 — 출력이 흐르면 부르는 쪽에 알린다(예약 연장).★
+    //   ★매 청크마다 DB 를 쓰지 않는다★ — 한 턴에 수백 번 올 수 있다. 최소 간격만 두고 흘린다.
+    let lastAliveAt = 0;
+    const noteAlive = (): void => {
+      if (!opts.onAlive) return;
+      const now = Date.now();
+      if (now - lastAliveAt < ALIVE_NOTIFY_MIN_INTERVAL_MS) return;
+      lastAliveAt = now;
+      // ★갱신 실패가 턴을 죽이지 않는다★ — 이건 보조 장치지 턴의 일부가 아니다.
+      try { opts.onAlive(); } catch { /* 무시 */ }
+    };
+    // ★시계 밀기는 매 청크마다★(공짜) · ★생존신호는 최소 간격으로★(DB 쓰기라 아낀다) — 둘은 다른 일이다.
+    proc.stdout.on("data", (c) => { stdout += c.toString(); bumpIdle(); noteAlive(); });
+    proc.stderr.on("data", (c) => { stderr += c.toString(); bumpIdle(); noteAlive(); });
     proc.on("error", (e) => {
-      clearTimeout(timer);
+      clearIdle();
       reject(e);
     });
     proc.on("close", (code) => {
-      clearTimeout(timer);
+      clearIdle();
       // ★실패한 턴은 답변이 아니다.★ hermes 는 턴을 못 끝내도 ★exit 0 으로★ 실패 문장을 stdout 에 찍는다
       //   ("Codex response remained incomplete…", "API call failed after 3 retries: HTTP 429…").
       //   그대로 발행하면 ★런타임 에러가 그 팀원의 말로 버스에 배달된다★ (실측: 전자 7건, 후자 3건 —

--- a/src/server/lib/hermesBridge.ts
+++ b/src/server/lib/hermesBridge.ts
@@ -354,9 +354,11 @@ export async function runHermesTeamTurn(opts: HermesTurnOptions): Promise<string
     // ★그래도 '안 끊기'로 갈 수는 없다★ — 자식이 매달리면 출력이 없고, 출력이 없으면 예약(lease)도 안 밀린다.
     //   그럼 예약이 만료돼 ★같은 메시지가 다시 디스패치된다★(중복 실행). 그때 옛 자식은 살아 있다.
     //   그래서 ★무응답일 때는 확실히 끝낸다★ — 이게 turn cap 을 대신하는 유일한 조치다.
+    let finished = false;
     let idleTimer: ReturnType<typeof setTimeout>;
     let killEscalation: ReturnType<typeof setTimeout> | undefined;
     const onIdle = (): void => {
+      finished = true;
       // ★SIGTERM 만으로는 종료가 보장되지 않는다★ — 무시하거나 syscall 에 걸려 있으면 그대로 산다.
       //   유예를 주고 ★SIGKILL 로 승격★ 한다. (승격이 없으면 위 '중복 실행 방지' 가 보장이 아니라 희망이 된다)
       proc.kill();
@@ -371,6 +373,7 @@ export async function runHermesTeamTurn(opts: HermesTurnOptions): Promise<string
     idleTimer = setTimeout(onIdle, timeoutMs);
     // 턴이 끝나면(error·close) 시계와 승격 예약을 함께 지운다 — 둘 중 하나만 지우면 승격이 뒤늦게 터진다.
     const clearIdle = (): void => {
+      finished = true;
       clearTimeout(idleTimer);
       if (killEscalation) clearTimeout(killEscalation);
     };
@@ -378,6 +381,10 @@ export async function runHermesTeamTurn(opts: HermesTurnOptions): Promise<string
     //   ★매 청크마다 DB 를 쓰지 않는다★ — 한 턴에 수백 번 올 수 있다. 최소 간격만 두고 흘린다.
     let lastAliveAt = 0;
     const noteAlive = (): void => {
+      // ★턴이 끝난 뒤에 온 신호는 흘리지 않는다.★ onIdle 이 reject 한 뒤에도 SIGKILL 승격까지 리스너가
+      //   붙어 있어서, 그 사이 자식이 마지막 출력을 흘리면 ★부르는 쪽이 이미 지운 키를 되살린다★(누수).
+      //   무응답으로 죽은 턴이라 직전 신호가 오래돼 아래 최소간격 게이트도 그냥 통과한다.
+      if (finished) return;
       if (!opts.onAlive) return;
       const now = Date.now();
       if (now - lastAliveAt < ALIVE_NOTIFY_MIN_INTERVAL_MS) return;

--- a/src/server/lib/hermesIdleLease.test.ts
+++ b/src/server/lib/hermesIdleLease.test.ts
@@ -1,0 +1,156 @@
+/**
+ * ★턴 상한이 재는 것을 '일한 시간' 에서 '조용한 시간' 으로 바꾸고, 예약(lease)을 생존신호로 갱신한다.★
+ *
+ * ★고치는 결함 두 개 — 서로 반대 방향이다★
+ *  ① 지금까지: 출력이 계속 나오는 ★멀쩡한 턴도★ 상한에서 죽었다(실측 12건이 90초에).
+ *  ② 그렇다고 상한만 없애면: 매달린 자식은 출력이 없어 ★예약도 안 밀리고★ → 예약 만료 →
+ *     `recoverStaleClaims` 가 행을 `pending` 으로 되돌림 → ★같은 메시지가 다시 디스패치★ → ★중복 실행.★
+ *
+ * 그래서 ★둘을 한 세트로★ 시험한다 — 하나만 있으면 다른 하나가 깨진다.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { EventEmitter } from "node:events";
+import type { AgentRecord } from "../types";
+import {
+  markDispatching,
+  extendLease,
+  recoverStaleClaims,
+  markWakeDispatched,
+} from "../db/inboxQueries";
+import { runHermesTeamTurn, __setHermesBridgeTestDeps } from "./hermesBridge";
+
+// ── DB 최소 스키마 (이 시험이 쓰는 열만) ────────────────────────────────────
+function setupDb(): Database {
+  const db = new Database(":memory:");
+  db.run(`CREATE TABLE message_recipient (
+    message_id TEXT NOT NULL, agent_id TEXT NOT NULL,
+    delivery_state TEXT NOT NULL DEFAULT 'pending',
+    claimed_at TEXT, lease_until TEXT,
+    PRIMARY KEY (message_id, agent_id))`);
+  db.run(`INSERT INTO message_recipient (message_id, agent_id) VALUES ('m1','hermes')`);
+  return db;
+}
+/** 예약을 ★과거 시각★ 으로 되돌린다 — "턴이 예약보다 오래 걸린" 상태를 실제로 만든다.
+ *  (markDispatching 에 음수 초를 넘기면 `'+-5 seconds'` 가 되어 SQLite 가 NULL 을 준다 — 그러면
+ *   회수 조건 `lease_until < now` 가 성립하지 않아 ★시험이 조용히 통과해버린다.★) */
+function expireLease(db: Database, id = "m1"): void {
+  db.run(`UPDATE message_recipient SET lease_until = datetime('now','-5 seconds') WHERE message_id = ?`, [id]);
+}
+const stateOf = (db: Database, id = "m1") =>
+  (db.query(`SELECT delivery_state AS s FROM message_recipient WHERE message_id = ?`).get(id) as { s: string }).s;
+const leaseOf = (db: Database, id = "m1") =>
+  (db.query(`SELECT lease_until AS l FROM message_recipient WHERE message_id = ?`).get(id) as { l: string | null }).l;
+
+describe("예약(lease)을 생존신호로 갱신한다", () => {
+  test("★대조군 — 갱신하지 않으면 예약이 만료돼 같은 메시지가 다시 나간다★ (지금까지 kill 이 막던 그 길)", () => {
+    const db = setupDb();
+    markDispatching(db, "m1", "hermes", 60);
+    expireLease(db); // 턴이 예약보다 오래 걸린 상태
+    expect(stateOf(db), "맡긴 직후는 처리중이다").toBe("dispatching");
+
+    expect(recoverStaleClaims(db), "만료됐으니 죽은 워커로 보고 회수한다").toBe(1);
+    expect(stateOf(db), "★대기로 돌아갔다 = 폴러가 같은 메시지를 다시 집어간다(중복 실행)★").toBe("pending");
+  });
+
+  test("★생존신호로 예약을 밀면 회수되지 않는다★ — 일하는 중인 턴을 죽은 것으로 오인하지 않는다", () => {
+    const db = setupDb();
+    markDispatching(db, "m1", "hermes", 60);
+    expireLease(db);
+    expect(extendLease(db, "m1", "hermes", 600), "처리중인 행이므로 연장된다").toBe(true);
+
+    expect(recoverStaleClaims(db), "★예약이 미래로 밀렸으니 회수 대상이 아니다★").toBe(0);
+    expect(stateOf(db), "★처리중을 유지한다 = 중복 디스패치가 안 생긴다★").toBe("dispatching");
+  });
+
+  test("★끝난 턴의 예약은 되살리지 않는다★ (상태 가드 — 없으면 완료된 행이 다시 살아난다)", () => {
+    const db = setupDb();
+    markDispatching(db, "m1", "hermes", 60);
+    markWakeDispatched(db, "m1", "hermes");
+    const before = leaseOf(db);
+
+    expect(extendLease(db, "m1", "hermes", 600), "처리중이 아니므로 연장하지 않는다").toBe(false);
+    expect(leaseOf(db), "★예약 값이 그대로여야 한다★").toBe(before);
+    expect(stateOf(db)).toBe("wake_dispatched");
+  });
+});
+
+// ── 무응답 시계 ────────────────────────────────────────────────────────────
+const hermes: AgentRecord = {
+  id: "hermes", display_name: "Hermes", role: "CSO", runtime: "hermes_agent",
+  status_provider: "hermes_gateway", tmux_session: null,
+  telegram_bot_username: "example_hermes_bot", workspace_path: "/tmp",
+  persona_file: "", moderator_eligible: true, avatar_emoji: "", hermes_profile: undefined,
+};
+
+/** 진짜 hermes 를 띄우지 않고 ★출력만 흉내내는★ 가짜 자식. */
+function fakeProc() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter; stderr: EventEmitter;
+    kill: (sig?: string) => void; signals: string[];
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.signals = [];
+  proc.kill = (sig?: string) => { proc.signals.push(sig ?? "SIGTERM"); };
+  return proc;
+}
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+afterEach(() => __setHermesBridgeTestDeps());
+
+describe("무응답 시계 — 재는 것은 '조용한 시간' 이다", () => {
+  test("★출력이 계속 오면 상한을 훨씬 넘겨도 안 죽는다★ (라이브에서 12건이 죽은 그 상황)", async () => {
+    const proc = fakeProc();
+    __setHermesBridgeTestDeps({ spawn: (() => proc) as never });
+    const alive: number[] = [];
+
+    const turn = runHermesTeamTurn({
+      agent: hermes, threadId: "t1", messageId: "m1", body: "일 시킴",
+      fromLabel: "bill", replyRoute: { kind: "teammate", to: "bill" },
+      timeoutMs: 150,
+      onAlive: () => alive.push(Date.now()),
+    }).catch((e: Error) => `REJECTED:${e.message}`);
+
+    // 상한(150ms)보다 짧은 간격으로 계속 떠든다 — 총 600ms = 상한의 4배
+    for (let i = 0; i < 8; i++) { await sleep(75); proc.stdout.emit("data", Buffer.from(`진행 ${i}\n`)); }
+    expect(proc.signals, "★일하는 중인데 죽였다 — 이게 라이브에서 난 일이다★").toEqual([]);
+
+    proc.emit("close", 0);
+    await turn;
+    expect(alive.length, "생존신호가 최소 한 번은 나가야 예약이 밀린다").toBeGreaterThan(0);
+  });
+
+  test("★대조군 — 아무 소식이 없으면 상한에서 끝낸다★ (상한을 없앤 게 아니다)", async () => {
+    const proc = fakeProc();
+    __setHermesBridgeTestDeps({ spawn: (() => proc) as never });
+
+    const started = Date.now();
+    const r = await runHermesTeamTurn({
+      agent: hermes, threadId: "t1", messageId: "m1", body: "일 시킴",
+      fromLabel: "bill", replyRoute: { kind: "teammate", to: "bill" },
+      timeoutMs: 150,
+    }).catch((e: Error) => `REJECTED:${e.message}`);
+
+    expect(String(r), "무응답이면 끝낸다").toContain("REJECTED:hermes_timeout");
+    expect(String(r), "★'오래 걸려서' 가 아니라 '조용해서' 라는 것을 사유에 남긴다★").toContain("idle");
+    expect(Date.now() - started, "상한 근처에서 끊긴다").toBeLessThan(1000);
+    expect(proc.signals[0], "먼저 정중히 종료를 요청한다").toBe("SIGTERM");
+  });
+
+  test("★SIGTERM 을 무시하면 SIGKILL 로 승격한다★ — 안 그러면 '중복 실행 방지' 가 보장이 아니라 희망이다", async () => {
+    const proc = fakeProc();
+    __setHermesBridgeTestDeps({ spawn: (() => proc) as never });
+
+    void runHermesTeamTurn({
+      agent: hermes, threadId: "t1", messageId: "m1", body: "일 시킴",
+      fromLabel: "bill", replyRoute: { kind: "teammate", to: "bill" },
+      timeoutMs: 100,
+    }).catch(() => {});
+
+    await sleep(160);
+    expect(proc.signals, "아직은 SIGTERM 만").toEqual(["SIGTERM"]);
+    await sleep(5200); // KILL_ESCALATION_MS = 5s
+    expect(proc.signals, "★죽지 않으면 확실히 죽인다★").toEqual(["SIGTERM", "SIGKILL"]);
+  }, 10_000);
+});

--- a/src/server/lib/openclawBridge.ts
+++ b/src/server/lib/openclawBridge.ts
@@ -182,7 +182,11 @@ const OPENCLAW_GATEWAY_TIMEOUT_MS = Number(process.env.OPENCLAW_GATEWAY_TIMEOUT_
 function isOpenclawTimeoutNoticeEnabled(): boolean {
   return process.env.OPENCLAW_TIMEOUT_NOTICE === "1";
 }
-/** CLI 자기 `--timeout` 이 먼저 끝내도록 주는 ★유예★. 이 시간을 넘겨도 안 죽으면 그때만 우리가 죽인다. */
+/**
+ * CLI 자기 `--timeout` 이 먼저 끝내도록 주는 ★유예★. 이 시간을 넘겨도 안 죽으면 그때만 우리가 죽인다.
+ * ★이 값에는 근거가 없다★ — CLI 가 자기 타임아웃 뒤 결과 JSON 을 쓰는 데 충분해 보인다는 판단일 뿐,
+ * 재서 정한 값이 아니다. ★조정하려면 먼저 재라★(백스톱이 실제로 터진 audit 이 있으면 그게 자료다).
+ */
 const CLI_TIMEOUT_BACKSTOP_MARGIN_MS = 10_000;
 const OPENCLAW_PREVIEW_LIMIT = Number(process.env.OPENCLAW_PREVIEW_LIMIT ?? 80);
 // 2026-06-05 롤백: 오늘 넣었던 "작성 중"(EARLY_PROGRESS)·별도 보이는-한도(VISIBLE_REPLY_TIMEOUT)

--- a/src/server/lib/openclawBridge.ts
+++ b/src/server/lib/openclawBridge.ts
@@ -182,6 +182,8 @@ const OPENCLAW_GATEWAY_TIMEOUT_MS = Number(process.env.OPENCLAW_GATEWAY_TIMEOUT_
 function isOpenclawTimeoutNoticeEnabled(): boolean {
   return process.env.OPENCLAW_TIMEOUT_NOTICE === "1";
 }
+/** CLI 자기 `--timeout` 이 먼저 끝내도록 주는 ★유예★. 이 시간을 넘겨도 안 죽으면 그때만 우리가 죽인다. */
+const CLI_TIMEOUT_BACKSTOP_MARGIN_MS = 10_000;
 const OPENCLAW_PREVIEW_LIMIT = Number(process.env.OPENCLAW_PREVIEW_LIMIT ?? 80);
 // 2026-06-05 롤백: 오늘 넣었던 "작성 중"(EARLY_PROGRESS)·별도 보이는-한도(VISIBLE_REPLY_TIMEOUT)
 // 제거. 응답 대기는 게이트웨이 타임아웃(OPENCLAW_GATEWAY_TIMEOUT_MS, 300초)만 사용.
@@ -240,7 +242,20 @@ async function runOpenclawJson(args: string[], timeoutMs = 30_000): Promise<unkn
       );
     }
   })();
-  const timeout = setTimeout(() => proc.kill(), timeoutMs);
+  // ★우리가 먼저 죽이지 않는다 — CLI 자기 타임아웃이 먼저 끝내게 둔다.★
+  //   바로 위에서 CLI 에 ★같은 값★ 을 `--timeout` 으로 넘긴다. 그런데 우리 kill 도 ★같은 시각★ 에 걸려 있었다
+  //   = ★둘이 같은 순간에 경주한다.★ 우리가 이기면 CLI 가 쓰려던 `{ok:false, error:{kind:"timeout"}}` 을
+  //   ★끝까지 못 쓰고 죽는다★ — 깔끔한 타임아웃 보고가 '출력 없이 죽은 프로세스' 로 바뀐다.
+  //   ★그래서 유예를 준다.★ 정상 경로에서는 CLI 자기 타임아웃이 항상 먼저 끝낸다.
+  //   여기 kill 이 실제로 터졌다 = ★CLI 가 자기 약속을 안 지켰다★ 는 뜻이라 ★기록을 남긴다★(안 남기면 안 보인다).
+  const timeout = setTimeout(() => {
+    appendAuditFile("openclaw_bridge", "cli_timeout_backstop_kill", null, {
+      call: args[0] ?? "(unknown)",
+      cli_timeout_ms: timeoutMs,
+      waited_ms: timeoutMs + CLI_TIMEOUT_BACKSTOP_MARGIN_MS,
+    });
+    proc.kill();
+  }, timeoutMs + CLI_TIMEOUT_BACKSTOP_MARGIN_MS);
   try {
     const [stdout, stderr, exitCode] = await Promise.all([
       new Response(proc.stdout).text(),

--- a/src/server/runtimes/codex/runner.ts
+++ b/src/server/runtimes/codex/runner.ts
@@ -160,7 +160,13 @@ export function redactPromptArg(args: string[]): string[] {
 export async function runCodexTurn(opts: CodexTurnOptions): Promise<CodexTurnResult> {
   const started = Date.now();
   const sandbox = opts.sandbox ?? "read-only";
-  const timeoutMs = opts.timeoutMs ?? 240_000;
+  // ★기본값을 두지 않는다★ — 240초는 ★라이브에서 도달하지 않는 죽은 값★ 이었다.
+  //   이 함수는 DEPRECATED 고, 유일한 제품 호출부(`runtimeSubscription.ts`)는 자기 상한을 명시로 넘긴다.
+  //   그런데 숫자가 남아 있으면 ★"우리 정책이 240초" 로 읽힌다.★ 조용히 기본값을 주는 대신 크게 실패한다.
+  const timeoutMs = opts.timeoutMs;
+  if (timeoutMs == null) {
+    throw new Error("runCodexTurn: timeoutMs 를 명시하세요 (DEPRECATED 경로 — 기본값을 두지 않습니다)");
+  }
   const writableRoots = writableRootsFor(opts, sandbox);
 
   const lastMsgDir = mkdtempSync(join(tmpdir(), "codexrt-"));


### PR DESCRIPTION
일하는 중인 턴이 상한에 죽고 있었다. 그 상한을 그냥 없애면 이번엔 같은 일이 두 번 돈다.
둘은 한 세트라 함께 고친다.

## 무엇이 문제인가

**① 살아 있는 턴을 끊었다.** hermes 는 턴 시작에 시계를 한 번 걸고, 출력을 받아도 되돌리지 않는다
(`hermesBridge.ts` 의 `proc.stdout.on("data")` 가 문자열만 이어붙였다). 그래서 글자가 계속 나오는
턴도 상한에서 끊긴다. 실측 12건이 90초에 끊겼고, **그 90초는 상수가 아니라 두 호출부의 하드코딩**이었다
(상수는 그때도 600초였다).

**② 그렇다고 상한만 없애면 중복 실행이 열린다.** hermes 는 턴 내내 붙잡는 런타임이라
`markWakeDispatched` 가 턴이 끝난 뒤에야 찍힌다 - 그 행은 **턴 내내 `dispatching`** 에 머문다.
`recoverStaleClaims` 는 `dispatching` + 예약 만료를 죽은 워커로 보고 `pending` 으로 되돌리고,
폴러가 **같은 메시지를 다시 집어간다.** 그때 옛 자식은 살아 있다.

## 왜 지금까지 안 터졌나

강제 종료(600초)가 예약 만료(660초)보다 **60초 먼저** 끝냈다. 그래서 ②의 경로가 한 번도 안 열렸다.
**그 종료는 자원 회수 장치가 아니라 중복 실행 마개였다.** 순서를 뒤집어 종료부터 없애면 ②가 그대로 열린다.

## 어떻게 고쳤나

- **`extendLease`** (`db/inbox/dispatch.ts`) - `dispatching` 인 행만 예약을 민다. 끝난 행은 되살리지 않는다
- **생존신호** (`hermesBridge.ts`) - 출력이 오면 시계를 다시 걸고(매 청크), 부르는 쪽에 알린다(최소 30초 간격 - DB 쓰기라 아낀다)
- **버스 배선** (`wakeDispatcher.ts`) - 그 신호로 DB 예약과 프로세스 내 잠금을 **함께** 민다.
  한쪽만 밀어서는 부족한 이유는 "먼저 풀리는 쪽" 이 아니라 **나중에 터지는 중복**이다: DB 예약만 만료되면
  그 순간에는 폴러가 `inFlight.has(key)` 로 막지만, `recoverStaleClaims` 가 행을 이미 `pending` 으로
  돌려놨기 때문에 **턴이 끝나 잠금이 풀리는 순간 그 행이 다시 디스패치된다** - 끝난 일이 한 번 더 돈다.
  반대 방향(잠금만 밀기)도 같은 이유로 불충분하다
- **종료 보장** - 무응답일 때만 끝내되 SIGTERM 후 유예를 두고 SIGKILL 로 승격한다. 승격이 없으면 위 마개가 보장이 아니라 희망이 된다
- **openclaw** - CLI 에 `--timeout` 을 넘기면서 우리 kill 도 **같은 시각**에 걸려 둘이 경주했다. 우리가 이기면 CLI 가 쓰려던 타임아웃 응답이 잘린다. 유예를 줘 CLI 가 항상 먼저 끝내게 하고, 우리 kill 이 실제로 터지면 기록을 남긴다
- **`runner.ts` 240초 제거** - deprecated 함수의 도달 불가 기본값. 남아 있으면 우리 정책으로 읽힌다.
  기본값을 주는 대신 안 넘기면 실패한다. **저장소 안에서는 깨지지 않는다**(유일한 제품 호출부가 명시로 넘긴다) -
  저장소 밖 스크립트·도구는 확인 범위 밖이다

## 검증

- 저장소 전체 **2946 pass / 8 skip / 0 fail** (235 파일) · `tsc --noEmit` 0
- 새 시험 6건 (`hermesIdleLease.test.ts`) - 대조군을 함께 뒀다
  - 예약을 안 밀면 회수돼 **같은 메시지가 다시 나간다**(문제 재현) / 밀면 안 나간다(수정 효과)
  - 끝난 턴의 예약은 되살리지 않는다
  - 출력이 계속 오면 상한의 4배를 넘겨도 안 죽는다 / **조용하면 상한에서 끝낸다**(상한을 없앤 게 아니다)
  - SIGTERM 을 무시하면 SIGKILL 로 승격한다
- **뮤턴트 3종 전부 사망** (적용을 diff 로 확인, 구문 유지 상태에서 측정)
  - `extendLease` 상태 가드 제거 → 1 fail
  - 출력에서 시계 밀기 제거(옛 동작 복원) → 1 fail
  - SIGKILL 승격 제거 → 1 fail

## 남는 것

- `hermesBridge` 에 시험용 spawn 주입 이음매(`__setHermesBridgeTestDeps`)를 추가했다. `openclawBridge` 와 같은 관례다
- 무응답 상한 값 자체(600초)는 바꾸지 않았다. 판정 축만 바꿨다
- openclaw 백스톱 유예 10초는 **근거를 댈 수 있는 값이 아니다**. CLI 가 자기 타임아웃 뒤 결과를 쓰는 시간으로
  충분해 보인다는 판단이고, 조정할 사람이 알 수 있게 여기 남긴다

Submitted-by: bill

