### PR TITLE
fix(reports): preserve selection interactions

### DIFF
--- a/src/web/components/Reports.ts
+++ b/src/web/components/Reports.ts
@@ -711,6 +711,11 @@ function rememberListScroll(): void {
   if (scroller) _listScrollTop = scroller.scrollTop;
 }
 
+function renderListPreservingScroll(): void {
+  rememberListScroll();
+  renderList();
+}
+
 function rememberDetailScroll(): void {
   const scroller = _root?.querySelector<HTMLElement>("[data-reports-detail-scroll]");
   if (scroller) _detailScrollTop = scroller.scrollTop;
@@ -824,7 +829,7 @@ function renderList(): void {
       : "text-txt-amber border-amber-300 bg-transparent hover:border-amber-500"}`;
   const pills =
     `<button class="${pillCls(_cat === ALL_FILTER)}" data-cat="${ALL_FILTER}">${pick("전체", "All")}<span class="ml-1.5 text-[11px] text-slate-500" data-reports-all-count>${allCount}</span></button>` +
-    `<button class="${pillCls(_cat === IMPORTANT_FILTER)}" data-cat="${IMPORTANT_FILTER}" title="${pick("중요 표시만 보기", "Show important only")}" aria-label="${pick("중요 표시만 보기", "Show important only")}"><span>${pick("별표", "Starred")}</span><span class="text-[11px] text-slate-500" data-reports-important-count>${_importantCount}</span></button>` +
+    `<button class="${pillCls(_cat === IMPORTANT_FILTER)}" data-cat="${IMPORTANT_FILTER}" title="${pick("중요 표시만 보기", "Show important only")}" aria-label="${pick("중요 표시만 보기", "Show important only")}"><span class="text-rose-300">${starIcon(true)}</span><span class="text-[11px] text-slate-500" data-reports-important-count>${_importantCount}</span></button>` +
     cats.map((c) => `<button class="${pillCls(_cat === c)}" data-cat="${escape(c)}">${folderIcon()}${escape(c)}<span class="ml-1.5 text-[11px] text-slate-500" data-reports-category-count="${escape(c)}">${counts[c]}</span></button>`).join("");
   const tagPills = tagPillsHtml(_tags, _selectedTagIds, tagPillCls);
 
@@ -871,7 +876,7 @@ function renderList(): void {
   const loadMore = items.length
     ? `<div class="py-4 text-center text-[12px] text-slate-500" data-reports-page-status>${_loading ? pick("더 불러오는 중…", "Loading more…") : _hasMore ? pick("아래로 스크롤하면 더 불러옵니다", "Scroll down to load more") : pick("마지막 보고서입니다", "End of reports")}</div>`
     : "";
-  const selectionBar = _selectionMode ? `<div class="mt-2 rounded-xl border border-accent-green/40 bg-accent-green/[0.07] px-4 py-2.5 text-[12px] flex items-center justify-between">
+  const selectionBar = _selectionMode ? `<div class="mb-2 rounded-xl border border-accent-green/40 bg-accent-green/[0.07] px-4 py-2.5 text-[12px] flex items-center justify-between">
     <span class="text-accent-green font-semibold">${_selectedReportIds.size}${pick("건 선택됨", " selected")}</span>
     <span class="flex gap-1.5"><button id="reports-move-selected" class="px-2.5 py-1 rounded-md border border-surface-3 bg-surface-2 text-slate-300 text-[11px] disabled:opacity-40"${_selectedReportIds.size ? "" : " disabled"}>${pick("분류로 이동 ▾", "Move to category ▾")}</button><button id="reports-cancel-selection" class="px-2.5 py-1 rounded-md text-slate-500 text-[11px]">${pick("취소", "Cancel")}</button></span>
   </div>` : "";
@@ -893,11 +898,12 @@ function renderList(): void {
           <div class="relative flex-1"><svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
             <input id="reports-q" type="search" placeholder="${pick("제목·작성자·요약 검색", "Search title · author · summary")}" value="${escape(_query)}" class="w-full bg-surface-2 border border-surface-3 rounded-xl text-sm text-slate-200 pl-9 pr-3 py-2.5 outline-none focus:border-accent-green/40 placeholder:text-slate-600" />
           </div>
-          <button id="reports-selection-mode" class="shrink-0 px-3 py-2 rounded-lg text-[12px] font-semibold border border-surface-3 bg-surface-2 text-slate-400">${pick("선택", "Select")}</button>
+          <button id="reports-selection-mode" class="shrink-0 px-3 py-2 rounded-lg text-[12px] font-semibold border border-surface-3 bg-surface-2 text-slate-400">${_selectionMode ? pick("선택 해제", "Deselect") : pick("선택", "Select")}</button>
         </div>
+        ${selectionBar}
         ${loadingBar}
         <div class="${_reloading ? "opacity-50 transition-opacity" : "transition-opacity"}">
-        ${_loadError ? error : items.length ? `<div class="flex flex-col gap-2.5">${cards}</div>${selectionBar}${loadMore}` : empty}
+        ${_loadError ? error : items.length ? `<div class="flex flex-col gap-2.5">${cards}</div>${loadMore}` : empty}
         </div>
       </div>
     </div>`;
@@ -930,12 +936,13 @@ function renderList(): void {
     void manageCategories(cats).catch(reportTagFailure);
   });
   _root.querySelector<HTMLButtonElement>("#reports-selection-mode")?.addEventListener("click", () => {
-    _selectionMode = true;
-    renderList();
+    _selectionMode = !_selectionMode;
+    if (!_selectionMode) clearReportSelection();
+    renderListPreservingScroll();
   });
   _root.querySelector<HTMLButtonElement>("#reports-cancel-selection")?.addEventListener("click", () => {
     clearReportSelection();
-    renderList();
+    renderListPreservingScroll();
   });
   _root.querySelector<HTMLButtonElement>("#reports-move-selected")?.addEventListener("click", () => {
     void moveSelectedReports(cats).catch(reportTagFailure);
@@ -945,7 +952,7 @@ function renderList(): void {
       e.preventDefault(); e.stopPropagation();
       const id = button.dataset.id || "";
       if (_selectedReportIds.has(id)) _selectedReportIds.delete(id); else _selectedReportIds.add(id);
-      renderList();
+      renderListPreservingScroll();
     });
   });
   _root.querySelectorAll<HTMLElement>(".reports-card").forEach((el) => {
@@ -953,7 +960,7 @@ function renderList(): void {
       const id = el.dataset.id || "";
       if (_selectionMode) {
         if (_selectedReportIds.has(id)) _selectedReportIds.delete(id); else _selectedReportIds.add(id);
-        renderList();
+        renderListPreservingScroll();
         return;
       }
       rememberListScroll(); _curId = id || null; if (_curId) setDetailHash(_curId); _curType = null; _view = "detail"; renderDetail();
@@ -963,7 +970,7 @@ function renderList(): void {
       if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();
         const id = el.dataset.id || "";
-        if (_selectionMode) { if (_selectedReportIds.has(id)) _selectedReportIds.delete(id); else _selectedReportIds.add(id); renderList(); return; }
+        if (_selectionMode) { if (_selectedReportIds.has(id)) _selectedReportIds.delete(id); else _selectedReportIds.add(id); renderListPreservingScroll(); return; }
         rememberListScroll(); _curId = id || null; if (_curId) setDetailHash(_curId); _curType = null; _view = "detail"; void renderDetail();
       }
     });

--- a/src/web/components/reportsSelection.dom.test.ts
+++ b/src/web/components/reportsSelection.dom.test.ts
@@ -1,0 +1,104 @@
+/** Reports 선택 모드 — 토글과 선택 재렌더의 스크롤 보존 회귀 테스트. */
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+
+const installedGlobals: string[] = [];
+const savedGlobals: Record<string, unknown> = {};
+let previousFetch: typeof fetch;
+
+const reports = Array.from({ length: 3 }, (_, index) => ({
+  id: `report-${index + 1}`,
+  title: `검증 보고서 ${index + 1}`,
+  author: "Devon",
+  summary: "선택 모드 검증",
+  category: "보고서",
+  is_important: index === 0,
+  created_at: `2026-08-${29 - index} 08:00:00`,
+  forms: ["md"],
+}));
+
+beforeAll(() => {
+  const globals = globalThis as Record<string, unknown>;
+  const window = (globals.window as Window | undefined) ?? new Window();
+  for (const [key, value] of [
+    ["window", window],
+    ["document", window.document],
+    ["Element", window.Element],
+    ["HTMLElement", window.HTMLElement],
+    ["HTMLButtonElement", window.HTMLButtonElement],
+    ["MutationObserver", window.MutationObserver],
+  ] as const) {
+    if (!globals[key]) {
+      savedGlobals[key] = globals[key];
+      installedGlobals.push(key);
+      globals[key] = value;
+    }
+  }
+  (window as unknown as { SyntaxError: typeof SyntaxError }).SyntaxError = SyntaxError;
+
+  previousFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    if (String(input).includes("/reports/api/list")) {
+      return new Response(JSON.stringify({
+        reports,
+        next_cursor: null,
+        has_more: false,
+        total: reports.length,
+        important_count: 1,
+        category_counts: { "보고서": reports.length },
+        tags: [],
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+afterAll(() => {
+  globalThis.fetch = previousFetch;
+  const globals = globalThis as Record<string, unknown>;
+  for (const key of installedGlobals) {
+    if (savedGlobals[key] === undefined) delete globals[key];
+    else globals[key] = savedGlobals[key];
+  }
+});
+
+async function renderFixture(): Promise<HTMLElement> {
+  const { renderReports } = await import("./Reports");
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  renderReports(root);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  expect(root.querySelectorAll(".reports-card")).toHaveLength(reports.length);
+  return root;
+}
+
+describe("Reports selection interactions", () => {
+  test("선택 버튼 두 번 클릭 → 체크박스가 나타났다가 사라진다", async () => {
+    const root = await renderFixture();
+    expect(root.querySelectorAll(".reports-select")).toHaveLength(0);
+
+    root.querySelector<HTMLButtonElement>("#reports-selection-mode")!.click();
+    expect(root.querySelectorAll(".reports-select")).toHaveLength(reports.length);
+    expect(root.querySelector("#reports-selection-mode")?.textContent).toBe("선택 해제");
+
+    root.querySelector<HTMLButtonElement>("#reports-selection-mode")!.click();
+    expect(root.querySelectorAll(".reports-select")).toHaveLength(0);
+    expect(root.querySelector("#reports-selection-mode")?.textContent).toBe("선택");
+  });
+
+  test("체크박스 클릭 재렌더 전후 scrollTop이 같다", async () => {
+    const root = await renderFixture();
+    root.querySelector<HTMLButtonElement>("#reports-selection-mode")!.click();
+    const scroller = root.querySelector<HTMLElement>("[data-reports-list-scroll]")!;
+    scroller.scrollTop = 246;
+
+    root.querySelector<HTMLButtonElement>(".reports-select")!.click();
+
+    expect(root.querySelector<HTMLElement>("[data-reports-list-scroll]")!.scrollTop).toBe(246);
+    expect(root.querySelectorAll(".reports-select[aria-pressed='true']")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## 핵심 3줄
1. Reports 선택 모드가 다시 눌러도 꺼지지 않고, 선택 동작마다 목록 스크롤이 이전 값으로 이동했습니다.
2. 보고서가 많은 목록에서 체크박스와 이동바를 사용하기 어려웠고, 중요 필터 아이콘도 텍스트로 바뀐 상태였습니다.
3. 선택 재렌더의 스크롤을 보존하고 토글·이동바 위치·별 SVG 색상을 27줄 범위에서 수정했습니다.

## 무엇을 바꿨나
| 문제 | 고친 방법 |
|---|---|
| 선택 버튼이 항상 활성화만 됨 | 동일 버튼으로 켜고 끄며, 끌 때 선택 집합을 초기화 |
| 선택·체크박스 클릭 시 스크롤 이동 | 선택 관련 재렌더를 `renderListPreservingScroll()`로 통합 |
| 이동바가 목록 끝에 표시됨 | 검색창과 첫 카드 사이로 이동 |
| 중요 필터가 "별표" 텍스트로 표시됨 | 기존 `starIcon(true)` SVG와 `text-rose-300` 적용 |

## 검증
- `bun test src/web/components/reportsSelection.dom.test.ts src/web/components/reportsTagPills.test.ts src/web/lib/mdInline.test.ts`: 31 pass, 0 fail
- `bun run typecheck`: 통과
- `bun run build`: 통과, 생성 CSS에서 `text-rose-300` 확인
- 뮤턴트: 격리 worktree에서 `_selectionMode = true`로 되돌리면 토글 테스트가 `Expected length: 0, Received length: 3`으로 실패
- Chrome CDP 실제 클릭:
  - 선택 켜기/끄기: `scrollTop 40 → 40 → 40`, 체크박스 `0 → 30 → 0`
  - 체크박스 클릭: `scrollTop 420 → 420`, 선택 개수 `1`
  - 배치: 검색창 하단 `105.75` < 이동바 `114.25–164.5` < 첫 카드 상단 `173`
  - 별 필터: SVG 존재, 계산 색상 `rgb(253, 164, 175)`

## 범위
- 머지·배포는 포함하지 않습니다.
- 임시 CDP 검증 페이지는 실행 후 제거하여 커밋에 포함하지 않았습니다.

Submitted-by: Devon
