### PR TITLE
fix(capture): 주입 분기 없는 팀원은 버스가 깨우고, codex 는 그룹에 답한다

### DIFF
--- a/src/server/runtimes/codex/envelope.test.ts
+++ b/src/server/runtimes/codex/envelope.test.ts
@@ -93,3 +93,45 @@ test("★팀 컨텍스트는 다른 런타임과 똑같이 들어간다★ — c
   expect(env.teamContext).toBe("팀 규칙 요약 줄");
   expect(b.toPrompt(env)).toContain("팀 규칙 요약 줄");
 });
+
+// ── ★그룹 스레드면 방으로 답한다★ (2026-08-24) ──
+//
+// 그룹 캡처가 만든 행은 `from_agent_id='user'` 다. 예전 규칙(`--to <from>`)이면 `--to user` 가 나오는데
+// `user` 는 팀원이 아니라 ★답이 방에 안 간다.★ 깨어나기는 하는데 방은 조용한, 원인만 바뀐 같은 증상이다.
+describe("replyCommand — 그룹 스레드 대상", () => {
+  function groupRow(db: Database, threadId: string, from: string) {
+    db.prepare(
+      `INSERT INTO thread (id, title, kind, participants_json, opened_by) VALUES (?, 'group', 'broadcast', '[]', 'user')`,
+    ).run(threadId);
+    return {
+      message_id: "g1", agent_id: "cody", delivery_state: "dispatching", retry_count: 0, last_error: null,
+      from_agent_id: from, to_agent_id: "cody", body: "@덱스 들려?", source: "user", created_by: null,
+      max_hop: 16, hop_count: 0, in_reply_to: null, parent_message_id: null, sync: "none", thread_id: threadId,
+      type: "dm", created_at: new Date().toISOString(), priority: "normal", meta_json: null,
+    } as unknown as PendingDispatchRow;
+  }
+
+  test("★그룹 스레드 → --to broadcast★ (--to user 가 나오면 안 된다)", () => {
+    const { db, agent } = setup();
+    const row = groupRow(db, "tg--1003947108339", "user");
+    const env = new CodexTurnEnvelopeBuilder(db).buildForBus({ agent, row, teamContext: "" });
+    expect(env.howToReply).toContain("--to broadcast");
+    expect(env.howToReply).not.toContain("--to user");
+    expect(env.howToReply).toContain("--thread tg--1003947108339");
+  });
+
+  test("★팀원이 보낸 그룹 메시지도 방으로 간다★ — 방 판정이 발신자보다 우선", () => {
+    const { db, agent } = setup();
+    const row = groupRow(db, "tg--1003947108339", "bill");
+    const env = new CodexTurnEnvelopeBuilder(db).buildForBus({ agent, row, teamContext: "" });
+    expect(env.howToReply).toContain("--to broadcast");
+    expect(env.howToReply).not.toContain("--to bill");
+  });
+
+  test("★그룹이 아닌 스레드는 그대로★ — 요청자에게 간다(회귀 방지)", () => {
+    const { db, agent, row } = setup();
+    const env = new CodexTurnEnvelopeBuilder(db).buildForBus({ agent, row, teamContext: "" });
+    expect(env.howToReply).toContain("--to bill");
+    expect(env.howToReply).not.toContain("--to broadcast");
+  });
+});

--- a/src/server/runtimes/codex/envelope.ts
+++ b/src/server/runtimes/codex/envelope.ts
@@ -3,6 +3,7 @@ import type { PendingDispatchRow } from "../../bus/types";
 import { recentThreadMessages } from "../../db/inboxQueries";
 import type { AgentRecord } from "../../types";
 import { buildCodexMemoryRefs, type CodexMemoryRef } from "./memory";
