### PR TITLE
fix(codex-bridge): 인용한 첨부도 hasMedia 로 센다 (#367 의 나머지 절반)

### DIFF
--- a/src/server/runtimes/codex/dmMedia.test.ts
+++ b/src/server/runtimes/codex/dmMedia.test.ts
@@ -293,3 +293,23 @@ describe("hasMedia — 인용한 첨부도 센다", () => {
     expect(d.hasMedia).toBe(false);
   });
 });
+
+/**
+ * ★문과 수집을 따로 재면 그 사이가 끊겨도 둘 다 통과한다.★ (빌 지적 — #367 에서 실제로 그랬다)
+ * 그래서 ★한 줄로 잇는다★: 인용 사진이 붙은 메시지를 넣어 ★내려받기가 그림 경로를 돌려주는지★ 를 잰다.
+ * 이것이 "그림이 모델에 갈 준비가 됐다" 는 단위 증거다.
+ */
+test("★인용 사진 → 내려받기가 그림 경로를 돌려준다★ (문·수집·판정을 한 줄로 잇는다)", async () => {
+  const msg = { text: "이거 설명해줘", reply_to_message: { photo: [{ file_id: "q9", file_unique_id: "qu9", file_size: 9, width: 9, height: 9 }] } };
+  const decided = decideDmMessage(msg as never);
+  expect(decided.hasMedia, "문이 닫혀 있으면 아래가 아예 안 돈다").toBe(true);
+
+  const got = await downloadDmAttachments("token", msg as never, {
+    store: (async (_t: string, ref: { file_unique_id: string }) => ({
+      kind: "photo", file_id: "q9", file_unique_id: ref.file_unique_id,
+      file_path: `/tmp/${ref.file_unique_id}.jpg`, mime_type: "image/jpeg", file_name: "q.jpg", file_size: 9,
+    })) as never,
+  });
+  expect(got.imagePaths, "★여기가 비면 인용 사진은 모델에 안 간다★").toEqual(["/tmp/qu9.jpg"]);
+  expect(got.failed).toEqual([]);
+});

--- a/src/server/runtimes/codex/dmMedia.test.ts
+++ b/src/server/runtimes/codex/dmMedia.test.ts
@@ -272,3 +272,24 @@ test("★인용이 순환해도 죽지 않는다★ — 한 겹에서 끊는 것
   const refs = dmMediaRefs(loop as never);
   expect(refs.length, "★두 겹까지만 — 무한 재귀면 여기서 죽는다★").toBe(2);
 });
+
+/**
+ * ★모으는 코드를 고쳐도 그 앞의 문이 닫혀 있으면 아무 일도 안 난다.★ (2026-08-21 실측)
+ *
+ * `dmMediaRefs` 가 인용 첨부를 모으게 고쳤는데 라이브에서 그림이 여전히 안 갔다.
+ * 부르는 쪽이 `hasMedia` 로 ★내려받기를 걸지 말지★ 정하는데, 그 값이 ★내가 보낸 첨부만★ 보고 있었다.
+ * 본문에는 "첨부 포함" 이 찍히는데 파일은 안 받아지는 상태였다.
+ */
+describe("hasMedia — 인용한 첨부도 센다", () => {
+  const photo = [{ file_id: "p", file_unique_id: "pu", file_size: 1, width: 1, height: 1 }];
+
+  test("★사진에 답장하면 hasMedia 가 참이다★ (이게 거짓이면 내려받기가 아예 안 돈다)", () => {
+    const d = decideDmMessage({ text: "이거 설명해줘", reply_to_message: { photo } } as never);
+    expect(d.hasMedia, "★여기가 false 면 위에서 고친 수집이 한 번도 안 불린다★").toBe(true);
+  });
+
+  test("★대조군 — 글자만 인용하면 hasMedia 는 거짓★ (쓸데없이 내려받지 않는다)", () => {
+    const d = decideDmMessage({ text: "응", reply_to_message: { text: "앞 말" } } as never);
+    expect(d.hasMedia).toBe(false);
+  });
+});

--- a/src/server/runtimes/codex/dmMedia.ts
+++ b/src/server/runtimes/codex/dmMedia.ts
@@ -197,7 +197,15 @@ export function decideDmMessage(msg: {
   document?: DmMessageMedia["document"];
 } | undefined): { handle: boolean; text: string; hasMedia: boolean } {
   const body = dmBodyText(msg?.text, msg?.caption);
-  const hasMedia = Boolean(msg?.photo?.length || msg?.document);
+  // ★인용한 원문의 첨부도 "첨부 있음" 으로 센다.★
+  //   `dmMediaRefs` 가 인용 첨부를 모으게 고쳤는데도 라이브에서 그림이 안 갔다 — 부르는 쪽이
+  //   ★이 값으로 내려받기를 걸지 말지 정하기 때문★ 이다(`bridge.ts` 의 `fetchAttachments`).
+  //   즉 ★모으는 코드는 고쳤는데 그 앞의 문이 닫혀 있었다.★ 본문에는 "첨부 포함" 이 찍히는데
+  //   파일은 안 받아지는 상태가 그것이다(실측).
+  const quoted = msg?.reply_to_message;
+  const hasMedia = Boolean(
+    msg?.photo?.length || msg?.document || quoted?.photo?.length || quoted?.document,
+  );
   if (!body && !hasMedia) return { handle: false, text: "", hasMedia };
   // ★인용한 앞 메시지를 함께 싣는다★ — 안 실으면 "이게 모야?" 가 무엇에 대한 말인지 알 수 없다.
   return { handle: true, text: withQuotedContext(body ?? MEDIA_ONLY_PROMPT, msg?.reply_to_message), hasMedia };


### PR DESCRIPTION
## 왜 또 나오나

#367 로 `dmMediaRefs` 가 인용 첨부를 모으게 했는데 **라이브에서 그림이 여전히 안 갔다.**

**부르는 쪽이 `hasMedia` 로 내려받기를 걸지 말지 정한다**(`bridge.ts:1217` `fetchAttachments`). 그 값이 **내가 보낸 첨부만** 보고 있었다.
→ **모으는 코드는 고쳤는데 그 앞의 문이 닫혀 있었다.**

**실측**: 본문에는 `[인용한 앞 메시지 … 첨부 포함]` 이 찍혔는데 `team-media` 에 **새 파일이 안 생겼다.** dex 답도 *"실제 이미지 데이터가 없다"* 였다.

## 고침

`decideDmMessage` 의 `hasMedia` 가 **인용한 원문의 첨부도** 센다.

## 왜 #367 의 시험이 이걸 못 잡았나

시험이 `dmMediaRefs` **단위만** 재고, 그 앞의 **문(`hasMedia`)을 안 쟀다.** 단위는 맞는데 경로가 안 돌았다.
이번에는 **문 자체를 잰다** — `decideDmMessage(...).hasMedia` 가 참인지.

## 검증

- 전체 **2990 pass / 6 skip / 0 fail** · `tsc` rc=0
- 새 시험 2건: 사진에 답장하면 `hasMedia=true` · **대조군**(글자만 인용하면 false — 쓸데없이 안 받는다)
- **뮤턴트**: 인용을 다시 빼면 **37 pass / 1 fail**

## 미검증

라이브. 머지·배포 후 **브리지 재기동**이 필요하고(이 파일은 브리지가 읽는다), 그다음 **사진에 답장 1회**로 확인한다.