### PR TITLE
feat(inbox): 보낸 메시지가 버스 밖으로 나간 결과를 조회할 수 있게 한다

### DIFF
--- a/skills/b3os-team-inbox/scripts/inbox.sh
+++ b/skills/b3os-team-inbox/scripts/inbox.sh
@@ -1,19 +1,65 @@
 #!/bin/bash
 # Show my unread inbox messages.
 # Usage: inbox.sh [--limit N] [--as agent_id]
+#        inbox.sh --delivery <msg_id>      내가 보낸 메시지가 어느 채널로 나갔는지 본다
+#
+# ★--delivery 와 send.sh --confirm 은 보는 곳이 다르다★
+#   --confirm  : ★버스 안★ 수신자의 처리 상태(message_recipient).
+#   --delivery : ★버스 밖★ 으로 나간 결과(telegram DM·팀방).
+#   `--direct-to-gd` 처럼 목적지가 버스 밖이면 --confirm 으로는 그 구간이 안 보인다.
+#   ★둘 다 '발송' 까지다. 받는 사람이 읽었는지는 어느 쪽도 알려주지 않는다.★
 set -e
 HERE="$(cd "$(dirname "$0")" && pwd)"
 BASE="${TEAM_BASE:-http://127.0.0.1:7878/team}"
 LIMIT=20
 AS=""
+DELIVERY=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --limit) LIMIT="$2"; shift 2 ;;
     --as) AS="$2"; shift 2 ;;
+    --delivery) DELIVERY="$2"; shift 2 ;;
     *) echo "unknown arg: $1" >&2; exit 1 ;;
   esac
 done
+
+if [ -n "$DELIVERY" ]; then
+  curl -sS "$BASE/api/messages/$DELIVERY" | MSG_ID="$DELIVERY" python3 -c '
+import sys, json, os
+mid = os.environ["MSG_ID"]
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(mid + " — 서버 응답을 읽을 수 없습니다")
+    sys.exit(1)
+if d.get("error"):
+    print(mid + " — 그런 메시지가 없습니다")
+    sys.exit(0)
+# ★키가 없는 것과 빈 배열은 다르다★ — 키가 없으면 서버가 아직 옛 버전이다(재시작 필요).
+if "deliveries" not in d:
+    print(mid + " — 이 서버는 배달 기록을 주지 않습니다(서버 재시작 필요)")
+    sys.exit(0)
+ds = d["deliveries"]
+if not ds:
+    print(mid + " — 배달 기록 없음 (아직 처리 전이거나 발송 경로를 안 탄 메시지)")
+    sys.exit(0)
+LABEL = {"bus": "버스", "telegram_dm": "텔레그램 팀장 DM", "telegram_group": "텔레그램 팀방"}
+print(mid)
+for x in ds:
+    ch = x.get("channel") or "?"
+    label = LABEL.get(ch, ch)
+    if ch == "bus" and x.get("to"):
+        label = "버스 → " + str(x["to"])
+    state = "성공" if x.get("ok") else "★실패★"
+    line = "  " + str(x.get("at", "?")) + "  " + label + "  " + state
+    if not x.get("ok") and x.get("error"):
+        line += "  (" + str(x["error"]) + ")"
+    print(line)
+print("  ※ 발송까지만 확인됩니다. 받는 사람이 읽었는지는 알 수 없습니다.")
+'
+  exit 0
+fi
 
 ME="${AS:-$($HERE/_me.sh)}"
 curl -sS "$BASE/api/inbox/$ME?limit=$LIMIT" | python3 -c "

