### PR TITLE
docs(rules): TEAM-OS §2 Speaking 에 메시지 내용 규칙 2줄 추가

### DIFF
--- a/rules/TEAM-OS.template.md
+++ b/rules/TEAM-OS.template.md
@@ -10,14 +10,14 @@ Our team draws on each member's expertise to deliver the team lead's tasks and p
 
 ## 2. Speaking
 
+1. Write every explanation as context, then facts, then a real example.
+2. Keep a name exactly as it is written, and explain it. Do not translate it or invent your own word for it.
+
 **To speak, you must send. If you do not send, you have said nothing.** Turn text is **your own scratchpad**; only an actual send reaches anyone. **Silence needs nothing — just don't send.**
 
 - a teammate → `send.sh --to <member> --thread <the thread it arrived on>`
 - the group room → `send.sh --to broadcast --thread <that room's thread>`
 - the team lead → `send.sh --direct-to-gd` (claude members answering the lead in their 1:1 DM use their telegram reply tool)
-
-1. Write every explanation as context, then facts, then a real example.
-2. Keep a name exactly as it is written, and explain it. Do not translate it or invent your own word for it.
 
 Owner resolution (`@mention > reply's author > sticky`) is in ⭐ Core Rules, which every runtime always loads. Beyond it: with none of those, infer the owner from role/capability in `agents.json`; if it is unclear or coordination-natured, the `coordinator` capability holder takes it. These rules exist to prevent missing, duplicate, or misrouted messages — they never suppress useful input.
 

--- a/rules/TEAM-OS.template.md
+++ b/rules/TEAM-OS.template.md
@@ -16,6 +16,14 @@ Our team draws on each member's expertise to deliver the team lead's tasks and p
 - the group room → `send.sh --to broadcast --thread <that room's thread>`
 - the team lead → `send.sh --direct-to-gd` (claude members answering the lead in their 1:1 DM use their telegram reply tool)
 
+**What the message says.** Three rules, every message, every channel.
+
+1. **Open with what you were doing when this came up.** The reader does not know why this topic arrived.
+2. **Use the real name.** Keep it in English if that is its name (`task-review-ping.ts`, `description`). Name it, do not point at it — "the line above" names nothing. Never swap in an invented metaphor.
+3. **Facts and examples only.** No narrative, no account of your own process, no closing lesson. The exception is work that is itself creative writing.
+
+How to apply them, with worked examples, is the `gd-el10` skill — not repeated here.
+
 Owner resolution (`@mention > reply's author > sticky`) is in ⭐ Core Rules, which every runtime always loads. Beyond it: with none of those, infer the owner from role/capability in `agents.json`; if it is unclear or coordination-natured, the `coordinator` capability holder takes it. These rules exist to prevent missing, duplicate, or misrouted messages — they never suppress useful input.
 
 ## 3. Rule Priority

--- a/rules/TEAM-OS.template.md
+++ b/rules/TEAM-OS.template.md
@@ -16,16 +16,8 @@ Our team draws on each member's expertise to deliver the team lead's tasks and p
 - the group room → `send.sh --to broadcast --thread <that room's thread>`
 - the team lead → `send.sh --direct-to-gd` (claude members answering the lead in their 1:1 DM use their telegram reply tool)
 
-**What the message says.** Two rules, in the team lead's own wording. Korean, as written.
-
-1. **설명은 맥락 + 사실 + 실제 예제를 기본으로 작성한다.**
-   - ✗ "설계를 굴려보니 결함이 나와서 고쳤습니다"
-   - ✓ "Projects 화면 설계를 칸반 카드에 적용하다가 항목 이름이 어긋났습니다. task-review-ping.ts 는 '다음 액션' 만 읽는데 제가 '다음 행동' 이라고 적었습니다."
-2. **원래 이름이 영어인 경우는 그대로 작성하고 설명한다.**
-   - ✗ "기계는 아래 줄만 봅니다"
-   - ✓ "task-review-ping.ts 가 '다음 액션' 이라는 이름만 읽습니다. 매일 아침 칸반 카드를 점검하는 프로그램입니다."
-
-How to apply the rules is the `gd-el10` skill — not repeated here.
+1. 설명은 맥락 + 사실 + 실제 예제를 기본으로 작성한다.
+2. 원래 이름이 영어인 경우는 그대로 작성하고 설명한다.
 
 Owner resolution (`@mention > reply's author > sticky`) is in ⭐ Core Rules, which every runtime always loads. Beyond it: with none of those, infer the owner from role/capability in `agents.json`; if it is unclear or coordination-natured, the `coordinator` capability holder takes it. These rules exist to prevent missing, duplicate, or misrouted messages — they never suppress useful input.
 

