### PR TITLE
fix(codex-bridge): 창구 경로는 서버가 대신 말하지 않는다

### DIFF
--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -1093,3 +1093,78 @@ describe("codex bridge — 진행 중 작업에 끼어들기", () => {
     expect(t).toContain("이 메시지에도 답해라");
   });
 });
+
+// ── ★조립된 값을 잰다★ — 부품 시험은 다 통과하는데 조립하면 뒤집혀 있었다 ──
+//
+// 경고는 `res.ok` 를 읽는 자리에 있었는데, 창구 경로는 발신을 일부러 떼서 `ok` 가 ★항상 false★ 다.
+// 그래서 ★정상 성공에도 경고가 떴다.★ 부품(문자열·발신 0회)만 재는 시험은 이걸 못 잡는다.
+import { runGroupTurn } from "./bridge";
+
+describe("runGroupTurn — 성공·반환실패·예외실패가 서로 다르게 보인다", () => {
+  type Ctx = Parameters<typeof runGroupTurn>[0];
+  function make(run: unknown): { reacts: string[]; audits: Record<string, unknown>[]; ctx: Ctx } {
+    const reacts: string[] = [];
+    const audits: Record<string, unknown>[] = [];
+    const ctx = {
+      deps: {
+        sendMessage: async () => 1,
+        editMessage: async () => true,
+        reactMessage: async (_c: number, _m: number, e: string) => { reacts.push(e); return true; },
+      },
+      agentId: "dex",
+      repoRoot: "/repo",
+      chatId: -100,
+      tgMsgId: 42,
+      req: { body: "@덱스 들려?", threadId: "tg--100", messageId: "tg-1" },
+      audit: (_a: string, _t: string, d: Record<string, unknown>) => { audits.push(d); },
+      run,
+    } as unknown as Ctx;
+    return { reacts, audits, ctx };
+  }
+
+  test("★턴 성공 → 경고가 안 뜬다★ (발신을 뗐어도 성공은 성공이다)", async () => {
+    const { reacts, audits, ctx } = make(async () => ({ ok: false, turnOk: true, reply: "네", detail: "send_failed" }));
+    await runGroupTurn(ctx);
+    expect(reacts).toEqual([]);
+    expect(audits[0]?.turn_ok).toBe(true);
+    // ★send_failed 를 실패 사유로 적지 않는다★ — 이 경로의 기대값이다
+    expect(audits[0]?.detail).toBe("turn_ok");
+  });
+
+  test("★턴 실패(반환) → 경고 + 실패 audit★", async () => {
+    const { reacts, audits, ctx } = make(async () => ({ ok: false, turnOk: false, reply: "", detail: "codex_turn_failed:empty" }));
+    await runGroupTurn(ctx);
+    expect(reacts).toEqual(["⚠️"]);
+    expect(audits[0]?.turn_ok).toBe(false);
+    expect(audits[0]?.detail).toBe("codex_turn_failed:empty");
+  });
+
+  test("★턴이 던져도 같은 모양으로 보인다★ — 큐 catch 에 맡기면 눈 표시만 남는다", async () => {
+    const { reacts, audits, ctx } = make(async () => { throw new Error("boom"); });
+    await runGroupTurn(ctx);
+    expect(reacts).toEqual(["⚠️"]);
+    expect(audits[0]?.turn_ok).toBe(false);
+    expect(String(audits[0]?.detail)).toContain("threw:");
+  });
+
+  test("★턴에 넘어가는 본문에 send.sh 명령이 실려 있다★ — 조립된 값으로 확인", async () => {
+    let seen = "";
+    const { ctx } = make(async (_c: number, body: string) => {
+      seen = body;
+      return { ok: false, turnOk: true, reply: "", detail: "send_failed" };
+    });
+    await runGroupTurn(ctx);
+    expect(seen).toContain("--to broadcast");
+    expect(seen).toContain("--body-file");
+  });
+
+  test("★턴에 넘어가는 deps 는 발신이 떨어져 있다★", async () => {
+    let sent: unknown = "unset";
+    const { ctx } = make(async (_c: number, _b: string, _m: unknown, deps: { sendMessage: () => Promise<unknown> }) => {
+      sent = await deps.sendMessage();
+      return { ok: false, turnOk: true, reply: "", detail: "send_failed" };
+    });
+    await runGroupTurn(ctx);
+    expect(sent).toBeNull();
+  });
+});

--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -1168,3 +1168,17 @@ describe("runGroupTurn — 성공·반환실패·예외실패가 서로 다르�
     expect(sent).toBeNull();
   });
 });
+
+// ── ★안내 문구를 '발신' 으로 전하는 경로는 창구에서 실패다★ (리뷰 지적) ──
+//
+// 예약 요청인데 예약 도구가 꺼져 있으면 LLM 앞에서 조기 반환하며 안내 문구를 ★보낸다.★
+// 그런데 창구 경로는 그 발신을 뗐다 — 그러면 ★답 0건 · 경고 없음 · 성공 기록★ 이 되어
+// 사람도 기록도 "잘 됐다" 로 읽는다. 아무것도 전달되지 않았으므로 실패로 보여야 한다.
+test("★예약 미지원 안내는 창구에서 실패로 보인다★ — 답 0건인데 성공으로 적히면 안 된다", async () => {
+  const { deps } = spies(() => ok("답"));
+  // 예약 도구가 꺼진 상태(기본값)에서 예약형 문장을 넣는다.
+  const r = await handleMessage(-123, "10분 뒤에 알려줘", 55, deps, undefined, "window");
+  expect(r.detail).toContain("schedule");
+  // ★turnOk 가 거짓이어야 창구 경로가 경고를 띄운다★
+  expect(r.turnOk).toBe(false);
+});

--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -18,6 +18,7 @@ import {
   tgEdit,
   isTurnRunningFor,
   buildDmSteerText,
+  noAutopostDeps,
 } from "./bridge";
 import type { CodexTurnResult } from "./runner";
 import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
@@ -1091,5 +1092,35 @@ describe("codex bridge — 진행 중 작업에 끼어들기", () => {
     expect(t).toContain("로그인이 안되면 알려줘");
     expect(t).toContain("반영해서 계속하라");
     expect(t).toContain("이 메시지에도 답해라");
+  });
+});
+
+// ── ★창구 경로는 서버가 대신 말하지 않는다★ (2026-08-24 실측) ──
+describe("noAutopostDeps — 발신만 떼고 리액션은 남긴다", () => {
+  test("★sendMessage·editMessage 가 아무것도 안 보낸다★", async () => {
+    let sent = 0, edited = 0;
+    const base = {
+      sendMessage: async () => { sent += 1; return 1; },
+      editMessage: async () => { edited += 1; return true; },
+    } as unknown as Parameters<typeof noAutopostDeps>[0];
+    const d = noAutopostDeps(base);
+    expect(await d.sendMessage!(1, "x")).toBeNull();
+    expect(await d.editMessage!(1, 2, "x")).toBe(false);
+    expect(sent).toBe(0);
+    expect(edited).toBe(0);
+  });
+
+  test("★리액션은 그대로 남는다★ — '그 팀원이 받았다' 는 발신과 다른 값이다", async () => {
+    let reacted = 0;
+    const base = { reactMessage: async () => { reacted += 1; return true; } } as unknown as Parameters<typeof noAutopostDeps>[0];
+    await noAutopostDeps(base).reactMessage!(1, 2, "👀");
+    expect(reacted).toBe(1);
+  });
+
+  test("나머지 deps 는 그대로 넘어간다", () => {
+    const base = { agentId: "dex", teamBaseUrl: "http://x" } as unknown as Parameters<typeof noAutopostDeps>[0];
+    const d = noAutopostDeps(base);
+    expect(d.agentId).toBe("dex");
+    expect(d.teamBaseUrl).toBe("http://x");
   });
 });

--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -18,7 +18,6 @@ import {
   tgEdit,
   isTurnRunningFor,
   buildDmSteerText,
-  noAutopostDeps,
 } from "./bridge";
 import type { CodexTurnResult } from "./runner";
 import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
