### PR TITLE
fix(team-os): up 이 팀 서버를 먼저 켜게 한다

### DIFF
--- a/bin/team-os
+++ b/bin/team-os
@@ -112,6 +112,31 @@ boot_services() {
   done
 }
 
+# ─── 켜는 순서 ────────────────────────────────────────────────────────────
+# ★무엇을 켜는지는 boot_services 가 정한다.★ 설치마다 팀원이 다르므로 발견에 맡긴다.
+#   여기서 정하는 것은 ★순서뿐★ 이다. 팀 서버가 먼저 떠야 팀원 poller 가 붙는다.
+#   알파벳순으로 켜면 com.gdmini.team-collab 이 claude-telegram-* 보다 뒤라 봇이 먼저 뜬다.
+#
+# ★목록에 없는 라벨은 rank 50 으로 뒤에 붙는다.★ 새 팀원이 들어와도 빠지지 않는다 —
+#   이 목록은 "누가 켜지나" 가 아니라 "무엇이 먼저냐" 만 정한다.
+#   서버 라벨이 바뀌면 목록이 안 맞아 알파벳순으로 돌아간다. 안 켜지는 게 아니라 순서만 잃는다.
+boot_rank() {
+  case "$1" in
+    *team-collab*) echo 10 ;;
+    *openclaw*)    echo 20 ;;
+    *)             echo 50 ;;
+  esac
+}
+
+# rank 로 안정 정렬(-s)한다. 같은 rank 안에서는 boot_services 가 준 순서가 그대로 남는다.
+boot_services_ordered() {
+  local _lbl _plist
+  while IFS='|' read -r _lbl _plist; do
+    [ -n "$_lbl" ] || continue
+    printf '%s\t%s|%s\n' "$(boot_rank "$_lbl")" "$_lbl" "$_plist"
+  done < <(boot_services) | sort -n -s -k1,1 | cut -f2-
+}
+
 loaded() { launchctl print "gui/$(id -u)/$1" >/dev/null 2>&1; }
 
 # 팀원 런처인가. 런처는 팀원을 tmux 로 띄우고 자기는 끝난다 — 그래서 launchd 상태로는
@@ -418,7 +443,7 @@ case "${1:-help}" in
         echo "  ✗ $_lbl 등록 실패 — ${_err:-(메시지 없음)}"
         FAILED="$FAILED $_lbl"
       fi
-    done < <(boot_services)
+    done < <(boot_services_ordered)
     # 서버 HTTP 는 ★확인용으로만★ 쓴다. 여기서 다시 올리지 않는다.
     #   프로세스는 살아 있는데 HTTP 가 아직 안 열린 상태(부팅 직후)가 정상적으로 있고,
     #   그때 재시작하면 ★막 올라오던 서버를 죽이고 처음부터★ 시작한다 —

--- a/bin/team-os
+++ b/bin/team-os
@@ -120,10 +120,15 @@ boot_services() {
 # ★목록에 없는 라벨은 rank 50 으로 뒤에 붙는다.★ 새 팀원이 들어와도 빠지지 않는다 —
 #   이 목록은 "누가 켜지나" 가 아니라 "무엇이 먼저냐" 만 정한다.
 #   서버 라벨이 바뀌면 목록이 안 맞아 알파벳순으로 돌아간다. 안 켜지는 게 아니라 순서만 잃는다.
+#
+# ★여기에 라벨을 적기 전에 boot_services 가 그 라벨을 낼 수 있는지 먼저 봐라.★
+#   openclaw 게이트웨이를 넣었다가 뺐다 — ai.openclaw.gateway.plist 는 이 저장소 경로를
+#   참조하지 않아 boot_services 가 내놓지 않는다(위 grep -Fq "$REPO" 필터).
+#   적어두면 다루는 것처럼 읽히는데 그 case 에 한 번도 안 들어간다. 순위표만 낡는다. (steve 지적)
+#   그 게이트웨이는 RunAtLoad·KeepAlive 가 둘 다 true 라 로그인 때 스스로 뜬다.
 boot_rank() {
   case "$1" in
     *team-collab*) echo 10 ;;
-    *openclaw*)    echo 20 ;;
     *)             echo 50 ;;
   esac
 }