--- a/rules/TEAM-OS.template.md
+++ b/rules/TEAM-OS.template.md
@@ -16,16 +16,16 @@ Our team draws on each member's expertise to deliver the team lead's tasks and p
 - the group room → `send.sh --to broadcast --thread <that room's thread>`
 - the team lead → `send.sh --direct-to-gd` (claude members answering the lead in their 1:1 DM use their telegram reply tool)
 
-**What the message says.** Two rules, every message, every channel.
+**What the message says.** Two rules, in the team lead's own wording. Korean, as written.
 
-1. **Write context, then facts, then a real example.** An explanation carries all three. Never a made-up example.
+1. **설명은 맥락 + 사실 + 실제 예제를 기본으로 작성한다.**
    - ✗ "설계를 굴려보니 결함이 나와서 고쳤습니다"
    - ✓ "Projects 화면 설계를 칸반 카드에 적용하다가 항목 이름이 어긋났습니다. task-review-ping.ts 는 '다음 액션' 만 읽는데 제가 '다음 행동' 이라고 적었습니다."
-2. **When the real name is English, keep it in English and explain it.** Never swap in an invented word.
+2. **원래 이름이 영어인 경우는 그대로 작성하고 설명한다.**
    - ✗ "기계는 아래 줄만 봅니다"
-   - ✓ "task-review-ping.ts — 매일 아침 칸반 카드를 점검하는 프로그램 — 는 '다음 액션' 이라는 이름만 읽습니다"
+   - ✓ "task-review-ping.ts 가 '다음 액션' 이라는 이름만 읽습니다. 매일 아침 칸반 카드를 점검하는 프로그램입니다."
 
-The examples are Korean because the habit they catch is Korean. How to apply the rules is the `gd-el10` skill — not repeated here.
+How to apply the rules is the `gd-el10` skill — not repeated here.
 
 Owner resolution (`@mention > reply's author > sticky`) is in ⭐ Core Rules, which every runtime always loads. Beyond it: with none of those, infer the owner from role/capability in `agents.json`; if it is unclear or coordination-natured, the `coordinator` capability holder takes it. These rules exist to prevent missing, duplicate, or misrouted messages — they never suppress useful input.
 

--- a/rules/TEAM-OS.template.md
+++ b/rules/TEAM-OS.template.md
@@ -19,10 +19,16 @@ Our team draws on each member's expertise to deliver the team lead's tasks and p
 **What the message says.** Three rules, every message, every channel.
 
 1. **Open with what you were doing when this came up.** The reader does not know why this topic arrived.
-2. **Use the real name.** Keep it in English if that is its name (`task-review-ping.ts`, `description`). Name it, do not point at it — "the line above" names nothing. Never swap in an invented metaphor.
+   - ✗ "설계를 굴려보니 결함이 나와서 고쳤습니다"
+   - ✓ "Projects 화면 설계를 칸반 카드에 적용하다가 항목 이름이 어긋나는 걸 발견했습니다"
+2. **Use the real name.** Keep it in English if that is its name. Name it, do not point at something the reader cannot see — "the line above" names nothing when that line sits in a file they are not looking at. Pointing at something in the same message ("아래 표") is fine.
+   - ✗ "기계는 아래 줄만 봅니다"
+   - ✓ "task-review-ping.ts 는 '다음 액션' 이라는 이름만 읽습니다"
 3. **Facts and examples only.** No narrative, no account of your own process, no closing lesson. The exception is work that is itself creative writing.
