### PR TITLE
fix(media): 사진 저장 폴더가 cwd 에 기대어 브리지에서 /team-media 로 풀리던 것

### DIFF
--- a/src/server/lib/mediaDirCwd.test.ts
+++ b/src/server/lib/mediaDirCwd.test.ts
@@ -1,0 +1,46 @@
+/**
+ * ★미디어 폴더는 실행 위치(cwd)에 기대면 안 된다.★
+ *
+ * 라이브에서 난 일: dex 브리지는 launchd 가 ★작업 디렉토리 없이★ 띄운다 → `process.cwd()` 가 `/` 다.
+ * 옛 기본값 `join(process.cwd(), "..", "team-media")` 는 그때 ★`/team-media`★ 로 풀렸고,
+ * 루트는 읽기전용이라 팀장님이 보낸 사진이 전부 `EROFS: mkdir /team-media` 로 실패했다.
+ * ★서버는 plist 에 WorkingDirectory 가 있어 멀쩡했다★ — 그래서 시험도 라이브 그룹 경로도 이 결함을 못 봤다.
+ *
+ * ★이 시험은 cwd 를 실제로 `/` 로 바꿔놓고 잰다★ — 그게 이 결함이 사는 유일한 조건이다.
+ */
+import { describe, expect, test, afterEach } from "bun:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MODULE = join(HERE, "mediaStore.ts");
+const ORIG_CWD = process.cwd();
+afterEach(() => process.chdir(ORIG_CWD));
+
+/** 옛 구현 그대로 — 이 시험이 무엇을 막는지 보여주는 대조군. */
+const legacyResolve = (): string => join(process.cwd(), "..", "team-media");
+
+describe("미디어 폴더는 cwd 와 무관해야 한다", () => {
+  test("★cwd 가 / 여도 같은 폴더를 가리킨다★ (브리지가 그 상태로 뜬다)", async () => {
+    delete process.env.TEAM_MEDIA_DIR;
+    const fromRepo = (await import(`${MODULE}?a=${Date.now()}`)).DEFAULT_MEDIA_DIR as string;
+
+    process.chdir("/");
+    const fromRoot = (await import(`${MODULE}?b=${Date.now()}`)).DEFAULT_MEDIA_DIR as string;
+
+    expect(fromRoot, "★실행 위치가 바뀌면 저장 폴더가 바뀐다 = 라이브에서 사진이 죽는다★").toBe(fromRepo);
+    expect(fromRoot.startsWith("/team-media"), "★루트로 풀리면 EROFS 다★").toBe(false);
+  });
+
+  test("★대조군 — 옛 방식은 cwd 를 따라 움직인다★ (이 시험이 실제로 무언가를 재고 있다는 증거)", () => {
+    process.chdir("/");
+    expect(legacyResolve(), "옛 식은 cwd=/ 에서 루트로 간다").toBe("/team-media");
+  });
+
+  test("TEAM_MEDIA_DIR 을 주면 그것을 쓴다 (기존 계약 유지)", async () => {
+    process.env.TEAM_MEDIA_DIR = "/tmp/some-media";
+    const v = (await import(`${MODULE}?c=${Date.now()}`)).DEFAULT_MEDIA_DIR as string;
+    delete process.env.TEAM_MEDIA_DIR;
+    expect(v).toBe("/tmp/some-media");
+  });
+});