+import { resolveThreadKind } from "../../channels/registry";
 
 export interface CodexTurnEnvelope {
   runtime: "codex_cli";
@@ -89,7 +90,17 @@ export class CodexTurnEnvelopeBuilder {
   /** ★이 턴의 답을 실제로 보내는 명령.★ 스레드·in-reply-to 를 박아 준다(사람이 조립하다 틀리지 않게). */
   private replyCommand(row: PendingDispatchRow): string {
     const repo = process.env.B3OS_REPO_ROOT ?? `${process.env.HOME ?? "~"}/Development/b3rys-team-os`;
-    const to = row.from_agent_id ? `--to ${row.from_agent_id}` : "--direct-to-gd";
+    // ★그룹 스레드면 방으로 답한다★ (2026-08-24).
+    //   그룹 캡처가 만든 행은 `from_agent_id='user'` 라, 예전엔 `--to user` 가 나왔다 — `user` 는
+    //   팀원이 아니므로 ★답이 방에 안 간다.★ 깨어나기는 하는데 방은 조용한, 원인만 바뀐 같은 증상이다.
+    //   '방이 어디냐' 는 ★정본 하나에 묻는다★ — `resolveThreadKind`(claude 분기도 같은 것을 쓴다).
+    //   복붙한 접두어 규칙을 두면 방 이름 규칙이 바뀔 때 한쪽만 어긋난다.
+    const to =
+      resolveThreadKind(row.thread_id) === "telegram_group"
+        ? "--to broadcast"
+        : row.from_agent_id
+          ? `--to ${row.from_agent_id}`
+          : "--direct-to-gd";
     return `${repo}/skills/b3os-team-inbox/scripts/send.sh ${to} --thread ${row.thread_id} --in-reply-to ${row.message_id} --body '<your answer>'`;
   }
 

--- a/src/server/workers/telegramCapture.test.ts
+++ b/src/server/workers/telegramCapture.test.ts
@@ -21,6 +21,7 @@ import {
   bestPhoto,
   mcpOnoffRow,
   applyMcpOnoff,
+  armBusFallback,
 } from "./telegramCapture";
 
 const codex: AgentRecord = {
@@ -402,5 +403,85 @@ describe("slash command formatters (fmt*)", () => {
     const out = fmtStatus(dbWithTasks(), roster);
     expect(out).toContain("등록 에이전트: 2명");
     expect(out).toContain("실행중 1 / 완료 1");
+  });
+});
+
+
+describe("armBusFallback — 주입 분기 없는 팀원을 버스가 깨우게", () => {
+  function seed(): { db: Database; mid: string } {
+    const db = new Database(":memory:");
+    migrate(db);
+    const mid = "m-grp-1";
+    for (const [id, rt, sp] of [["dex", "codex", "codex_cli"], ["bill", "claude_channel", "claude_tmux"]] as const) {
+      db.prepare(
+        `INSERT INTO agent (id, display_name, role, runtime, status_provider, workspace_path, persona_file)
+         VALUES (?, ?, 'Dev', ?, ?, '', '')`,
+      ).run(id, id, rt, sp);
+    }
+    // ★INSERT OR IGNORE 로 thread 를 만들면 NOT NULL 위반이 조용히 삼켜진다★ — 정본 헬퍼를 쓴다.
+    db.prepare(
+      `INSERT INTO thread (id, title, kind, participants_json, opened_by) VALUES ('tg--100', 'group', 'broadcast', '[]', 'user')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO message (id, thread_id, from_agent_id, to_agent_id, type, body, source, created_at)
+       VALUES (?, 'tg--100', 'user', 'dex', 'dm', '@덱스 들려?', 'user', datetime('now'))`,
+    ).run(mid);
+    return { db, mid };
+  }
+  function rcpt(db: Database, mid: string, agentId: string, state: string) {
+    db.prepare(
+      `INSERT INTO message_recipient (message_id, agent_id, delivery_state) VALUES (?, ?, ?)`,
+    ).run(mid, agentId, state);
+  }
+  function stateOf(db: Database, mid: string, agentId: string): string | undefined {
+    return (
+      db
+        .prepare(`SELECT delivery_state AS s FROM message_recipient WHERE message_id = ? AND agent_id = ?`)
+        .get(mid, agentId) as { s: string } | undefined
+    )?.s;
+  }
+
+  test("completed 행 → pending 으로 되돌린다 (changes 1)", () => {
+    const { db, mid } = seed();
+    rcpt(db, mid, "dex", "completed");
+    expect(armBusFallback(db, mid, "dex")).toBe(1);
+    expect(stateOf(db, mid, "dex")).toBe("pending");
+  });
+
+  test("★completed 가 아닌 행은 안 덮는다★ — dispatching 은 그대로", () => {
+    const { db, mid } = seed();
+    rcpt(db, mid, "dex", "dispatching");
+    expect(armBusFallback(db, mid, "dex")).toBe(0);
+    expect(stateOf(db, mid, "dex")).toBe("dispatching");
+  });
+
+  test("이미 pending 이면 아무 일도 안 한다 (changes 0)", () => {
+    const { db, mid } = seed();
+    rcpt(db, mid, "dex", "pending");
+    expect(armBusFallback(db, mid, "dex")).toBe(0);
+    expect(stateOf(db, mid, "dex")).toBe("pending");
+  });
+
+  test("행이 없으면 0 — 부르는 쪽이 audit 할 수 있어야 한다", () => {
+    const { db, mid } = seed();
+    expect(armBusFallback(db, mid, "dex")).toBe(0);
+  });
+
+  test("★수신자 단위★ — 같은 메시지의 다른 팀원 행은 안 건드린다(이중배달 방지)", () => {
+    const { db, mid } = seed();
+    rcpt(db, mid, "dex", "completed");
+    rcpt(db, mid, "bill", "completed");
+    expect(armBusFallback(db, mid, "dex")).toBe(1);
+    expect(stateOf(db, mid, "dex")).toBe("pending");
+    expect(stateOf(db, mid, "bill")).toBe("completed");
+  });
+
+  test("★연결 시험 — 되돌린 행을 pendingDispatch 가 실제로 집는다★", async () => {
+    const { db, mid } = seed();
+    rcpt(db, mid, "dex", "completed");
+    const { pendingDispatch } = await import("../db/inbox/dispatch");
+    expect(pendingDispatch(db).some((r) => r.message_id === mid && r.agent_id === "dex")).toBe(false);
+    armBusFallback(db, mid, "dex");
+    expect(pendingDispatch(db).some((r) => r.message_id === mid && r.agent_id === "dex")).toBe(true);
   });
 });

--- a/src/server/workers/telegramCapture.ts
+++ b/src/server/workers/telegramCapture.ts
@@ -335,6 +335,30 @@ export function findExistingTelegramOriginMessage(
 // 답장 원문 작성자(봇 username)를 agent id 로 매핑. @멘션 없을 때 라우터가 owner 로 씀.
 // GD 본인/외부 메시지에 대한 답장이면 매칭 없음 → undefined (reply-owner 미적용).
 // (2026-06-06 split: startTelegramCapture 클로저 → 모듈 함수. agents 를 인자로 받는 것 외 동작 동일.)
+/**
+ * ★주입 분기가 없는 팀원의 수신 행을 버스가 깨우도록 되돌린다.★
+ *
+ * 텔레그램 사용자 메시지의 수신 행은 삽입 시점에 `'completed'` 다 — "채널 담당이 배달하므로
+ * 버스는 안 깨운다" 는 전제다(`db/inbox/dispatch.ts`). 그 채널 담당이 없는 팀원에게는 그 전제가
+ * 성립하지 않으므로 `'pending'` 으로 되돌려 `pendingDispatch` 가 집게 한다.
+ *
+ * ★`'completed'` 인 행만 바꾼다★ — 이미 `pending`·`dispatching` 이거나 다른 경로가 손댄 행을 덮지 않는다.
+ * ★그 팀원의 행 하나만 바꾼다★ — 같은 메시지의 다른 수신자(주입 성공)는 영향이 없다.
+ *
+ * @returns 바뀐 행 수. ★1 이 아니면 부르는 쪽이 audit 한다★ — 0 은 "구제할 행이 없었다" 이고,
+ *          조용히 넘기면 그 팀원은 그룹에서 침묵한다.
+ */
+export function armBusFallback(db: Database, messageId: string, agentId: string): number {
+  const res = db
+    .prepare(
+      `UPDATE message_recipient
+          SET delivery_state = 'pending'
+        WHERE message_id = ? AND agent_id = ? AND delivery_state = 'completed'`,
+    )
+    .run(messageId, agentId);
+  return Number(res.changes ?? 0);
+}
+
 export function replyAuthorAgentId(fromUsername: string | undefined, agents: AgentRecord[]): string | undefined {
   if (!fromUsername) return undefined;
   // P3 신원 seam: 채널 어댑터로 위임. channel_identities.telegram 우선 → legacy telegram_bot_username 폴백.
@@ -714,6 +738,7 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
   const pendingBroadcasts = new Map<string, {
     decision: any; roster: any; deliveryBody: string; media: any;
     threadId: string; origTgMessageId?: string; teamContext: string; text: string;
+    storedMessageId?: string;
   }>();
   async function sendBroadcastConfirm(pid: string, text: string, targetCount: number, replyTo?: string): Promise<void> {
     const locale = getLocale(deps.db);
@@ -763,7 +788,7 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
       await tg("answerCallbackQuery", { callback_query_id: cb.id, text: pick(locale, "전송 중…", "Sending…") });
       if (mid) await tg("editMessageText", { chat_id: chatId, message_id: mid, text: pick(locale, `✅ 전체전송 승인 — 팀원 ${pending.decision.targetAgentIds.length}명에게 전송`, `✅ Broadcast approved — sending to ${pending.decision.targetAgentIds.length} member(s)`) });
       appendAuditFile("capture", "broadcast_approved", pid, { from: fromId, targets: pending.decision.targetAgentIds });
-      await runInjection(pending.decision, pending.roster, pending.deliveryBody, pending.media, pending.threadId, pending.origTgMessageId, pending.teamContext, pending.text);
+      await runInjection(pending.decision, pending.roster, pending.deliveryBody, pending.media, pending.threadId, pending.origTgMessageId, pending.teamContext, pending.text, pending.storedMessageId);
       return;
     }
 
@@ -1005,6 +1030,9 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
     });
     const deliveryBody = withReplyContext(text, replyText);
     const threadId = `tg-${GROUP_ID}`;
+    // ★버스에 저장된 메시지 id★ — 아래 persist 블록에서 채운다. 주입 분기가 없는 팀원의
+    //   수신 행을 'pending' 으로 되돌릴 때 이 값으로 행을 특정한다(runInjection 의 버스 fallback).
+    let storedMessageId: string | undefined;
     // 가시성 Stage C: 깨우기 전 공유 버스의 최근 팀 맥락(최대 10건/6h)을 모은다 — 현재 메시지 적재 전 = 직전 맥락.
     let teamContext = "";
     try {
@@ -1063,6 +1091,7 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
         });
         return;
       }