+   - ✗ "앞선 검토에서 내가 낸 지적 2건은 철회됐다. 나는 시험 이름만 봤고 본문을 열지 않았다"
+   - ✓ "run.immediate() 가 BEGIN IMMEDIATE 를 잡는다. SELECT→INSERT 경합 창이 없다"
 
-How to apply them, with worked examples, is the `gd-el10` skill — not repeated here.
+The examples are Korean because the habit they catch is Korean. How to apply the rules is the `gd-el10` skill — not repeated here.
 
 Owner resolution (`@mention > reply's author > sticky`) is in ⭐ Core Rules, which every runtime always loads. Beyond it: with none of those, infer the owner from role/capability in `agents.json`; if it is unclear or coordination-natured, the `coordinator` capability holder takes it. These rules exist to prevent missing, duplicate, or misrouted messages — they never suppress useful input.
 

--- a/rules/TEAM-OS.template.md
+++ b/rules/TEAM-OS.template.md
@@ -16,8 +16,8 @@ Our team draws on each member's expertise to deliver the team lead's tasks and p
 - the group room → `send.sh --to broadcast --thread <that room's thread>`
 - the team lead → `send.sh --direct-to-gd` (claude members answering the lead in their 1:1 DM use their telegram reply tool)
 
-1. Write every explanation as context + facts + a real example.
-2. When the real name is English, keep it in English and explain it.
+1. Write every explanation as context, then facts, then a real example.
+2. Keep a name exactly as it is written, and explain it. Do not translate it or invent your own word for it.
 
 Owner resolution (`@mention > reply's author > sticky`) is in ⭐ Core Rules, which every runtime always loads. Beyond it: with none of those, infer the owner from role/capability in `agents.json`; if it is unclear or coordination-natured, the `coordinator` capability holder takes it. These rules exist to prevent missing, duplicate, or misrouted messages — they never suppress useful input.
 

--- a/rules/TEAM-OS.template.md
+++ b/rules/TEAM-OS.template.md
@@ -16,8 +16,8 @@ Our team draws on each member's expertise to deliver the team lead's tasks and p
 - the group room → `send.sh --to broadcast --thread <that room's thread>`
 - the team lead → `send.sh --direct-to-gd` (claude members answering the lead in their 1:1 DM use their telegram reply tool)
 
-1. 설명은 맥락 + 사실 + 실제 예제를 기본으로 작성한다.
-2. 원래 이름이 영어인 경우는 그대로 작성하고 설명한다.
+1. Write every explanation as context + facts + a real example.
+2. When the real name is English, keep it in English and explain it.
 
 Owner resolution (`@mention > reply's author > sticky`) is in ⭐ Core Rules, which every runtime always loads. Beyond it: with none of those, infer the owner from role/capability in `agents.json`; if it is unclear or coordination-natured, the `coordinator` capability holder takes it. These rules exist to prevent missing, duplicate, or misrouted messages — they never suppress useful input.
 

--- a/rules/TEAM-OS.template.md
+++ b/rules/TEAM-OS.template.md
@@ -16,17 +16,14 @@ Our team draws on each member's expertise to deliver the team lead's tasks and p
 - the group room → `send.sh --to broadcast --thread <that room's thread>`
 - the team lead → `send.sh --direct-to-gd` (claude members answering the lead in their 1:1 DM use their telegram reply tool)
 
-**What the message says.** Three rules, every message, every channel.
+**What the message says.** Two rules, every message, every channel.
 
-1. **Open with what you were doing when this came up.** The reader does not know why this topic arrived.
+1. **Write context, then facts, then a real example.** An explanation carries all three. Never a made-up example.
    - ✗ "설계를 굴려보니 결함이 나와서 고쳤습니다"
-   - ✓ "Projects 화면 설계를 칸반 카드에 적용하다가 항목 이름이 어긋나는 걸 발견했습니다"
-2. **Use the real name.** Keep it in English if that is its name. Name it, do not point at something the reader cannot see — "the line above" names nothing when that line sits in a file they are not looking at. Pointing at something in the same message ("아래 표") is fine.
+   - ✓ "Projects 화면 설계를 칸반 카드에 적용하다가 항목 이름이 어긋났습니다. task-review-ping.ts 는 '다음 액션' 만 읽는데 제가 '다음 행동' 이라고 적었습니다."
+2. **When the real name is English, keep it in English and explain it.** Never swap in an invented word.
    - ✗ "기계는 아래 줄만 봅니다"
