### PR TITLE
feat(web): add Vocab Rise to global navigation

### DIFF
--- a/src/web/components/MetricsBar.ts
+++ b/src/web/components/MetricsBar.ts
@@ -222,7 +222,7 @@ export function renderMetricsBar(root: HTMLElement): void {
             </button>
             <a id="global-vocab-rise-link"
               href="/reports/file/vocab-rise-b2-c1/html"
-              class="inline-flex items-center px-2 py-1 rounded-md text-[11px] md:text-[13px] text-slate-400 hover:bg-surface-3 hover:text-slate-200 whitespace-nowrap"
+              class="inline-flex min-h-10 items-center px-2 py-1 rounded-md text-[11px] md:text-[13px] text-slate-400 hover:bg-surface-3 hover:text-slate-200 whitespace-nowrap [touch-action:manipulation]"
               title="${pick("Vocab Rise — 중상급 영어 단어·표현 학습", "Vocab Rise — upper-intermediate vocabulary and phrases")}">Vocab Rise</a>
           </div>
           <div class="flex items-center justify-end gap-2 md:gap-3 text-[10px] md:text-[11px] min-w-0 shrink overflow-hidden">

--- a/src/web/components/MetricsBar.ts
+++ b/src/web/components/MetricsBar.ts
@@ -220,6 +220,10 @@ export function renderMetricsBar(root: HTMLElement): void {
               title="${pick("팀 설정 — 팀명·미션·팀원", "Team settings — team name·mission·members")}">
               ${navIcon("settings", "Settings")}
             </button>
+            <a id="global-vocab-rise-link"
+              href="/reports/file/vocab-rise-b2-c1/html"
+              class="inline-flex items-center px-2 py-1 rounded-md text-[11px] md:text-[13px] text-slate-400 hover:bg-surface-3 hover:text-slate-200 whitespace-nowrap"
+              title="${pick("Vocab Rise — 중상급 영어 단어·표현 학습", "Vocab Rise — upper-intermediate vocabulary and phrases")}">Vocab Rise</a>
           </div>
           <div class="flex items-center justify-end gap-2 md:gap-3 text-[10px] md:text-[11px] min-w-0 shrink overflow-hidden">
             <span class="hidden lg:inline-flex items-center gap-1 font-mono tabular-nums text-slate-500 whitespace-nowrap" title="${pick("실시간 CPU 사용률", "Live CPU usage")}">

--- a/src/web/components/vocabRiseMenu.test.ts
+++ b/src/web/components/vocabRiseMenu.test.ts
@@ -13,10 +13,15 @@ describe("Vocab Rise global menu", () => {
 
   it("is the final item in the left global navigation", () => {
     const settings = source.indexOf('id="global-settings-tab"');
-    const vocab = source.indexOf('id="global-vocab-rise-link"');
+    const vocab = source.indexOf('<a id="global-vocab-rise-link"');
     const clusterEnd = source.indexOf('</div>\n          <div class="flex items-center justify-end', settings);
+    const finalFragment = source.slice(vocab, clusterEnd);
     expect(settings).toBeGreaterThan(-1);
     expect(vocab).toBeGreaterThan(settings);
     expect(vocab).toBeLessThan(clusterEnd);
+    expect(finalFragment.match(/<(?:a|button)\b/g)).toHaveLength(1);
+    expect(finalFragment).not.toContain('target=');
+    expect(finalFragment).toContain('min-h-10');
+    expect(finalFragment).toContain('[touch-action:manipulation]');
   });
 });

--- a/src/web/components/vocabRiseMenu.test.ts
+++ b/src/web/components/vocabRiseMenu.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const source = readFileSync(join(import.meta.dir, "MetricsBar.ts"), "utf8");
+
+describe("Vocab Rise global menu", () => {
+  it("links to the canonical published app", () => {
+    expect(source).toContain('id="global-vocab-rise-link"');
+    expect(source).toContain('href="/reports/file/vocab-rise-b2-c1/html"');
+    expect(source).toContain('>Vocab Rise<');
+  });
+
+  it("is the final item in the left global navigation", () => {
+    const settings = source.indexOf('id="global-settings-tab"');
+    const vocab = source.indexOf('id="global-vocab-rise-link"');
+    const clusterEnd = source.indexOf('</div>\n          <div class="flex items-center justify-end', settings);
+    expect(settings).toBeGreaterThan(-1);
+    expect(vocab).toBeGreaterThan(settings);
+    expect(vocab).toBeLessThan(clusterEnd);
+  });
+});


### PR DESCRIPTION
## 핵심 3줄
1. 상단 global navigation에 Vocab Rise 진입점이 없습니다.
2. Settings 뒤 마지막 메뉴로 canonical 학습 앱 링크를 추가합니다.
3. URL은 `/reports/file/vocab-rise-b2-c1/html`; web 142 tests, typecheck, production build 통과.

## 변경
- `MetricsBar.ts`: 마지막 `Vocab Rise` 링크 추가
- 회귀 테스트: canonical URL 및 Settings 뒤 마지막 위치

## 검증
- `bun test src/web`: 142 pass, 1 skip
- `bun run typecheck`: pass
- `bun run build`: pass