### PR TITLE
fix(codex-bridge): 사진에 답장하면 그 사진도 함께 간다

### DIFF
--- a/src/server/runtimes/codex/dmMedia.test.ts
+++ b/src/server/runtimes/codex/dmMedia.test.ts
@@ -226,3 +226,40 @@ describe("★인용 답장 — 무엇에 대한 말인지 함께 보낸다★ (�
     expect(decideDmMessage({ text: "안녕", reply_to_message: { text: "  " } }).text).toBe("안녕");
   });
 });
+
+/**
+ * ★인용한 원문이 사진이면 그 사진도 함께 가야 한다.★ (2026-08-21 실측)
+ *
+ * 라이브: 팀장님이 사진에 답장해 "이거 설명해줘" 라고 물으니 dex 가 ★"텍스트는 보입니다"★ 라고 답했다 —
+ * 정작 봐야 할 그림이 안 갔다. 인용은 ★원문 글자만★ 싣고 있었다.
+ */
+describe("인용한 원문의 첨부", () => {
+  const photoMsg = {
+    photo: [{ file_id: "q1", file_unique_id: "qu1", file_size: 100, width: 10, height: 10 }],
+  };
+
+  test("★사진에 답장하면 그 사진도 실린다★ (전에는 글자만 갔다)", () => {
+    const refs = dmMediaRefs({ text: "이거 설명해줘", reply_to_message: photoMsg } as never);
+    expect(refs.length, "★인용한 사진이 빠지면 모델이 볼 것이 없다★").toBe(1);
+    expect(refs[0]!.file_unique_id).toBe("qu1");
+  });
+
+  test("★내가 보낸 사진 + 인용한 사진 = 둘 다★", () => {
+    const refs = dmMediaRefs({
+      photo: [{ file_id: "n1", file_unique_id: "nu1", file_size: 100, width: 10, height: 10 }],
+      reply_to_message: photoMsg,
+    } as never);
+    expect(refs.map((r) => r.file_unique_id)).toEqual(["nu1", "qu1"]);
+  });
+
+  test("★대조군 — 인용이 글자뿐이면 첨부는 안 는다★", () => {
+    const refs = dmMediaRefs({ text: "응", reply_to_message: { text: "앞 말" } } as never);
+    expect(refs.length).toBe(0);
+  });
+
+  test("★글자 없이 사진만 인용해도 인용 표시가 남는다★ — 무엇의 인용인지 사라지면 안 된다", () => {
+    const out = withQuotedContext("이거 뭐야", photoMsg as never);
+    expect(out).toContain("[인용한 앞 메시지");
+    expect(out).toContain("첨부 포함");
+  });
+});

--- a/src/server/runtimes/codex/dmMedia.test.ts
+++ b/src/server/runtimes/codex/dmMedia.test.ts
@@ -263,3 +263,12 @@ describe("인용한 원문의 첨부", () => {
     expect(out).toContain("첨부 포함");
   });
 });
+
+test("★인용이 순환해도 죽지 않는다★ — 한 겹에서 끊는 것을 코드가 보장한다(텔레그램 사정에 안 기댄다)", () => {
+  const loop: Record<string, unknown> = {
+    photo: [{ file_id: "l1", file_unique_id: "lu1", file_size: 1, width: 1, height: 1 }],
+  };
+  loop.reply_to_message = loop; // 스스로를 인용 — 실제 API 는 안 주지만 우리 코드가 견뎌야 한다
+  const refs = dmMediaRefs(loop as never);
+  expect(refs.length, "★두 겹까지만 — 무한 재귀면 여기서 죽는다★").toBe(2);
+});

--- a/src/server/runtimes/codex/dmMedia.ts
+++ b/src/server/runtimes/codex/dmMedia.ts
@@ -70,6 +70,13 @@ export function dmMediaRefs(msg: DmMessageMedia): TelegramMediaRef[] {
       file_size: doc.file_size,
     });
   }
+  // ★인용한 원문의 첨부도 함께 싣는다.★
+  //   사람이 사진에 답장하면 텔레그램은 새로 친 글자만 보내고, 그 사진은 `reply_to_message` 에 있다.
+  //   전에는 ★원문 텍스트만★ 실어서, 팀장님이 사진에 "이거 설명해줘" 라고 답하면 dex 는
+  //   ★"텍스트는 보입니다"★ 라고 답했다 — 정작 봐야 할 그림이 안 갔다(실측).
+  //   같은 파일을 다시 인용해도 저장소가 file_unique_id 로 같은 경로를 돌려주므로 중복 비용은 없다.
+  const quoted = (msg as { reply_to_message?: DmMessageMedia }).reply_to_message;
+  if (quoted) refs.push(...dmMediaRefs(quoted));
   return refs;
 }
 