@@ -1092,35 +1091,5 @@ describe("codex bridge — 진행 중 작업에 끼어들기", () => {
     expect(t).toContain("로그인이 안되면 알려줘");
     expect(t).toContain("반영해서 계속하라");
     expect(t).toContain("이 메시지에도 답해라");
-  });
-});
-
-// ── ★창구 경로는 서버가 대신 말하지 않는다★ (2026-08-24 실측) ──
-describe("noAutopostDeps — 발신만 떼고 리액션은 남긴다", () => {
-  test("★sendMessage·editMessage 가 아무것도 안 보낸다★", async () => {
-    let sent = 0, edited = 0;
-    const base = {
-      sendMessage: async () => { sent += 1; return 1; },
-      editMessage: async () => { edited += 1; return true; },
-    } as unknown as Parameters<typeof noAutopostDeps>[0];
-    const d = noAutopostDeps(base);
-    expect(await d.sendMessage!(1, "x")).toBeNull();
-    expect(await d.editMessage!(1, 2, "x")).toBe(false);
-    expect(sent).toBe(0);
-    expect(edited).toBe(0);
-  });
-
-  test("★리액션은 그대로 남는다★ — '그 팀원이 받았다' 는 발신과 다른 값이다", async () => {
-    let reacted = 0;
-    const base = { reactMessage: async () => { reacted += 1; return true; } } as unknown as Parameters<typeof noAutopostDeps>[0];
-    await noAutopostDeps(base).reactMessage!(1, 2, "👀");
-    expect(reacted).toBe(1);
-  });
-
-  test("나머지 deps 는 그대로 넘어간다", () => {
-    const base = { agentId: "dex", teamBaseUrl: "http://x" } as unknown as Parameters<typeof noAutopostDeps>[0];
-    const d = noAutopostDeps(base);
-    expect(d.agentId).toBe("dex");
-    expect(d.teamBaseUrl).toBe("http://x");
   });
 });

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -615,8 +615,11 @@ export async function handleMessage(
     const sent = await send(chatId, SCHEDULE_UNSUPPORTED_TEXT);
     return {
       ok: sent !== null,
-      // 턴을 안 돌린 것이지 실패한 게 아니다 — 창구 경로에서 경고를 띄울 일이 아니다.
-      turnOk: true,
+      // ★창구 경로에서는 실패다★ (리뷰 지적): 여기서는 안내 문구를 ★발신으로★ 전하는데,
+      //   그 경로는 발신을 뗐다 — 그러면 ★답 0건 · 경고 없음 · 성공 기록★ 이 되어
+      //   사람도 기록도 "잘 됐다" 로 읽는다. 아무것도 전달되지 않았으므로 turnOk 는 거짓이다.
+      //   1:1 은 실제로 보내므로 `ok` 로 판정되어 영향이 없다.
+      turnOk: false,
       reply: SCHEDULE_UNSUPPORTED_TEXT,
       detail: sent !== null ? "schedule_unsupported" : "send_failed",
     };

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -471,6 +471,64 @@ async function fetchOwnerGate(
 }
 
 /**
+ * ★창구(그룹) 턴 한 건을 돌린다.★ 호출부를 시험할 수 있게 떼어 뒀다.
+ *
+ * ★서버는 팀원 대신 말하지 않는다★ (hermes 와 같은 계약 · 실측):
+ *   전에는 이 경로도 `handleMessage` 의 텔레그램 발신을 그대로 탔다 — 방에는 떴지만
+ *   ★버스에는 아무 기록이 없었다.★ 같은 방에서 claude 팀원의 답은 남고 이쪽만 0건이었다.
+ *   그룹 native 차단은 ★들어오는 쪽★ 만 막는다 — 나가는 쪽은 여기서 막는다.
+ *
+ * ★실패를 조용히 두지 않는다★: 발신을 뗐으므로 에러 문구도 같이 사라진다 —
+ *   사람 화면에서 "도는 중" 과 "죽었다" 가 같아진다. 리액션은 발신이 아니라 계약을 안 깨므로
+ *   👀 를 ⚠️ 로 바꿔 남긴다. ★반환 실패와 예외 실패를 같은 모양으로★ 남긴다(둘 다 실패다).
+ *
+ * ★`ok` 가 아니라 `turnOk` 를 본다★: `ok` 는 "텔레그램에 보냈나" 라서 이 경로에선 항상 false 다.
+ *   그걸로 판정하면 ★성공할 때마다 실패로 읽는다.★
+ */
+export async function runGroupTurn(ctx: {
+  deps: BridgeDeps;
+  agentId: string;
+  repoRoot: string;
+  chatId: number;
+  tgMsgId: number | undefined;
+  req: { body: string; threadId: string; messageId: string };
+  run?: typeof handleMessage;
+  audit?: (action: string, target: string, detail: Record<string, unknown>) => void;
+}): Promise<void> {
+  const { deps, chatId, tgMsgId, req } = ctx;
+  const run = ctx.run ?? handleMessage;
+  const audit = ctx.audit ?? ((a, t, d) => appendAuditFile("codex_bridge", a, t, d));
+  const warn = () => {
+    if (tgMsgId !== undefined && Number.isFinite(tgMsgId)) void deps.reactMessage?.(chatId, tgMsgId, "⚠️");
+  };
+  // ★한 번만 부른다★ — 발신을 떼는 것과 답 보내는 명령을 넣는 것은 한 쌍이다.
+  const call = groupTurnCall(deps, {
+    repoRoot: ctx.repoRoot,
+    body: req.body,
+    threadId: req.threadId,
+    messageId: req.messageId,
+  });
+  let res: Awaited<ReturnType<typeof handleMessage>>;
+  try {
+    res = await run(chatId, call.body, tgMsgId, call.deps, undefined, "window");
+  } catch (e) {
+    warn();
+    audit("turn_completed_no_autopost", req.messageId, {
+      agent_id: ctx.agentId, thread_id: req.threadId, turn_ok: false, chars: 0,
+      detail: `threw:${e instanceof Error ? e.message.slice(0, 120) : String(e).slice(0, 120)}`,
+    });
+    return;
+  }
+  console.log(`[codex-bridge] 창구 턴 완료(자동게시 없음) → ${res.detail} · ${res.reply.length}자`);
+  audit("turn_completed_no_autopost", req.messageId, {
+    agent_id: ctx.agentId, thread_id: req.threadId, turn_ok: res.turnOk, chars: res.reply.length,
+    // ★send_failed 는 이 경로의 기대값이다★ — 발신을 뗐으므로. 실패 사유로 적으면 전부 거짓값이 된다.
+    detail: res.turnOk ? "turn_ok" : res.detail,
+  });
+  if (!res.turnOk) warn();
+}
+
+/**
  * 텔레그램 메시지 1건 처리(순수 로직 — 토큰 불필요, mock 테스트 가능).
  * 흐름: 👀 리액션 → "작업 중…" 게시 → codex 턴 → 작업중 메시지를 답으로 교체(편집 실패 시 신규 발신).
  */
@@ -493,7 +551,7 @@ export async function handleMessage(
    *   ★플래그로 게이트를 끄는 게 아니라, 게이트가 애초에 그 입구의 것이다.★
    */
   ingress: "poll" | "window" = "poll",
-): Promise<{ ok: boolean; reply: string; detail: string }> {
+): Promise<{ ok: boolean; turnOk: boolean; reply: string; detail: string }> {
   // ★브리지도 app-server 로 간다.★
   //   전에는 브리지만 옛 exec 경로였다 — 그래서 ★사람이 직접 말 거는 길에만★ 그때까지의 개선
   //   (중간 개입 · 프로세스 상주 · 서브에이전트 생존 · 승인창)이 하나도 안 붙어 있었다.
@@ -537,7 +595,7 @@ export async function handleMessage(
       if (enforceOn) {
         // 그룹 native 전체 drop (react/runTurn 전 → 👀도 안 찍힘). DM/health 무관(chatId<0 only).
         appendAuditFile("codex_bridge", "group_native_denied", String(messageId), auditFields);
-        return { ok: true, reply: "", detail: "group_native_denied" };
+        return { ok: true, turnOk: true, reply: "", detail: "group_native_denied" };
       }
       // shadow: drop 없이 effective authority audit만 (24h 3자비교로 capture 커버 검증).
       appendAuditFile("codex_bridge", "group_native_shadow", String(messageId), { ...auditFields, shadow: true });
@@ -557,6 +615,8 @@ export async function handleMessage(
     const sent = await send(chatId, SCHEDULE_UNSUPPORTED_TEXT);
     return {
       ok: sent !== null,
+      // 턴을 안 돌린 것이지 실패한 게 아니다 — 창구 경로에서 경고를 띄울 일이 아니다.
+      turnOk: true,
       reply: SCHEDULE_UNSUPPORTED_TEXT,
       detail: sent !== null ? "schedule_unsupported" : "send_failed",
     };
@@ -622,7 +682,7 @@ export async function handleMessage(
     const errText = toMarkdownV2("⚠️ 권한 게이트가 이 Codex 런타임 실행을 막았습니다. 설정 승인이 필요합니다.");
     if (workingMsgId !== null) await edit(chatId, workingMsgId, errText);
     else await send(chatId, errText);
-    return { ok: false, reply: "", detail: `permission_${preflight.tier}:${preflight.rule}` };
+    return { ok: false, turnOk: false, reply: "", detail: `permission_${preflight.tier}:${preflight.rule}` };
   }
   // ★진행 표시★ — codex 가 도구를 시작할 때마다 오는 줄을 모아 "작업 중…" 메시지를 고쳐 쓴다.
   //   창이 없는 런타임이라 이게 없으면 사람 눈에는 몇 분간 문구 하나만 남는다.
@@ -763,7 +823,7 @@ export async function handleMessage(
     // ★마지막 버블에 쓴다★ — 넘김이 일어났으면 첫 버블에 쓸 경우 오류가 진행 줄 위로 올라간다.
     if (bubbleId !== null) await edit(chatId, bubbleId, errText);
     else await send(chatId, errText);
-    return { ok: false, reply: "", detail: `codex_turn_failed:${result.detail}` };
+    return { ok: false, turnOk: false, reply: "", detail: `codex_turn_failed:${result.detail}` };
   }
   // 성공 턴에서 첫 인사를 했다면 영속 마커를 남긴다 → 다음부터(재시작·새 스레드 포함) 재소개 안 함.
   if (!greetedBefore) markGreetedFirstContact(greetAgentId);
@@ -797,7 +857,11 @@ export async function handleMessage(
     const id = await send(chatId, rest);
     if (id === null) { delivered = false; break; }
   }
-  return { ok: delivered, reply, detail: delivered ? "delivered" : "send_failed" };
+  // ★`ok` 와 `turnOk` 는 다른 질문에 답한다★ (리뷰 지적 — 한 이름에 두 뜻이 들어 있었다).
+  //   `ok` = 텔레그램에 ★보냈나★ · `turnOk` = 턴이 ★됐나★.
+  //   창구 경로는 발신을 일부러 뗐으므로 `ok` 는 ★항상 false★ 다 — 거기서 `ok` 로 실패를 판정하면
+  //   ★성공할 때마다 실패로 읽는다.★ 그 경로는 `turnOk` 를 본다.
+  return { ok: delivered, turnOk: true, reply, detail: delivered ? "delivered" : "send_failed" };
 }
 
 /** 테스트/리셋용 — 채팅 thread 맥락 비우기. */
@@ -1195,35 +1259,7 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
       if (tgMsgId !== undefined && Number.isFinite(tgMsgId)) {
         void live.reactMessage?.(chatId, tgMsgId, "👀");
       }
-      turns.enqueue(async () => {
-        // ★서버는 팀원 대신 말하지 않는다★ (hermes 와 같은 계약 · 실측 2026-08-24).
-        //   전에는 이 경로도 `handleMessage` 의 텔레그램 발신을 그대로 탔다 — 방에는 떴지만
-        //   ★버스에는 아무 기록이 없었다.★ 같은 방에서 claude 팀원의 답은 남고 dex 것만 0건이었다
-        //   (대조군으로 확인). 버스만 보는 팀원에게 그 답은 ★존재하지 않는다.★
-        //   그룹 native 차단은 ★들어오는 쪽★ 만 막는다 — 나가는 쪽은 여기서 막는다.
-        //
-        //   ★리액션은 남긴다★ — "그 팀원이 받았다" 를 사람이 보는 신호라 발신과 다른 값이다.
-        // ★한 번만 부른다★ — 발신을 떼는 것과 답 보내는 명령을 넣는 것은 한 쌍이다.
-        //   따로 부르면 나중에 한쪽만 지워져도 컴파일이 통과하고 ★그때 dex 가 조용해진다★(리뷰 지적).
-        const call = groupTurnCall(live, {
-          repoRoot: REPO_ROOT,
-          body: r.body,
-          threadId: r.threadId,
-          messageId: r.messageId,
-        });
-        const res = await handleMessage(chatId, call.body, tgMsgId, call.deps, undefined, "window");
-        // ★본문은 안 남긴다★ — 말한 게 아니라 메모다(hermes 와 같은 기록 모양).
-        console.log(`[codex-bridge] 창구 턴 완료(자동게시 없음) → ${res.detail} · ${res.reply.length}자`);
-        // ★실패를 조용히 두지 않는다★ (리뷰 지적 — 오늘 그룹에서 두 번 났다).
-        //   발신을 뗐으므로 ★에러 문구도 같이 사라진다★ — 사람 화면에서 "도는 중" 과 "죽었다" 가 같아진다.
-        //   리액션은 발신이 아니라서 계약을 안 깬다. 👀 를 ⚠️ 로 바꿔 ★받았지만 못 했다★ 를 남긴다.
-        if (!res.ok && tgMsgId !== undefined && Number.isFinite(tgMsgId)) {
-          void live.reactMessage?.(chatId, tgMsgId, "⚠️");
-        }
-        appendAuditFile("codex_bridge", "turn_completed_no_autopost", r.messageId, {
-          agent_id: liveAgentId, thread_id: r.threadId, detail: res.detail, chars: res.reply.length,
-        });
-      });
+      turns.enqueue(() => runGroupTurn({ deps: live, agentId: liveAgentId, repoRoot: REPO_ROOT, chatId, tgMsgId, req: r }));
     },
   });
   if (windowHandle) {

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -16,7 +16,7 @@ import {
   type DmAttachments, type DmMessageMedia,
 } from "./dmMedia";
 import { createSerialTurnQueue } from "./serialTurnQueue";
-import { startBridgeWindow } from "./bridgeWindow";
+import { startBridgeWindow, groupTurnBody } from "./bridgeWindow";
 import { makeChatSessionStore, NOOP_DM_SESSION_STORE, type DmSessionStore } from "./dmSessionStore";
 import { toMarkdownV2, splitForTelegram, toPlain } from "./telegramMarkdown";
 import { steerActiveTurn } from "./activeTurns";
@@ -474,6 +474,20 @@ async function fetchOwnerGate(
  * 텔레그램 메시지 1건 처리(순수 로직 — 토큰 불필요, mock 테스트 가능).
  * 흐름: 👀 리액션 → "작업 중…" 게시 → codex 턴 → 작업중 메시지를 답으로 교체(편집 실패 시 신규 발신).
  */
+/**
+ * ★서버가 팀원 대신 말하지 못하게 발신을 떼어낸 deps.★
+ *
+ * 창구(그룹) 경로 전용이다. 이 경로의 답은 팀원이 `send.sh --to broadcast` 로 직접 보내야
+ * ★버스에 남고★ 거기서 방으로 릴레이된다. 브리지가 텔레그램으로 바로 쏘면 방에는 뜨지만
+ * ★기록이 아무 데도 없다★ — 같은 방에서 claude 팀원 답은 남고 이쪽만 0건이었다(대조군 실측).
+ *
+ * ★리액션은 떼지 않는다★ — "그 팀원이 받았다" 는 사람이 보는 신호이고 발신과 다른 값이다.
+ * 1:1 경로는 이 함수를 쓰지 않는다(거기서는 브리지가 답하는 게 맞다).
+ */
+export function noAutopostDeps(deps: BridgeDeps): BridgeDeps {
+  return { ...deps, sendMessage: async () => null, editMessage: async () => false };
+}
+
 export async function handleMessage(
   chatId: number,
   text: string,
@@ -1195,8 +1209,27 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
         void live.reactMessage?.(chatId, tgMsgId, "👀");
       }
       turns.enqueue(async () => {
-        const res = await handleMessage(chatId, r.body, tgMsgId, live, undefined, "window");
-        console.log(`[codex-bridge] 창구 턴 → ${res.detail}: ${res.reply.slice(0, 60)}`);
+        // ★서버는 팀원 대신 말하지 않는다★ (hermes 와 같은 계약 · 실측 2026-08-24).
+        //   전에는 이 경로도 `handleMessage` 의 텔레그램 발신을 그대로 탔다 — 방에는 떴지만
+        //   ★버스에는 아무 기록이 없었다.★ 같은 방에서 claude 팀원의 답은 남고 dex 것만 0건이었다
+        //   (대조군으로 확인). 버스만 보는 팀원에게 그 답은 ★존재하지 않는다.★
+        //   그룹 native 차단은 ★들어오는 쪽★ 만 막는다 — 나가는 쪽은 여기서 막는다.
+        //
+        //   ★리액션은 남긴다★ — "그 팀원이 받았다" 를 사람이 보는 신호라 발신과 다른 값이다.
+        const noAutopost = noAutopostDeps(live);
+        const res = await handleMessage(
+          chatId,
+          groupTurnBody({ repoRoot: REPO_ROOT, body: r.body, threadId: r.threadId, messageId: r.messageId }),
+          tgMsgId,
+          noAutopost,
+          undefined,
+          "window",
+        );
+        // ★본문은 안 남긴다★ — 말한 게 아니라 메모다(hermes 와 같은 기록 모양).
+        console.log(`[codex-bridge] 창구 턴 완료(자동게시 없음) → ${res.detail} · ${res.reply.length}자`);
+        appendAuditFile("codex_bridge", "turn_completed_no_autopost", r.messageId, {
+          agent_id: liveAgentId, thread_id: r.threadId, detail: res.detail, chars: res.reply.length,
+        });
       });
     },
   });

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -16,7 +16,7 @@ import {
   type DmAttachments, type DmMessageMedia,
 } from "./dmMedia";
 import { createSerialTurnQueue } from "./serialTurnQueue";