+      storedMessageId = accepted.stored.id;
     } catch (e) {
       console.error("[capture] bus persist failed:", (e as Error).message);
     }
@@ -1100,17 +1129,32 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
       if (decision.reason === "broadcast_marker") {
         // @all 보류 — 주입하지 않고 GD 승인 버튼을 띄운다(오발송 방지).
         const pid = `bcast-${Date.now()}`;
-        pendingBroadcasts.set(pid, { decision, roster, deliveryBody, media, threadId, origTgMessageId, teamContext, text });
+        pendingBroadcasts.set(pid, { decision, roster, deliveryBody, media, threadId, origTgMessageId, teamContext, text, storedMessageId });
         appendAuditFile("capture", "broadcast_held", pid, { targets: decision.targetAgentIds, text: text.slice(0, 120) });
         await sendBroadcastConfirm(pid, text, decision.targetAgentIds.length, origTgMessageId);
       } else {
-        await runInjection(decision, roster, deliveryBody, media, threadId, origTgMessageId, teamContext, text);
+        await runInjection(decision, roster, deliveryBody, media, threadId, origTgMessageId, teamContext, text, storedMessageId);
       }
     }
   }
 
   // 주입 루프 추출(2026-06-18, @all confirm 준비) — 정상 라우팅과 @all 승인 후 재실행이 같은 코드를 쓰도록 함수화.
   // 동작 보존: 호출부 조건/본문 변경 없음.