@@ -179,7 +186,10 @@ export const MEDIA_ONLY_PROMPT = "(설명 없이 첨부만 보냈다. 첨부를 
 export function decideDmMessage(msg: {
   text?: string;
   caption?: string;
-  reply_to_message?: { text?: string; caption?: string; from?: { username?: string; first_name?: string } };
+  reply_to_message?: {
+    text?: string; caption?: string; from?: { username?: string; first_name?: string };
+    photo?: DmMessageMedia["photo"]; document?: DmMessageMedia["document"];
+  };
   photo?: DmMessageMedia["photo"];
   document?: DmMessageMedia["document"];
 } | undefined): { handle: boolean; text: string; hasMedia: boolean } {
@@ -200,12 +210,19 @@ export function decideDmMessage(msg: {
  */
 export function withQuotedContext(
   body: string,
-  quoted: { text?: string; caption?: string; from?: { username?: string; first_name?: string } } | undefined,
+  quoted: {
+    text?: string; caption?: string; from?: { username?: string; first_name?: string };
+    photo?: DmMessageMedia["photo"]; document?: DmMessageMedia["document"];
+  } | undefined,
 ): string {
   const q = (quoted?.text ?? quoted?.caption ?? "").trim();
-  if (!q) return body;
+  // ★원문이 사진뿐이어도 인용은 실린다★ — 글자가 없다고 "인용 없음" 으로 처리하면
+  //   그 그림이 무엇의 인용인지 사라진다(그림 자체는 dmMediaRefs 가 함께 싣는다).
+  const hasMedia = Boolean(quoted?.photo?.length || quoted?.document);
+  if (!q && !hasMedia) return body;
   const who = quoted?.from?.username ?? quoted?.from?.first_name;
-  return `${body}\n\n[인용한 앞 메시지${who ? ` — ${who}` : ""}]\n${q}`;
+  const mark = hasMedia ? " · 첨부 포함(아래 그림이 그 첨부다)" : "";
+  return `${body}\n\n[인용한 앞 메시지${who ? ` — ${who}` : ""}${mark}]\n${q || "(글자 없이 첨부만)"}`;
 }
 
 /** 본문 = 글 또는 캡션. 둘 다 없으면 첨부만 온 것이다. */

--- a/src/server/runtimes/codex/dmMedia.ts
+++ b/src/server/runtimes/codex/dmMedia.ts
@@ -45,7 +45,7 @@ export function largestPhotoVariant(
 }
 
 /** 내려받을 대상을 뽑는다 — 순수 함수라 통신 없이 잴 수 있다. */
-export function dmMediaRefs(msg: DmMessageMedia): TelegramMediaRef[] {
+export function dmMediaRefs(msg: DmMessageMedia, depth = 1): TelegramMediaRef[] {
   const refs: TelegramMediaRef[] = [];
   const photo = largestPhotoVariant(msg.photo);
   if (photo) {
@@ -75,8 +75,11 @@ export function dmMediaRefs(msg: DmMessageMedia): TelegramMediaRef[] {
   //   전에는 ★원문 텍스트만★ 실어서, 팀장님이 사진에 "이거 설명해줘" 라고 답하면 dex 는
   //   ★"텍스트는 보입니다"★ 라고 답했다 — 정작 봐야 할 그림이 안 갔다(실측).
   //   같은 파일을 다시 인용해도 저장소가 file_unique_id 로 같은 경로를 돌려주므로 중복 비용은 없다.
-  const quoted = (msg as { reply_to_message?: DmMessageMedia }).reply_to_message;
-  if (quoted) refs.push(...dmMediaRefs(quoted));
+  //   ★깊이를 코드가 제한한다★ — 텔레그램은 인용의 인용을 안 주지만 그건 ★남의 API 의 사정★ 이다.
+  //   우리 코드는 캐스팅으로 읽으므로 타입이 재귀를 못 막는다. 틀리면 대가가 ★스택 오버플로 =
+  //   1:1 경로 전체 정지★ 라, 한 겹으로 잘라 둔다(빌 리뷰).
+  const quoted = depth > 0 ? (msg as { reply_to_message?: DmMessageMedia }).reply_to_message : undefined;
+  if (quoted) refs.push(...dmMediaRefs(quoted, depth - 1));
   return refs;
 }
 


### PR DESCRIPTION
## 무엇을 고치나

팀장님이 **사진에 답장**해서 "이거 설명해줘" 라고 물으면, dex 는 **"텍스트는 보입니다"** 라고 답했다 — **정작 봐야 할 그림이 안 갔다.**

인용 답장은 `reply_to_message` 의 **글자만** 싣고 있었다. 그림은 거기 있는데 아무도 안 가져갔다.

## 고침

- `dmMediaRefs` 가 **인용한 원문의 첨부도** 모은다. 같은 파일을 다시 인용해도 저장소가 `file_unique_id` 로 같은 경로를 돌려줘 **중복 비용이 없다**
- `withQuotedContext` 는 **원문이 사진뿐이어도 인용 표시를 남기고**, `첨부 포함(아래 그림이 그 첨부다)` 를 적어 **어느 그림이 인용된 것인지** 알린다
  (전에는 글자가 없으면 인용 자체가 사라져서, 그림이 가도 무엇의 인용인지 모른다)

## 검증

- 전체 **2977 pass / 6 skip / 0 fail** · `tsc --noEmit` rc=0
- 새 시험 4건: 인용 사진이 실린다 · **내 사진 + 인용 사진 둘 다** · **대조군**(글자만 인용하면 첨부가 안 는다) · 글자 없는 사진 인용도 표시가 남는다
- **뮤턴트**: 인용 첨부 수집을 지우면 **33 pass / 2 fail**

## 참고 — claude 런타임(demis)은 이 경로가 아예 없다

같은 시험을 내 1:1 에서 해봤다: **사진은 보이는데, 사진에 답장하면 원문도 그림도 안 온다**(텔레그램 플러그인이 안 실어 보낸다). **우리 코드로 고칠 수 있는 범위가 아니다** — 이 PR 은 codex 브리지만 고친다.

## 미검증

라이브 확인 안 했다. 머지·배포 후 **사진에 답장 1회**로 확인한다.