-import { startBridgeWindow, groupTurnBody } from "./bridgeWindow";
+import { startBridgeWindow, groupTurnCall } from "./bridgeWindow";
 import { makeChatSessionStore, NOOP_DM_SESSION_STORE, type DmSessionStore } from "./dmSessionStore";
 import { toMarkdownV2, splitForTelegram, toPlain } from "./telegramMarkdown";
 import { steerActiveTurn } from "./activeTurns";
@@ -474,19 +474,6 @@ async function fetchOwnerGate(
  * 텔레그램 메시지 1건 처리(순수 로직 — 토큰 불필요, mock 테스트 가능).
  * 흐름: 👀 리액션 → "작업 중…" 게시 → codex 턴 → 작업중 메시지를 답으로 교체(편집 실패 시 신규 발신).
  */
-/**
- * ★서버가 팀원 대신 말하지 못하게 발신을 떼어낸 deps.★
- *
- * 창구(그룹) 경로 전용이다. 이 경로의 답은 팀원이 `send.sh --to broadcast` 로 직접 보내야
- * ★버스에 남고★ 거기서 방으로 릴레이된다. 브리지가 텔레그램으로 바로 쏘면 방에는 뜨지만
- * ★기록이 아무 데도 없다★ — 같은 방에서 claude 팀원 답은 남고 이쪽만 0건이었다(대조군 실측).
- *
- * ★리액션은 떼지 않는다★ — "그 팀원이 받았다" 는 사람이 보는 신호이고 발신과 다른 값이다.
- * 1:1 경로는 이 함수를 쓰지 않는다(거기서는 브리지가 답하는 게 맞다).
- */
-export function noAutopostDeps(deps: BridgeDeps): BridgeDeps {
-  return { ...deps, sendMessage: async () => null, editMessage: async () => false };
-}
 
 export async function handleMessage(
   chatId: number,
@@ -1216,17 +1203,23 @@ export async function runBridge(deps: BridgeDeps = {}): Promise<void> {
         //   그룹 native 차단은 ★들어오는 쪽★ 만 막는다 — 나가는 쪽은 여기서 막는다.
         //
         //   ★리액션은 남긴다★ — "그 팀원이 받았다" 를 사람이 보는 신호라 발신과 다른 값이다.
-        const noAutopost = noAutopostDeps(live);
-        const res = await handleMessage(
-          chatId,
-          groupTurnBody({ repoRoot: REPO_ROOT, body: r.body, threadId: r.threadId, messageId: r.messageId }),
-          tgMsgId,
-          noAutopost,
-          undefined,
-          "window",
-        );
+        // ★한 번만 부른다★ — 발신을 떼는 것과 답 보내는 명령을 넣는 것은 한 쌍이다.
+        //   따로 부르면 나중에 한쪽만 지워져도 컴파일이 통과하고 ★그때 dex 가 조용해진다★(리뷰 지적).
+        const call = groupTurnCall(live, {
+          repoRoot: REPO_ROOT,
+          body: r.body,
+          threadId: r.threadId,
+          messageId: r.messageId,
+        });
+        const res = await handleMessage(chatId, call.body, tgMsgId, call.deps, undefined, "window");
         // ★본문은 안 남긴다★ — 말한 게 아니라 메모다(hermes 와 같은 기록 모양).
         console.log(`[codex-bridge] 창구 턴 완료(자동게시 없음) → ${res.detail} · ${res.reply.length}자`);
+        // ★실패를 조용히 두지 않는다★ (리뷰 지적 — 오늘 그룹에서 두 번 났다).
+        //   발신을 뗐으므로 ★에러 문구도 같이 사라진다★ — 사람 화면에서 "도는 중" 과 "죽었다" 가 같아진다.
+        //   리액션은 발신이 아니라서 계약을 안 깬다. 👀 를 ⚠️ 로 바꿔 ★받았지만 못 했다★ 를 남긴다.
+        if (!res.ok && tgMsgId !== undefined && Number.isFinite(tgMsgId)) {
+          void live.reactMessage?.(chatId, tgMsgId, "⚠️");
+        }
         appendAuditFile("codex_bridge", "turn_completed_no_autopost", r.messageId, {
           agent_id: liveAgentId, thread_id: r.threadId, detail: res.detail, chars: res.reply.length,
         });

--- a/src/server/runtimes/codex/bridgeWindow.test.ts
+++ b/src/server/runtimes/codex/bridgeWindow.test.ts
@@ -231,3 +231,44 @@ describe("startBridgeWindow — 실제 왕복", () => {
   });
 });
 
+
+// ── ★서버는 팀원 대신 말하지 않는다★ (hermes 와 같은 계약) ──
+//
+// 창구 경로가 텔레그램으로 직접 쏘면 방에는 뜨지만 ★버스에는 아무 기록이 없다.★
+// 같은 방에서 claude 팀원 답은 남고 dex 것만 0건이었다(대조군 실측). 그래서 턴 본문은
+// 메모로 두고, 방에 말하려면 팀원이 직접 `send.sh --to broadcast` 를 불러야 한다.
+import { groupTurnBody } from "./bridgeWindow";
+
+describe("groupTurnBody — 답을 어디로 보낼지 함께 준다", () => {
+  const made = () =>
+    groupTurnBody({
+      repoRoot: "/repo",
+      body: "@덱스 들려?",
+      threadId: "tg--1003947108339",
+      messageId: "tg-8874",
+    });
+
+  test("★send.sh --to broadcast 명령이 들어간다★ — 없으면 답이 아무 데도 안 간다", () => {
+    const t = made();
+    expect(t).toContain("/repo/skills/b3os-team-inbox/scripts/send.sh");
+    expect(t).toContain("--to broadcast");
+  });
+
+  test("★스레드와 in-reply-to 가 박혀 있다★ — 사람이 조립하다 틀리지 않게", () => {
+    const t = made();
+    expect(t).toContain("--thread tg--1003947108339");
+    expect(t).toContain("--in-reply-to tg-8874");
+  });
+
+  test("★'서버가 대신 게시하지 않는다' 를 말해준다★ — 안 보내면 말한 게 아니다", () => {
+    expect(made()).toContain("서버가 대신 게시하지 않는다");
+  });
+
+  test("원문이 맨 앞에 그대로 있다 — 지시문이 질문을 덮지 않는다", () => {
+    expect(made().startsWith("@덱스 들려?")).toBe(true);
+  });
+
+  test("★--to <보낸사람> 이 아니다★ — 그룹 행의 발신자는 팀원이 아니다", () => {
+    expect(made()).not.toContain("--to user");
+  });
+});

--- a/src/server/runtimes/codex/bridgeWindow.test.ts
+++ b/src/server/runtimes/codex/bridgeWindow.test.ts
@@ -320,3 +320,94 @@ describe("groupTurnCall — 발신을 떼고, 답 보내는 법을 함께 준다
     expect(made().body).not.toContain("--to user");
   });
 });