+  /**
+   * ★capture 가 넣을 수 없는 런타임은 버스가 깨우게 한다.★
+   *
+   * 이 함수는 런타임별 분기로 팀원에게 그룹 메시지를 넣는다. 분기가 없는 런타임은 예전에
+   * `no_supported_path` 로그만 남기고 ★조용히 끝났다★ — 그 팀원은 그룹에서 아무 말도 못 듣는다
+   * (실측 2026-08-24: dex(runtime=codex) 호출 3건이 전부 이 자리로 떨어졌다).
+   *
+   * 텔레그램 사용자 메시지의 수신 행은 ★삽입 시점에 'completed'★ 다(`db/inbox/messages.ts`) —
+   * "채널 담당이 배달하므로 버스는 안 깨운다"는 전제다(`db/inbox/dispatch.ts` 주석). 그 채널 담당이
+   * 없는 팀원에게는 그 전제가 성립하지 않으므로, ★그 수신 행만★ 'pending' 으로 돌려 버스가 깨우게 한다.
+   *
+   * ★수신자 단위★ 라 같은 메시지의 다른 팀원(주입 성공)은 영향이 없다 — 이중배달이 안 난다.
+   * ★구제 범위는 '분기 없음' 하나다★ (리뷰 지적) — 주입을 시도했다가 실패한 경우(`ok:false`,
+   * openclaw 비동기 실패)는 여기 오지 않으므로 여전히 fallback 이 없다. 그건 별건이다.
+   */
   async function runInjection(
     decision: any,
     roster: any,
@@ -1120,6 +1164,7 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
     origTgMessageId: string | undefined,
     teamContext: string,
     text: string,
+    storedMessageId: string | undefined,
   ): Promise<void> {
       for (const id of decision.targetAgentIds) {
         // 빌-제외 해제(2026-06-02): 빌 requireMention=true 전환 → owned 무-@멘션(sticky/default/reply/@별칭)을
@@ -1265,6 +1310,20 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
         }
         console.log(`[capture] inject skip ${id} (no supported injection path)`);
         appendAuditFile("capture", "injection_skip", id, { reason: "no_supported_path", text: text.slice(0, 120) });
+        // ★버스 fallback★ — 이 팀원은 주입 경로가 없으므로 수신 행을 'pending' 으로 돌려 깨운다.
+        if (!storedMessageId) {
+          // 저장 id 가 없으면 구제할 행을 특정할 수 없다. ★조용히 넘기지 않는다★ — 이 팀원은 침묵한다.
+          console.log(`[capture] bus fallback unavailable → ${id} (no stored message id)`);
+          appendAuditFile("capture", "bus_fallback_unavailable", id, {
+            reason: "no_stored_message_id", runtime: agent.runtime ?? null, text: text.slice(0, 120),
+          });
+          continue;
+        }
+        const changed = armBusFallback(deps.db, storedMessageId, id);
+        appendAuditFile("capture", changed === 1 ? "bus_fallback_armed" : "bus_fallback_no_row", id, {
+          message_id: storedMessageId, runtime: agent.runtime ?? null, changes: changed, text: text.slice(0, 120),
+        });
+        console.log(`[capture] bus fallback → ${id}: ${changed === 1 ? "armed" : `no_row(changes=${changed})`}`);
       }
   }
 


