### PR TITLE
feat(codex): 그룹 턴을 브리지 창구로 넣는다 (다른 런타임과 같은 모양)

### DIFF
--- a/src/server/lib/codexBridgeClient.test.ts
+++ b/src/server/lib/codexBridgeClient.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { callCodexBridge } from "./codexBridgeClient";
+import { writeWindowFile, type BridgeWindowRequest } from "../runtimes/codex/bridgeWindow";
+
+const TOKEN = "a".repeat(64);
+
+function seedWindow(agentId = "dex", port = 51234): { pidFile: string } {
+  const dir = mkdtempSync(join(tmpdir(), "cbc-"));
+  const pidFile = join(dir, `${agentId}.pid`);
+  writeWindowFile(join(dir, `${agentId}.window.json`), { port, token: TOKEN, pid: 1, agentId });
+  return { pidFile };
+}
+
+const REQ: BridgeWindowRequest = {
+  agentId: "dex",
+  groupId: "-100",
+  threadId: "tg--100",
+  messageId: "tg-1",
+  body: "@덱스 들려?",
+};
+
+describe("callCodexBridge", () => {
+  test("★202 는 접수★ — queued 이지 '답했다' 가 아니다", async () => {
+    const { pidFile } = seedWindow();
+    const r = await callCodexBridge(REQ, {
+      pidFile,
+      fetchImpl: (async () => new Response("{}", { status: 202 })) as unknown as typeof fetch,
+    });
+    expect(r).toEqual({ ok: true, duplicate: false });
+  });
+
+  test("200 은 이미 접수된 중복", async () => {
+    const { pidFile } = seedWindow();
+    const r = await callCodexBridge(REQ, {
+      pidFile,
+      fetchImpl: (async () => new Response("{}", { status: 200 })) as unknown as typeof fetch,
+    });
+    expect(r).toEqual({ ok: true, duplicate: true });
+  });
+
+  test("★토큰을 헤더에 싣고 127.0.0.1 로만 부른다★", async () => {
+    const { pidFile } = seedWindow("dex", 45678);
+    let seenUrl = "";
+    let seenToken = "";
+    await callCodexBridge(REQ, {
+      pidFile,
+      fetchImpl: (async (url: string, init: RequestInit) => {
+        seenUrl = String(url);
+        seenToken = String((init.headers as Record<string, string>)["x-b3os-token"]);
+        return new Response("{}", { status: 202 });
+      }) as unknown as typeof fetch,
+    });
+    expect(seenUrl).toBe("http://127.0.0.1:45678/turn");
+    expect(seenToken).toBe(TOKEN);
+  });
+
+  test("★창구 파일이 없으면 no_window★ — 조용히 성공으로 읽지 않는다", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cbc-"));
+    const r = await callCodexBridge(REQ, { pidFile: join(dir, "dex.pid") });
+    expect(r).toEqual({ ok: false, reason: "no_window" });
+  });
+
+  test("pidFile 자체가 없으면 no_window", async () => {
+    const r = await callCodexBridge(REQ, { pidFile: undefined });
+    expect(r).toEqual({ ok: false, reason: "no_window" });
+  });
+
+  test("★남의 창구 파일이면 부르지 않는다★ (stale 파일 방지)", async () => {
+    const { pidFile } = seedWindow("dex");
+    const r = await callCodexBridge({ ...REQ, agentId: "codex" }, { pidFile });
+    expect(r).toEqual({ ok: false, reason: "no_window" });
+  });
+
+  test("★끊긴 것과 늦은 것을 가른다 — unreachable★", async () => {
+    const { pidFile } = seedWindow();
+    const r = await callCodexBridge(REQ, {
+      pidFile,
+      fetchImpl: (async () => {
+        throw new Error("ECONNREFUSED");
+      }) as unknown as typeof fetch,
+    });
+    expect(r).toEqual({ ok: false, reason: "unreachable" });
+  });
+
+  test("★타임아웃은 timeout 으로 갈린다★ — 재시도하지 않으므로 사유가 남아야 한다", async () => {
+    const { pidFile } = seedWindow();
+    const r = await callCodexBridge(REQ, {
+      pidFile,
+      timeoutMs: 10,
+      fetchImpl: ((_u: string, init: RequestInit) =>
+        new Promise((_res, rej) => {
+          init.signal?.addEventListener("abort", () => {
+            const e = new Error("aborted");
+            e.name = "AbortError";
+            rej(e);
+          });
+        })) as unknown as typeof fetch,
+    });
+    expect(r).toEqual({ ok: false, reason: "timeout" });
+  });
+
+  test("401 등 거절은 rejected + status", async () => {
+    const { pidFile } = seedWindow();
+    const r = await callCodexBridge(REQ, {
+      pidFile,
+      fetchImpl: (async () => new Response("{}", { status: 401 })) as unknown as typeof fetch,
+    });
+    expect(r).toEqual({ ok: false, reason: "rejected", status: 401 });
+  });
+
+  test("★매 호출마다 파일을 다시 읽는다★ — 재기동하면 포트가 바뀐다", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cbc-"));
+    const pidFile = join(dir, "dex.pid");
+    const wf = join(dir, "dex.window.json");
+    const ports: number[] = [];
+    const impl = (async (url: string) => {
+      ports.push(Number(String(url).split(":")[2]?.split("/")[0]));
+      return new Response("{}", { status: 202 });
+    }) as unknown as typeof fetch;
+
+    writeWindowFile(wf, { port: 1111, token: TOKEN, pid: 1, agentId: "dex" });
+    await callCodexBridge(REQ, { pidFile, fetchImpl: impl });
+    writeWindowFile(wf, { port: 2222, token: TOKEN, pid: 2, agentId: "dex" });
+    await callCodexBridge(REQ, { pidFile, fetchImpl: impl });
+
+    expect(ports).toEqual([1111, 2222]);
+  });
+});

--- a/src/server/lib/codexBridgeClient.test.ts
+++ b/src/server/lib/codexBridgeClient.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { callCodexBridge } from "./codexBridgeClient";
+import { callCodexBridge, pidAlive } from "./codexBridgeClient";
 import { writeWindowFile, type BridgeWindowRequest } from "../runtimes/codex/bridgeWindow";
 
 const TOKEN = "a".repeat(64);
@@ -10,7 +10,7 @@ const TOKEN = "a".repeat(64);
 function seedWindow(agentId = "dex", port = 51234): { pidFile: string } {
   const dir = mkdtempSync(join(tmpdir(), "cbc-"));
   const pidFile = join(dir, `${agentId}.pid`);
-  writeWindowFile(join(dir, `${agentId}.window.json`), { port, token: TOKEN, pid: 1, agentId });
+  writeWindowFile(join(dir, `${agentId}.window.json`), { port, token: TOKEN, pid: process.pid, agentId });
   return { pidFile };
 }
 
@@ -121,11 +121,77 @@ describe("callCodexBridge", () => {
       return new Response("{}", { status: 202 });
     }) as unknown as typeof fetch;
 
-    writeWindowFile(wf, { port: 1111, token: TOKEN, pid: 1, agentId: "dex" });
+    writeWindowFile(wf, { port: 1111, token: TOKEN, pid: process.pid, agentId: "dex" });
     await callCodexBridge(REQ, { pidFile, fetchImpl: impl });
-    writeWindowFile(wf, { port: 2222, token: TOKEN, pid: 2, agentId: "dex" });
+    writeWindowFile(wf, { port: 2222, token: TOKEN, pid: process.pid, agentId: "dex" });
     await callCodexBridge(REQ, { pidFile, fetchImpl: impl });
 
     expect(ports).toEqual([1111, 2222]);