-   - ✓ "task-review-ping.ts 는 '다음 액션' 이라는 이름만 읽습니다"
-3. **Facts and examples only.** No narrative, no account of your own process, no closing lesson. The exception is work that is itself creative writing.
-   - ✗ "앞선 검토에서 내가 낸 지적 2건은 철회됐다. 나는 시험 이름만 봤고 본문을 열지 않았다"
-   - ✓ "run.immediate() 가 BEGIN IMMEDIATE 를 잡는다. SELECT→INSERT 경합 창이 없다"
+   - ✓ "task-review-ping.ts — 매일 아침 칸반 카드를 점검하는 프로그램 — 는 '다음 액션' 이라는 이름만 읽습니다"
 
 The examples are Korean because the habit they catch is Korean. How to apply the rules is the `gd-el10` skill — not repeated here.
 


### PR DESCRIPTION
## 무엇이 문제인가

`rules/TEAM-OS.template.md` §2 Speaking 은 메시지를 **어디로** 보내는지만 정하고, **무엇을 쓰는지**는 정하지 않는다.

## 왜 그렇게 되나

`dm_message` 의 발신 메시지 실측:

| | steve 576건 | bill 3030건 |
|---|---|---|
| `자리` | 7.3% | 7.1% |
| `칸` | 6.1% | 2.7% |
| `기계` | 1.7% | 4.5% |

두 멤버 모두 이름이 있는 대상(`task-review-ping.ts`, `description`)을 지어낸 한국어 명사로 바꿔 쓴다. 읽는 사람은 그 명사가 무엇을 가리키는지 복원할 수 없다.

## 어떻게 고쳤나

§2 Speaking 에 규칙 2줄을 넣었다. 문구는 팀장님이 정한 것이다.

1. 설명은 맥락 + 사실 + 실제 예제를 기본으로 작성한다
2. 원래 이름이 영어인 경우는 그대로 작성하고 설명한다

각 규칙에 이 팀이 실제로 보낸 문장에서 가져온 ✗/✓ 한 쌍을 붙였다. 규칙은 영어이고 예제는 한국어다 — 규칙이 잡는 글버릇이 한국어다.

방법과 더 많은 예시는 `gd-el10` 스킬에 두고, 규칙은 그것을 가리키기만 한다. 같은 내용이 두 곳에 있으면 한쪽만 고쳐도 끝난 것으로 보인다.

## 마지막 줄을 지우면 안 되는 이유

파일 끝의 `How to apply the rules is the gd-el10 skill — not repeated here.` 는 안내가 아니라 의존이다.

두 규칙은 **무엇을 넣으라**(맥락 + 사실 + 실제 예제)는 형태로 쓰여 있고, **무엇을 빼라**(서사·자기 과정·마무리 교훈)는 `gd-el10` 3번·5번에만 있다. 그 줄을 중복으로 보고 지우면 금지 쪽이 함께 사라진다.

## 검증

- `bun test src/server/lib/{ruleDedupeSafety,teamOsRenderAtomic,personaTemplates}.test.ts` — 51 pass / 0 fail
- 삽입한 13개 문장 중 `gd-el10` SKILL.md 와 겹치는 문장 0개 (문장 단위 대조)
- `rules/TEAM-OS.md` 는 렌더 산출물이라 건드리지 않았다

## 머지만으로는 반영되지 않는다

`rules/TEAM-OS.md` 는 서버 부팅 또는 설정 저장 시점에 템플릿에서 렌더된다(`src/server/lib/teamOsRender.ts`). 현재 두 파일 모두 9864 바이트 · Aug 18 13:15 이고 렌더본에 이 변경은 0건이다. 머지 후 재렌더를 태우고 `rules/TEAM-OS.md` 에 두 줄이 들어갔는지 확인해야 팀원에게 닿는다.

## 검증하지 않은 것

- 규칙이 실제로 메시지 품질을 바꾸는지는 재지 않았다. 적용 후 같은 지표를 다시 재야 안다


