### PR TITLE
fix(codex-bridge): 그룹방 native 응답 차단을 기본값으로

### DIFF
--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -123,14 +123,26 @@ describe("codex bridge (M2) — 채널 I/O", () => {
     });
     const gate = (suppress: boolean) => { let n = 0; const fn = async () => { n++; return { suppress, reason: "explicit_mention", targets: ["bill"] }; }; return { fn, calls: () => n }; };
 
-    test("flag off 기본 → ownerGate 미호출, 정상 delivered (라이브 영향 0)", async () => {
+    test("★미설정 = 켜짐★ → 그룹은 drop(group_native_denied), react 안 함", async () => {
       delete process.env.CODEX_GROUP_NATIVE_DENY_SHADOW; delete process.env.CODEX_GROUP_NATIVE_DENY;
+      const { deps, calls } = spies(() => ok("답")); deps.ownerGate = gate(false).fn;
+      const r = await handleMessage(-123, "x", 55, deps);
+      expect(r.detail).toBe("group_native_denied"); expect(calls.reacts.length).toBe(0);
+    });
+    test("★명시적 \"false\" 만 끈다★ → 그룹 native 통과, ownerGate 미호출", async () => {
+      process.env.CODEX_GROUP_NATIVE_DENY = "false"; delete process.env.CODEX_GROUP_NATIVE_DENY_SHADOW;
       const { deps, calls } = spies(() => ok("답")); const g = gate(true); deps.ownerGate = g.fn;
       const r = await handleMessage(-123, "x", 55, deps);
       expect(g.calls()).toBe(0); expect(calls.reacts.length).toBe(1); expect(r.detail).toBe("delivered");
     });
+    test("미설정이어도 ★DM(chatId>0) 은 영향 없다★", async () => {
+      delete process.env.CODEX_GROUP_NATIVE_DENY_SHADOW; delete process.env.CODEX_GROUP_NATIVE_DENY;
+      const { deps, calls } = spies(() => ok("답")); deps.ownerGate = gate(true).fn;
+      const r = await handleMessage(123, "x", 55, deps);
+      expect(r.detail).toBe("delivered"); expect(calls.reacts.length).toBe(1);
+    });
     test("shadow on + suppress + group → delivered 유지, react 계속(로그만)", async () => {
-      process.env.CODEX_GROUP_NATIVE_DENY_SHADOW = "true"; delete process.env.CODEX_GROUP_NATIVE_DENY;
+      process.env.CODEX_GROUP_NATIVE_DENY_SHADOW = "true"; process.env.CODEX_GROUP_NATIVE_DENY = "false";
       const { deps, calls } = spies(() => ok("답")); deps.ownerGate = gate(true).fn;
       const r = await handleMessage(-123, "x", 55, deps);
       expect(calls.reacts.length).toBe(1); expect(r.detail).toBe("delivered");
@@ -149,7 +161,7 @@ describe("codex bridge (M2) — 채널 I/O", () => {
       expect(r.detail).toBe("delivered"); expect(calls.reacts.length).toBe(1);
     });
     test("shadow on + gate null(조회실패) → fail-open, 정상 delivered", async () => {
-      process.env.CODEX_GROUP_NATIVE_DENY_SHADOW = "true";
+      process.env.CODEX_GROUP_NATIVE_DENY_SHADOW = "true"; process.env.CODEX_GROUP_NATIVE_DENY = "false";
       const { deps, calls } = spies(() => ok("답")); deps.ownerGate = async () => null;
       const r = await handleMessage(-123, "x", 55, deps);
       expect(r.detail).toBe("delivered"); expect(calls.reacts.length).toBe(1);

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -507,7 +507,11 @@ export async function handleMessage(
 
   if (chatId < 0 && messageId !== undefined) {
     const shadowOn = process.env.CODEX_GROUP_NATIVE_DENY_SHADOW === "true";
-    const enforceOn = process.env.CODEX_GROUP_NATIVE_DENY === "true";
+    // ★기본값 = 켜짐★ (제품 결정 2026-08-24): 그룹은 다른 런타임과 같이 capture→bus 로만 받는다.
+    //   native 가 그룹에 직접 답하면 ★자기 앞으로 온 것이 아닌 호출에도 답한다★ — 실측: 그룹에서
+    //   다른 팀원을 @멘션한 두 건을 이 브리지가 집어 빈 응답을 냈다. owner 판정은 capture→bus 가 한다.
+    //   끄려면 명시적으로 "false" 를 준다. ★미설정은 켜짐이다★ — 새 팀원이 설정을 빠뜨려도 안전한 쪽이 기본이다.
+    const enforceOn = (process.env.CODEX_GROUP_NATIVE_DENY ?? "true") !== "false";
     if (shadowOn || enforceOn) {
       const self = selfAgentId;
       const teamBaseUrl = deps.teamBaseUrl ?? process.env.TEAM_BASE_URL ?? "http://127.0.0.1:7878/team";


### PR DESCRIPTION
codex 런타임의 **그룹방 동작을 다른 런타임과 같게** 맞춥니다. 그룹은 capture 봇 → 버스 경로로만 받고, 브리지가 그룹에 직접 답하지 않습니다.

## 왜

브리지가 그룹에 native 로 답하면 **자기 앞으로 온 것이 아닌 호출에도 답합니다.** owner 판정은 capture→bus 가 하는데 native 경로는 그 판정을 거치지 않기 때문입니다.

실측 (`var/codex-bridge/dex.log` 659-666):

```
← chat -1003947108339: @빌 팀버스로 덱스랑 얘기해보면 되지 않아?
  턴 실패했지만 세션은 유지한다: appserver_completed_empty
← chat -1003947108339: @빌 이거 보여?
  턴 실패했지만 세션은 유지한다: appserver_completed_empty
```

두 건 모두 **다른 팀원을 부른 메시지**를 이 브리지가 집었고, 사람 화면에는 실패 문구가 떴습니다.

게이트는 이미 있었습니다(`bridge.ts`, 그룹 전체 drop + shadow/audit 분리). **플래그가 기본 off 였을 뿐입니다.**

## 무엇이 바뀌나

```
before: enforceOn = env.CODEX_GROUP_NATIVE_DENY === "true"      // 미설정 = 꺼짐
after:  enforceOn = (env.CODEX_GROUP_NATIVE_DENY ?? "true") !== "false"   // 미설정 = 켜짐
```

- **미설정이 켜짐**입니다. 새 팀원이 설정을 빠뜨려도 안전한 쪽이 기본이 됩니다
- 끄려면 명시적으로 `"false"` 를 줍니다
- **DM(`chatId > 0`)은 영향 없습니다** — 게이트는 `chatId < 0` 에서만 걸립니다
- shadow 플래그 의미는 그대로입니다

## 검증

`bun test src/server/runtimes/codex/bridge.test.ts` → **66 pass / 0 fail**

기존 "flag off 기본 → 정상 delivered" 시험은 이제 전제가 뒤집혔으므로 세 개로 갈랐습니다:

- **미설정 = 켜짐** → 그룹 `group_native_denied`, react 안 함
- **명시적 `"false"` 만 끈다** → 그룹 native 통과, ownerGate 미호출
- **미설정이어도 DM 은 영향 없다** → `delivered`, react 1회

**뮤턴트로 확인했습니다.** 기본값을 예전 식(`=== "true"`)으로 되돌리면 **65 pass / 1 fail** — 새 시험이 실제로 이 변경을 잡습니다. 되돌린 뒤 커밋 기준으로 복원했습니다.

## 배포 시 확인할 것

라이브 `dex` 는 launch 스크립트에 이 값이 손으로 들어가 있는 임시 상태입니다(`launcher.ts` 가 파일을 재생성하면 사라집니다). 이 PR 이 코드 기본값이 되므로 그 줄 없이도 유지됩니다.

**그룹에서 `dex` 가 버스 경로로 답한 기록은 아직 0건입니다.** 배포 후 그룹 호출 1건으로 실제 응답을 확인해야 합니다 — 게이트만 켜고 버스 응답이 안 되면 그룹에서 조용해집니다.