+  });
+});
+
+// ── ★"파일이 있다" 와 "그 프로세스가 살아 있다" 는 다른 값이다★ ──
+//
+// close() 는 SIGTERM·SIGINT 에만 걸린다. 크래시·SIGKILL 이면 창구 파일이 남고, 포트는
+// ephemeral 대역이라 커널이 그 포트를 다른 로컬 프로세스에 다시 줄 수 있다. 그러면
+// ★본문(그룹 원문 + 팀 맥락)과 토큰이 무관한 리스너에게 그대로 날아간다.★
+describe("죽은 브리지 — 보내기 전에 막는다", () => {
+  test("★pid 가 죽었으면 POST 자체를 안 한다★ (토큰·본문 유출 방지)", async () => {
+    const { pidFile } = seedWindow();
+    let called = 0;
+    const r = await callCodexBridge(REQ, {
+      pidFile,
+      isAlive: () => false,
+      removeStale: () => {},
+      fetchImpl: (async () => {
+        called += 1;
+        return new Response("{}", { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+    expect(r).toEqual({ ok: false, reason: "no_window" });
+    expect(called).toBe(0);
+  });
+
+  test("★죽었으면 stale 파일을 치운다★ — 다음 호출이 깨끗하게 실패한다", async () => {
+    const { pidFile } = seedWindow();
+    const removed: string[] = [];
+    await callCodexBridge(REQ, { pidFile, isAlive: () => false, removeStale: (p) => removed.push(p) });
+    expect(removed.length).toBe(1);
+    expect(removed[0]).toContain("dex.window.json");
+  });
+
+  test("살아 있으면 그대로 보낸다", async () => {
+    const { pidFile } = seedWindow();
+    const r = await callCodexBridge(REQ, {
+      pidFile,
+      isAlive: () => true,
+      fetchImpl: (async () => new Response("{}", { status: 202 })) as unknown as typeof fetch,
+    });
+    expect(r).toEqual({ ok: true, duplicate: false });
+  });
+});
+
+describe("pidAlive — 던진 이유를 가른다", () => {
+  test("자기 프로세스는 살아 있다", () => {
+    expect(pidAlive(process.pid)).toBe(true);
+  });
+
+  test("★없는 pid 는 죽은 것★ (ESRCH)", () => {
+    // 아주 큰 pid — 존재하지 않는다.
+    expect(pidAlive(2 ** 22 - 1)).toBe(false);
+  });
+
+  test("★EPERM 은 살아 있다는 뜻이다★ — 던졌다고 죽은 것으로 읽으면 그룹이 조용해진다", () => {
+    const orig = process.kill;
+    try {
+      (process as { kill: unknown }).kill = () => {
+        const e = new Error("operation not permitted") as Error & { code: string };
+        e.code = "EPERM";
+        throw e;
+      };
+      expect(pidAlive(1)).toBe(true);
+    } finally {
+      (process as { kill: unknown }).kill = orig;
+    }
   });
 });

--- a/src/server/lib/codexBridgeClient.test.ts
+++ b/src/server/lib/codexBridgeClient.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { callCodexBridge, pidAlive } from "./codexBridgeClient";
-import { writeWindowFile, type BridgeWindowRequest } from "../runtimes/codex/bridgeWindow";
+import { writeWindowFile, readWindowFile, type BridgeWindowRequest } from "../runtimes/codex/bridgeWindow";
 
 const TOKEN = "a".repeat(64);
 
@@ -142,7 +142,6 @@ describe("죽은 브리지 — 보내기 전에 막는다", () => {
     const r = await callCodexBridge(REQ, {
       pidFile,
       isAlive: () => false,
-      removeStale: () => {},
       fetchImpl: (async () => {
         called += 1;
         return new Response("{}", { status: 200 });
@@ -152,12 +151,30 @@ describe("죽은 브리지 — 보내기 전에 막는다", () => {
     expect(called).toBe(0);
   });
 
-  test("★죽었으면 stale 파일을 치운다★ — 다음 호출이 깨끗하게 실패한다", async () => {
-    const { pidFile } = seedWindow();
-    const removed: string[] = [];
-    await callCodexBridge(REQ, { pidFile, isAlive: () => false, removeStale: (p) => removed.push(p) });
-    expect(removed.length).toBe(1);
-    expect(removed[0]).toContain("dex.window.json");
+  // ★남은 파일을 지우면 안 된다★ — 읽고 나서 생존을 보는 사이에 브리지가 재기동하면
+  //   그 파일은 새 pid·포트·토큰으로 원자 교체된다. 옛 pid 로 ESRCH 를 보고 지우면
+  //   ★방금 뜬 새 창구 파일을 지운다★ = 정상 재기동 직후에 계속 조용해진다.
+  test("★재기동 경쟁 — 생존 확인 중 새 브리지가 파일을 갈아도 그 파일을 안 지운다★", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cbc-race-"));
+    const pidFile = join(dir, "dex.pid");
+    const wf = join(dir, "dex.window.json");
+    writeWindowFile(wf, { port: 1111, token: TOKEN, pid: 999999, agentId: "dex" });
+
+    const r = await callCodexBridge(REQ, {
+      pidFile,
+      isAlive: () => {
+        // 생존을 재는 그 사이에 새 브리지가 뜬다 — 원자 교체.
+        writeWindowFile(wf, { port: 2222, token: "c".repeat(64), pid: process.pid, agentId: "dex" });
+        return false; // 우리가 읽은 옛 pid 는 죽어 있다
+      },
+      fetchImpl: (async () => new Response("{}", { status: 202 })) as unknown as typeof fetch,
+    });
+
+    expect(r).toEqual({ ok: false, reason: "no_window" });
+    // ★새 파일이 살아 있어야 한다★ — 다음 호출이 새 창구로 간다.
+    const after = readWindowFile(wf);
+    expect(after).not.toBeNull();
+    expect(after?.port).toBe(2222);
   });
 
   test("살아 있으면 그대로 보낸다", async () => {

--- a/src/server/lib/codexBridgeClient.ts
+++ b/src/server/lib/codexBridgeClient.ts
@@ -9,6 +9,7 @@
  * ★매 호출 전에 창구 파일을 다시 읽는다.★ 브리지가 재시작하면 포트가 바뀌는데
  * 캐시하고 있으면 ★조용히 안 간다.★
  */
+import { rmSync } from "node:fs";
 import { readWindowFile, windowFilePathFor, type BridgeWindowRequest } from "../runtimes/codex/bridgeWindow";
 
 /** 창구 호출 결과. ★queued 는 "접수" 지 "답했다" 가 아니다.★ */
@@ -21,6 +22,28 @@ export interface CodexBridgeCallDeps {
   pidFile: string | undefined;
   timeoutMs?: number;
   fetchImpl?: typeof fetch;
+  /** 그 pid 가 살아 있나. 시험에서 갈아 끼운다. */
+  isAlive?: (pid: number) => boolean;
+  /** 죽은 브리지의 창구 파일을 치운다. 시험에서 갈아 끼운다. */
+  removeStale?: (path: string) => void;
+}
+
+/**
+ * `signal 0` 은 신호를 안 보내고 ★존재만★ 묻는다.
+ *
+ * ★던진 이유를 갈라야 한다★ (리뷰 지적):
+ * · `ESRCH` = 그런 프로세스가 없다 → ★죽었다★
+ * · `EPERM` = 있는데 신호를 보낼 권한이 없다 → ★살아 있다★
+ * 둘을 뭉쳐서 "던졌으니 죽었다" 로 읽으면 ★살아 있는 브리지를 죽은 것으로 판정★ 해 그룹이 조용해진다.
+ * 모르는 오류도 ★살아 있는 쪽★ 으로 둔다 — 여기서 틀리면 배달이 멈추고, 유출은 ESRCH 로만 생긴다.
+ */
+export function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as { code?: string }).code !== "ESRCH";
+  }
 }
 
 /** 기본 타임아웃 — 창구는 큐에 넣고 바로 답한다(턴을 기다리지 않는다). 짧게 잡는다. */
@@ -34,8 +57,27 @@ export async function callCodexBridge(
   if (!path) return { ok: false, reason: "no_window" };
   const file = readWindowFile(path);
   if (!file) return { ok: false, reason: "no_window" };
-  // ★파일에 적힌 주인이 이 팀원인지 본다★ — 남은 파일(stale)을 잘못 부르지 않게.
+  // ★파일에 적힌 주인이 이 팀원인지 본다★ — 다만 이 검사만으로는 부족하다.
+  //   파일 경로가 이미 `${agentId}.window.json` 이라 남의 파일이 올 일이 거의 없고,
+  //   ★죽은 내 파일★ 은 agentId 가 그대로라 이걸로 못 거른다.
   if (file.agentId !== req.agentId) return { ok: false, reason: "no_window" };
+
+  // ★"파일이 있다" 와 "그 프로세스가 살아 있다" 는 다른 값이다.★ (리뷰 지적 — 유출 경로)
+  //   close() 는 SIGTERM·SIGINT 에만 걸린다. ★크래시·SIGKILL 이면 파일이 그대로 남는다.★
+  //   포트는 `listen(0)` 이라 ephemeral 대역이고, 브리지가 죽은 뒤 커널이 그 포트를
+  //   ★다른 로컬 프로세스★ 에 다시 줄 수 있다. 그러면 이 요청이 그쪽으로 간다 —
+  //   ★본문(그룹 원문 + 팀 맥락)과 토큰이 무관한 리스너에게 그대로 날아간다.★
+  //   게다가 그쪽이 200 을 주면 부르는 쪽은 `duplicate` 로 읽어 ★성공으로 기록★ 한다.
+  //   보내기 전에 존재를 확인하고, 죽었으면 그 파일을 치워 다음 호출을 깨끗하게 한다.
+  const alive = (deps.isAlive ?? pidAlive)(file.pid);
+  if (!alive) {
+    try {
+      (deps.removeStale ?? ((p: string) => rmSync(p, { force: true })))(path);
+    } catch {
+      /* 정리 실패가 판정을 바꾸지 않는다 — 어차피 안 보낸다 */
+    }
+    return { ok: false, reason: "no_window" };
+  }
 
   const doFetch = deps.fetchImpl ?? fetch;
   const ac = new AbortController();

--- a/src/server/lib/codexBridgeClient.ts
+++ b/src/server/lib/codexBridgeClient.ts
@@ -9,7 +9,6 @@
  * ★매 호출 전에 창구 파일을 다시 읽는다.★ 브리지가 재시작하면 포트가 바뀌는데
  * 캐시하고 있으면 ★조용히 안 간다.★
  */
-import { rmSync } from "node:fs";
 import { readWindowFile, windowFilePathFor, type BridgeWindowRequest } from "../runtimes/codex/bridgeWindow";
 
 /** 창구 호출 결과. ★queued 는 "접수" 지 "답했다" 가 아니다.★ */
@@ -24,8 +23,6 @@ export interface CodexBridgeCallDeps {
   fetchImpl?: typeof fetch;
   /** 그 pid 가 살아 있나. 시험에서 갈아 끼운다. */
   isAlive?: (pid: number) => boolean;
-  /** 죽은 브리지의 창구 파일을 치운다. 시험에서 갈아 끼운다. */
-  removeStale?: (path: string) => void;
 }
 
 /**
@@ -69,15 +66,18 @@ export async function callCodexBridge(
   //   ★본문(그룹 원문 + 팀 맥락)과 토큰이 무관한 리스너에게 그대로 날아간다.★
   //   게다가 그쪽이 200 을 주면 부르는 쪽은 `duplicate` 로 읽어 ★성공으로 기록★ 한다.
   //   보내기 전에 존재를 확인하고, 죽었으면 그 파일을 치워 다음 호출을 깨끗하게 한다.
+  //
+  //   ★남은 파일을 지우지는 않는다★ (리뷰 지적 — 경쟁 조건).
+  //   읽고 나서 생존을 확인하는 사이에 브리지가 재기동하면 그 파일은 ★새 pid·포트·토큰으로
+  //   원자 교체★ 된다. 그때 옛 pid 로 ESRCH 를 보고 지우면 ★방금 뜬 새 창구 파일을 지운다★ —
+  //   정상 재기동 직후에 ★계속 no_window★ 가 되어 조용해진다. 치우는 일은 새 브리지가 이미 한다.
+  //
+  //   ★남는 구멍 — 완전 차단이 아니다★: pid 는 재사용된다. 브리지가 죽고 그 번호를 다른
+  //   프로세스가 물려받으면 `pidAlive` 는 참을 준다. 이 검사가 막는 것은 ★그 번호가 아예 없는
+  //   경우(ESRCH)★ 이고, 그게 크래시 직후의 대부분이다. 완전한 증명은 파일에 기동 시각·nonce 를
+  //   같이 싣고 창구가 자기 것을 확인해야 한다 — 별건이다.
   const alive = (deps.isAlive ?? pidAlive)(file.pid);
-  if (!alive) {
-    try {
-      (deps.removeStale ?? ((p: string) => rmSync(p, { force: true })))(path);
-    } catch {
-      /* 정리 실패가 판정을 바꾸지 않는다 — 어차피 안 보낸다 */
-    }
-    return { ok: false, reason: "no_window" };
-  }
+  if (!alive) return { ok: false, reason: "no_window" };
 
   const doFetch = deps.fetchImpl ?? fetch;
   const ac = new AbortController();

--- a/src/server/lib/codexBridgeClient.ts
+++ b/src/server/lib/codexBridgeClient.ts
@@ -1,0 +1,60 @@
+/**
+ * ★서버가 codex 브리지의 창구를 부르는 쪽.★ (telegramCapture 의 codex 분기가 쓴다)
+ *
+ * 다른 런타임과 같은 모양이다 — 서버는 턴을 돌지 않고 ★런타임을 소유한 프로세스★ 를 부른다.
+ *
+ * ★재시도하지 않는다.★ 타임아웃이 나도 턴은 브리지에서 계속 돌고 있을 수 있다 —
+ * 다시 부르면 그게 곧 이중응답이다(리뷰 지적). 실패는 실패로 두고 audit 만 남긴다.
+ *
+ * ★매 호출 전에 창구 파일을 다시 읽는다.★ 브리지가 재시작하면 포트가 바뀌는데
+ * 캐시하고 있으면 ★조용히 안 간다.★
+ */
+import { readWindowFile, windowFilePathFor, type BridgeWindowRequest } from "../runtimes/codex/bridgeWindow";
+
+/** 창구 호출 결과. ★queued 는 "접수" 지 "답했다" 가 아니다.★ */
+export type CodexBridgeCallResult =
+  | { ok: true; duplicate: boolean }
+  | { ok: false; reason: "unreachable" | "timeout" | "rejected" | "no_window"; status?: number };
+
+export interface CodexBridgeCallDeps {
+  /** 그 팀원 브리지의 pid 파일 경로(창구 파일은 그 옆에 있다). */
+  pidFile: string | undefined;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+/** 기본 타임아웃 — 창구는 큐에 넣고 바로 답한다(턴을 기다리지 않는다). 짧게 잡는다. */
+export const BRIDGE_CALL_TIMEOUT_MS = 5_000;
+
+export async function callCodexBridge(
+  req: BridgeWindowRequest,
+  deps: CodexBridgeCallDeps,
+): Promise<CodexBridgeCallResult> {
+  const path = windowFilePathFor(deps.pidFile, req.agentId);
+  if (!path) return { ok: false, reason: "no_window" };
+  const file = readWindowFile(path);
+  if (!file) return { ok: false, reason: "no_window" };
+  // ★파일에 적힌 주인이 이 팀원인지 본다★ — 남은 파일(stale)을 잘못 부르지 않게.
+  if (file.agentId !== req.agentId) return { ok: false, reason: "no_window" };
+
+  const doFetch = deps.fetchImpl ?? fetch;
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), deps.timeoutMs ?? BRIDGE_CALL_TIMEOUT_MS);
+  try {
+    const res = await doFetch(`http://127.0.0.1:${file.port}/turn`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-b3os-token": file.token },
+      body: JSON.stringify(req),
+      signal: ac.signal,
+    });
+    if (res.status === 202) return { ok: true, duplicate: false };
+    if (res.status === 200) return { ok: true, duplicate: true };
+    return { ok: false, reason: "rejected", status: res.status };
+  } catch (e) {
+    // ★끊긴 것과 늦은 것을 가른다★ — audit 에서 원인이 갈려야 다음 사람이 안 헤맨다.
+    const aborted = (e as { name?: string }).name === "AbortError";
+    return { ok: false, reason: aborted ? "timeout" : "unreachable" };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -123,6 +123,25 @@ describe("codex bridge (M2) — 채널 I/O", () => {
     });
     const gate = (suppress: boolean) => { let n = 0; const fn = async () => { n++; return { suppress, reason: "explicit_mention", targets: ["bill"] }; }; return { fn, calls: () => n }; };
 
+    // ★차단은 '폴링 입구' 의 것이다★ — 그 입구엔 오너 판정이 없어 남을 부른 메시지에도 답했다.
+    //   창구(window)로 들어온 것은 서버(capture)가 오너를 정한 뒤 넣은 것이라 그 차단을 지나지 않는다.
+    test("★창구 입구는 차단을 지나지 않는다★ — 미설정(차단 켜짐)이어도 그룹 턴이 돈다", async () => {
+      delete process.env.CODEX_GROUP_NATIVE_DENY_SHADOW; delete process.env.CODEX_GROUP_NATIVE_DENY;
+      const { deps, calls } = spies(() => ok("답")); const g = gate(false); deps.ownerGate = g.fn;
+      const r = await handleMessage(-123, "x", 55, deps, undefined, "window");
+      expect(r.detail).toBe("delivered");
+      expect(g.calls()).toBe(0); // 브리지는 오너 판정을 하지 않는다 — capture 가 이미 했다
+      expect(calls.reacts.length).toBe(1);
+    });
+
+    test("★같은 메시지라도 폴링 입구면 여전히 막힌다★ (기본값이 우회 수단이 되면 안 된다)", async () => {
+      delete process.env.CODEX_GROUP_NATIVE_DENY_SHADOW; delete process.env.CODEX_GROUP_NATIVE_DENY;
+      const { deps, calls } = spies(() => ok("답")); deps.ownerGate = gate(false).fn;
+      const r = await handleMessage(-123, "x", 55, deps, undefined, "poll");
+      expect(r.detail).toBe("group_native_denied");
+      expect(calls.reacts.length).toBe(0);
+    });
+
     test("★미설정 = 켜짐★ → 그룹은 drop(group_native_denied), react 안 함", async () => {
       delete process.env.CODEX_GROUP_NATIVE_DENY_SHADOW; delete process.env.CODEX_GROUP_NATIVE_DENY;
       const { deps, calls } = spies(() => ok("답")); deps.ownerGate = gate(false).fn;

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -1205,6 +1205,13 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
     //   창구만 닫고 끝내면 폴 루프가 계속 돌아 ★SIGTERM 으로 안 죽는다★ —
     //   launchd 재기동이 SIGKILL 까지 기다리게 된다. 치우고 ★직접 나간다.★
     const stop = () => {
+      // ★종료에 물려 사라지는 턴을 기록에 남긴다★ (리뷰 지적).
+      //   창구는 202(접수)까지만 답한다. 이미 접수돼 큐에 든 턴은 여기서 프로세스가 끝나며
+      //   ★확정적으로 사라지는데, 안 돌았다는 기록이 어디에도 없다★ —
+      //   ★보낸 쪽은 갔다고 믿고 받는 쪽은 온 적이 없는★, 이 창구가 고치려는 그 실패 모양이다.
+      //   막지는 않는다(비우려면 종료가 늘어진다). 남은 개수를 남겨 나중에 읽히게 한다.
+      const left = turns.pendingCount();
+      if (left > 0) console.log(`[codex-bridge] 종료 — ★큐에 남은 턴 ${left}건은 돌지 않는다★`);
       try {
         windowHandle.close();
       } catch {

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -16,7 +16,8 @@ import {
   type DmAttachments, type DmMessageMedia,
 } from "./dmMedia";
 import { createSerialTurnQueue } from "./serialTurnQueue";
-import { makeDmSessionStore, NOOP_DM_SESSION_STORE, type DmSessionStore } from "./dmSessionStore";
+import { startBridgeWindow } from "./bridgeWindow";
+import { makeChatSessionStore, NOOP_DM_SESSION_STORE, type DmSessionStore } from "./dmSessionStore";
 import { toMarkdownV2, splitForTelegram, toPlain } from "./telegramMarkdown";
 import { steerActiveTurn } from "./activeTurns";
 import { spawn } from "node:child_process";
@@ -484,6 +485,13 @@ export async function handleMessage(
    * 함수로 넘겨 이 턴 안에서 받게 한다(시험에서는 통신 없이 대신 넣는다).
    */
   fetchAttachments?: () => Promise<DmAttachments>,
+  /**
+   * ★어느 입구로 들어왔나.★ 그룹 native 차단은 ★폴링 입구★ 에 거는 것이다 —
+   *   그 입구엔 오너 판정이 없어서 남을 부른 메시지에도 답했다(실측 2026-08-24).
+   *   `"window"` 는 서버(capture)가 오너를 정한 뒤 창구로 넣은 것이라 그 차단을 지나지 않는다.
+   *   ★플래그로 게이트를 끄는 게 아니라, 게이트가 애초에 그 입구의 것이다.★
+   */
+  ingress: "poll" | "window" = "poll",
 ): Promise<{ ok: boolean; reply: string; detail: string }> {
   // ★브리지도 app-server 로 간다.★
   //   전에는 브리지만 옛 exec 경로였다 — 그래서 ★사람이 직접 말 거는 길에만★ 그때까지의 개선
@@ -505,7 +513,7 @@ export async function handleMessage(
   //   그게 승인 요청의 주인으로도 쓰인다 — 실제로 dex 요청 4건이 codex 앞으로 기록됐다.
   const selfAgentId = deps.agentId ?? process.env.CODEX_AGENT_ID ?? "codex";
 
-  if (chatId < 0 && messageId !== undefined) {
+  if (ingress === "poll" && chatId < 0 && messageId !== undefined) {
     const shadowOn = process.env.CODEX_GROUP_NATIVE_DENY_SHADOW === "true";
     // ★기본값 = 켜짐★ (제품 결정 2026-08-24): 그룹은 다른 런타임과 같이 capture→bus 로만 받는다.
     //   native 가 그룹에 직접 답하면 ★자기 앞으로 온 것이 아닌 호출에도 답한다★ — 실측: 그룹에서
@@ -1137,7 +1145,7 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
     // ★agentId 를 실어 보낸다★ — 안 실으면 handleMessage 가 같은 식을 다시 계산해,
     //   runBridge({agentId}) 로 부를 때 두 값이 갈린다. 그러면 steer 가 등록 안 된 id 를 찾아 늘 실패한다.
     agentId: liveAgentId,
-    dmSessions: deps.dmSessions ?? makeDmSessionStore(liveAgentId, defaultTeamDbPath()),
+    dmSessions: deps.dmSessions ?? makeChatSessionStore(liveAgentId, defaultTeamDbPath()),
     sendMessage: deps.sendMessage ?? tgSend(token),
     editMessage: deps.editMessage ?? tgEdit(token),
     reactMessage: deps.reactMessage ?? tgReact(token),
@@ -1168,6 +1176,35 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
   const turns = createSerialTurnQueue((e) => {
     console.error(`[codex-bridge] 턴 처리 실패: ${e instanceof Error ? e.message : e}`);
   });
+
+  // ★그룹 턴은 서버(capture)가 창구로 넣는다★ — 오너 판정은 거기서 이미 끝났다.
+  //   같은 `turns` 큐를 타므로 ★한 팀원 한 턴★ 불변식이 유지된다(1:1 과 겹치지 않는다).
+  //   리액션은 ★이 봇으로★ 단다 — 팀 op 봇이 달면 "누가 받았는지" 가 안 보인다(리뷰 지적).
+  const windowHandle = await startBridgeWindow({
+    agentId: liveAgentId,
+    pidFile,
+    log: (line) => console.log(line),
+    enqueue: (r) => {
+      const chatId = Number(r.groupId);
+      if (!Number.isFinite(chatId)) {
+        console.log(`[codex-bridge] 창구 요청 무시: groupId 가 숫자가 아니다 msg=${r.messageId}`);
+        return;
+      }
+      const tgMsgId = r.origTgMessageId ? Number(r.origTgMessageId) : undefined;
+      if (tgMsgId !== undefined && Number.isFinite(tgMsgId)) {
+        void live.reactMessage?.(chatId, tgMsgId, "👀");
+      }
+      turns.enqueue(async () => {
+        const res = await handleMessage(chatId, r.body, tgMsgId, live, undefined, "window");
+        console.log(`[codex-bridge] 창구 턴 → ${res.detail}: ${res.reply.slice(0, 60)}`);
+      });
+    },
+  });
+  if (windowHandle) {
+    const stop = () => windowHandle.close();
+    process.once("SIGTERM", stop);
+    process.once("SIGINT", stop);
+  }
 
   for (;;) {
     try {

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -1201,7 +1201,17 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
     },
   });
   if (windowHandle) {
-    const stop = () => windowHandle.close();
+    // ★신호 처리기를 달면 Node 의 기본 종료가 사라진다★ (리뷰 지적).
+    //   창구만 닫고 끝내면 폴 루프가 계속 돌아 ★SIGTERM 으로 안 죽는다★ —
+    //   launchd 재기동이 SIGKILL 까지 기다리게 된다. 치우고 ★직접 나간다.★
+    const stop = () => {
+      try {
+        windowHandle.close();
+      } catch {
+        /* 정리 실패가 종료를 막지 않는다 */
+      }
+      process.exit(0);
+    };
     process.once("SIGTERM", stop);
     process.once("SIGINT", stop);
   }

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -1210,6 +1210,11 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
       //   ★확정적으로 사라지는데, 안 돌았다는 기록이 어디에도 없다★ —
       //   ★보낸 쪽은 갔다고 믿고 받는 쪽은 온 적이 없는★, 이 창구가 고치려는 그 실패 모양이다.
       //   막지는 않는다(비우려면 종료가 늘어진다). 남은 개수를 남겨 나중에 읽히게 한다.
+      //   ★이 줄이 남는 이유는 조건부다★ (리뷰 지적): `process.exit(0)` 은 ★버퍼를 안 비우고★
+      //   나간다. 지금 살아남는 것은 stdout 이 ★일반 파일★ 이라 Node 가 동기로 쓰기 때문이다
+      //   (`launcher.ts` — plist 의 `StandardOutPath` 가 파일이고, wrapper 의 `exec bun` 뒤에 파이프가 없다).
+      //   ★wrapper 에 `| tee` 같은 파이프를 하나 붙이면 stdout 이 파이프(비동기)가 되어 이 줄이 잘린다★ —
+      //   "안 돌았다" 를 증명하려고 넣은 기록이 바로 그 순간 같이 사라진다.
       const left = turns.pendingCount();
       if (left > 0) console.log(`[codex-bridge] 종료 — ★큐에 남은 턴 ${left}건은 돌지 않는다★`);
       try {

--- a/src/server/runtimes/codex/bridgeWindow.test.ts
+++ b/src/server/runtimes/codex/bridgeWindow.test.ts
@@ -220,4 +220,14 @@ describe("startBridgeWindow — 실제 왕복", () => {
     h.close();
     expect(readWindowFile(file)).toBeNull();
   });
+  test("★파일을 못 쓰면 창구를 연 채로 두지 않는다★ — 아무도 못 부르는 리스너가 남으면 종료도 막는다", async () => {
+    // 존재하지 않는 디렉터리 → writeWindowFile 이 ENOENT 로 던진다.
+    const h = await startBridgeWindow({
+      agentId: "dex",
+      pidFile: join(tmpdir(), "no-such-dir-cbw", "dex.pid"),
+      enqueue: () => {},
+    });
+    expect(h).toBeNull();
+  });
 });
+

--- a/src/server/runtimes/codex/bridgeWindow.test.ts
+++ b/src/server/runtimes/codex/bridgeWindow.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, chmodSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  decideWindowRequest,
+  readWindowFile,
+  tokensMatch,
+  windowFilePathFor,
+  writeWindowFile,
+  WindowDedupe,
+  WINDOW_BODY_LIMIT_BYTES,
+} from "./bridgeWindow";
+
+const TOKEN = "a".repeat(64);
+
+function req(over: Record<string, unknown> = {}) {
+  return {
+    agentId: "dex",
+    groupId: "-1003947108339",
+    threadId: "tg--1003947108339",
+    messageId: "tg-1",
+    body: "@덱스 들려?",
+    ...over,
+  };
+}
+function opts(over: Record<string, unknown> = {}) {
+  return {
+    selfAgentId: "dex",
+    presentedToken: TOKEN,
+    expectedToken: TOKEN,
+    contentType: "application/json",
+    byteLength: 100,
+    ...over,
+  } as Parameters<typeof decideWindowRequest>[1];
+}
+
+describe("창구 파일 — 포트·토큰·주인", () => {
+  test("★0600 으로 쓰고 그대로 읽는다★ (토큰이 다른 사용자에게 보이면 안 된다)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cbw-"));
+    const path = join(dir, "dex.window.json");
+    writeWindowFile(path, { port: 51234, token: TOKEN, pid: 42, agentId: "dex" });
+    expect(readWindowFile(path)).toEqual({ port: 51234, token: TOKEN, pid: 42, agentId: "dex" });
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  test("★깨진 파일은 null★ — 반쯤 쓰인 값을 주소로 쓰지 않는다", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cbw-"));
+    const path = join(dir, "x.json");
+    writeFileSync(path, "{not json");
+    expect(readWindowFile(path)).toBeNull();
+  });
+
+  test("★값이 빠졌으면 null★ — 포트 0·짧은 토큰·주인 없음은 안 받는다", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cbw-"));
+    for (const [name, obj] of [
+      ["port0", { port: 0, token: TOKEN, pid: 1, agentId: "dex" }],
+      ["shorttoken", { port: 1, token: "abc", pid: 1, agentId: "dex" }],
+      ["noagent", { port: 1, token: TOKEN, pid: 1 }],
+    ] as const) {
+      const p = join(dir, `${name}.json`);
+      writeFileSync(p, JSON.stringify(obj));
+      expect(readWindowFile(p)).toBeNull();
+    }
+  });
+
+  test("pid 파일이 없으면 창구 자리도 없다", () => {
+    expect(windowFilePathFor(undefined, "dex")).toBeNull();
+    expect(windowFilePathFor("/tmp/x/dex.pid", "dex")).toBe("/tmp/x/dex.window.json");
+  });
+});
+
+describe("토큰 비교", () => {
+  test("같으면 참, 다르면 거짓", () => {
+    expect(tokensMatch(TOKEN, TOKEN)).toBe(true);
+    expect(tokensMatch(TOKEN, "b".repeat(64))).toBe(false);
+  });
+  test("★길이가 달라도 던지지 않는다★ — timingSafeEqual 은 길이가 다르면 예외를 낸다", () => {
+    expect(() => tokensMatch("short", TOKEN)).not.toThrow();
+    expect(tokensMatch("short", TOKEN)).toBe(false);
+  });
+});
+
+describe("요청 판정", () => {
+  test("정상 요청은 받는다", () => {
+    expect(decideWindowRequest(req(), opts())).toEqual({ accept: true });
+  });
+
+  test("★토큰이 틀리면 401★ — 로컬이라도 아무나 턴을 못 돌린다", () => {
+    const v = decideWindowRequest(req(), opts({ presentedToken: "b".repeat(64) }));
+    expect(v).toEqual({ accept: false, status: 401, reason: "bad_token" });
+  });
+
+  test("토큰이 아예 없어도 401", () => {
+    expect(decideWindowRequest(req(), opts({ presentedToken: null })).accept).toBe(false);
+  });
+
+  test("★남의 신원으로는 못 돈다 — 403★", () => {
+    const v = decideWindowRequest(req({ agentId: "codex" }), opts());
+    expect(v).toEqual({ accept: false, status: 403, reason: "agent_mismatch" });
+  });
+
+  test("content-type 이 json 이 아니면 415", () => {
+    expect(decideWindowRequest(req(), opts({ contentType: "text/plain" })).accept).toBe(false);
+  });
+
+  test("★본문이 상한을 넘으면 413★", () => {
+    const v = decideWindowRequest(req(), opts({ byteLength: WINDOW_BODY_LIMIT_BYTES + 1 }));
+    expect(v).toEqual({ accept: false, status: 413, reason: "body_too_large" });
+  });
+
+  test("필수 값이 빠지면 400 — 어느 값인지 사유에 남는다", () => {
+    for (const k of ["agentId", "groupId", "threadId", "messageId", "body"]) {
+      const v = decideWindowRequest(req({ [k]: "" }), opts());
+      expect(v.accept).toBe(false);
+      if (!v.accept) expect(v.reason).toContain(k === "agentId" ? "agentId" : k);
+    }
+  });
+
+  test("★판정은 순서가 있다 — 토큰이 먼저다★ (본문이 깨졌어도 인증이 먼저 걸린다)", () => {
+    const v = decideWindowRequest(null, opts({ presentedToken: "b".repeat(64) }));
+    expect(v).toEqual({ accept: false, status: 401, reason: "bad_token" });
+  });
+
+  test("★거절 사유에 토큰이 안 담긴다★", () => {
+    const v = decideWindowRequest(req(), opts({ presentedToken: "b".repeat(64) }));
+    expect(JSON.stringify(v)).not.toContain(TOKEN);
+    expect(JSON.stringify(v)).not.toContain("b".repeat(64));
+  });
+});
+
+describe("멱등 — 같은 messageId 는 한 번만", () => {
+  test("★두 번째는 안 받는다★ — 받으면 dex 가 두 번 답한다", () => {
+    const d = new WindowDedupe(1000);
+    expect(d.admit("tg-1", 0)).toBe(true);
+    expect(d.admit("tg-1", 10)).toBe(false);
+  });
+
+  test("다른 messageId 는 각각 받는다", () => {
+    const d = new WindowDedupe(1000);
+    expect(d.admit("tg-1", 0)).toBe(true);
+    expect(d.admit("tg-2", 0)).toBe(true);
+  });
+
+  test("★기억 창을 넘기면 다시 받는다★ — 영원히 들고 있지 않는다", () => {
+    const d = new WindowDedupe(1000);
+    expect(d.admit("tg-1", 0)).toBe(true);
+    expect(d.admit("tg-1", 1001)).toBe(true);
+  });
+});
+
+// ── 실제로 창구를 열어 본다 (127.0.0.1 · 토큰 · 멱등) ──
+import { startBridgeWindow } from "./bridgeWindow";
+
+describe("startBridgeWindow — 실제 왕복", () => {
+  async function open(): Promise<{ h: NonNullable<Awaited<ReturnType<typeof startBridgeWindow>>>; file: string; got: unknown[] }> {
+    const dir = mkdtempSync(join(tmpdir(), "cbw-live-"));
+    const pidFile = join(dir, "dex.pid");
+    const got: unknown[] = [];
+    const h = await startBridgeWindow({ agentId: "dex", pidFile, enqueue: (r) => got.push(r) });
+    if (!h) throw new Error("window did not open");
+    return { h, file: join(dir, "dex.window.json"), got };
+  }
+  function post(port: number, token: string | null, body: unknown, ct = "application/json") {
+    return fetch(`http://127.0.0.1:${port}/turn`, {
+      method: "POST",
+      headers: { "content-type": ct, ...(token ? { "x-b3os-token": token } : {}) },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    });
+  }
+
+  test("★정상 요청 → 202 + 큐에 1건★", async () => {
+    const { h, file, got } = await open();
+    const wf = readWindowFile(file)!;
+    const res = await post(h.port, wf.token, req());
+    expect(res.status).toBe(202);
+    expect(got.length).toBe(1);
+    h.close();
+  });
+
+  test("★같은 messageId 두 번 → 두 번째는 큐에 안 들어간다★ (dex 가 두 번 답하면 안 된다)", async () => {
+    const { h, file, got } = await open();
+    const wf = readWindowFile(file)!;
+    expect((await post(h.port, wf.token, req())).status).toBe(202);
+    const second = await post(h.port, wf.token, req());
+    expect(second.status).toBe(200);
+    expect(await second.json()).toEqual({ ok: true, duplicate: true });
+    expect(got.length).toBe(1);
+    h.close();
+  });
+
+  test("★토큰 없이 부르면 401 · 큐는 그대로 0★", async () => {
+    const { h, got } = await open();
+    expect((await post(h.port, null, req())).status).toBe(401);
+    expect(got.length).toBe(0);
+    h.close();
+  });
+
+  test("★다른 팀원 id 로 부르면 403★", async () => {
+    const { h, file, got } = await open();
+    const wf = readWindowFile(file)!;
+    expect((await post(h.port, wf.token, req({ agentId: "codex" }))).status).toBe(403);
+    expect(got.length).toBe(0);
+    h.close();
+  });
+
+  test("★POST /turn 이 아니면 404★ — 창구는 입구가 하나다", async () => {
+    const { h, file } = await open();
+    const wf = readWindowFile(file)!;
+    const res = await fetch(`http://127.0.0.1:${h.port}/other`, {
+      method: "POST", headers: { "content-type": "application/json", "x-b3os-token": wf.token }, body: "{}",
+    });
+    expect(res.status).toBe(404);
+    h.close();
+  });
+
+  test("★닫으면 창구 파일이 사라진다★ — 남으면 서버가 죽은 포트를 부른다", async () => {
+    const { h, file } = await open();
+    expect(readWindowFile(file)).not.toBeNull();
+    h.close();
+    expect(readWindowFile(file)).toBeNull();
+  });
+});

--- a/src/server/runtimes/codex/bridgeWindow.ts
+++ b/src/server/runtimes/codex/bridgeWindow.ts
@@ -1,0 +1,258 @@
+/**
+ * ★브리지의 로컬 창구.★ 서버(telegramCapture)가 그룹 턴을 이 창구로 넣는다.
+ *
+ * 왜 브리지인가 — 다른 런타임과 같은 모양이다. openclaw·hermes 도 서버가 턴을 도는 게 아니라
+ * ★런타임을 소유한 프로세스★ 를 부른다(`OPENCLAW_GATEWAY_URL`). codex 에서 그 자리는 브리지다.
+ * 서버가 따로 돌리면 `clientPool` 이 ★모듈 전역(프로세스마다 따로)★ 이라 같은 팀원에 app-server
+ * 자식이 둘 뜨고, 같은 세션 행을 동시에 resume 한다(`serialTurnQueue` 주석의 그 사고).
+ *
+ * ★이 창구는 자기 폴링을 안 지나는 새 입구다★ — 브리지의 중복 방지(update_id offset)가 여기엔
+ * 없다. 그래서 ★messageId 를 멱등키로 여기서 직접 막는다★ (리뷰 지적). 막지 않으면 같은 요청이
+ * 두 번 들어올 때 큐가 ★겹치지 않게 하지만 두 번 돌린다★ = dex 가 두 번 답한다.
+ *
+ * ★202 는 "접수" 지 "답했다" 가 아니다.★ 턴 결과와 배달은 이 응답에 실리지 않는다 —
+ * 답은 팀원이 `send.sh` 로 직접 보낸다(서버는 팀원 대신 말하지 않는다).
+ */
+import { createServer, type Server } from "node:http";
+import { timingSafeEqual, randomBytes } from "node:crypto";
+import { writeFileSync, renameSync, rmSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/** 창구가 받는 한 건. capture 가 정한 것만 담는다 — 브리지는 오너 판정을 하지 않는다. */
+export interface BridgeWindowRequest {
+  agentId: string;
+  groupId: string;
+  threadId: string;
+  messageId: string;
+  body: string;
+  origTgMessageId?: string;
+  teamContext?: string;
+  attachments?: { kind: string; value: string; note?: string }[];
+}
+
+/** 창구 파일에 적히는 것. ★토큰은 이 파일 밖으로 나가지 않는다★ — 로그·audit·에러에 안 싣는다. */
+export interface BridgeWindowFile {
+  port: number;
+  token: string;
+  pid: number;
+  agentId: string;
+}
+
+/** 본문 상한 — 입구에서 자른다(그룹 메시지에 첨부 목록까지 실려도 넉넉하다). */
+export const WINDOW_BODY_LIMIT_BYTES = 256 * 1024;
+
+/** 멱등 기억을 얼마나 들고 있나. 재시도·중복 요청은 이 창 안에서만 오면 막힌다. */
+export const WINDOW_DEDUPE_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * ★파일 경로는 pid 파일 옆이다★ — 브리지가 이미 그 자리에 자기 표식을 쓴다.
+ * `CODEX_BRIDGE_PID_FILE` 이 없으면 창구를 열 자리가 없다는 뜻이라 null 을 준다.
+ */
+export function windowFilePathFor(pidFile: string | undefined, agentId: string): string | null {
+  if (!pidFile) return null;
+  return join(dirname(pidFile), `${agentId}.window.json`);
+}
+
+/**
+ * ★임시파일 → rename 으로 원자 교체.★ 반쯤 쓰인 파일을 서버가 읽는 일이 없어야 한다.
+ * 권한은 0600 — 같은 기계의 다른 사용자가 토큰을 읽으면 안 된다.
+ */
+export function writeWindowFile(path: string, data: BridgeWindowFile): void {
+  const tmp = `${path}.tmp-${process.pid}`;
+  writeFileSync(tmp, JSON.stringify(data), { mode: 0o600 });
+  renameSync(tmp, path);
+}
+
+/**
+ * 창구 파일을 읽는다. ★부르는 쪽은 매 호출 전에 다시 읽는다★ — 브리지가 재시작하면 포트가
+ * 바뀌는데 캐시하고 있으면 ★조용히 안 간다★(리뷰 지적).
+ */
+export function readWindowFile(path: string): BridgeWindowFile | null {
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf8")) as Partial<BridgeWindowFile>;
+    if (typeof raw.port !== "number" || !Number.isInteger(raw.port) || raw.port <= 0) return null;
+    if (typeof raw.token !== "string" || raw.token.length < 16) return null;
+    if (typeof raw.pid !== "number" || !Number.isInteger(raw.pid)) return null;
+    if (typeof raw.agentId !== "string" || !raw.agentId) return null;
+    return { port: raw.port, token: raw.token, pid: raw.pid, agentId: raw.agentId };
+  } catch {
+    return null;
+  }
+}
+
+/** 길이가 달라도 상수 시간에 비교한다 — 길이만으로 토큰을 좁히지 못하게. */
+export function tokensMatch(a: string, b: string): boolean {
+  const ba = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ba.length !== bb.length) {
+    // 길이가 다르면 어차피 불일치지만, 그 사실만으로 빠르게 반환하지 않는다.
+    timingSafeEqual(ba, ba);
+    return false;
+  }
+  return timingSafeEqual(ba, bb);
+}
+
+/**
+ * ★요청을 받을지 판정한다.★ 순수 함수라 서버 없이 잴 수 있다.
+ * 거절 사유를 문자열로 돌려준다 — ★토큰 값은 절대 담지 않는다.★
+ */
+export function decideWindowRequest(
+  req: Partial<BridgeWindowRequest> | null,
+  opts: { selfAgentId: string; presentedToken: string | null; expectedToken: string; contentType: string | null; byteLength: number },
+): { accept: true } | { accept: false; status: number; reason: string } {
+  if (!opts.presentedToken || !tokensMatch(opts.presentedToken, opts.expectedToken)) {
+    return { accept: false, status: 401, reason: "bad_token" };
+  }
+  if (!opts.contentType || !opts.contentType.toLowerCase().startsWith("application/json")) {
+    return { accept: false, status: 415, reason: "bad_content_type" };
+  }
+  if (opts.byteLength > WINDOW_BODY_LIMIT_BYTES) {
+    return { accept: false, status: 413, reason: "body_too_large" };
+  }
+  if (!req || typeof req !== "object") return { accept: false, status: 400, reason: "bad_json" };
+  for (const k of ["agentId", "groupId", "threadId", "messageId", "body"] as const) {
+    if (typeof req[k] !== "string" || !(req[k] as string).trim()) {
+      return { accept: false, status: 400, reason: `missing_${k}` };
+    }
+  }
+  // ★남의 신원으로 도는 것을 막는다★ — 이 창구는 자기 팀원 것만 받는다.
+  if (req.agentId !== opts.selfAgentId) return { accept: false, status: 403, reason: "agent_mismatch" };
+  return { accept: true };
+}
+
+/**
+ * ★messageId 로 중복을 막는다.★ 진행중과 최근 완료를 같이 본다 —
+ * 끝난 직후 다시 오는 재시도도 같은 턴을 두 번 돌리면 안 된다.
+ */
+export class WindowDedupe {
+  private seen = new Map<string, number>();
+  constructor(private readonly ttlMs = WINDOW_DEDUPE_TTL_MS) {}
+
+  /** 처음 보는 것이면 true(받는다). 이미 본 것이면 false. */
+  admit(messageId: string, nowMs: number): boolean {
+    this.sweep(nowMs);
+    if (this.seen.has(messageId)) return false;
+    this.seen.set(messageId, nowMs);
+    return true;
+  }
+
+  private sweep(nowMs: number): void {
+    for (const [id, at] of this.seen) if (nowMs - at > this.ttlMs) this.seen.delete(id);
+  }
+}
+
+export interface BridgeWindowDeps {
+  agentId: string;
+  pidFile: string | undefined;
+  /** 턴을 큐에 넣는다. ★기다리지 않는다★ — 창구는 접수(202)까지만 책임진다. */
+  enqueue: (req: BridgeWindowRequest) => void;
+  log?: (line: string) => void;
+  now?: () => number;
+}
+
+export interface BridgeWindowHandle {
+  port: number;
+  close: () => void;
+}
+
+/**
+ * 창구를 연다. ★127.0.0.1 에만 붙는다★ — 밖에서 이 창구에 닿을 수 없어야 한다.
+ * 열지 못하면 null 을 준다(창구 없이도 1:1 은 그대로 돈다 — 창구 실패가 브리지를 죽이지 않는다).
+ */
+export async function startBridgeWindow(deps: BridgeWindowDeps): Promise<BridgeWindowHandle | null> {
+  const filePath = windowFilePathFor(deps.pidFile, deps.agentId);
+  if (!filePath) {
+    deps.log?.("[codex-bridge] 창구 못 엶: pid 파일 경로가 없다");
+    return null;
+  }
+  const token = randomBytes(32).toString("hex");
+  const dedupe = new WindowDedupe();
+  const now = deps.now ?? (() => Date.now());
+
+  const server: Server = createServer((req, res) => {
+    void (async () => {
+      const reject = (status: number, reason: string) => {
+        res.writeHead(status, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: false, reason }));
+      };
+      if (req.method !== "POST" || req.url !== "/turn") return reject(404, "not_found");
+      const chunks: Buffer[] = [];
+      let size = 0;
+      for await (const c of req) {
+        size += (c as Buffer).length;
+        if (size > WINDOW_BODY_LIMIT_BYTES) return reject(413, "body_too_large");
+        chunks.push(c as Buffer);
+      }
+      const raw = Buffer.concat(chunks);
+      let parsed: Partial<BridgeWindowRequest> | null = null;
+      try {
+        parsed = JSON.parse(raw.toString("utf8")) as Partial<BridgeWindowRequest>;
+      } catch {
+        parsed = null;
+      }
+      const verdict = decideWindowRequest(parsed, {
+        selfAgentId: deps.agentId,
+        presentedToken: (req.headers["x-b3os-token"] as string | undefined) ?? null,
+        expectedToken: token,
+        contentType: (req.headers["content-type"] as string | undefined) ?? null,
+        byteLength: raw.length,
+      });
+      if (!verdict.accept) {
+        // ★거절 사유는 남기되 토큰은 안 남긴다.★
+        deps.log?.(`[codex-bridge] 창구 거절: ${verdict.reason}`);
+        return reject(verdict.status, verdict.reason);
+      }
+      const body = parsed as BridgeWindowRequest;
+      if (!dedupe.admit(body.messageId, now())) {
+        // 이미 받은 것 — ★큐에 두 번 넣지 않는다.★ 200 으로 "이미 접수" 를 알린다.
+        deps.log?.(`[codex-bridge] 창구 중복 무시: msg=${body.messageId}`);
+        res.writeHead(200, { "content-type": "application/json" });
+        return res.end(JSON.stringify({ ok: true, duplicate: true }));
+      }
+      deps.enqueue(body);
+      // ★202 = 큐에 넣었다.★ 턴이 끝났다는 뜻도, 답이 갔다는 뜻도 아니다.
+      res.writeHead(202, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, queued: true }));
+    })().catch(() => {
+      try {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: false, reason: "window_error" }));
+      } catch {
+        /* 응답 실패가 브리지를 죽이지 않는다 */
+      }
+    });
+  });
+
+  const port = await new Promise<number | null>((resolve) => {
+    server.once("error", () => resolve(null));
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      resolve(typeof addr === "object" && addr ? addr.port : null);
+    });
+  });
+  if (port === null) {
+    deps.log?.("[codex-bridge] 창구 못 엶: listen 실패");
+    return null;
+  }
+
+  writeWindowFile(filePath, { port, token, pid: process.pid, agentId: deps.agentId });
+  deps.log?.(`[codex-bridge] 창구 열림 127.0.0.1:${port} (${filePath})`);
+
+  return {
+    port,
+    close: () => {
+      try {
+        // ★자기 것만 지운다★ — 다른 인스턴스가 이미 덮어썼으면 그건 그쪽 파일이다.
+        const cur = readWindowFile(filePath);
+        if (cur && cur.pid === process.pid) rmSync(filePath, { force: true });
+      } catch {
+        /* 정리 실패가 종료를 막지 않는다 */
+      }
+      try {
+        server.close();
+      } catch {
+        /* noop */
+      }
+    },
+  };
+}

--- a/src/server/runtimes/codex/bridgeWindow.ts
+++ b/src/server/runtimes/codex/bridgeWindow.ts
@@ -235,7 +235,20 @@ export async function startBridgeWindow(deps: BridgeWindowDeps): Promise<BridgeW
     return null;
   }
 
-  writeWindowFile(filePath, { port, token, pid: process.pid, agentId: deps.agentId });
+  // ★파일을 못 쓰면 창구를 연 채로 두지 않는다★ (리뷰 지적).
+  //   파일이 없으면 부르는 쪽이 이 포트를 알 수 없으니 ★아무도 못 부르는 리스너★ 가 남는다.
+  //   그런 리스너는 프로세스를 붙잡고 있어 종료도 방해한다. 열었으면 닫고 실패로 돌려준다.
+  try {
+    writeWindowFile(filePath, { port, token, pid: process.pid, agentId: deps.agentId });
+  } catch (e) {
+    try {
+      server.close();
+    } catch {
+      /* 닫기 실패가 이 실패를 가리지 않는다 */
+    }
+    deps.log?.(`[codex-bridge] 창구 못 엶: 파일 기록 실패(${(e as Error).message})`);
+    return null;
+  }
   deps.log?.(`[codex-bridge] 창구 열림 127.0.0.1:${port} (${filePath})`);
 
   return {

--- a/src/server/runtimes/codex/dmSessionStore.test.ts
+++ b/src/server/runtimes/codex/dmSessionStore.test.ts
@@ -91,3 +91,57 @@ describe("1:1 세션 기억 — 재시작 연속성", () => {
     expect(() => s.clear(111)).not.toThrow();
   });
 });
+
+// ── ★그룹과 1:1 은 다른 surface 로 적힌다★ (2026-08-24) ──
+//
+// 섞어도 chatId 가 달라 충돌은 안 나지만 ★이름이 거짓말★ 이 된다. 6.8 을 재는 판별자
+// (`created_at` 보존)도 두 대화가 한 이름에 섞이면 못 쓰게 된다.
+import { makeChatSessionStore, GROUP_SURFACE } from "./dmSessionStore";
+
+describe("makeChatSessionStore — chatId 부호로 surface 를 고른다", () => {
+  function fresh(): { db: Database; path: string } {
+    const dir = mkdtempSync(join(tmpdir(), "css-"));
+    const path = join(dir, "team.db");
+    const db = new Database(path);
+    migrate(db);
+    db.prepare(
+      `INSERT INTO agent (id, display_name, role, runtime, status_provider, workspace_path, persona_file)
+       VALUES ('dex','Dex','Dev','codex','codex_cli','','')`,
+    ).run();
+    db.close();
+    return { db: new Database(path), path };
+  }
+  const surfaceOf = (db: Database, key: string): string | undefined =>
+    (db.prepare(`SELECT surface AS s FROM codex_session_map WHERE conversation_key = ?`).get(key) as { s: string } | undefined)?.s;
+
+  test("★그룹(음수 chatId)은 telegram_group 으로 적힌다★", () => {
+    const { db, path } = fresh();
+    makeChatSessionStore("dex", path).save(-1003947108339, "sess-g");
+    expect(surfaceOf(db, "-1003947108339")).toBe(GROUP_SURFACE);
+  });
+
+  test("1:1(양수 chatId)은 telegram_dm 그대로", () => {
+    const { db, path } = fresh();
+    makeChatSessionStore("dex", path).save(7066867819, "sess-d");
+    expect(surfaceOf(db, "7066867819")).toBe(DM_SURFACE);
+  });
+
+  test("★두 대화가 서로를 안 덮는다★ — 각자 자기 세션을 돌려준다", () => {
+    const { path } = fresh();
+    const s = makeChatSessionStore("dex", path);
+    s.save(-100, "sess-group");
+    s.save(200, "sess-dm");
+    expect(s.get(-100)).toBe("sess-group");
+    expect(s.get(200)).toBe("sess-dm");
+  });
+
+  test("★지울 때도 자기 surface 만★ — 그룹을 지워도 1:1 은 남는다", () => {
+    const { path } = fresh();
+    const s = makeChatSessionStore("dex", path);
+    s.save(-100, "sess-group");
+    s.save(200, "sess-dm");
+    s.clear(-100);
+    expect(s.get(-100)).toBeUndefined();
+    expect(s.get(200)).toBe("sess-dm");
+  });
+});

--- a/src/server/runtimes/codex/dmSessionStore.ts
+++ b/src/server/runtimes/codex/dmSessionStore.ts
@@ -17,6 +17,13 @@ import { CodexSessionStore } from "./state";
 /** 이 표에서 1:1 대화가 쓰는 surface. 버스(team_bus)와 갈라 둔다. */
 export const DM_SURFACE = "telegram_dm";
 
+/**
+ * ★그룹방이 쓰는 surface.★ 1:1 과 갈라 둔다 — chatId 가 달라서 섞어도 충돌은 안 나지만
+ *   ★섞으면 이름이 거짓말이 된다★(리뷰 지적). 6.8 을 재는 판별자(`created_at` 보존)도
+ *   두 대화가 한 이름에 섞이면 못 쓰게 된다.
+ */
+export const GROUP_SURFACE = "telegram_group";
+
 export interface DmSessionStore {
   /** 이 대화의 지난 세션. 없으면 undefined(새 대화로 시작). */
   get: (chatId: number) => string | undefined;
@@ -38,7 +45,7 @@ export const NOOP_DM_SESSION_STORE: DmSessionStore = {
  * ★DB 문제가 대화를 막지 않는다★ — 읽기 실패는 '지난 세션 없음', 쓰기 실패는 조용히 넘긴다.
  * 맥락이 끊기는 것은 불편이지만, 답을 못 하는 것은 고장이다.
  */
-export function makeDmSessionStore(agentId: string, dbPath: string): DmSessionStore {
+export function makeDmSessionStore(agentId: string, dbPath: string, surface: string = DM_SURFACE): DmSessionStore {
   let db: Database | null = null;
   const open = (): Database | null => {
     if (db) return db;
@@ -56,7 +63,7 @@ export function makeDmSessionStore(agentId: string, dbPath: string): DmSessionSt
   return {
     get: (chatId) => {
       try {
-        return store()?.get(agentId, DM_SURFACE, String(chatId));
+        return store()?.get(agentId, surface, String(chatId));
       } catch {
         return undefined;
       }
@@ -65,7 +72,7 @@ export function makeDmSessionStore(agentId: string, dbPath: string): DmSessionSt
       try {
         store()?.save({
           agentId,
-          surface: DM_SURFACE,
+          surface,
           conversationKey: String(chatId),
           codexSessionId: sessionId,
         });
@@ -75,8 +82,25 @@ export function makeDmSessionStore(agentId: string, dbPath: string): DmSessionSt
       try {
         open()?.prepare(
           `DELETE FROM codex_session_map WHERE agent_id = ? AND surface = ? AND conversation_key = ?`,
-        ).run(agentId, DM_SURFACE, String(chatId));
+        ).run(agentId, surface, String(chatId));
       } catch { /* 지우기 실패가 답을 막지 않는다 */ }
     },
+  };
+}
+
+/**
+ * ★대화 종류에 따라 surface 를 고르는 저장소.★ 텔레그램 그룹 chat id 는 ★음수★ 다.
+ *
+ * 한 저장소로 두 surface 를 쓰면 그룹 행이 `telegram_dm` 으로 적혀 ★이름이 거짓말★ 이 된다.
+ * 그렇다고 파일을 하나 더 만들면 같은 코드가 두 벌이 된다 — ★surface 만 갈라 끼운다.★
+ */
+export function makeChatSessionStore(agentId: string, dbPath: string): DmSessionStore {
+  const dm = makeDmSessionStore(agentId, dbPath, DM_SURFACE);
+  const group = makeDmSessionStore(agentId, dbPath, GROUP_SURFACE);
+  const pick = (chatId: number): DmSessionStore => (chatId < 0 ? group : dm);
+  return {
+    get: (chatId) => pick(chatId).get(chatId),
+    save: (chatId, sessionId) => pick(chatId).save(chatId, sessionId),
+    clear: (chatId) => pick(chatId).clear(chatId),
   };
 }

--- a/src/server/runtimes/codex/serialTurnQueue.test.ts
+++ b/src/server/runtimes/codex/serialTurnQueue.test.ts
@@ -63,3 +63,19 @@ test("사슬이 끝나면 비었다고 보고한다 — 진단용", async () => 
   await q.drain();
   expect(q.idle()).toBe(true);
 });
+
+// ★종료할 때 남은 턴을 세려면 개수를 물어볼 수 있어야 한다★ —
+//   창구는 202(접수)까지만 답하므로, 접수된 채 사라진 턴은 이 값 없이는 기록조차 안 남는다.
+test("pendingCount — 접수된 채 아직 안 끝난 턴 수를 준다", async () => {
+  const q = createSerialTurnQueue();
+  expect(q.pendingCount()).toBe(0);
+  let release: (() => void) | null = null;
+  q.enqueue(() => new Promise<void>((r) => { release = r; }));
+  q.enqueue(async () => {});
+  expect(q.pendingCount()).toBe(2);
+  // 사슬은 마이크로태스크로 돈다 — 첫 턴이 실제로 시작할 틈을 준다.
+  await new Promise((r) => setTimeout(r, 0));
+  release!();
+  await q.drain();
+  expect(q.pendingCount()).toBe(0);
+});

--- a/src/server/runtimes/codex/serialTurnQueue.ts
+++ b/src/server/runtimes/codex/serialTurnQueue.ts
@@ -28,6 +28,8 @@ export interface SerialTurnQueue {
   enqueue: (run: () => Promise<void>) => void;
   /** 사슬이 비어 있나(시험·진단용). */
   idle: () => boolean;
+  /** ★아직 안 끝난 턴 수.★ 종료할 때 남은 것을 세어 기록하는 데 쓴다. */
+  pendingCount: () => number;
   /** 지금 사슬이 끝날 때까지(시험용). */
   drain: () => Promise<void>;
 }
@@ -52,6 +54,7 @@ export function createSerialTurnQueue(onError?: (err: unknown) => void): SerialT
   return {
     enqueue,
     idle: () => pending === 0,
+    pendingCount: () => pending,
     drain: async () => { await chain; },
   };
 }

--- a/src/server/workers/telegramCapture.ts
+++ b/src/server/workers/telegramCapture.ts
@@ -2,6 +2,8 @@ import type { AgentRecord, WsEvent } from "../types";
 import type { Database } from "bun:sqlite";
 import { routeTeamMessageHybrid } from "../lib/teamRouter";
 import { setGroupOwner, getGroupOwners } from "../lib/groupOwner";
+import { callCodexBridge } from "../lib/codexBridgeClient";
+import { codexBridgePaths } from "../runtimes/codex/launcher";
 import { appendAuditFile } from "../lib/auditFile";
 import { injectPrompt } from "../lib/tmuxInject";
 import { injectOpenclawTelegramTurn } from "../lib/openclawBridge";
@@ -1260,6 +1262,45 @@ export function startTelegramCapture(deps: CaptureDeps): () => void {
                 error: e instanceof Error ? e.message : String(e),
               });
             }
+          })();
+          continue;
+        }
+        if (agent.runtime === "codex") {
+          // ★codex 는 브리지가 세션을 소유한다★ — 서버가 턴을 돌지 않고 그 프로세스의 창구를 부른다.
+          //   openclaw·hermes 와 같은 모양이다(서버 → 런타임 소유 프로세스). 서버가 따로 돌리면
+          //   `clientPool` 이 프로세스마다 따로라 같은 팀원에 app-server 자식이 둘 뜬다.
+          //
+          //   ★재시도하지 않는다★ — 타임아웃이어도 턴은 브리지에서 계속 돌 수 있다. 다시 부르면 이중응답이다.
+          //   ★202 는 접수지 배달이 아니다★ — 답은 dex 가 `send.sh --to broadcast` 로 직접 보낸다.
+          appendAuditFile("capture", "injection", id, { mode: "codex", ok: "queued", async: true, text: text.slice(0, 120) });
+          void (async () => {
+            const r = await callCodexBridge(
+              {
+                agentId: id,
+                groupId: String(GROUP_ID),
+                threadId,
+                messageId,
+                body: deliveryBody,
+                origTgMessageId,
+                teamContext: scopedTeamContext,
+                attachments: mediaAttachments(media),
+              },
+              { pidFile: codexBridgePaths(id).pidFile },
+            );
+            if (r.ok) {
+              console.log(`[capture] injected codex → ${id}: ${r.duplicate ? "duplicate(ignored)" : "queued"}`);
+              appendAuditFile("capture", "injection", id, {
+                mode: "codex", ok: true, duplicate: r.duplicate, async: true, text: text.slice(0, 120),
+              });
+              return;
+            }
+            // ★`no_supported_path` 를 재사용하지 않는다★ — 그 이름은 "분기가 없다" 전용이다(리뷰 지적).
+            //   창구 장애를 같은 이름으로 적으면 분기 누락을 찾던 신호가 무뎌진다.
+            const action = r.reason === "timeout" ? "codex_bridge_timeout" : "codex_bridge_unreachable";
+            console.log(`[capture] codex bridge ${r.reason} → ${id}`);
+            appendAuditFile("capture", action, id, {
+              reason: r.reason, status: r.status ?? null, text: text.slice(0, 120),
+            });
           })();
           continue;
         }


