### PR TITLE
fix(inbox): 배달 조회의 시각을 로컬로 보여준다

### DIFF
--- a/scripts/inbox-delivery-time.test.sh
+++ b/scripts/inbox-delivery-time.test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# inbox.sh --delivery 의 시각 표시 검증. ★서버·네트워크 안 씀★ — 변환 함수만 떼어 돌린다.
+#
+# ★왜 있나★: 저장은 UTC 인데 출력이 그대로 나가서, 화면의 09:39 가 실제로는 18:39(KST) 였다.
+#   9시간 어긋난 값을 사람이 "언제 나갔나" 로 읽으면 매번 틀린다. 이 시험이 그 축을 고정한다.
+set -uo pipefail
+SRC="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/b3os-team-inbox/scripts/inbox.sh}"
+FAIL=0
+ok(){ echo "  ✓ $1"; }; bad(){ echo "  ✗ $1"; FAIL=1; }
+
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+# 변환 함수만 떼어낸다(관례: send-mention.test.sh 와 같은 방식)
+sed -n '/^def local_time(v):/,/^        return str(v)/p' "$SRC" > "$T/lt.py"
+[ -s "$T/lt.py" ] || { echo "  ✗ local_time 을 못 떼어냈다 — 함수 이름이 바뀌었나"; exit 1; }
+
+run(){ TZ="$1" python3 -c "
+$(cat "$T/lt.py")
+print(local_time('$2'))"; }
+
+echo "── T1: UTC 저장값을 로컬로 바꾼다 ──"
+[ "$(run Asia/Seoul '2026-08-21 09:39:46')" = "2026-08-21 18:39:46" ] \
+  && ok "KST 는 +9 (09:39 → 18:39)" || bad "KST: $(run Asia/Seoul '2026-08-21 09:39:46')"
+[ "$(run UTC '2026-08-21 09:39:46')" = "2026-08-21 09:39:46" ] \
+  && ok "UTC 기계에서는 그대로" || bad "UTC: $(run UTC '2026-08-21 09:39:46')"
+
+echo "── T2: ★오프셋을 박지 않았다★ — 기계 설정을 따른다 ──"
+[ "$(run Asia/Kolkata '2026-08-21 09:39:46')" = "2026-08-21 15:09:46" ] \
+  && ok "+05:30 처럼 분 단위 오프셋도 맞다" || bad "Kolkata: $(run Asia/Kolkata '2026-08-21 09:39:46')"
+
+echo "── T3: 날짜 경계 ──"
+[ "$(run Asia/Seoul '2026-08-21 15:30:00')" = "2026-08-22 00:30:00" ] \
+  && ok "자정을 넘으면 날짜도 넘어간다" || bad "경계: $(run Asia/Seoul '2026-08-21 15:30:00')"
+
+echo "── T4: ★모양이 다르면 원문 그대로★ (못 바꾼 걸 바꾼 척하지 않는다) ──"
+[ "$(run Asia/Seoul '?')" = "?" ] && ok "물음표 통과" || bad "물음표: $(run Asia/Seoul '?')"
+[ "$(run Asia/Seoul '2026-08-21T09:39:46Z')" = "2026-08-21T09:39:46Z" ] \
+  && ok "ISO 형태는 손대지 않는다" || bad "ISO: $(run Asia/Seoul '2026-08-21T09:39:46Z')"
+
+echo "── T5: ★호출부까지 — 스텁 서버로 실제 경로를 돌린다★ ──"
+#   함수만 재면 ★호출부가 변환을 안 거치도록 되돌려도 시험이 통과한다.★ 그래서 여기까지 온다.
+PORT=17879
+python3 - "$PORT" <<'PY' &
+import http.server, json, sys
+BODY = json.dumps({"id": "m1", "recipients": [],
+                   "deliveries": [{"channel": "bus", "to": "bill", "ok": True,
+                                   "at": "2026-08-21 09:39:46"}]}).encode()
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200); self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(BODY))); self.end_headers(); self.wfile.write(BODY)
+    def log_message(self, *a): pass
+http.server.HTTPServer(("127.0.0.1", int(sys.argv[1])), H).serve_forever()
+PY
+STUB=$!; trap 'kill $STUB 2>/dev/null; rm -rf "$T"' EXIT
+for _ in 1 2 3 4 5 6 7 8 9 10; do curl -sS "http://127.0.0.1:$PORT/" >/dev/null 2>&1 && break; sleep 0.2; done
+
+OUT="$(TZ=Asia/Seoul TEAM_BASE="http://127.0.0.1:$PORT" bash "$SRC" --delivery m1 2>&1)"
+case "$OUT" in
+  *"2026-08-21 18:39:46"*) ok "출력 줄에 로컬 시각이 찍힌다" ;;
+  *"2026-08-21 09:39:46"*) bad "★UTC 가 그대로 나갔다 — 호출부가 변환을 안 거친다★" ;;
+  *) bad "예상 못 한 출력: $OUT" ;;
+esac
+
+[ "$FAIL" = 0 ] && echo "PASS" || echo "FAIL"
+exit "$FAIL"

--- a/skills/b3os-team-inbox/scripts/inbox.sh
+++ b/skills/b3os-team-inbox/scripts/inbox.sh
@@ -44,6 +44,17 @@ ds = d["deliveries"]
 if not ds:
     print(mid + " — 배달 기록 없음 (아직 처리 전이거나 발송 경로를 안 탄 메시지)")
     sys.exit(0)