--- a/skills/b3os-team-inbox/scripts/send.sh
+++ b/skills/b3os-team-inbox/scripts/send.sh
@@ -249,12 +249,19 @@ RESP=$(curl -sS -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$BASE
 #   그래서 이 시점에 배달 여부를 아는 것은 구조적으로 불가능하다. 실측: 미배달 메시지에 '✓ sent' 가
 #   찍혔고, 보낸 사람은 전달된 줄 알았다 — 실제로 정정 메시지 한 건이 그렇게 사라졌다.
 #   알 수 없는 것을 안다고 말하지 않는다 — '접수됨'까지만 단정하고, 확인은 --confirm 이 한다.
+#
+# ★확인 경로를 출력에 적는다★ — '배달 확인 전' 만 적고 ★어디서 확인하는지는 안 적었다.★
+#   그래서 보낸 쪽은 스스로 표를 찾아야 했고, 목적지가 버스 밖인 메시지(`--direct-to-gd`)는
+#   message_recipient 에 그 구간이 없어 ★'기록이 아예 없다'★ 로 읽혔다. 기록은 audit_event 에
+#   있었다. 조회 경로가 없으면 '확인 안 됨' 이 아니라 ★'기능이 없음' 으로 결론난다.★
+#   두 확인법은 보는 곳이 다르다 — --confirm 은 버스 안, --delivery 는 버스 밖.
 MSG_ID=$(echo "$RESP" | python3 -c "
 import sys, json
 d = json.load(sys.stdin)
 if d.get('ok'):
     m = d['message']
     print(f'접수됨 {m[\"id\"]} thread={m[\"thread_id\"]} (hop={m[\"hop_count\"]}) — 배달 확인 전', file=sys.stderr)
+    print(f'  확인: inbox.sh --delivery {m[\"id\"]}   (버스 밖 발송) · send.sh --confirm  (버스 안 수신)', file=sys.stderr)
     print(m['id'])
 else:
     print(f'✗ 접수 실패: {json.dumps(d, ensure_ascii=False)}', file=sys.stderr)

--- a/src/server/routes/inbox.ts
+++ b/src/server/routes/inbox.ts
@@ -639,7 +639,36 @@ export function createInboxRoutes(deps: InboxRouteDeps): Hono {
       .all(id) as Array<Record<string, unknown>>;
     // recipients 는 ★항상 배열★ 이다. 빈 배열은 '수신자가 0명' 이라는 사실이며 '모름' 이 아니다 —
     //   호출부가 그 둘을 구분할 수 있어야 수신자 미연결 사고를 '아직 안 왔음' 으로 흘리지 않는다.
-    return c.json({ message: m, recipients });
+    // ★외부 채널(telegram DM·팀방) 로 나간 결과도 함께 준다.★
+    //   recipients 는 ★버스 안★ 수신자만 다룬다. `--direct-to-gd` 처럼 목적지가 버스 밖이면 그 구간이
+    //   recipients 에 안 나타나서, 보낸 쪽에서 보면 ★기록이 아예 없는 것처럼 보인다.★ 실제로는
+    //   recordReportDelivery 가 audit_event 에 남겨두고 있다(전송 결과를 await 한 뒤에 기록하므로
+    //   '보내려 했다' 가 아니라 '채널이 받았다' 를 뜻한다). 조회 경로가 없어서 안 보였을 뿐이다.
+    //   ★ok 는 '발송 성공' 까지다 — 수신자가 읽었는지는 어떤 채널도 알려주지 않는다.★
+    const deliveries = deps.db
+      .prepare(
+        `SELECT actor, action, detail_json, at
+         FROM audit_event
+         WHERE target = ? AND action IN ('report_delivered', 'report_delivery_failed')
+         ORDER BY at, id`,
+      )
+      .all(id) as Array<{ actor: string; action: string; detail_json: string | null; at: string }>;
+    return c.json({
+      message: m,
+      recipients,
+      deliveries: deliveries.map((d) => {
+        let detail: { channel?: string; to?: string; error?: string } = {};
+        try { detail = d.detail_json ? JSON.parse(d.detail_json) : {}; } catch { /* 기록이 깨져도 나머지는 준다 */ }
+        return {
+          actor: d.actor,
+          channel: detail.channel ?? null,
+          to: detail.to ?? null,
+          ok: d.action === "report_delivered",
+          error: detail.error ?? null,
+          at: d.at,
+        };
+      }),
+    });
   });
 
   return r;

--- a/src/server/routes/messageDeliveries.test.ts
+++ b/src/server/routes/messageDeliveries.test.ts
@@ -1,0 +1,136 @@
+// GET /api/inbox/messages/:id 가 ★버스 밖★ 으로 나간 결과(deliveries)도 준다.
+//
+// 왜 필요한가: recipients 는 ★버스 안★ 수신자만 다룬다. 목적지가 버스 밖인 메시지
+//   (`--direct-to-gd` → 팀장 텔레그램 DM)는 그 구간이 recipients 에 나타나지 않는다.
+//   그래서 보낸 쪽에서 보면 ★기록이 아예 없는 것처럼 보이고★, 멀쩡히 도착한 메시지를
+//   '도달 확인 불가' 로 판단하게 된다. 기록 자체는 recordReportDelivery 가 audit_event 에
+//   남겨두고 있다 — 없던 것은 기록이 아니라 ★조회 경로★ 다.
+import { describe, test, expect } from "bun:test";
+import { Database } from "bun:sqlite";
+import { migrate } from "../db/migrate";
+import { createInboxRoutes } from "./inbox";
+
+function setup(): { db: Database; app: ReturnType<typeof createInboxRoutes> } {
+  const db = new Database(":memory:");
+  migrate(db);
+  for (const a of ["jane", "lisa"]) {
+    db.prepare(
+      `INSERT OR IGNORE INTO agent (id, display_name, role, runtime, status_provider, workspace_path, persona_file)
+       VALUES (?, ?, 'r', 'claude_channel', 'claude_tmux', '/tmp', 'P.md')`,
+    ).run(a, a);
+  }
+  db.prepare(
+    `INSERT INTO thread (id, title, kind, participants_json, opened_by) VALUES ('t1','t','dm','[]','jane')`,
+  ).run();
+  const app = createInboxRoutes({
+    db,
+    broadcast: () => {},
+    registeredAgentIds: () => new Set(["jane", "lisa"]),
+  } as unknown as Parameters<typeof createInboxRoutes>[0]);
+  return { db, app };
+}
+
+function seedMessage(db: Database, id: string): void {
+  db.prepare(
+    `INSERT INTO message (id, thread_id, from_agent_id, to_agent_id, type, body, source)
+     VALUES (?, 't1', 'lisa', 'jane', 'dm', 'b', 'agent')`,
+  ).run(id);
+}
+
+/** recordReportDelivery 가 남기는 것과 같은 모양의 audit_event 행을 심는다. */
+function seedDelivery(
+  db: Database,
+  msgId: string,
+  d: { channel: string; to: string; ok?: boolean; error?: string; at?: string },
+): void {
+  db.prepare(
+    `INSERT INTO audit_event (actor, action, target, detail_json, at) VALUES (?, ?, ?, ?, ?)`,
+  ).run(
+    "lisa",
+    d.ok === false ? "report_delivery_failed" : "report_delivered",
+    msgId,
+    JSON.stringify({ to: d.to, channel: d.channel, ...(d.error ? { error: d.error } : {}) }),
+    d.at ?? "2026-08-19 01:05:28",
+  );
+}
+
+const get = async (app: ReturnType<typeof createInboxRoutes>, id: string) =>
+  await (await app.request(`/messages/${id}`)).json();
+
+describe("GET /api/inbox/messages/:id — deliveries", () => {
+  test("★--direct-to-gd: 팀장 DM 구간이 보인다★ — recipients 에는 없는 구간이다", async () => {
+    const { db, app } = setup();
+    seedMessage(db, "m1");
+    seedDelivery(db, "m1", { channel: "bus", to: "jane", at: "2026-08-19 01:05:27" });
+    seedDelivery(db, "m1", { channel: "telegram_dm", to: "gd", at: "2026-08-19 01:05:28" });
+    const body = (await get(app, "m1")) as { deliveries: Array<Record<string, unknown>>; recipients: unknown[] };
+    expect(body.deliveries).toHaveLength(2);
+    // 시간순이어야 한다 — 버스 접수가 먼저, 외부 채널 발송이 나중이다.
+    expect(body.deliveries[0]!.channel).toBe("bus");
+    expect(body.deliveries[1]!.channel).toBe("telegram_dm");
+    expect(body.deliveries[1]!.to).toBe("gd");
+    expect(body.deliveries[1]!.ok).toBe(true);
+    // ★이게 이 변경의 핵심★ — recipients 만 보면 팀장 DM 구간을 알 수 없다.
+    expect(body.recipients).toHaveLength(0);
+  });
+
+  test("broadcast: 팀방 발송 구간이 보인다", async () => {
+    const { db, app } = setup();
+    seedMessage(db, "m2");
+    seedDelivery(db, "m2", { channel: "bus", to: "broadcast", at: "2026-08-20 21:01:45" });
+    seedDelivery(db, "m2", { channel: "telegram_group", to: "-100", at: "2026-08-20 21:01:46" });
+    const body = (await get(app, "m2")) as { deliveries: Array<Record<string, unknown>> };
+    expect(body.deliveries.map((d) => d.channel)).toEqual(["bus", "telegram_group"]);
+  });
+
+  test("★실패도 사유와 함께 남는다★ — 조용히 흘리면 보낸 쪽이 성공으로 믿는다", async () => {
+    const { db, app } = setup();
+    seedMessage(db, "m3");
+    seedDelivery(db, "m3", { channel: "telegram_dm", to: "gd", ok: false, error: "telegram_send_failed" });
+    const body = (await get(app, "m3")) as { deliveries: Array<Record<string, unknown>> };
+    expect(body.deliveries).toHaveLength(1);
+    expect(body.deliveries[0]!.ok).toBe(false);
+    expect(body.deliveries[0]!.error).toBe("telegram_send_failed");
+  });
+
+  test("★기록이 없으면 빈 배열★ — '모름' 이 아니라 '아직 안 나갔다' 는 사실이다", async () => {
+    const { db, app } = setup();
+    seedMessage(db, "m4");
+    const body = (await get(app, "m4")) as { deliveries: unknown[] };
+    expect(Array.isArray(body.deliveries)).toBe(true);
+    expect(body.deliveries).toHaveLength(0);
+  });
+
+  test("다른 메시지의 기록이 섞이지 않는다", async () => {
+    const { db, app } = setup();
+    seedMessage(db, "m5");
+    seedMessage(db, "m6");
+    seedDelivery(db, "m5", { channel: "telegram_dm", to: "gd" });
+    seedDelivery(db, "m6", { channel: "telegram_group", to: "-100" });
+    const body = (await get(app, "m5")) as { deliveries: Array<Record<string, unknown>> };
+    expect(body.deliveries).toHaveLength(1);
+    expect(body.deliveries[0]!.channel).toBe("telegram_dm");
+  });
+
+  test("detail_json 이 깨져도 나머지 필드는 준다", async () => {
+    const { db, app } = setup();
+    seedMessage(db, "m7");
+    db.prepare(
+      `INSERT INTO audit_event (actor, action, target, detail_json) VALUES ('lisa','report_delivered','m7','{not json')`,
+    ).run();
+    const body = (await get(app, "m7")) as { deliveries: Array<Record<string, unknown>> };
+    expect(body.deliveries).toHaveLength(1);
+    expect(body.deliveries[0]!.ok).toBe(true);
+    expect(body.deliveries[0]!.channel).toBeNull();
+  });
+
+  test("배달과 무관한 audit_event 는 섞이지 않는다", async () => {
+    const { db, app } = setup();
+    seedMessage(db, "m8");
+    db.prepare(
+      `INSERT INTO audit_event (actor, action, target, detail_json) VALUES ('lisa','some_other_action','m8','{}')`,
+    ).run();
+    const body = (await get(app, "m8")) as { deliveries: unknown[] };
+    expect(body.deliveries).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## 문제

`GET /api/inbox/messages/:id` 는 `recipients` 만 준다. 이건 **버스 안** 수신자의 처리 상태(`message_recipient`)다.

목적지가 버스 밖인 메시지 — `send.sh --direct-to-gd` 로 보내면 팀장 텔레그램 DM 으로 릴레이된다 — 는 **그 구간이 `recipients` 에 나타나지 않는다.** 실측: `--direct-to-gd` 메시지 한 건의 `recipients` 는 릴레이가 성공한 뒤에도 DM 구간을 담지 않는다.

그래서 보낸 쪽에서 보면 **기록이 아예 없는 것처럼 보인다.** `send.sh` 출력은 `— 배달 확인 전` 이라고만 하고 확인 경로를 적지 않으므로, 보낸 사람은 스스로 표를 찾아야 한다. 그 결과 **도착한 메시지를 "이 경로는 도달 확인이 안 된다" 로 판단**하게 된다.

## 왜 그렇게 되나

기록은 이미 있다. `recordReportDelivery` 가 `audit_event` 에 채널·대상·성공여부를 남긴다(`bus/deliveryRecord.ts`).

그 기록은 **전송 결과를 `await` 한 뒤에** 쓰인다 — `routes/inbox.ts` 의 텔레그램 릴레이가 `const r = await getChannel("telegram").send(...)` 로 결과를 받고 그 `ok` 를 그대로 싣는다. 즉 "보내려 했다" 가 아니라 **"채널이 받았다"** 를 뜻한다.

**없던 것은 기록이 아니라 조회 경로다.**

## 무엇을 바꿨나

- `GET /api/inbox/messages/:id` 응답에 `deliveries` 추가 — 채널·대상·성공여부·사유·시각
- `inbox.sh --delivery <msg_id>` — 그 결과를 사람이 읽는 형태로 출력
- `send.sh` 접수 출력에 두 확인법을 한 줄로 안내

**읽기 전용 변경이다.** 새로 기록하는 것은 없고 발송 경로는 한 줄도 건드리지 않는다.

### 두 확인법의 차이를 출력에 적는다

| | 보는 곳 | 무엇을 |
|---|---|---|
| `send.sh --confirm` | `message_recipient` | **버스 안** 수신자의 처리 상태 |
| `inbox.sh --delivery` | `audit_event` | **버스 밖** 으로 나간 결과 |

둘 다 **발송까지**다. 수신자가 읽었는지는 어떤 채널도 알려주지 않는다. 출력 끝에 그렇게 적는다 — 이 구분을 흐리면 `성공` 을 `읽었다` 로 읽는 **반대 방향의 오판**이 생긴다.

### 세 가지 상태를 구분한다

`deliveries` 는 항상 배열이다.

- 빈 배열 = "아직 안 나갔다" 는 **사실**
- 키 자체가 없음 = 서버가 **옛 버전** (재시작 필요)
- `error` 키 = 실패 **사유**

스크립트가 이 셋을 구분해서 말한다. 옛 서버에 대고 실행하면 없는 값을 지어내지 않고 `이 서버는 배달 기록을 주지 않습니다(서버 재시작 필요)` 라고 한다.

## 검증

### 시험 7개 (`src/server/routes/messageDeliveries.test.ts`)

`--direct-to-gd` DM 구간 · broadcast 팀방 구간 · 실패 기록 · 기록 없음 · 다른 메시지 격리 · `detail_json` 파손 · 무관한 `audit_event` 배제.

### 뮤턴트 — 시험이 실제로 잡는지 확인

| 뮤턴트 | 결과 |
|---|---|
| `action` 필터 제거 (무관한 감사기록 유입) | `배달과 무관한 audit_event 는 섞이지 않는다` **fail** |
| `target` 필터 제거 (다른 메시지 기록 유입) | `다른 메시지의 기록이 섞이지 않는다` **fail** |
| `ok` 를 항상 `true` 로 (실패를 성공으로 보고) | `실패도 사유와 함께 남는다` **fail** |
| `ORDER BY at, id` → `ORDER BY id DESC` | DM·팀방 시험 2건 **fail** |

네 뮤턴트 모두 죽는다. 각 뮤턴트 후 소스를 원본으로 되돌리고 다음을 심었다.

### 전체

- `bun test` — **2965 pass / 8 skip / 0 fail**
- `bunx tsc --noEmit` — 종료코드 0
- 셸 6경로 실행 확인(DM · 팀방 · 실패 · 기록없음 · 옛서버 · 없는 id) — 스텁 서버로 응답 모양별 출력 확인
- 옛 코드가 도는 라이브 서버에 대고 실제 실행 — `서버 재시작 필요` 로 나온다(없는 값을 지어내지 않는다)

## 검증하지 못한 것

**새 API 를 붙인 서버로 셸을 돌려보지는 못했다.** 워크트리에서 서버를 기동하면 팀원 로딩파일이 그 트리 기준으로 덮이는 사고가 있어 금지돼 있다. 그래서 API 는 단위 시험으로, 셸은 스텁 응답으로 나눠 검증했다. 접합부(실서버 응답 → 셸 출력)는 머지 후 재기동 시점에 한 번 확인이 필요하다.