### PR TITLE
fix(web): remove unrequested Vocab Rise dashboard link

### DIFF
--- a/src/web/components/MetricsBar.ts
+++ b/src/web/components/MetricsBar.ts
@@ -220,10 +220,6 @@ export function renderMetricsBar(root: HTMLElement): void {
               title="${pick("팀 설정 — 팀명·미션·팀원", "Team settings — team name·mission·members")}">
               ${navIcon("settings", "Settings")}
             </button>
-            <a id="global-vocab-rise-link"
-              href="/vocab-rise/"
-              class="inline-flex min-h-10 items-center px-2 py-1 rounded-md text-[11px] md:text-[13px] text-slate-400 hover:bg-surface-3 hover:text-slate-200 whitespace-nowrap [touch-action:manipulation]"
-              title="${pick("Vocab Rise — 중상급 영어 단어·표현 학습", "Vocab Rise — upper-intermediate vocabulary and phrases")}">Vocab Rise</a>
           </div>
           <div class="flex items-center justify-end gap-2 md:gap-3 text-[10px] md:text-[11px] min-w-0 shrink overflow-hidden">
             <span class="hidden lg:inline-flex items-center gap-1 font-mono tabular-nums text-slate-500 whitespace-nowrap" title="${pick("실시간 CPU 사용률", "Live CPU usage")}">

--- a/src/web/components/vocabRiseMenu.test.ts
+++ b/src/web/components/vocabRiseMenu.test.ts
@@ -4,24 +4,10 @@ import { join } from "node:path";
 
 const source = readFileSync(join(import.meta.dir, "MetricsBar.ts"), "utf8");
 
-describe("Vocab Rise global menu", () => {
-  it("links to the canonical published app", () => {
-    expect(source).toContain('id="global-vocab-rise-link"');
-    expect(source).toContain('href="/vocab-rise/"');
-    expect(source).toContain('>Vocab Rise<');
-  });
-
-  it("is the final item in the left global navigation", () => {
-    const settings = source.indexOf('id="global-settings-tab"');
-    const vocab = source.indexOf('<a id="global-vocab-rise-link"');
-    const clusterEnd = source.indexOf('</div>\n          <div class="flex items-center justify-end', settings);
-    const finalFragment = source.slice(vocab, clusterEnd);
-    expect(settings).toBeGreaterThan(-1);
-    expect(vocab).toBeGreaterThan(settings);
-    expect(vocab).toBeLessThan(clusterEnd);
-    expect(finalFragment.match(/<(?:a|button)\b/g)).toHaveLength(1);
-    expect(finalFragment).not.toContain('target=');
-    expect(finalFragment).toContain('min-h-10');
-    expect(finalFragment).toContain('[touch-action:manipulation]');
+describe("dashboard navigation scope", () => {
+  it("does not expose Vocab Rise in the b3os global menu", () => {
+    expect(source).not.toContain('id="global-vocab-rise-link"');
+    expect(source).not.toContain('href="/vocab-rise/"');
+    expect(source).not.toContain('>Vocab Rise</a>');
   });
 });


### PR DESCRIPTION
## 핵심
- b3os 전역 메뉴에서 요청하지 않은 Vocab Rise 링크를 제거합니다.
- Vocab Rise는 dev.b3rys.com 서비스 목록에서만 노출합니다.
- 링크가 다시 추가되지 않도록 부재 계약 테스트로 변경합니다.

## 검증
- focused test 1/1
- typecheck pass
- production build pass

## Rollback
- 이 commit revert

Submitted-by: Ames