--- a/scripts/team-os.test.sh
+++ b/scripts/team-os.test.sh
@@ -71,6 +71,63 @@ else
   ok "인라인 중복 설명 없음"
 fi
 
+echo "── T5: up 은 ★팀 서버를 먼저★ 켠다 (알파벳순이면 봇이 먼저 뜬다) ──"
+# ★이름 목록을 세지 않는다.★ 새 팀원 plist 를 하나 만들어 넣고,
+#   그 팀원이 대상에 들어오면서 ★서버 뒤★ 에 오는지를 본다.
+#   개수를 상수로 박으면 그 시험은 오늘만 맞다 (steve 지적).
+T5H="$TMP/home5"; mkdir -p "$T5H/Library/LaunchAgents"
+mk_plist() { # mk_plist <라벨> <본문에 넣을 저장소경로>
+  cat > "$T5H/Library/LaunchAgents/$1.plist" <<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>$1</string>
+  <key>RunAtLoad</key><true/>
+  <key>ProgramArguments</key><array><string>$2/bin/dummy</string></array>
+</dict></plist>
+XML
+}
+T5REPO="$TMP/repo5"; mkdir -p "$T5REPO/src/server"; : > "$T5REPO/package.json"
+mk_plist "com.test.aaa-first-alphabetically" "$T5REPO"
+mk_plist "com.test.team-collab"              "$T5REPO"
+mk_plist "com.test.claude-telegram-newbie"   "$T5REPO"   # ← 오늘 없던 팀원
+
+ORDER="$(HOME="$T5H" TEAM_OS_REPO="$T5REPO" TEAMOS_LIB_ONLY=1          bash -c 'source "'"$TARGET"'"; boot_services_ordered | cut -d"|" -f1')"
+
+case "$(printf '%s\n' "$ORDER" | head -1)" in
+  *team-collab*) ok "팀 서버가 맨 앞이다" ;;
+  *) bad "팀 서버가 맨 앞이 아니다 — 실제 순서: $(printf '%s' "$ORDER" | tr '\n' ' ')" ;;
+esac
+
+printf '%s\n' "$ORDER" | grep -q 'claude-telegram-newbie' \
+  && ok "목록에 없던 새 팀원도 대상에 들어온다" \
+  || bad "새 팀원이 빠졌다 — 이름을 박아둔 것이다"
+
+SRV_N="$(printf '%s\n' "$ORDER" | grep -n 'team-collab' | cut -d: -f1)"
+NEW_N="$(printf '%s\n' "$ORDER" | grep -n 'claude-telegram-newbie' | cut -d: -f1)"
+if [ -n "$SRV_N" ] && [ -n "$NEW_N" ] && [ "$SRV_N" -lt "$NEW_N" ]; then
+  ok "새 팀원은 서버보다 뒤다"
+else
+  bad "새 팀원이 서버보다 앞이다 (서버 ${SRV_N} · 팀원 ${NEW_N})"
+fi
+
+echo "── T6: ★up 이 실제로 그 순서를 쓰는지★ (함수만 고치고 배선을 안 하면 여기서 걸린다) ──"
+# T5 는 boot_services_ordered 를 직접 부른다. 그래서 up 이 옛 열거를 쓰도록 되돌려도 T5 는 통과한다.
+#   실제로 그 뮤턴트를 넣어보니 T5 가 살아남았다. 그래서 up 을 돌려서 처리 순서를 본다.
+#   가짜 HOME·가짜 저장소·stub launchctl 이라 실제 서비스는 건드리지 않는다.
+UPOUT="$(HOME="$T5H" TEAM_OS_REPO="$T5REPO" PATH="$STUB:$PATH" bash "$TARGET" up 2>&1)"
+
+UP_SRV="$(printf '%s\n' "$UPOUT" | grep -n 'team-collab' | head -1 | cut -d: -f1)"
+UP_NEW="$(printf '%s\n' "$UPOUT" | grep -n 'claude-telegram-newbie' | head -1 | cut -d: -f1)"
+
+if [ -z "$UP_SRV" ] || [ -z "$UP_NEW" ]; then
+  bad "up 출력에 서버나 새 팀원이 안 보인다 — 순서를 잴 수 없다"
+elif [ "$UP_SRV" -lt "$UP_NEW" ]; then
+  ok "up 이 서버를 새 팀원보다 먼저 처리한다"
+else
+  bad "up 이 새 팀원을 서버보다 먼저 처리한다 (서버 ${UP_SRV}번째 · 팀원 ${UP_NEW}번째)"
+fi
+
 echo
 if [ "$FAILED" -eq 0 ]; then echo "ALL PASS — team-os 진입 동작"; else echo "FAIL — team-os 진입 동작"; fi
 exit "$FAILED"