--- a/src/server/lib/mediaStore.ts
+++ b/src/server/lib/mediaStore.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
-import { basename, extname, join, resolve } from "node:path";
+import { basename, dirname, extname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 export interface TelegramMediaRef {
   kind: "photo" | "document";
@@ -71,7 +72,19 @@ const ALLOWED_EXTENSIONS = new Set([
   ".zip",
 ]);
 
-export const DEFAULT_MEDIA_DIR = process.env.TEAM_MEDIA_DIR ?? join(process.cwd(), "..", "team-media");
+/**
+ * 미디어 저장 폴더.
+ *
+ * ★cwd 에 기대지 않는다.★ 전에는 `join(process.cwd(), "..", "team-media")` 였는데,
+ * ★작업 디렉토리 없이 뜨는 프로세스(launchd 브리지)에서는 cwd 가 `/` 라 `/team-media` 로 풀렸다★ —
+ * 루트는 읽기전용이라 1:1 사진 첨부가 전부 `EROFS: mkdir /team-media` 로 실패했다(dex 실측).
+ * ★서버는 plist 에 WorkingDirectory 가 있어 멀쩡했다★ — 그래서 그룹 경로만 보면 안 드러났다.
+ *
+ * 그래서 ★이 파일의 위치★ 를 기준으로 잡는다(`src/server/lib` → repo 루트 → 그 옆 `team-media`).
+ * 실행 위치가 어디든 같은 폴더가 나온다. `TEAM_MEDIA_DIR` 덮어쓰기는 그대로 둔다.
+ */
+export const DEFAULT_MEDIA_DIR = process.env.TEAM_MEDIA_DIR
+  ?? join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..", "team-media");
 
 export function mediaUrlFor(mediaFile: string, urlBase = "/media"): string {
   return `${urlBase.replace(/\/$/, "")}/${mediaFile}`;

--- a/src/server/runtimes/codex/launcher.test.ts
+++ b/src/server/runtimes/codex/launcher.test.ts
@@ -46,6 +46,20 @@ describe("codex launcher (M4) — 순수 렌더러", () => {
     expect(xml).not.toMatch(/[0-9]{8,}:[A-Za-z0-9_-]{30,}/); // 텔레그램 토큰 형식 없음
   });
 
+  /**
+   * ★작업 디렉토리가 없으면 launchd 는 cwd `/` 로 띄운다.★ 그러면 cwd 기준 상대경로가 전부 루트로 풀린다 —
+   * 실측: 사진 저장 폴더가 `/team-media` 가 되어 1:1 사진 첨부가 `EROFS` 로 전부 실패했다.
+   * ★서버 plist 에는 이 키가 원래 있었다★(그래서 서버 경로만 멀쩡했다). 브리지도 같은 모양이어야 한다.
+   */
+  test("★plist 에 WorkingDirectory 가 있다★ — 없으면 cwd 가 / 라 상대경로가 루트로 풀린다", () => {
+    const p = codexBridgePaths("cody");
+    const xml = renderBridgePlist(p);
+    expect(xml, "★이 키가 빠지면 launchd 가 cwd=/ 로 띄운다★").toContain("<key>WorkingDirectory</key>");
+    // 값은 repo 루트여야 한다 — wrapper 가 실행하는 bridge.ts 가 그 안에 있다
+    const root = p.wrapper.replace(/\/var\/codex-bridge\/.*$/, "");
+    expect(xml).toContain(`<key>WorkingDirectory</key><string>${root}</string>`);
+  });
+
   test("wrapper: 토큰 파일→env(평문 노출 없음) + bridge.ts exec", () => {
     const p = codexBridgePaths("cody");
     const sh = renderLaunchWrapper(p);

--- a/src/server/runtimes/codex/launcher.ts
+++ b/src/server/runtimes/codex/launcher.ts
@@ -152,6 +152,11 @@ export function renderBridgePlist(p: CodexBridgePaths): string {
     `  <key>Label</key><string>${p.label}</string>`,
     "  <key>ProgramArguments</key>",
     `  <array><string>/bin/bash</string><string>${p.wrapper}</string></array>`,
+    // ★작업 디렉토리를 명시한다★ — 없으면 launchd 가 cwd `/` 로 띄운다.
+    //   그러면 cwd 기준 상대경로가 전부 루트로 풀린다(실측: 사진 저장이 `/team-media` 로 가서
+    //   `EROFS: read-only file system` 로 1:1 사진 첨부가 전부 실패했다).
+    //   ★서버 plist 는 이미 이 키가 있어서 멀쩡했다★ — 브리지만 빠져 있었다. 같은 모양으로 맞춘다.
+    `  <key>WorkingDirectory</key><string>${REPO_ROOT}</string>`,
     "  <key>RunAtLoad</key><true/>",
     "  <key>KeepAlive</key><true/>",
     `  <key>StandardOutPath</key><string>${p.log}</string>`,


### PR DESCRIPTION
## 무엇을 고치나

팀장님이 dex 1:1 로 보낸 **사진이 전부 실패했다**:
```
[첨부(photo) 내려받기 실패: EROFS: read-only file system, mkdir /team-media]
```

## 원인 — 두 겹이다

1. `mediaStore.ts` 의 기본값이 **cwd 기준**이었다: `join(process.cwd(), "..", "team-media")`
2. **dex 브리지 plist 에 `WorkingDirectory` 가 없다** → launchd 가 **cwd `/`** 로 띄운다

→ `join("/", "..", "team-media")` = **`/team-media`** → 루트는 읽기전용 → `EROFS`

### 왜 여태 안 드러났나

| | WorkingDirectory | 결과 |
|---|---|---|
| 서버 `com.gdmini.team-collab` | **있음**(repo 루트) | `~/Development/team-media` ✓ (파일 실재) |
| 브리지 `com.gdmini.codex-bridge-dex` | **없음** | `/team-media` ✗ |

**서버 경로(그룹·웹)는 멀쩡했다.** 그래서 코드 리뷰·시험·그룹 사용에서 안 보였다.
수용시험 **6.1·6.2(사진 첨부·설명)** 는 "코드·시험 충족" 으로 판정돼 있었는데 **라이브는 깨져 있었다** — 시험이 cwd 를 재지 않기 때문이다.

## 고침

- **`mediaStore.ts`**: 기본값을 **모듈 위치 기준**으로 바꿔 실행 위치와 무관하게 만든다. `TEAM_MEDIA_DIR` 덮어쓰기는 그대로
- **`launcher.ts`**: 생성 plist 에 **`WorkingDirectory = REPO_ROOT`** — 서버 plist 와 같은 모양. cwd 상대경로를 쓰는 **다른 코드도 같이 보호**된다

`TEAM_MEDIA_DIR` 을 wrapper 에 넣는 안(진단 때 제안한 1번)은 **넣지 않았다** — 위 두 가지로 cwd 의존이 사라져서 **불필요하고, 생성 파일에 절대경로가 하나 더 늘 뿐**이다.

## 검증

- 전체 **2975 pass / 6 skip / 0 fail** · `tsc --noEmit` rc=0
- 새 시험 4건:
  - **cwd 를 실제로 `/` 로 바꿔놓고** 저장 폴더가 안 바뀌는지 (이 결함이 사는 유일한 조건)
  - **대조군**: 옛 방식이 cwd=`/` 에서 `/team-media` 로 가는 것
  - `TEAM_MEDIA_DIR` 덮어쓰기 계약
  - plist 에 `WorkingDirectory` 가 있고 값이 repo 루트인지
- **뮤턴트 2종 사망**: cwd 의존 복원 → 2/1 · plist 키 제거 → 10/1
  (plist 키는 **처음엔 시험이 없어 뮤턴트가 살아남았다**(535 pass) — 그래서 시험을 추가했다)

## 미검증 · 다음 단계

- **라이브 확인은 아직이다.** 브리지 재기동은 **승인 게이트**라 안 했다
- 머지 후: 브리지 재기동 → **팀장님이 사진 1장** → `~/Development/team-media/tg_*.jpg` 생성 + dex 입력에 경로가 들어오는지 확인
- 롤백: 두 파일 revert(생성 plist 는 다음 재기동 때 옛 모양으로 돌아온다)