+
+// ── ★적대 입력 왕복 시험★ — 모양 단언이 아니라 실제 동작을 잰다 ──
+//
+// "mktemp 를 쓴다"·"종료자가 EOF 가 아니다" 는 ★생성된 문자열의 모양★ 이라, 템플릿을 바꾸면
+// 같이 바뀐다. ★인용을 잘못해도 통과한다.★ 유일한 증명은 실제로 셸에 태워서
+// ★나온 파일이 원문과 바이트로 같은가★ 를 보는 것이다.
+//
+// ★이 시험이 증명하지 않는 것★: dex 가 이 조각을 ★그대로 실행한다★ 는 것.
+//   본문은 프롬프트고 dex 는 다르게 쓸 수 있다 — 그건 배포 후 ② 로만 재진다.
+//   (부품이 맞다 ≠ 조립된 게 돈다 ≠ 실제로 그 경로로 간다)
+import { readFileSync, existsSync, mkdirSync } from "node:fs";
+
+describe("템플릿이 적대 입력을 손상 없이 통과시킨다 (dex 가 그대로 실행하는지는 배포 후 ②)", () => {
+  // 한 덩어리로 넣는다 — 하나씩 넣으면 조합에서 새는 것을 못 잡는다.
+  const HOSTILE = [
+    "홑따옴표 ' 하나",
+    ' 겹따옴표 " 하나',
+    "백틱 `id` 와 달러괄호 $(id) 와 달러변수 $HOME",
+    "EOF",
+    "B3OS_REPLY_DEADBEEF",
+    "탭\t끝",
+    "역슬래시 \\ 와 이모지 ✦ 와 한글",
+    "",
+    "마지막 줄",
+  ].join("\n");
+
+  test("★적대 입력이 파일까지 바이트 그대로 간다★", () => {
+    const dir = mkdtempSync(join(tmpdir(), "rt-"));
+    // send.sh 스텁 — --body-file 의 내용을 그대로 밖으로 복사한다.
+    const stubRoot = join(dir, "root");
+    const stubDir = join(stubRoot, "skills", "b3os-team-inbox", "scripts");
+    mkdirSync(stubDir, { recursive: true });
+    const out = join(dir, "captured.txt");
+    writeFileSync(
+      join(stubDir, "send.sh"),
+      ['#!/bin/bash', 'while [ $# -gt 0 ]; do', '  if [ "$1" = "--body-file" ]; then cp "$2" "' + out + '"; shift; fi',
+       '  shift', 'done', ''].join("\n"),
+      { mode: 0o755 },
+    );
+    chmodSync(join(stubDir, "send.sh"), 0o755);
+
+    const { body } = groupTurnCall(
+      { sendMessage: async () => null, editMessage: async () => false },
+      { repoRoot: stubRoot, body: "질문", threadId: "tg--100", messageId: "tg-1" },
+    );
+
+    // 본문에서 셸 조각만 떼어낸다: f=... 줄부터 rm -f 줄까지.
+    const lines = body.split("\n");
+    const from = lines.findIndex((l) => l.startsWith('f="$(mktemp'));
+    const to = lines.findIndex((l) => l.startsWith('rm -f'));
+    expect(from).toBeGreaterThan(-1);
+    expect(to).toBeGreaterThan(from);
+    // <답> 자리를 적대 입력으로 갈아끼운다.
+    const snippet = lines.slice(from, to + 1).join("\n").replace("<답>", HOSTILE);
+
+    const r = Bun.spawnSync(["bash", "-c", snippet]);
+    expect(r.exitCode).toBe(0);
+    expect(existsSync(out)).toBe(true);
+    // ★바이트로 비교한다★ — heredoc 은 끝에 개행을 하나 붙인다.
+    expect(readFileSync(out, "utf8")).toBe(HOSTILE + "\n");
+  });
+
+  test("★종료자가 매번 다르다★ — 고정이면 답이 그 줄을 맞힐 수 있다", () => {
+    const term = (b: string) => b.split("\n").find((l) => l.startsWith("cat > "))!;
+    const a = groupTurnCall({}, { repoRoot: "/r", body: "x", threadId: "t", messageId: "m" }).body;
+    const b = groupTurnCall({}, { repoRoot: "/r", body: "x", threadId: "t", messageId: "m" }).body;
+    expect(term(a)).not.toBe(term(b));
+  });
+
+  test("★보낸 뒤 임시파일이 남지 않는다★ — 팀 대화가 /tmp 에 평문으로 남으면 안 된다", () => {
+    const dir = mkdtempSync(join(tmpdir(), "rt2-"));
+    const stubDir = join(dir, "skills", "b3os-team-inbox", "scripts");
+    mkdirSync(stubDir, { recursive: true });
+    const seen = join(dir, "path.txt");
+    writeFileSync(
+      join(stubDir, "send.sh"),
+      ['#!/bin/bash', 'while [ $# -gt 0 ]; do', '  if [ "$1" = "--body-file" ]; then echo -n "$2" > "' + seen + '"; shift; fi',
+       '  shift', 'done', ''].join("\n"),
+      { mode: 0o755 },
+    );
+    chmodSync(join(stubDir, "send.sh"), 0o755);
+    const { body } = groupTurnCall({}, { repoRoot: dir, body: "질문", threadId: "t", messageId: "m" });
+    const lines = body.split("\n");
+    const from = lines.findIndex((l) => l.startsWith('f="$(mktemp'));
+    const to = lines.findIndex((l) => l.startsWith("rm -f"));
+    Bun.spawnSync(["bash", "-c", lines.slice(from, to + 1).join("\n").replace("<답>", "내용")]);
+    const used = readFileSync(seen, "utf8");
+    expect(used).toContain("b3os-reply");
+    expect(existsSync(used)).toBe(false);
+  });
+});

