### PR TITLE
fix(codex-bridge): 운반을 서버 입구로 직접 넣는다

### DIFF
--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -1107,7 +1107,7 @@ describe("runGroupTurn — ★턴 성공·답 함·운반됨은 서로 다른 �
   function make(run: unknown, out: Out = { kind: "reply", text: "네 들립니다" }, deliverOk = true) {
     const reacts: string[] = [];
     const audits: Record<string, unknown>[] = [];
-    const delivered: { text: string; threadId: string; messageId: string }[] = [];
+    const delivered: { text: string; threadId: string; messageId: string; agentId: string }[] = [];
     const consumed: string[] = [];
     const ctx = {
       deps: {
@@ -1125,9 +1125,9 @@ describe("runGroupTurn — ★턴 성공·답 함·운반됨은 서로 다른 �
       run,
       replyPath: join(tmpRoot, "var", "codex-bridge", "outbox", "dex", "fixed.txt"),
       consume: (p: string) => { consumed.push(p); return out; },
-      deliver: async (a: { text: string; threadId: string; messageId: string }) => {
-        delivered.push({ text: a.text, threadId: a.threadId, messageId: a.messageId });
-        return deliverOk;
+      deliver: async (a: { agentId: string; text: string; threadId: string; messageId: string }) => {
+        delivered.push({ text: a.text, threadId: a.threadId, messageId: a.messageId, agentId: a.agentId });
+        return deliverOk ? { ok: true, detail: "" } : { ok: false, detail: "exit 1: 발신자 해석 실패" };
       },
     } as unknown as Ctx;
     return { reacts, audits, delivered, consumed, ctx };
@@ -1137,7 +1137,8 @@ describe("runGroupTurn — ★턴 성공·답 함·운반됨은 서로 다른 �
   test("★답 파일이 있으면 브리지가 운반한다★ — 팀원은 셸을 안 탄다", async () => {
     const { reacts, audits, delivered, ctx } = make(okTurn);
     await runGroupTurn(ctx);
-    expect(delivered).toEqual([{ text: "네 들립니다", threadId: "tg--100", messageId: "tg-1" }]);
+    // ★누가 보내는지를 브리지가 넘긴다★ — 안 넘기면 스크립트가 디렉터리·tmux 로 추측한다
+    expect(delivered).toEqual([{ text: "네 들립니다", threadId: "tg--100", messageId: "tg-1", agentId: "dex" }]);
     expect(audits[0]?.replied).toBe(true);
     expect(audits[0]?.delivered).toBe(true);
     expect(audits[0]?.chars).toBe("네 들립니다".length);
@@ -1162,7 +1163,9 @@ describe("runGroupTurn — ★턴 성공·답 함·운반됨은 서로 다른 �
     await runGroupTurn(ctx);
     expect(audits[0]?.replied).toBe(true);
     expect(audits[0]?.delivered).toBe(false);
-    expect(audits[0]?.detail).toBe("deliver_failed");
+    // ★사유를 버리지 않는다★ — 버리면 다음 실패도 넉 자로만 남아 같은 조사를 반복한다
+    expect(String(audits[0]?.detail)).toContain("deliver_failed:");
+    expect(String(audits[0]?.detail)).toContain("발신자 해석 실패");
     expect(reacts).toEqual(["⚠️"]);
   });
 

--- a/src/server/runtimes/codex/bridge.test.ts
+++ b/src/server/runtimes/codex/bridge.test.ts
@@ -1099,6 +1099,7 @@ describe("codex bridge — 진행 중 작업에 끼어들기", () => {
 // 경고는 `res.ok` 를 읽는 자리에 있었는데, 창구 경로는 발신을 일부러 떼서 `ok` 가 ★항상 false★ 다.
 // 그래서 ★정상 성공에도 경고가 떴다.★ 부품(문자열·발신 0회)만 재는 시험은 이걸 못 잡는다.
 import { runGroupTurn } from "./bridge";
+import { groupReplyPath, ensureOutboxDir } from "./groupOutbox";
 
 describe("runGroupTurn — ★턴 성공·답 함·운반됨은 서로 다른 값이다★", () => {
   const tmpRoot = mkdtempSync(join(tmpdir(), "grt-"));
@@ -1243,4 +1244,86 @@ test("★예약 미지원 안내는 창구에서 실패로 보인다★ — 답 
   expect(r.detail).toContain("schedule");
   // ★turnOk 가 거짓이어야 창구 경로가 경고를 띄운다★
   expect(r.turnOk).toBe(false);
+});
+
+// ── ★진짜 운반 경로를 통과시킨다★ ──
+//
+// 주입된 스텁만 재면 ★스텁이 받은 값★ 을 잴 뿐이고, 실제 함수에서 from_agent_id 줄을 지워도
+// 전부 초록이다. 서버 입구를 세워 ★실제로 POST 되는 것★ 을 본다.
+describe("deliverGroupReply — 실제로 서버 입구에 넣는다", () => {
+  type Ctx = Parameters<typeof runGroupTurn>[0];
+  const root2 = mkdtempSync(join(tmpdir(), "dlv-"));
+
+  async function withServer(
+    status: number,
+    body: string,
+    run: (audits: Record<string, unknown>[]) => Promise<void>,
+  ): Promise<Record<string, unknown>[]> {
+    const seen: Record<string, unknown>[] = [];
+    const srv = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      async fetch(req) {
+        seen.push({ path: new URL(req.url).pathname, ...(await req.json() as Record<string, unknown>) });
+        return new Response(body, { status });
+      },
+    });
+    const prev = process.env.TEAM_BASE_URL;
+    process.env.TEAM_BASE_URL = `http://127.0.0.1:${srv.port}/team`;
+    const audits: Record<string, unknown>[] = [];
+    try {
+      await run(audits);
+    } finally {
+      if (prev === undefined) delete process.env.TEAM_BASE_URL; else process.env.TEAM_BASE_URL = prev;
+      srv.stop(true);
+    }
+    return [...seen, ...audits];
+  }
+
+  function ctxFor(audits: Record<string, unknown>[], replyPath: string): Ctx {
+    writeFileSync(replyPath, "방에 올릴 답");
+    return {
+      deps: { sendMessage: async () => 1, editMessage: async () => true, reactMessage: async () => true },
+      agentId: "dex",
+      repoRoot: root2,
+      chatId: -100,
+      tgMsgId: 42,
+      req: { body: "@덱스 들려?", threadId: "tg--100", messageId: "tg-1" },
+      audit: (_a: string, _t: string, d: Record<string, unknown>) => { audits.push(d); },
+      run: async () => ({ ok: false, turnOk: true, reply: "", detail: "send_failed" }),
+      replyPath,
+      // ★deliver 를 안 넘긴다★ — 진짜 함수를 태운다
+    } as unknown as Ctx;
+  }
+
+  test("★from_agent_id 에 이 턴의 주인이 실린다★ — 서버가 누가 보냈는지 추측하지 않는다", async () => {
+    const p = groupReplyPath(root2, "dex");
+    ensureOutboxDir(p);
+    let audits: Record<string, unknown>[] = [];
+    const all = await withServer(201, '{"ok":true}', async (a) => {
+      audits = a;
+      await runGroupTurn(ctxFor(a, p));
+    });
+    const posted = all[0] as Record<string, unknown>;
+    expect(posted.path).toBe("/team/api/inbox");
+    expect(posted.from_agent_id).toBe("dex");
+    expect(posted.to_agent_id).toBe("broadcast");
+    expect(posted.body).toBe("방에 올릴 답");
+    expect(posted.thread_id).toBe("tg--100");
+    expect(posted.in_reply_to).toBe("tg-1");
+    expect(audits[0]?.delivered).toBe(true);
+  });
+
+  test("★거절되면 상태 코드와 응답이 사유에 남는다★ — 넉 자만 남으면 손으로 재현해야 한다", async () => {
+    const p = groupReplyPath(root2, "dex");
+    ensureOutboxDir(p);
+    let audits: Record<string, unknown>[] = [];
+    await withServer(422, '{"error":"unknown agent"}', async (a) => {
+      audits = a;
+      await runGroupTurn(ctxFor(a, p));
+    });
+    expect(audits[0]?.delivered).toBe(false);
+    expect(String(audits[0]?.detail)).toContain("422");
+    expect(String(audits[0]?.detail)).toContain("unknown agent");
+  });
 });

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -497,7 +497,8 @@ export async function runGroupTurn(ctx: {
   audit?: (action: string, target: string, detail: Record<string, unknown>) => void;
   /** 답 파일을 읽고 지우는 것 · 버스로 운반하는 것. 시험에서 갈아 끼운다. */
   consume?: typeof consumeGroupReply;
-  deliver?: (a: { repoRoot: string; text: string; threadId: string; messageId: string }) => Promise<boolean>;
+  deliver?: (a: { repoRoot: string; agentId: string; text: string; threadId: string; messageId: string })
+    => Promise<{ ok: boolean; detail: string }>;
   replyPath?: string;
 }): Promise<void> {
   const { deps, chatId, tgMsgId, req } = ctx;
@@ -546,10 +547,12 @@ export async function runGroupTurn(ctx: {
   let deliverDetail = "";
   if (out.kind === "reply") {
     try {
-      delivered = await deliver({
-        repoRoot: ctx.repoRoot, text: out.text, threadId: req.threadId, messageId: req.messageId,
+      const d = await deliver({
+        repoRoot: ctx.repoRoot, agentId: ctx.agentId, text: out.text,
+        threadId: req.threadId, messageId: req.messageId,
       });
-      if (!delivered) deliverDetail = "deliver_failed";
+      delivered = d.ok;
+      if (!d.ok) deliverDetail = `deliver_failed:${d.detail}`;
     } catch (e) {
       deliverDetail = `deliver_threw:${e instanceof Error ? e.message.slice(0, 80) : String(e).slice(0, 80)}`;
     }
@@ -581,8 +584,8 @@ export async function runGroupTurn(ctx: {
  * 해석될 자리가 없다. 파일은 보낸 뒤 지운다(팀 대화가 디스크에 남지 않게).
  */
 async function deliverGroupReply(a: {
-  repoRoot: string; text: string; threadId: string; messageId: string;
-}): Promise<boolean> {
+  repoRoot: string; agentId: string; text: string; threadId: string; messageId: string;
+}): Promise<{ ok: boolean; detail: string }> {
   const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
   const { tmpdir } = await import("node:os");
   const { join } = await import("node:path");
@@ -596,8 +599,20 @@ async function deliverGroupReply(a: {
       "--thread", a.threadId,
       "--in-reply-to", a.messageId,
       "--body-file", file,
-    ], { stdout: "pipe", stderr: "pipe", cwd: a.repoRoot });
-    return (await proc.exited) === 0;
+    ], {
+      stdout: "pipe",
+      stderr: "pipe",
+      cwd: a.repoRoot,
+      // ★발신자를 명시한다★: 그 스크립트는 기본적으로 ★현재 디렉터리↔작업폴더★ 로 누가 보내는지를
+      //   정하고, 실패하면 tmux 세션 이름으로 넘어간다. 이 프로세스의 디렉터리는 저장소 뿌리라
+      //   어느 팀원의 작업폴더도 아니고 tmux 세션도 없다 → ★해석이 실패해 발신이 통째로 죽는다.★
+      //   해석이 우연히 성공하는 환경에서는 더 나쁘다 — ★다른 팀원 이름으로 나간다.★
+      //   브리지는 이 턴의 주인을 알고 있으므로 추측 대신 그 값을 넘긴다(스크립트가 DB 로 검증한다).
+      env: { ...process.env, GD_AGENT_ID: a.agentId },
+    });
+    const [code, err] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
+    // ★실패 사유를 버리지 않는다★ — 버리면 다음 실패도 "운반 실패" 넉 자로만 남아 같은 조사를 반복한다.
+    return { ok: code === 0, detail: code === 0 ? "" : `exit ${code}: ${err.trim().slice(0, 160)}` };
   } finally {
     try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
   }

--- a/src/server/runtimes/codex/bridge.ts
+++ b/src/server/runtimes/codex/bridge.ts
@@ -497,7 +497,7 @@ export async function runGroupTurn(ctx: {
   audit?: (action: string, target: string, detail: Record<string, unknown>) => void;
   /** 답 파일을 읽고 지우는 것 · 버스로 운반하는 것. 시험에서 갈아 끼운다. */
   consume?: typeof consumeGroupReply;
-  deliver?: (a: { repoRoot: string; agentId: string; text: string; threadId: string; messageId: string })
+  deliver?: (a: { agentId: string; text: string; threadId: string; messageId: string })
     => Promise<{ ok: boolean; detail: string }>;
   replyPath?: string;
 }): Promise<void> {
@@ -548,8 +548,7 @@ export async function runGroupTurn(ctx: {
   if (out.kind === "reply") {
     try {
       const d = await deliver({
-        repoRoot: ctx.repoRoot, agentId: ctx.agentId, text: out.text,
-        threadId: req.threadId, messageId: req.messageId,
+        agentId: ctx.agentId, text: out.text, threadId: req.threadId, messageId: req.messageId,
       });
       delivered = d.ok;
       if (!d.ok) deliverDetail = `deliver_failed:${d.detail}`;
@@ -578,43 +577,42 @@ export async function runGroupTurn(ctx: {
 }
 
 /**
- * ★브리지가 답을 버스로 운반한다.★ 팀원이 셸을 안 타므로 승인 팝업이 안 뜬다.
+ * ★브리지가 답을 버스로 운반한다 — 서버 입구에 직접 넣는다.★
  *
- * 본문은 ★argv 에 싣지 않는다★ — `--body-file` 로 넘긴다. 답에 홑따옴표·백틱·`$` 가 있어도
- * 해석될 자리가 없다. 파일은 보낸 뒤 지운다(팀 대화가 디스크에 남지 않게).
+ * `send.sh` 도 결국 이 입구로 POST 한다. 셸을 거치면 ★발신자를 현재 디렉터리·tmux 로 추측하는 층★ 이
+ * 하나 더 붙는데, 브리지의 디렉터리는 어느 팀원의 작업폴더도 아니고 launchd 아래라 tmux 도 없다.
+ * 그 조건에서 해석은 실패하고(fail-closed) 발신이 죽는다 — 실측: 팀원 작업폴더가 아닌 cwd 는
+ * tmux 없이 전부 exit 1 이다. 조용한 오배송이 아니라 시끄러운 실패다.
+ * 브리지는 이 턴의 주인을 알고 있으므로 `from_agent_id` 로 그대로 싣는다 — 추측할 자리가 없어진다.
+ *
+ * 하위 프로세스·임시 파일·환경변수가 전부 사라진다. 팀원이 셸을 안 타므로 승인 팝업이 안 뜬다.
+ *
+ * 본문은 ★셸을 안 지나므로★ 따옴표·백틱·`$` 가 해석될 자리가 없다.
  */
 async function deliverGroupReply(a: {
-  repoRoot: string; agentId: string; text: string; threadId: string; messageId: string;
+  agentId: string; text: string; threadId: string; messageId: string;
 }): Promise<{ ok: boolean; detail: string }> {
-  const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
-  const { tmpdir } = await import("node:os");
-  const { join } = await import("node:path");
-  const dir = mkdtempSync(join(tmpdir(), "b3os-out-"));
-  const file = join(dir, "body.txt");
+  const base = process.env.TEAM_BASE_URL ?? "http://127.0.0.1:7878/team";
   try {
-    writeFileSync(file, a.text, { mode: 0o600 });
-    const proc = Bun.spawn([
-      `${a.repoRoot}/skills/b3os-team-inbox/scripts/send.sh`,
-      "--to", "broadcast",
-      "--thread", a.threadId,
-      "--in-reply-to", a.messageId,
-      "--body-file", file,
-    ], {
-      stdout: "pipe",
-      stderr: "pipe",
-      cwd: a.repoRoot,
-      // ★발신자를 명시한다★: 그 스크립트는 기본적으로 ★현재 디렉터리↔작업폴더★ 로 누가 보내는지를
-      //   정하고, 실패하면 tmux 세션 이름으로 넘어간다. 이 프로세스의 디렉터리는 저장소 뿌리라
-      //   어느 팀원의 작업폴더도 아니고 tmux 세션도 없다 → ★해석이 실패해 발신이 통째로 죽는다.★
-      //   해석이 우연히 성공하는 환경에서는 더 나쁘다 — ★다른 팀원 이름으로 나간다.★
-      //   브리지는 이 턴의 주인을 알고 있으므로 추측 대신 그 값을 넘긴다(스크립트가 DB 로 검증한다).
-      env: { ...process.env, GD_AGENT_ID: a.agentId },
+    const res = await fetch(`${base}/api/inbox`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        from_agent_id: a.agentId,
+        to_agent_id: "broadcast",
+        body: a.text,
+        type: "dm",
+        priority: "normal",
+        source: "agent",
+        thread_id: a.threadId,
+        in_reply_to: a.messageId,
+      }),
     });
-    const [code, err] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
-    // ★실패 사유를 버리지 않는다★ — 버리면 다음 실패도 "운반 실패" 넉 자로만 남아 같은 조사를 반복한다.
-    return { ok: code === 0, detail: code === 0 ? "" : `exit ${code}: ${err.trim().slice(0, 160)}` };
-  } finally {
-    try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    // ★사유를 버리지 않는다★ — 버리면 다음 실패도 "운반 실패" 넉 자로만 남아 같은 조사를 반복한다.
+    if (res.ok) return { ok: true, detail: "" };
+    return { ok: false, detail: `http ${res.status}: ${(await res.text()).slice(0, 160)}` };
+  } catch (e) {
+    return { ok: false, detail: `fetch: ${e instanceof Error ? e.message.slice(0, 120) : String(e).slice(0, 120)}` };
   }
 }
 


### PR DESCRIPTION
## 문제

배포 후 실측에서 그룹 턴이 답까지는 갔는데 운반이 실패했다.

```
turn_ok:true · replied:true · chars:19 · delivered:false
```

브리지가 `send.sh` 를 실행해 운반했다. 그 스크립트는 발신자를 **현재 디렉터리 ↔ 팀원 작업폴더** 대조로 정하고, 실패하면 tmux 세션 이름으로 넘어간다. 브리지 프로세스의 디렉터리는 저장소 뿌리라 어느 팀원의 작업폴더도 아니고, launchd 아래라 tmux 세션도 없다 → 해석이 실패하고 발신이 죽는다.

실측(`GD_AGENT_ID` 없음 · `TMUX` 없음):

```
cwd=/                     → exit 1
cwd=/tmp                  → exit 1
cwd=<저장소 뿌리>          → exit 1     ← 브리지가 쓰는 자리
cwd=<그 팀원 작업폴더>     → dex
```

fail-closed 다. 조용한 오배송이 아니라 시끄러운 실패다.

## 해결 — 셸을 거치지 않는다

`send.sh` 도 결국 서버의 `/api/inbox` 로 POST 한다. 브리지가 그 스크립트를 실행하면 같은 목적지에 가면서 층이 하나 더 붙는다 — 하위 프로세스, 임시 파일, 환경변수, 그리고 위의 발신자 해석 단계다.

브리지는 이 턴의 주인을 알고 있다. `from_agent_id` 로 그대로 실으면 해석할 자리가 없어진다.

```
전:  브리지 → send.sh 실행 → (발신자 해석) → POST /api/inbox
후:  브리지 → POST /api/inbox   (from_agent_id 를 직접 싣는다)
```

본문도 셸을 안 지나므로 따옴표·백틱·`$` 가 해석될 자리가 없다.

## 실패 사유를 버리고 있었다

`stderr` 를 파이프로 받아놓고 읽지 않아 audit 에 `deliver_failed` 넉 자만 남았다. 원인을 알려면 손으로 재현해야 했다. 이제 상태 코드와 응답 본문 앞부분을 사유에 싣는다.

## 검증

- 라이브 입구로 왕복: `from_agent_id=dex` 로 POST → **201**, `from`/`to`/`thread` 가 그대로 기록된다
- **진짜 `deliverGroupReply` 를 통과하는 시험**: 시험 안에 서버 입구를 세우고 `deliver` 를 주입하지 않는다. 스텁만 재면 실제 함수에서 `from_agent_id` 를 바꿔도 초록이다
- 뮤턴트 3종 — `from_agent_id` 고정값 · 사유에서 응답 본문 제거 · `thread_id` 다른 값 → 전부 빨간불
- 전체 **3085 pass / 0 fail**

## 미검증

브리지 프로세스에서의 실제 운반 성공 여부는 배포 후에만 재진다.

완료 기준: `@<팀원>` → 방에 답 · 버스에 `from=<팀원> to=broadcast` 1건 · 승인 팝업 0건.
