### PR TITLE
fix(reports): keep total count stable and open HTML files

### DIFF
--- a/src/server/db/reports.ts
+++ b/src/server/db/reports.ts
@@ -37,6 +37,7 @@ export interface ReportListPage {
   next_cursor: string | null;
   has_more: boolean;
   total: number;
+  total_all: number;
   important_count: number;
   category_counts: Record<string, number>;
   tags: ReportTag[];
@@ -202,6 +203,7 @@ export function listReportsPage(db: Database, options: ReportListOptions = {}): 
   }
   const totalWhereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
   const total = countScalar(db, totalWhereSql, args);
+  const totalAll = countScalar(db, "", []);
 
   const cursor = decodeCursor(options.cursor);
   if (cursor) {
@@ -232,6 +234,7 @@ export function listReportsPage(db: Database, options: ReportListOptions = {}): 
     next_cursor: hasMore && pageRows.length ? encodeCursor(pageRows[pageRows.length - 1]!) : null,
     has_more: hasMore,
     total,
+    total_all: totalAll,
     important_count: importantCount,
     category_counts: categoryCounts,
     tags: listReportTags(db),

--- a/src/server/routes/portal.test.ts
+++ b/src/server/routes/portal.test.ts
@@ -93,6 +93,19 @@ describe("portal 리포트 요청 — 접수회신 플로우", () => {
     expect(new Set([...firstJson.reports, ...secondJson.reports].map((r) => r.id)).size).toBe(4);
   });
 
+  test("목록 필터와 무관한 전체 개수를 total_all로 반환한다", async () => {
+    const { app, db } = setup();
+    upsertReport(db, { id: "uncategorized", title: "무분류 보고서", category: null, forms: [] } as never);
+    upsertReport(db, { id: "research", title: "리서치 보고서", category: "리서치", forms: [] } as never);
+
+    const filtered = await app.request(`/api/list?limit=10&category=${encodeURIComponent("보고서")}`);
+    const body = (await filtered.json()) as { total: number; total_all: number; reports: { id: string }[] };
+
+    expect(body.total).toBe(1);
+    expect(body.reports.map((report) => report.id)).toEqual(["rep1"]);
+    expect(body.total_all).toBe(3);
+  });
+
   test("목록 pagination → 중요 필터와 검색을 서버에서 적용한다", async () => {
     const { app, db } = setup();
     upsertReport(db, { id: "star1", title: "중요 릴리즈", author: "steve", category: "교육자료", forms: [], date: "2026-07-03 10:00:00" } as never);

--- a/src/web/components/Reports.ts
+++ b/src/web/components/Reports.ts
@@ -47,6 +47,7 @@ interface ReportListPage {
   next_cursor?: string | null;
   has_more?: boolean;
   total?: number;
+  total_all?: number;
   important_count?: number;
   category_counts?: Record<string, number>;
   tags?: ReportTag[];
@@ -66,6 +67,7 @@ let _loadError: string | null = null;
 let _hasMore = false;
 let _nextCursor: string | null = null;
 let _totalCount = 0;
+let _totalAllCount = 0;
 let _importantCount = 0;
 let _categoryCounts: Record<string, number> = {};
 let _tags: ReportTag[] = [];
@@ -131,13 +133,14 @@ function asPage(res: unknown): ReportListPage {
       next_cursor: page.next_cursor ?? null,
       has_more: Boolean(page.has_more),
       total: typeof page.total === "number" ? page.total : page.reports.length,
+      total_all: typeof page.total_all === "number" ? page.total_all : (typeof page.total === "number" ? page.total : page.reports.length),
       important_count: typeof page.important_count === "number" ? page.important_count : page.reports.filter(isImportant).length,
       category_counts: page.category_counts ?? {},
       tags: page.tags ?? [],
     };
   }
   const reports = asList(res);
-  return { reports, next_cursor: null, has_more: false, total: reports.length, important_count: reports.filter(isImportant).length, category_counts: {}, tags: [] };
+  return { reports, next_cursor: null, has_more: false, total: reports.length, total_all: reports.length, important_count: reports.filter(isImportant).length, category_counts: {}, tags: [] };
 }
 // 정렬은 같은 방향으로 어긋나면 순서가 살아남지만, ★DB 형식과 ISO 가 섞이면 9시간짜리 오정렬이 난다.★
 // 같은 파서를 쓰면 그 위험 자체가 없어진다.
@@ -264,6 +267,7 @@ async function loadReportsPage(reset: boolean): Promise<void> {
     _nextCursor = page.next_cursor ?? null;
     _hasMore = Boolean(page.has_more);
     _totalCount = page.total ?? _all.length;
+    _totalAllCount = page.total_all ?? _totalCount;
     _importantCount = page.important_count ?? _all.filter(isImportant).length;
     _categoryCounts = page.category_counts ?? {};
     _tags = page.tags ?? _tags;
@@ -278,6 +282,7 @@ async function loadReportsPage(reset: boolean): Promise<void> {
       _nextCursor = null;
       _hasMore = false;
       _totalCount = 0;
+      _totalAllCount = 0;
       _importantCount = 0;
       _categoryCounts = {};
       _tags = [];
@@ -816,7 +821,7 @@ async function handleCardStarClick(e: MouseEvent): Promise<void> {
 function renderList(): void {
   if (!_root) return;
   const counts = _categoryCounts;
-  const allCount = _totalCount || _all.length;
+  const allCount = _totalAllCount || _all.length;
   const cats = Object.keys(counts).sort((a, b) => (a === DEFAULT_CAT ? -1 : b === DEFAULT_CAT ? 1 : a.localeCompare(b, "ko")));
 
   const pillCls = (active: boolean) =>
@@ -979,10 +984,17 @@ function renderList(): void {
     el.addEventListener("click", (e) => {
       e.preventDefault();
       e.stopPropagation();
+      const id = el.dataset.id || "";
+      const type = el.dataset.type || "";
+      if (id && type === "html") {
+        const href = absoluteUrl(fileUrl(id, type));
+        if (!openInSystemBrowser(href)) window.open(href, "_blank", "noopener");
+        return;
+      }
       rememberListScroll();
-      _curId = el.dataset.id || null;
+      _curId = id || null;
       if (_curId) setDetailHash(_curId);
-      _curType = el.dataset.type || null;
+      _curType = type || null;
       _view = "detail";
       void renderDetail();
     });
@@ -1002,7 +1014,8 @@ function renderList(): void {
         const removed = _all.find((r) => r.id === id);
         await deleteReport(id);
         _totalCount = Math.max(0, _totalCount - 1);
-        updateListCount("[data-reports-all-count]", _totalCount);
+        _totalAllCount = Math.max(0, _totalAllCount - 1);
+        updateListCount("[data-reports-all-count]", _totalAllCount);
         if (removed) {
           const category = catOf(removed);
           _categoryCounts[category] = Math.max(0, (_categoryCounts[category] || 0) - 1);

--- a/src/web/components/reportsSelection.dom.test.ts
+++ b/src/web/components/reportsSelection.dom.test.ts
@@ -14,12 +14,12 @@ const reports = Array.from({ length: 3 }, (_, index) => ({
   category: "보고서",
   is_important: index === 0,
   created_at: `2026-08-${29 - index} 08:00:00`,
-  forms: ["md"],
+  forms: index === 0 ? ["html", "md"] : ["md"],
 }));
 
 beforeAll(() => {
   const globals = globalThis as Record<string, unknown>;
-  const window = (globals.window as Window | undefined) ?? new Window();
+  const window = (globals.window as Window | undefined) ?? new Window({ url: "http://localhost/team?view=reports" });
   for (const [key, value] of [
     ["window", window],
     ["document", window.document],
@@ -44,6 +44,7 @@ beforeAll(() => {
         next_cursor: null,
         has_more: false,
         total: reports.length,
+        total_all: 72,
         important_count: 1,
         category_counts: { "보고서": reports.length },
         tags: [],
@@ -100,5 +101,17 @@ describe("Reports selection interactions", () => {
 
     expect(root.querySelector<HTMLElement>("[data-reports-list-scroll]")!.scrollTop).toBe(246);
     expect(root.querySelectorAll(".reports-select[aria-pressed='true']")).toHaveLength(1);
+  });
+
+  test("필터 결과와 별도로 전체 개수를 표시하고 HTML 배지는 새창으로 연다", async () => {
+    const root = await renderFixture();
+    expect(root.querySelector("[data-reports-all-count]")?.textContent).toBe("72");
+    root.querySelector<HTMLButtonElement>('.reports-form-badge[data-type="html"]')!
+      .dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    expect(window.location.hash).toBe("");
+
+    root.querySelector<HTMLButtonElement>('.reports-form-badge[data-type="md"]')!
+      .dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    expect(window.location.hash).toBe("#/r/report-1");
   });
 });


### PR DESCRIPTION
## 핵심 3줄
1. Reports 분류 필터를 선택하면 전체 개수가 필터 결과 개수로 바뀝니다.
2. 전체 72건 중 b3os 1건을 선택하면 전체가 1로 표시되고, 목록 HTML 배지는 상세 화면으로 이동합니다.
3. 필터와 무관한 `total_all`을 추가하고 HTML 배지를 새 창으로 열도록 수정했습니다. 변경 규모는 4파일, +49/-7줄입니다.

## 무엇을 바꿨나
| 문제 | 고친 방법 |
|---|---|
| `total`이 필터 결과 개수라 전체 배지까지 바뀜 | 필터 없는 COUNT를 `total_all`로 반환하고 전체 배지의 소스로 사용 |
| 분류가 없는 보고서는 category 합계에 포함되지 않음 | category 합계를 전체 개수로 사용하지 않고 전체 COUNT로 계산 |
| 목록 HTML 배지가 상세 화면으로 이동 | HTML만 절대 파일 URL을 시스템 브라우저 또는 `_blank` 창으로 열고 MD는 기존 동작 유지 |

## 검증
- 검증 범위: `portal.test.ts`, `reportsSelection.dom.test.ts`, TypeScript 타입체크, Chromium 실동작
- baseline: 18 tests pass, typecheck pass
- 실동작: 전체 72 → b3os 선택 후 전체 72·카드 1, HTML 클릭 시 탭 3→4 및 `/reports/file/r1/html` 확인
- mutation: UI가 `total`을 다시 사용하면 Expected 72 / Received 3으로 실패
- mutation: 서버 `total_all`이 필터 `total`을 사용하면 Expected 3 / Received 1로 실패
- 미검증: macOS 앱 WKWebView 브리지의 실제 외부 브라우저 전환, 라이브 배포 환경

Submitted-by: devon