### PR DESCRIPTION
그룹방에서 `runtime='codex'` 팀원이 침묵하는 문제를 고칩니다. **다른 런타임과 같은 모양**으로 맞춥니다.

## 원인

`telegramCapture.runInjection` 은 런타임별로 갈리는데 분기가 셋뿐입니다(`claude_channel`·`openclaw`·`hermes_agent`). `runtime='codex'` 는 마지막 줄로 떨어집니다:

```
actor=capture · action=injection_skip · reason=no_supported_path   (실측 3건)
```

버스도 깨우지 않습니다 — 텔레그램 사용자 메시지의 수신 행은 삽입 시점에 `'completed'` 이고(`db/inbox/messages.ts`), 이유가 `db/inbox/dispatch.ts` 주석에 있습니다: *"the channel poller delivers them"*. 그 "channel poller" 가 native 브리지였고, 그룹 native 를 막으면서 **배달 경로가 0** 이 됐습니다.

## 왜 브리지에 창구인가

`openclaw`·`hermes` 는 서버가 턴을 도는 게 아니라 **런타임을 소유한 프로세스**를 부릅니다(`OPENCLAW_GATEWAY_URL`). codex 에서 그 자리는 서버가 아니라 **브리지**입니다.

서버가 따로 돌리면:

```
appServerRunner.ts:92  acquireClient(opts.agentId, …)      ← 클라이언트는 팀원 단위 풀
clientPool.ts:22       const pool = new Map(...)           ← ★모듈 전역 = 프로세스마다 따로★
serialTurnQueue.ts     "runTurn 에는 동시 진입 가드가 없다"
```