--- a/src/server/runtimes/codex/bridgeWindow.test.ts
+++ b/src/server/runtimes/codex/bridgeWindow.test.ts
@@ -285,7 +285,21 @@ describe("groupTurnCall — 발신을 떼고, 답 보내는 법을 함께 준다
   });
 
   test("★heredoc 구분자가 따옴표로 감싸여 있다★ — $ ·백틱이 해석되면 본문이 훼손된다", () => {
-    expect(made().body).toContain("<<'EOF'");
+    expect(made().body).toMatch(/<<'[A-Z0-9_]+'/);
+  });
+
+  test("★종료자가 EOF 가 아니다★ — 답에 EOF 한 줄이 들어가면 거기서 끊기고 뒤가 셸 명령이 된다", () => {
+    expect(made().body).not.toContain("<<'EOF'");
+  });
+
+  test("★고정 경로를 안 쓴다 — mktemp 로 매번 새 파일★ (쓰기 실패 시 옛 답이 다시 나간다)", () => {
+    const { body } = made();
+    expect(body).toContain("mktemp");
+    expect(body).not.toContain("/tmp/dex-reply.txt");
+  });
+
+  test("★보낸 뒤 지운다★ — 팀 대화가 /tmp 에 평문으로 남지 않게", () => {
+    expect(made().body).toContain('rm -f "$f"');
   });
 
   test("스레드와 in-reply-to 가 박혀 있다 — 조립하다 틀리지 않게", () => {

--- a/src/server/runtimes/codex/bridgeWindow.test.ts
+++ b/src/server/runtimes/codex/bridgeWindow.test.ts
@@ -340,6 +340,9 @@ describe("템플릿이 적대 입력을 손상 없이 통과시킨다 (dex 가 �
     "백틱 `id` 와 달러괄호 $(id) 와 달러변수 $HOME",
     "EOF",
     "B3OS_REPLY_DEADBEEF",
+    // ★JS String.replace 의 치환 패턴 문자★ — 시험이 자기 이스케이프로 무너지는지도 같이 잰다.
+    //   bash ANSI-C 인용($'\\n')도 여기 걸린다. 아래 () => 형태가 아니면 이 줄에서 깨진다.
+    "치환패턴 $$ $& $` $' $1 끝",
     "탭\t끝",
     "역슬래시 \\ 와 이모지 ✦ 와 한글",
     "",
@@ -373,7 +376,13 @@ describe("템플릿이 적대 입력을 손상 없이 통과시킨다 (dex 가 �
     expect(from).toBeGreaterThan(-1);
     expect(to).toBeGreaterThan(from);
     // <답> 자리를 적대 입력으로 갈아끼운다.
-    const snippet = lines.slice(from, to + 1).join("\n").replace("<답>", HOSTILE);
+    // ★치환은 반드시 함수로 준다★ — 문자열로 주면 JS 가 $$·$&·$`·$'·$1 을 치환 패턴으로
+    //   먼저 해석해서, 적대 입력이 ★bash 에 닿기도 전에★ 뭉개진다. 그러면 빨간불이 뜨는데
+    //   범인은 시험인데 템플릿을 뒤지게 된다 — 이 PR 이 고치는 것과 ★같은 병★ 이다.
+    const snippet = lines.slice(from, to + 1).join("\n").replace("<답>", () => HOSTILE);
+    // 셸에 태우기 전에, 적대 입력이 ★온전한 채로★ 들어갔는지부터 확인한다.
+    // 여기서 깨지면 원인은 템플릿이 아니라 위 치환이다.
+    expect(snippet).toContain(HOSTILE);
 
     const r = Bun.spawnSync(["bash", "-c", snippet]);
     expect(r.exitCode).toBe(0);
@@ -405,7 +414,7 @@ describe("템플릿이 적대 입력을 손상 없이 통과시킨다 (dex 가 �
     const lines = body.split("\n");
     const from = lines.findIndex((l) => l.startsWith('f="$(mktemp'));
     const to = lines.findIndex((l) => l.startsWith("rm -f"));
-    Bun.spawnSync(["bash", "-c", lines.slice(from, to + 1).join("\n").replace("<답>", "내용")]);
+    Bun.spawnSync(["bash", "-c", lines.slice(from, to + 1).join("\n").replace("<답>", () => "내용")]);
     const used = readFileSync(seen, "utf8");
     expect(used).toContain("b3os-reply");
     expect(existsSync(used)).toBe(false);

--- a/src/server/runtimes/codex/bridgeWindow.test.ts
+++ b/src/server/runtimes/codex/bridgeWindow.test.ts
@@ -237,38 +237,72 @@ describe("startBridgeWindow — 실제 왕복", () => {
 // 창구 경로가 텔레그램으로 직접 쏘면 방에는 뜨지만 ★버스에는 아무 기록이 없다.★
 // 같은 방에서 claude 팀원 답은 남고 dex 것만 0건이었다(대조군 실측). 그래서 턴 본문은
 // 메모로 두고, 방에 말하려면 팀원이 직접 `send.sh --to broadcast` 를 불러야 한다.
-import { groupTurnBody } from "./bridgeWindow";
+//
+// ★한 함수만 내보낸다★ — 발신 떼기와 명령 넣기는 한 쌍이라, 한쪽만 있는 상태를 못 만들게 한다.
+import { groupTurnCall } from "./bridgeWindow";
 
-describe("groupTurnBody — 답을 어디로 보낼지 함께 준다", () => {
-  const made = () =>
-    groupTurnBody({
+describe("groupTurnCall — 발신을 떼고, 답 보내는 법을 함께 준다", () => {
+  const base = () => ({
+    sendMessage: async () => 1 as number | null,
+    editMessage: async () => true,
+    reactMessage: async () => true,
+    agentId: "dex",
+  });
+  const made = (over: Record<string, string> = {}) =>
+    groupTurnCall(base(), {
       repoRoot: "/repo",
       body: "@덱스 들려?",
       threadId: "tg--1003947108339",
       messageId: "tg-8874",
+      ...over,
     });
 
-  test("★send.sh --to broadcast 명령이 들어간다★ — 없으면 답이 아무 데도 안 간다", () => {
-    const t = made();
-    expect(t).toContain("/repo/skills/b3os-team-inbox/scripts/send.sh");
-    expect(t).toContain("--to broadcast");
+  test("★발신이 떨어진다★ — sendMessage·editMessage 가 아무것도 안 한다", async () => {
+    const { deps } = made();
+    expect(await deps.sendMessage()).toBeNull();
+    expect(await deps.editMessage()).toBe(false);
   });
 
-  test("★스레드와 in-reply-to 가 박혀 있다★ — 사람이 조립하다 틀리지 않게", () => {
-    const t = made();
-    expect(t).toContain("--thread tg--1003947108339");
-    expect(t).toContain("--in-reply-to tg-8874");
+  test("★리액션은 남는다★ — '받았다' 는 발신과 다른 값이다", async () => {
+    const { deps } = made();
+    expect(await deps.reactMessage()).toBe(true);
   });
 
-  test("★'서버가 대신 게시하지 않는다' 를 말해준다★ — 안 보내면 말한 게 아니다", () => {
-    expect(made()).toContain("서버가 대신 게시하지 않는다");
+  test("나머지 deps 는 그대로 넘어간다", () => {
+    expect(made().deps.agentId).toBe("dex");
+  });
+
+  test("★send.sh --to broadcast 가 본문에 있다★ — 없으면 답이 아무 데도 안 간다", () => {
+    const { body } = made();
+    expect(body).toContain("/repo/skills/b3os-team-inbox/scripts/send.sh");
+    expect(body).toContain("--to broadcast");
+  });
+
+  test("★--body 가 아니라 --body-file 을 시킨다★ — 답의 홑따옴표가 명령을 깬다", () => {
+    const { body } = made();
+    expect(body).toContain("--body-file");
+    expect(body).not.toContain("--body '");
+  });
+
+  test("★heredoc 구분자가 따옴표로 감싸여 있다★ — $ ·백틱이 해석되면 본문이 훼손된다", () => {
+    expect(made().body).toContain("<<'EOF'");
+  });
+
+  test("스레드와 in-reply-to 가 박혀 있다 — 조립하다 틀리지 않게", () => {
+    const { body } = made();
+    expect(body).toContain("--thread tg--1003947108339");
+    expect(body).toContain("--in-reply-to tg-8874");
+  });
+
+  test("'서버가 대신 게시하지 않는다' 를 말해준다 — 안 보내면 말한 게 아니다", () => {
+    expect(made().body).toContain("서버가 대신 게시하지 않는다");
   });
 
   test("원문이 맨 앞에 그대로 있다 — 지시문이 질문을 덮지 않는다", () => {
-    expect(made().startsWith("@덱스 들려?")).toBe(true);
+    expect(made().body.startsWith("@덱스 들려?")).toBe(true);
   });
 
-  test("★--to <보낸사람> 이 아니다★ — 그룹 행의 발신자는 팀원이 아니다", () => {
-    expect(made()).not.toContain("--to user");
+  test("★--to user 가 아니다★ — 그룹 행의 발신자는 팀원이 아니다", () => {
+    expect(made().body).not.toContain("--to user");
   });
 });

--- a/src/server/runtimes/codex/bridgeWindow.ts
+++ b/src/server/runtimes/codex/bridgeWindow.ts
@@ -271,15 +271,42 @@ export async function startBridgeWindow(deps: BridgeWindowDeps): Promise<BridgeW
 }
 
 /**
- * ★그룹 턴의 본문 — 답을 어디로 보낼지 함께 준다.★
+ * ★그룹 턴 한 건에 필요한 것을 한 번에 만든다.★
  *
- * 서버는 팀원 대신 말하지 않는다(hermes 와 같은 계약). 턴 본문은 ★그 팀원의 메모★ 이고,
- * 방에 말하려면 팀원이 ★직접★ `send.sh --to broadcast` 를 불러야 한다 —
- * 그래야 버스에 남고, 거기서 방으로 릴레이된다. ★보낸 것만 말한 것이다.★
+ * 서버는 팀원 대신 말하지 않는다(hermes 와 같은 계약). 그래서 두 가지가 ★항상 같이★ 가야 한다:
+ * · 발신을 뗀 deps — 브리지가 텔레그램으로 직접 쏘지 않는다
+ * · 답을 보내는 명령이 박힌 본문 — 팀원이 직접 `send.sh` 를 불러야 버스에 남는다
  *
- * 이 문장이 없으면 턴은 돌지만 ★답이 아무 데도 안 간다★(자동 게시를 막았으므로).
+ * ★한쪽만 있는 상태를 만들 수 없게 이 함수 하나만 내보낸다★ (리뷰 지적).
+ *   발신만 떼면 ★턴은 돌고 답은 아무 데도 안 간다.★ 본문만 넣으면 ★두 번 답한다.★
+ *   시험으로 묶는 것은 약하다 — 새 호출부가 생기면 시험은 통과하면서 한쪽이 빠진다.
  */
-export function groupTurnBody(input: {
+export function groupTurnCall<T extends { sendMessage?: unknown; editMessage?: unknown }>(
+  deps: T,
+  input: { repoRoot: string; body: string; threadId: string; messageId: string },
+): { deps: T; body: string } {
+  return { deps: noAutopostDeps(deps), body: groupTurnBody(input) };
+}
+
+/**
+ * ★발신을 떼어낸 deps.★ `groupTurnCall` 안에서만 쓴다 — 밖으로 내보내지 않는다.
+ * ★리액션은 떼지 않는다★ — "그 팀원이 받았다" 는 사람이 보는 신호이고 발신과 다른 값이다.
+ */
+function noAutopostDeps<T extends { sendMessage?: unknown; editMessage?: unknown }>(deps: T): T {
+  return { ...deps, sendMessage: async () => null, editMessage: async () => false };
+}
+
+/**
+ * ★그룹 턴의 본문 — 답을 어디로 보낼지 함께 준다.★ `groupTurnCall` 안에서만 쓴다.
+ *
+ * ★`--body` 가 아니라 `--body-file` 을 시킨다★ (리뷰 지적 · send.sh 가 자기 사용법에 적어둔 경고):
+ *   본문에 홑따옴표·백틱·`$(cmd)`·`$VAR` 가 있으면 셸이 해석해 ★본문이 조용히 훼손되거나
+ *   명령이 통째로 깨진다.★ dex 는 코딩 에이전트라 답에 코드·경로·영어 축약형이 들어간다 —
+ *   홑따옴표가 안 나올 리 없다. 깨지면 ★턴은 돌고 send 는 실패하고 방은 조용하다★ =
+ *   ★이 계약이 없애려는 그 실패 모양 그대로다.★ 자동 게시를 막았으므로 ★대체 경로도 없다.★
+ *   heredoc 의 구분자를 따옴표로 감싸면 `$`·백틱이 전부 무해해진다.
+ */
+function groupTurnBody(input: {
   repoRoot: string;
   body: string;
   threadId: string;
@@ -293,6 +320,13 @@ export function groupTurnBody(input: {
     "",
     "★답은 이 명령으로 보내야 전달된다.★ 이 턴의 본문은 아무 데도 안 간다 —",
     "서버가 대신 게시하지 않는다. 끝에 최종 답으로 한 번 실행하라:",
-    `${send} --to broadcast --thread ${input.threadId} --in-reply-to ${input.messageId} --body '<답>'`,
+    "",
+    "cat > /tmp/dex-reply.txt <<'EOF'",
+    "<답>",
+    "EOF",
+    `${send} --to broadcast --thread ${input.threadId} --in-reply-to ${input.messageId} --body-file /tmp/dex-reply.txt`,
+    "",
+    "★--body 로 넘기지 마라★ — 답에 홑따옴표·백틱·$ 가 있으면 셸이 해석해 명령이 깨지고,",
+    "그러면 턴은 돌았는데 방은 조용해진다. 위 heredoc 형태를 그대로 쓴다.",
   ].join("\n");
 }

--- a/src/server/runtimes/codex/bridgeWindow.ts
+++ b/src/server/runtimes/codex/bridgeWindow.ts
@@ -305,6 +305,14 @@ function noAutopostDeps<T extends { sendMessage?: unknown; editMessage?: unknown
  *   홑따옴표가 안 나올 리 없다. 깨지면 ★턴은 돌고 send 는 실패하고 방은 조용하다★ =
  *   ★이 계약이 없애려는 그 실패 모양 그대로다.★ 자동 게시를 막았으므로 ★대체 경로도 없다.★
  *   heredoc 의 구분자를 따옴표로 감싸면 `$`·백틱이 전부 무해해진다.
+ *
+ * ★고정 경로·고정 종료자를 쓰지 않는다★ (리뷰 지적):
+ *   · 같은 파일에 덮어쓰면 ★쓰기가 실패했을 때 직전 턴의 답이 그대로 다시 나간다★ —
+ *     빈 파일은 `send.sh` 가 거절하지만 ★옛 내용은 거절하지 않는다.★ 조용한 실패가 아니라
+ *     ★그럴듯하게 틀린★ 쪽이라 더 나쁘다. 예측 가능한 공용 경로라 선점 위험도 있다.
+ *   · 종료자가 `EOF` 면 ★답에 `EOF` 한 줄이 들어갈 때 거기서 끊기고★ 뒤가 셸 명령으로 읽힌다.
+ *     코딩 에이전트의 답에 셸 예시가 들어가는 것은 드문 일이 아니다.
+ *   `mktemp` 로 실행마다 새 파일을 만들고, 보낸 뒤 지운다(팀 대화가 `/tmp` 에 남지 않게).
  */
 function groupTurnBody(input: {
   repoRoot: string;
@@ -321,10 +329,12 @@ function groupTurnBody(input: {
     "★답은 이 명령으로 보내야 전달된다.★ 이 턴의 본문은 아무 데도 안 간다 —",
     "서버가 대신 게시하지 않는다. 끝에 최종 답으로 한 번 실행하라:",
     "",
-    "cat > /tmp/dex-reply.txt <<'EOF'",
+    'f="$(mktemp -t b3os-reply)"',
+    `cat > "$f" <<'B3OS_REPLY_EOF__DO_NOT_USE'`,
     "<답>",
-    "EOF",
-    `${send} --to broadcast --thread ${input.threadId} --in-reply-to ${input.messageId} --body-file /tmp/dex-reply.txt`,
+    "B3OS_REPLY_EOF__DO_NOT_USE",
+    `${send} --to broadcast --thread ${input.threadId} --in-reply-to ${input.messageId} --body-file "$f"`,
+    'rm -f "$f"',
     "",
     "★--body 로 넘기지 마라★ — 답에 홑따옴표·백틱·$ 가 있으면 셸이 해석해 명령이 깨지고,",
     "그러면 턴은 돌았는데 방은 조용해진다. 위 heredoc 형태를 그대로 쓴다.",

--- a/src/server/runtimes/codex/bridgeWindow.ts
+++ b/src/server/runtimes/codex/bridgeWindow.ts
@@ -321,6 +321,10 @@ function groupTurnBody(input: {
   messageId: string;
 }): string {
   const send = `${input.repoRoot}/skills/b3os-team-inbox/scripts/send.sh`;
+  // ★종료자는 매번 다르게★ (리뷰 지적): 고정 이름이면 답에 그 줄이 들어갈 때 거기서 끊긴다.
+  //   "EOF 가 아니다" 로는 부족하다 — 다른 고정 이름으로 바꿔도 같은 사고가 난다.
+  //   매번 다르면 ★답이 종료자를 맞힐 확률 자체가 사라진다.★
+  const term = `B3OS_REPLY_${randomBytes(6).toString("hex").toUpperCase()}`;
   return [
     input.body,
     "",
@@ -330,9 +334,9 @@ function groupTurnBody(input: {
     "서버가 대신 게시하지 않는다. 끝에 최종 답으로 한 번 실행하라:",
     "",
     'f="$(mktemp -t b3os-reply)"',
-    `cat > "$f" <<'B3OS_REPLY_EOF__DO_NOT_USE'`,
+    `cat > "$f" <<'${term}'`,
     "<답>",
-    "B3OS_REPLY_EOF__DO_NOT_USE",
+    term,
     `${send} --to broadcast --thread ${input.threadId} --in-reply-to ${input.messageId} --body-file "$f"`,
     'rm -f "$f"',
     "",

--- a/src/server/runtimes/codex/bridgeWindow.ts
+++ b/src/server/runtimes/codex/bridgeWindow.ts
@@ -269,3 +269,30 @@ export async function startBridgeWindow(deps: BridgeWindowDeps): Promise<BridgeW
     },
   };
 }
+
+/**
+ * ★그룹 턴의 본문 — 답을 어디로 보낼지 함께 준다.★
+ *
+ * 서버는 팀원 대신 말하지 않는다(hermes 와 같은 계약). 턴 본문은 ★그 팀원의 메모★ 이고,
+ * 방에 말하려면 팀원이 ★직접★ `send.sh --to broadcast` 를 불러야 한다 —
+ * 그래야 버스에 남고, 거기서 방으로 릴레이된다. ★보낸 것만 말한 것이다.★
+ *
+ * 이 문장이 없으면 턴은 돌지만 ★답이 아무 데도 안 간다★(자동 게시를 막았으므로).
+ */
+export function groupTurnBody(input: {
+  repoRoot: string;
+  body: string;
+  threadId: string;
+  messageId: string;
+}): string {
+  const send = `${input.repoRoot}/skills/b3os-team-inbox/scripts/send.sh`;
+  return [
+    input.body,
+    "",
+    `(그룹방 메시지 · thread=${input.threadId} · in-reply-to=${input.messageId})`,
+    "",
+    "★답은 이 명령으로 보내야 전달된다.★ 이 턴의 본문은 아무 데도 안 간다 —",
+    "서버가 대신 게시하지 않는다. 끝에 최종 답으로 한 번 실행하라:",
+    `${send} --to broadcast --thread ${input.threadId} --in-reply-to ${input.messageId} --body '<답>'`,
+  ].join("\n");
+}


### PR DESCRIPTION
창구(그룹) 경로의 답이 **버스에 남지 않는** 문제를 고칩니다. 서버가 팀원 대신 말하지 않게 맞춥니다.

## 무엇이 틀렸나

그룹 턴은 돌고 방에도 떴지만, **버스에는 아무 기록이 없었습니다.**

대조군을 놓고 재면 갈립니다 — 같은 방, 같은 종류의 답인데:

```
claude 팀원이 방에 답한 것   → message 행 3건  (→ broadcast, tg--1003947108339)
codex 팀원이 방에 답한 것    → 0건            (스레드·수신자 안 가리고 전수)
```

**6분 창을 두고 재확인**했습니다 — 턴이 끝난 뒤로도 0건입니다. 지연이 아니라 **경로가 없는 것**입니다. 하네스 시험만이 아니라 **실사용 호출에서도** 같습니다.

버스만 보는 팀원에게 그 답은 **존재하지 않습니다.** 스레드·`in-reply-to` 연결도 끊깁니다.

## 원인

창구 경로도 `handleMessage` 를 타는데, 그 함수가 **답을 직접 텔레그램으로 보냅니다**(`bridge.ts` 의 `send()` 세 자리 — 진행 버블·최종 답·이어지는 조각).

그리고 **그룹 native 차단은 들어오는 쪽만 막습니다** — 나가는 쪽은 아무도 안 막고 있었습니다. "native 응답을 없앴다" 가 **입구에만 참**이었습니다.

## 고침 — hermes 와 같은 계약

`turn_completed_no_autopost`: 턴 본문은 **그 팀원의 메모**이고, 방에 말하려면 팀원이 **직접** `send.sh --to broadcast` 를 부릅니다. 그래야 버스에 남고 거기서 방으로 릴레이됩니다. **보낸 것만 말한 것입니다.**

- **`noAutopostDeps`** — 창구 경로에서 `sendMessage`·`editMessage` 를 떼어냅니다
  - **리액션은 남깁니다** — "그 팀원이 받았다" 는 사람이 보는 신호라 발신과 다른 값입니다
  - **1:1 경로는 안 씁니다** — 거기서는 브리지가 답하는 게 맞습니다
- **`groupTurnBody`** — 턴 본문에 `send.sh --to broadcast --thread … --in-reply-to …` 를 박아 줍니다
  - **이게 없으면 턴은 돌지만 답이 아무 데도 안 갑니다**(자동 게시를 막았으므로). 둘은 한 쌍입니다
- **`turn_completed_no_autopost` audit** — 본문은 안 남깁니다(말한 게 아니라 메모)

`repoRoot` 는 **환경변수가 아니라 파일 위치 기준**입니다 — 같은 파일 `defaultTeamDbPath` 의 주석이 그 이유를 적어둡니다(브리지 프로세스에 그 변수가 없어 승인 버튼이 죽은 실측).

## 검증

- `bun test src/server/runtimes/codex/ src/server/workers/ src/server/lib/` → **1554 pass · 0 fail**
- 새 시험 8건
  - `groupTurnBody` 5건: `send.sh --to broadcast` 포함 · thread·in-reply-to 박힘 · "서버가 대신 게시하지 않는다" 명시 · 원문이 맨 앞 · **`--to user` 가 아님**
  - `noAutopostDeps` 3건: 발신 0회 · **리액션은 그대로** · 나머지 deps 통과

## 이 PR 전에 이미 통과한 것 (참고)

실사용 호출로 확인된 구간입니다 — 이 PR 은 마지막 한 칸만 고칩니다:

```
@덱스     → group_native_denied → 창구 턴 실행 → 방에 뜸        통과
@데미스   → group_native_denied 만. 창구 턴 없음                통과
들려?(무멘션) → group_native_denied 만. 창구 턴 없음             통과
@빌       → group_native_denied 만. 창구 턴 없음                통과
```

**자기 이름일 때만 움직이고 남을 부른 메시지엔 안 움직입니다.** 오너 판정은 브리지가 아니라 capture 가 한 번만 합니다.

## 배포 후 확인

`from_agent_id='dex' AND to_agent_id='broadcast' AND thread_id LIKE 'tg--%'` 가 **≥1** 이 되는지. 그리고 **방에도 그대로 뜨는지** — 버스에 남는 것과 방에 뜨는 것은 다른 값입니다.
