### PR TITLE
fix(web): point Vocab Rise menu at stable route

### DIFF
--- a/src/web/components/MetricsBar.ts
+++ b/src/web/components/MetricsBar.ts
@@ -221,7 +221,7 @@ export function renderMetricsBar(root: HTMLElement): void {
               ${navIcon("settings", "Settings")}
             </button>
             <a id="global-vocab-rise-link"
-              href="/reports/file/vocab-rise-b2-c1/html"
+              href="/vocab-rise/"
               class="inline-flex min-h-10 items-center px-2 py-1 rounded-md text-[11px] md:text-[13px] text-slate-400 hover:bg-surface-3 hover:text-slate-200 whitespace-nowrap [touch-action:manipulation]"
               title="${pick("Vocab Rise — 중상급 영어 단어·표현 학습", "Vocab Rise — upper-intermediate vocabulary and phrases")}">Vocab Rise</a>
           </div>

--- a/src/web/components/vocabRiseMenu.test.ts
+++ b/src/web/components/vocabRiseMenu.test.ts
@@ -7,7 +7,7 @@ const source = readFileSync(join(import.meta.dir, "MetricsBar.ts"), "utf8");
 describe("Vocab Rise global menu", () => {
   it("links to the canonical published app", () => {
     expect(source).toContain('id="global-vocab-rise-link"');
-    expect(source).toContain('href="/reports/file/vocab-rise-b2-c1/html"');
+    expect(source).toContain('href="/vocab-rise/"');
     expect(source).toContain('>Vocab Rise<');
   });
 


### PR DESCRIPTION
## 핵심
- Vocab Rise 메뉴를 compatibility file URL에서 canonical `/vocab-rise/`로 전환합니다.
- gate route와 old `/reports` rollback bundle은 이미 live입니다.

## 검증
- focused test 2/2
- typecheck pass
- production build pass
- canonical `/vocab-rise/` HTML/MP3 live 200

## Rollback
- 이 commit revert 시 기존 `/reports/file/vocab-rise-b2-c1/html`로 복원