= 같은 팀원에 app-server 자식이 둘 뜨고, 같은 세션 행을 **동시에 resume** 합니다.

## 무엇이 들어가나

**`bridgeWindow.ts`** — 브리지의 로컬 창구
- `127.0.0.1` 전용 · 포트 0(커널 배정) · `POST /turn` 하나
- 포트·토큰·pid 를 pid 파일 옆에 **임시파일 → rename 원자 교체**, `0600`
- **timing-safe** 토큰 대조 · 자기 `agentId` 만 수락 · content-type · 본문 상한
- **`messageId` 멱등** — 이 창구는 폴링의 `update_id` 중복 방지를 안 지나므로 여기서 직접 막습니다
- **`202` 는 접수**지 "답했다" 가 아닙니다
- 토큰은 로그·에러·거절 사유에 **안 담습니다**

**`codexBridgeClient.ts`** — 서버 쪽 호출부
- **매 호출 전에 창구 파일을 다시 읽습니다** — 브리지가 재시작하면 포트가 바뀝니다
- **재시도하지 않습니다** — 타임아웃이어도 턴은 계속 돌 수 있고, 재시도가 곧 이중응답입니다
- 끊긴 것(`unreachable`)과 늦은 것(`timeout`)을 가릅니다

**`telegramCapture`** — codex 분기
- 실패 사유를 `codex_bridge_unreachable` / `codex_bridge_timeout` 으로 남깁니다
- **`no_supported_path` 를 재사용하지 않습니다** — 그 이름은 "분기가 없다" 전용이고, 이 버그를 찾은 신호입니다