+# ★저장은 UTC, 표시는 이 기계의 로컬 시각.★ 사람이 읽는 출력이라 그대로 찍으면 9시간 어긋나 보이고
+#   "언제 나갔나" 를 매번 잘못 읽는다. 오프셋을 박지 않고 astimezone() 이 기계 설정을 따르게 둔다.
+#   ★모양이 다르면 원문 그대로 낸다★ — 못 바꾼 것을 바꾼 척하지 않는다.
+def local_time(v):
+    from datetime import datetime, timezone
+    try:
+        return (datetime.strptime(str(v), "%Y-%m-%d %H:%M:%S")
+                .replace(tzinfo=timezone.utc).astimezone().strftime("%Y-%m-%d %H:%M:%S"))
+    except Exception:
+        return str(v)
+
 LABEL = {"bus": "버스", "telegram_dm": "텔레그램 팀장 DM", "telegram_group": "텔레그램 팀방"}
 print(mid)
 for x in ds:
@@ -52,7 +63,7 @@ for x in ds:
     if ch == "bus" and x.get("to"):
         label = "버스 → " + str(x["to"])
     state = "성공" if x.get("ok") else "★실패★"
-    line = "  " + str(x.get("at", "?")) + "  " + label + "  " + state
+    line = "  " + local_time(x.get("at", "?")) + "  " + label + "  " + state
     if not x.get("ok") and x.get("error"):
         line += "  (" + str(x["error"]) + ")"
     print(line)

--- a/src/server/routes/inboxDeliveryTime.test.ts
+++ b/src/server/routes/inboxDeliveryTime.test.ts
@@ -1,0 +1,23 @@
+/**
+ * `inbox.sh --delivery` 의 시각 표시를 ★우리가 실제로 돌리는 수트에 묶는다.★
+ *
+ * ★왜 이 파일이 있나★ — 검증은 셸 시험(`scripts/inbox-delivery-time.test.sh`)에 있는데,
+ * ★`.test.sh` 는 아무것도 자동으로 돌리지 않는다★ (CI 는 타입체크만 · `bun test` 는 `.test.sh` 를 안 잡는다).
+ * 그대로 두면 그 시험은 ★누가 손으로 부를 때만★ 도는 장식이 된다. 그래서 여기서 불러 수트에 넣는다.
+ */
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+const REPO = join(import.meta.dir, "..", "..", "..");
+const SCRIPT = join(REPO, "scripts", "inbox-delivery-time.test.sh");
+
+describe("inbox.sh --delivery 시각 표시", () => {
+  test("★저장(UTC)을 로컬 시각으로 바꿔서 보여준다★ — 셸 시험을 수트 안에서 돌린다", async () => {
+    const p = Bun.spawn(["bash", SCRIPT], { cwd: REPO, stdout: "pipe", stderr: "pipe" });
+    const [out, err] = await Promise.all([new Response(p.stdout).text(), new Response(p.stderr).text()]);
+    const code = await p.exited;
+    // 실패하면 ★어느 항목이 깨졌는지★ 가 보여야 한다 — 종료코드만 보면 원인을 다시 찾아야 한다.
+    expect(code, `셸 시험 실패:\n${out}\n${err}`).toBe(0);
+    expect(out, "항목이 실제로 돌았는지(빈 통과 방지)").toContain("✓");
+  }, 30_000);
+});


### PR DESCRIPTION
배달 조회가 UTC 를 그대로 찍어서, 화면의 `09:39` 가 실제로는 `18:39`(KST) 였다.

## 무엇이 문제인가

`inbox.sh --delivery` 는 `audit_event.at` 을 그대로 출력했다. 그 값은 UTC 다.
```
화면 : 2026-08-21 09:39:46
실제 : 2026-08-21 18:39:46 (KST)
```
9시간 어긋난 값을 사람이 "언제 나갔나" 로 읽는다. 이 도구는 사람이 읽는 출력이다.

## 어떻게 고쳤나

표시할 때만 로컬로 바꾼다. **저장은 안 건드린다.**

- **오프셋을 박지 않는다** — `astimezone()` 이 기계 설정을 따른다. `+05:30` 같은 분 단위 오프셋도 맞는다
- **모양이 다르면 원문 그대로 낸다** — 못 바꾼 것을 바꾼 척하지 않는다(`?`, ISO 형태 등)

## 시험을 두 겹으로 둔 이유

**① 변환 함수만 재면 부족하다.** 호출부가 변환을 안 거치도록 되돌려도 통과한다.
그래서 스텁 HTTP 서버를 띄워 `TEAM_BASE` 로 물리고 **실제 조회 경로까지** 돌린다.

**② `.test.sh` 는 아무것도 자동으로 안 돌린다.** CI 는 타입체크만 하고(`ci.yml`), `bun test` 는
`.test.sh` 를 파일명 규칙상 잡지 않는다. 그대로 두면 손으로 부를 때만 도는 장식이 된다.
그래서 `bun test` 수트에서 그 셸 시험을 불러 묶었다.

## 검증

- `bun test` → **2981 pass / 8 skip / 0 fail** (241 파일) · `tsc --noEmit` 0
- 셸 시험 6항목: KST · UTC 기계 · `+05:30` · 자정 경계 · `?` · ISO 형태
- **뮤턴트 2종 사망**(적용을 diff 로 확인)
  - 호출부를 `str(...)` 로 되돌림 → 스텁 경로 시험 fail · `bun test` 도 fail
  - `astimezone()` 제거 → 변환 시험 fail

## 남는 것

`--confirm` 등 다른 출력의 시각 표기는 이 PR 범위 밖이다. 같은 문제가 있는지 세지 않았다.

Submitted-by: bill