### PR DESCRIPTION
그룹방에서 `runtime='codex'` 팀원이 침묵하는 문제를 고칩니다. 원인이 ★둘★ 이고 하나만 고치면 증상이 그대로입니다.

## 원인 ① — 주입 분기가 없으면 배달 경로가 0 이다

`telegramCapture.runInjection` 은 런타임별로 갈리는데 분기가 셋뿐입니다(`claude_channel`·`openclaw`·`hermes_agent`). `runtime='codex'` 는 마지막 줄로 떨어집니다:

```
actor=capture · action=injection_skip · reason=no_supported_path   (실측 3건: 02:02:05 · 02:54:26 · 02:54:55)
```

버스도 깨우지 않습니다. 그건 설계입니다 — 텔레그램 사용자 메시지의 수신 행은 삽입 시점에 `'completed'` 이고(`db/inbox/messages.ts`), 이유가 `db/inbox/dispatch.ts` 주석에 있습니다: *"Telegram/Slack user messages are completed-on-insert (**the channel poller delivers them**) ... no double-wake."*

그 "channel poller" 가 없는 팀원에게는 전제가 성립하지 않습니다. **문 하나만 있고 그게 없으면 0 입니다.**

**고침**: fall-through 에서 ★그 수신 행만★ `'pending'` 으로 되돌려 버스가 깨우게 합니다(`armBusFallback`).