**`handleMessage` 에 `ingress` 인자**
- 그룹 native 차단은 **폴링 입구의 것**입니다 — 그 입구엔 오너 판정이 없어 남을 부른 메시지에도 답했습니다
- 창구는 서버가 오너를 정한 뒤 넣으므로 그 차단을 지나지 않습니다. **플래그로 게이트를 끄는 게 아니라, 게이트가 애초에 그 입구의 것입니다**

**세션 저장소에 `surface` 인자** — 그룹은 `telegram_group` 으로 갈라 적습니다. 섞으면 이름이 거짓말이 되고, 6.8 을 재는 판별자(`created_at` 보존)도 못 쓰게 됩니다.

**리액션은 그 팀원 봇으로** — 팀 op 봇이 달면 "누가 받았는지" 가 안 보입니다.

## 검증

- `bun test src/server/runtimes/codex/ src/server/workers/ src/server/lib/` → **1531 pass · 0 fail**
- 새 시험 **43건**: 창구 파일(권한·깨진 값·주인) · 토큰 비교 · 요청 판정 8경로 · 멱등 3 · **실제 왕복 6**(202/중복 200/401/403/404/파일 정리) · 호출부 10 · `ingress` 2 · `surface` 4
- **뮤턴트 4건 전부 잡힙니다**