### PR DESCRIPTION
proposal prop_7d2106d5f461 의 1단계입니다. 팀장님 승인 받고 진행했습니다.

## 무슨 일인가

맥을 재부팅하면 서비스를 자동으로 켜주는 자동실행이 하나 있습니다 — `com.gdmini.team-os-boot-recovery`.

```
그게 부르는 것   ~/Development/b3rys-team-collab/scripts/team-os.sh   7월 17일 파일
지금 쓰는 것     ~/Development/b3rys-team-os/bin/team-os             7월 30일 파일
```

7월 17일 파일 26행에 팀원 이름이 글자로 박혀 있습니다.

```
CLAUDE_BOTS="bill steve demis dbak"      ← lui 없음. dex 브리지도 없음
```

## 확인해보니 대상 문제는 이미 해결돼 있습니다

`bin/team-os` 는 이름을 안 쓰고 `~/Library/LaunchAgents` 를 훑어 대상을 찾습니다(`boot_services`).
이 기계에서 실제로 뽑아보면 `claude-telegram-lui` 와 `codex-bridge-dex` 가 둘 다 들어옵니다.

빠져 있던 것은 **켜는 순서**입니다.

```
알파벳순    claude-telegram-bill … claude-telegram-steve  codex-bridge-dex  team-collab
                                                                          ↑ 서버가 맨 뒤
```

팀원 poller 는 그 서버에 붙습니다. 서버가 뒤에 켜지면 봇들이 먼저 떠서 붙을 데가 없습니다.

## 무엇을 바꿨나

`boot_rank` + `boot_services_ordered` 를 넣고 **`up` 만** 그것을 씁니다. `status`·`doctor` 는 그대로입니다.

- **누가 켜지는지는 안 바뀝니다.** 그건 `boot_services` 가 정합니다.
- 이 rank 는 순서만 정합니다. 목록에 없는 라벨은 50 으로 뒤에 붙어서 **새 팀원이 빠지지 않습니다.**
- 서버 라벨이 바뀌면 rank 가 안 맞아 알파벳순으로 돌아갑니다. 안 켜지는 게 아니라 순서만 잃습니다.

적용 후 실제 순서:

```
com.gdmini.team-collab            ← 앞으로 옴
com.gdmini.claude-telegram-bill
… (나머지는 원래 순서 그대로)
```

## 시험

`T5` — `boot_services_ordered` 가 서버를 앞에 놓는가.
가짜 팀원 plist(`claude-telegram-newbie`)를 만들어 넣고 **그 팀원이 대상에 들어오면서 서버 뒤에 오는지** 봅니다.
개수는 세지 않습니다. 개수를 상수로 박으면 그 시험은 오늘만 맞습니다.

`T6` — `up` 이 실제로 그 순서를 쓰는가. 가짜 HOME·가짜 저장소·stub `launchctl` 로 돌려 처리 순서를 봅니다.

## 뮤턴트

```
rank 를 전부 50 으로      → T5 실패
up 을 옛 열거로 되돌림    → T6 실패,  T5 는 통과
```

두 번째가 T6 를 넣은 이유입니다. 처음엔 T5 만 있었고, 그 뮤턴트가 살아남았습니다.

## 통과

`team-os.test.sh` · `team-os-booting` · `team-os-guards` · `team-os-poller` 전부 ALL PASS.

## 안 한 것

- 자동실행 plist 를 `bin/team-os` 로 바꾸는 것 — 이 PR 다음 단계입니다.
- 재부팅 확인 — 팀장님 맥이라 시점을 정해주셔야 합니다. **그 전에는 완료로 보지 않습니다.**
- 두 파일의 `up` 결과가 실제로 같은지는 안 돌려봤습니다. 지금 돌리면 서비스를 건드립니다.