### PR TITLE
fix(codex): deny native group ingress by default

### DIFF
--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -123,14 +123,20 @@ describe("codex bridge (M2) — 채널 I/O", () => {
     });
     const gate = (suppress: boolean) => { let n = 0; const fn = async () => { n++; return { suppress, reason: "explicit_mention", targets: ["bill"] }; }; return { fn, calls: () => n }; };
 
-    test("flag off 기본 → ownerGate 미호출, 정상 delivered (라이브 영향 0)", async () => {
+    test("flag 미설정 기본 → 그룹 native drop (capture→bus만 허용)", async () => {
       delete process.env.CODEX_GROUP_NATIVE_DENY_SHADOW; delete process.env.CODEX_GROUP_NATIVE_DENY;
+      const { deps, calls } = spies(() => ok("답")); const g = gate(true); deps.ownerGate = g.fn;
+      const r = await handleMessage(-123, "x", 55, deps);
+      expect(g.calls()).toBe(1); expect(calls.reacts.length).toBe(0); expect(r.detail).toBe("group_native_denied");
+    });
+    test("enforcement false 명시 → 그룹 native delivered (긴급 복구 opt-out)", async () => {
+      delete process.env.CODEX_GROUP_NATIVE_DENY_SHADOW; process.env.CODEX_GROUP_NATIVE_DENY = "false";
       const { deps, calls } = spies(() => ok("답")); const g = gate(true); deps.ownerGate = g.fn;
       const r = await handleMessage(-123, "x", 55, deps);
       expect(g.calls()).toBe(0); expect(calls.reacts.length).toBe(1); expect(r.detail).toBe("delivered");
     });
     test("shadow on + suppress + group → delivered 유지, react 계속(로그만)", async () => {
-      process.env.CODEX_GROUP_NATIVE_DENY_SHADOW = "true"; delete process.env.CODEX_GROUP_NATIVE_DENY;
+      process.env.CODEX_GROUP_NATIVE_DENY_SHADOW = "true"; process.env.CODEX_GROUP_NATIVE_DENY = "false";
       const { deps, calls } = spies(() => ok("답")); deps.ownerGate = gate(true).fn;
       const r = await handleMessage(-123, "x", 55, deps);
       expect(calls.reacts.length).toBe(1); expect(r.detail).toBe("delivered");
@@ -150,6 +156,7 @@ describe("codex bridge (M2) — 채널 I/O", () => {
     });
     test("shadow on + gate null(조회실패) → fail-open, 정상 delivered", async () => {
       process.env.CODEX_GROUP_NATIVE_DENY_SHADOW = "true";
+      process.env.CODEX_GROUP_NATIVE_DENY = "false";
       const { deps, calls } = spies(() => ok("답")); deps.ownerGate = async () => null;
       const r = await handleMessage(-123, "x", 55, deps);
       expect(r.detail).toBe("delivered"); expect(calls.reacts.length).toBe(1);

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -499,7 +499,9 @@ export async function handleMessage(
   // ★team-comm group native deny: 그룹(chatId<0) native 처리를 막는다.
   //   ★enforcement = gate 결과와 무관하게 그룹 전체 drop★ — capture→bus가 owner를 이미 처리하므로(runInjection이
   //   route targets 에만 주입) native 가 또 답하면 이중응답. gate는 shadow/audit(effective 권위 기록)용으로만.
-  //   env flag 2개 분리, 둘 다 off 기본 = ★라이브 영향 0(byte-level 불변)★. shadow=drop 없이 audit만.
+  //   enforcement는 fail-closed 기본이다. capture→bus가 그룹 owner를 판정하므로 설정 누락이 native 우회를
+  //   다시 열면 안 된다. 긴급 복구가 필요할 때만 CODEX_GROUP_NATIVE_DENY=false로 명시 해제한다.
+  //   shadow=drop 없이 audit만이며, enforcement를 false로 명시했을 때만 전달된다.
   // ★이 브리지가 '누구' 인지는 한 곳에서만 정한다★ (리뷰 지적).
   //   같은 식이 아래 네 곳에 흩어져 있었다. 그중 하나라도 빠지면 ★남의 신원으로 도는데★
   //   그게 승인 요청의 주인으로도 쓰인다 — 실제로 dex 요청 4건이 codex 앞으로 기록됐다.
@@ -507,7 +509,7 @@ export async function handleMessage(
 
   if (chatId < 0 && messageId !== undefined) {
     const shadowOn = process.env.CODEX_GROUP_NATIVE_DENY_SHADOW === "true";
-    const enforceOn = process.env.CODEX_GROUP_NATIVE_DENY === "true";
+    const enforceOn = process.env.CODEX_GROUP_NATIVE_DENY !== "false";
     if (shadowOn || enforceOn) {
       const self = selfAgentId;
       const teamBaseUrl = deps.teamBaseUrl ?? process.env.TEAM_BASE_URL ?? "http://127.0.0.1:7878/team";


### PR DESCRIPTION
## 핵심 3줄
1. Codex 그룹 native ingress가 env 미설정 시 열려 capture→bus owner 경로를 우회합니다.
2. 설정 누락만으로 그룹 메시지가 중복 처리될 수 있습니다.
3. 기본값을 차단으로 바꾸고, 명시적 `false`만 긴급 opt-out으로 유지합니다.

## 변경
- `CODEX_GROUP_NATIVE_DENY` 미설정 시 그룹 native 요청 차단
- `CODEX_GROUP_NATIVE_DENY=false`일 때만 native 그룹 전달
- DM 경로는 기존대로 전달

## 검증
- `bun test src/server/runtimes/codex/bridge.test.ts`: 65 pass, 0 fail
- `bun run typecheck`: 통과(라이브 트리 설치 의존성 참조)
- `git diff --check`: 통과

Submitted-by: Dex