```
agentId 검사 제거      → "남의 신원으로는 못 돈다" · 실제 왕복 403  실패
멱등 제거              → "두 번째는 안 받는다" · 실제 왕복 중복      실패
ingress 조건 제거      → "창구 입구는 차단을 지나지 않는다"          실패
surface 라우팅 무력화  → "그룹은 telegram_group 으로 적힌다"        실패
```

복원 후 113 pass / 0 fail.

## 배포 순서 — 순서를 틀리면 그룹이 조용해집니다

```
① 코드 배포 → ② ★라이브에 분기가 실제로 있는지 확인★ → ③ dex-launch.sh 의
   CODEX_GROUP_NATIVE_DENY=false 줄 삭제(→ 코드 기본값 true 로 복귀) → ④ 브리지 재기동
```

②를 건너뛰고 ③을 먼저 하면 **native 도 capture 도 없는 상태**가 됩니다.

## 수용 확인 — 부재 하나로 잡지 않습니다

```
양성: from_agent_id='dex' AND to_agent_id='broadcast' AND thread_id LIKE 'tg--%'   ★≥1건★
부재: codex adapter 의 "답이 팀에 도착하지 않았다" 로그 0건
그리고 ★실제로 방에 뜨는지★ — 버스에 남았는데 방에는 안 뜨는 조합이 가능합니다
```

## 켠 뒤 체감 변화 (배포 알림에 넣을 것)

`/api/route` 를 `self=dex` 로 물어본 값 중:

```
"복잡하게 말하지 말고 다른팀원처럼 만들어"  → suppress=false  targets=[dex]  (active_assignee_followup)
```

= **@멘션 없는 메시지에도 dex 가 답하기 시작합니다.** 기존 라우팅 규칙이라 결함은 아니지만, 켠 직후 "왜 덱스가 끼어들지" 로 보일 자리입니다.

## 남는 구멍 (과대주장하지 않습니다)

- `unknown_agent` · `telegram_mention_plugin_path` 는 runtime 분기보다 **위**에서 `continue` 하므로 이 분기에 오지 않습니다
- capture 가 만드는 행이 wake 후보가 아닌 것은 `(source==='user' && !dispatch)` 조건에 달려 있습니다 — 누가 `dispatch` 를 켜면 창구 + 버스로 두 번 돕니다. **지금 통과는 우연이 아니라 조건부입니다**