- `'completed'` 인 행만 바꿉니다 — 다른 상태를 덮지 않습니다
- ★수신자 단위★ 라 같은 메시지의 다른 팀원(주입 성공)은 영향이 없습니다. `@all` 혼합에서도 unsupported 대상만 전환됩니다
- 바뀐 행 수를 audit 에 남깁니다(`bus_fallback_armed` / `bus_fallback_no_row` / `bus_fallback_unavailable`) — 실패가 조용하지 않게

## 원인 ② — 깨워도 답이 방에 안 간다

codex 봉투의 답신 명령이 `--to <from_agent_id>` 였습니다. 그룹 캡처가 만든 행은 `from_agent_id='user'` 라 **`--to user`** 가 나옵니다. `user` 는 팀원이 아니므로 답이 방에 도착하지 않습니다.

**①만 고치면 깨어나기는 하는데 방은 그대로 조용합니다 — 증상이 같고 원인만 바뀝니다.**

**고침**: 그룹 스레드면 `--to broadcast` 를 줍니다. 방 판정은 ★정본 하나★(`resolveThreadKind`)를 씁니다 — `wakeDispatcher` 의 claude 분기도 같은 것을 쓰므로, 방 이름 규칙이 바뀔 때 한쪽만 어긋나지 않습니다.

## 검증

- `bun test src/server/runtimes/codex/ src/server/workers/ src/server/bus/` → **1006 pass · 0 fail**
- 새 시험 9건
  - `armBusFallback` 6건: `completed`→`pending` · `dispatching` 안 덮음 · 이미 `pending` 이면 0 · 행 없으면 0 · **수신자 단위(다른 팀원 행 불변)** · **연결 시험 — 되돌린 행을 `pendingDispatch` 가 실제로 집는다**
  - `replyCommand` 3건: 그룹 → `--to broadcast` · 팀원이 보낸 그룹 메시지도 방으로 · **비그룹은 그대로(회귀 방지)**
- **뮤턴트 2건 확인**
  - `AND delivery_state='completed'` 가드 제거 → 2건 실패
  - 그룹 분기 무력화 → 2건 실패
  - 되돌린 뒤 43 pass / 0 fail

## 리뷰에서 나온 한정 — 과대주장하지 않습니다

- 구제 범위는 ★분기 없음★ 하나입니다. 주입을 시도했다 실패한 경우(`injectPrompt` 가 `ok:false`, openclaw 비동기 실패)는 이 자리에 오지 않으므로 여전히 fallback 이 없습니다
- `native_routing` 이 없는 런타임의 `@username` 멘션은 runtime 분기보다 위에서 `continue` 하므로 역시 여기 안 옵니다
- 따라서 "어떤 런타임도 침묵 없음" 이 아니라 ★"새 runtime 분기 누락은 침묵 대신 버스로 간다"★ 가 정확합니다

## 재깨우기 확인

`pending` → `dispatching` → `wake_dispatched` 로 전이하고 `pendingDispatch` 는 `pending` 만 봅니다. 답이 오면 자동 닫기가 `wake_dispatched` 행을 `completed` 로 닫습니다. **재깨우기 루프는 생기지 않습니다.**

## 배포 후 확인

`from_agent_id='dex' AND to_agent_id='broadcast' AND thread_id LIKE 'tg--%'` 에 값이 생기는지. 통과하면 라이브 런처의 `CODEX_GROUP_NATIVE_DENY=false` 한 줄을 지워 다시 버스 단일 경로로 돌립니다.
