### PR TITLE
fix(scheduler): 평일 칸반·격주 self-learning 적용

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -57,7 +57,7 @@ Everything else — clone, install, dashboard, wiring, recruiting — Claude doe
 Default ops jobs are prepared **ON by default** after install, not as optional conditional extras (they safely no-op until the needed teammate/config exists):
 
 - **Daily kanban PM review** — checks active Tasks and missing next actions.
-- **Weekly self-learning** — gathers SHARED/TEAM-OS/skill improvement candidates for review.
+- **Fortnightly self-learning** — gathers SHARED/TEAM-OS/skill improvement candidates for review.
 - **Continuation guard** — wakes stalled handoffs, reviews, and approvals.
 - **Auto-heal** — checks bot/session health and recovers within the safe operating scope.
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ bun run start        # → 브라우저에서 http://localhost:7878/team
 - **매일 과제 리뷰 핑 (06:00)** — active Tasks를 점검하고 다음 액션 누락을 잡습니다.
 - **매일 과제 리뷰 다이제스트 (06:20)** — 그 결과를 모아 한 번에 보고합니다.
 - **주간 공유 큐레이션** — 팀 학습 로그에서 정리 후보를 모읍니다.
-- **주간 self-learning** — SHARED/TEAM-OS/스킬 개선 후보를 모아 리뷰합니다.
+- **격주 self-learning** — SHARED/TEAM-OS/스킬 개선 후보를 모아 리뷰합니다.
 
 > 미완 과제 재확인(continuation guard)·봇 자가치유(auto-heal)는 **opt-in** 입니다 — 기본으로 켜지지 않습니다.
 
@@ -335,7 +335,7 @@ b3os는 사람이 지휘하는 시스템입니다. 에이전트가 조율하고 
 | b3os-task-loop | Tasks 칸반 · 진행 추적 · 인계 검증 · 작업루프 wake |
 | b3os-team-inbox | 팀 메시지 버스 — 전송 · 답장 · 인계 추적 |
 | **b3os-github-workflow** | 변경을 PR로 — 격리 · 커밋 신원 · 팀 계정 PR · 검증 근거 기록 · 승인 · 머지 후 확인 |
-| b3os-team-learning-loop | 주간 self-learning — 팀 정책 자가발전 |
+| b3os-team-learning-loop | 격주 self-learning — 팀 정책 자가발전 |
 | b3os-team-member-lifecycle | 팀원 온보딩 / lifecycle |
 | b3os-harness-playbook | 병렬 실행(harness) 플레이북 |
 | b3os-ai-code-safety | AI 생성·수정 코드 안전 체크리스트 — SOLID+Effects, 완료 전 side effect·동시성·멱등성 점검 |

--- a/docs/B3OS_SKILLS.md
+++ b/docs/B3OS_SKILLS.md
@@ -23,7 +23,7 @@
 | b3os-workloop | skills | Deprecated compatibility stub — scheduled wake 처리도 `b3os-task-loop` 사용. 기존 참조 호환용으로 유지. |
 | b3os-scheduler | skills | b3os durable 스케줄러 — 반복(cron 시·분·요일·월)·간격·1회성 리마인드 잡을 `team.db`(`scheduled_job`)에 durable 등록, 서버 워커가 시각 맞춰 인박스 wake. 잡별 휴일정책(run/skip/shift, KST 고정오프셋). 세션 cron(유실됨) 대신 팀 정본 반복작업·launchd 이관에. API=`src/server/scheduler/core.ts`(`createCronJob`·`scheduleReminder`). 라이브발사·launchd제거=GD/운영자 게이트 |
 | **b3os-release-ops** | **skills** | **공개 정본 배포·PR 머지·핫픽스·force-push 안전 게이트.** `docs/DEPLOY_MERGE_HOTFIX_WORKFLOW.md` 정본 문서 + `scripts/release-preflight.sh` 기계적 가드(clean worktree·noreply author·branch protection·live repo 확인). 봇 자율머지 범위와 live deploy acceptance/rollback 보고 기준. |
-| b3os-team-learning-loop | skills | 주간 self-learning — 팀 정책 자가발전, SHARED→TEAM-OS 승격, compacting, 프로젝트별 운영리뷰, 월간 개선지표 |
+| b3os-team-learning-loop | skills | 격주 self-learning — 팀 정책 자가발전, SHARED→TEAM-OS 승격, compacting, 프로젝트별 운영리뷰, 월간 개선지표 |
 | b3os-team-member-lifecycle | skills | 팀원 온보딩/lifecycle |
 | **b3os** | **skills** | b3os(팀 OS) **설치·세팅·운영** 스킬 — 공개 repo clone→install→대시보드→팀 기본정보 채팅 세팅→첫 팀원 영입(텔레그램)까지 몰아주고 handoff. **신규 사용자 설치용** + 팀원이 세팅·운영 질문("다음 팀원 어떻게 영입?") 받을 때 참조하는 **ops 레퍼런스**(`references/recruit.md`·`b3os-ops-primer.md`·`troubleshooting.md` = 온디맨드 운영 지식). "b3os 설치/세팅해줘" |
 

--- a/skills/b3os-scheduler/SKILL.md
+++ b/skills/b3os-scheduler/SKILL.md
@@ -16,7 +16,7 @@ trigger: schedule recurring work
 
 세션 한정 임시 점검(몇 분 뒤 한 번 확인)은 런타임 세션 cron으로도 충분하다 — 이 스킬은 **유실되면 안 되는** 잡에 쓴다.
 
-**`b3os-task-loop`(작업루프)과 구분**: workloop = 정해진 코디네이터 루프(매일 칸반 PM·주간 self-learning 등 고정 프로그램)를 깨우는 기본 인프라. scheduler(이 스킬) = **임의의 durable 반복·예약 잡**을 자유롭게 등록하는 범용 도구. workloop의 스케줄 자체도 이 스케줄러로 이관 가능(launchd per-job → scheduled_job).
+**`b3os-task-loop`(작업루프)과 구분**: workloop = 정해진 코디네이터 루프(평일 칸반 PM·격주 self-learning 등 고정 프로그램)를 깨우는 기본 인프라. scheduler(이 스킬) = **임의의 durable 반복·예약 잡**을 자유롭게 등록하는 범용 도구. workloop의 스케줄 자체도 이 스케줄러로 이관 가능(launchd per-job → scheduled_job).
 
 ## 개념 (실제 구현)
 - **정본 저장**: `team.db`의 `scheduled_job` 테이블 (id·kind·schedule_kind·next_run_at(UTC)·schedule_expr·payload_json·enabled·lock_until…). 실행 이력=`scheduled_job_run`.

--- a/skills/b3os-team-learning-loop/SKILL.md
+++ b/skills/b3os-team-learning-loop/SKILL.md
@@ -6,7 +6,7 @@ trigger: record a team lesson
 
 # b3rys Team Learning Loop
 
-이 스킬은 b3rys 팀의 weekly self-learning(주간 자가학습) 세션을 운영할 때 사용한다. 목적은 문서 작업량을 늘리는 것이 아니라, 팀 정책·스킬·개인 설정·프로젝트 운영을 실제로 개선하고 그 개선이 측정되게 만드는 것이다.
+이 스킬은 b3rys 팀의 fortnightly self-learning(격주 자가학습) 세션을 운영할 때 사용한다. 목적은 문서 작업량을 늘리는 것이 아니라, 팀 정책·스킬·개인 설정·프로젝트 운영을 실제로 개선하고 그 개선이 측정되게 만드는 것이다.
 
 > **BWF와의 관계 (2026-06-22, 팀 7/7 합의)**: learning-loop은 `b3os-bwf`와 **별도**다. BWF=개별 과제 실행(미시) / learning-loop=주간 메타-개선(거시·cadence·승인게이트 다름). BWF 6단계의 "학습 hook"이 만든 교훈·재발사례·검증증거가 이 루프의 **입력**으로 흘러든다(합치지 않고 데이터만 연계).
 
@@ -29,10 +29,10 @@ trigger: record a team lesson
 
 ## 주간 운영 흐름
 
-금요일 05:00 KST self-learning 세션에서 실행한다. 자동화가 있더라도 파일을 바로 고치는 것이 아니라 후보를 만들고, 필요한 경우 공동 리뷰와 {{OWNER}} 승인 gate를 거친다. 금요일 10:00 KST에는 learning-loop PM이 {{OWNER}}에게 정리된 결과를 메시지로 보낸다.
+격주 금요일 05:00 KST self-learning 세션에서 실행한다. 자동화가 있더라도 파일을 바로 고치는 것이 아니라 후보를 만들고, 필요한 경우 공동 리뷰와 {{OWNER}} 승인 gate를 거친다. 같은 날 10:00 KST에는 learning-loop PM이 {{OWNER}}에게 정리된 결과를 메시지로 보낸다.
 
 1. 입력 수집
-   - 지난 1주일 `rules/SHARED.md` 신규 항목과 stale(낡음)/중복 후보
+   - 지난 2주일 `rules/SHARED.md` 신규 항목과 stale(낡음)/중복 후보
    - Tasks 칸반에서 반복적으로 멈춘 과제, owner 혼선, handoff 실패, 완료 기준 누락
    - team bus/audit log에서 라우팅 실패, 중복 위임, 응답 가시성 문제
    - 프로젝트별 서브주제 지표와 실패 사례

--- a/src/server/lib/opsRegistry.ts
+++ b/src/server/lib/opsRegistry.ts
@@ -114,7 +114,7 @@ export const OPS_CATALOG: OpsEntry[] = [
     note: "owner(coordinator)를 매일 깨워 칸반 점검·보고.",
   },
   {
-    id: "learning-weekly", type: "job", title: "주간 self-learning", scope: "public", default_desired: true,
+    id: "learning-weekly", type: "job", title: "격주 self-learning", scope: "public", default_desired: true,
     conditions: { all: [{ team: { capability: "coordinator", min: 1 } }, { members: { min: 2 } }] },
     note: "팀 ≥2명 + coordinator 있을 때. 혼자면 의미 약함.",
   },

--- a/src/server/scheduler/core.test.ts
+++ b/src/server/scheduler/core.test.ts
@@ -72,14 +72,15 @@ function db() {
 }
 
 describe("b3os scheduler core", () => {
-  test("weekly learning seeds 04:00 curation and 05:00 proposal jobs idempotently", () => {
+  test("learning seeds weekly 04:00 curation and fortnightly 05:00 proposal jobs idempotently", () => {
     const d = db();
     const first = ensureWeeklySelfLearningJobs(d);
     const second = ensureWeeklySelfLearningJobs(d);
     expect(second.map((job) => job.id)).toEqual(first.map((job) => job.id));
     expect(d.prepare(`SELECT count(*) AS n FROM scheduled_job WHERE id IN (?, ?)`).get(first[0]!.id, first[1]!.id)).toEqual({ n: 2 });
     expect(JSON.parse(first[0]!.schedule_expr!)).toMatchObject({ cron: "0 4 * * 5" });
-    expect(JSON.parse(first[1]!.schedule_expr!)).toMatchObject({ cron: "0 5 * * 5" });
+    expect(first[1]!.schedule_kind).toBe("interval");
+    expect(JSON.parse(first[1]!.schedule_expr!)).toMatchObject({ minutes: 20160 });
     expect(JSON.parse(first[0]!.payload_json)).toMatchObject({
       type: "capability_workloop",
       capability: "learning_loop_pm",
@@ -124,8 +125,9 @@ describe("b3os scheduler core", () => {
 
     const jobs = ensureWeeklySelfLearningJobs(d);
     const session = jobs[1]!;
-    expect(session.title).toBe("self-learning 세션 (금 05:00 KST)");
-    expect(JSON.parse(session.schedule_expr!)).toMatchObject({ cron: "0 5 * * 5" });
+    expect(session.title).toBe("self-learning 세션 (격주 금 05:00 KST)");
+    expect(session.schedule_kind).toBe("interval");
+    expect(JSON.parse(session.schedule_expr!)).toMatchObject({ minutes: 20160 });
     expect(JSON.parse(session.payload_json)).toMatchObject({ capability: "coordinator", fallbackCapability: "learning_loop_pm" });
     expect(session.status).toBe("pending");
     expect(session.enabled).toBe(1);
@@ -138,8 +140,8 @@ describe("b3os scheduler core", () => {
     expect(first.map((j) => j.id)).toEqual(["sched_task_review_ping", "sched_task_review_summary"]);
     expect(second.map((j) => j.id)).toEqual(first.map((j) => j.id));
     expect(d.prepare(`SELECT count(*) AS n FROM scheduled_job WHERE id IN (?, ?)`).get(first[0]!.id, first[1]!.id)).toEqual({ n: 2 });
-    expect(JSON.parse(first[0]!.schedule_expr!)).toMatchObject({ cron: "0 6 * * *" });
-    expect(JSON.parse(first[1]!.schedule_expr!)).toMatchObject({ cron: "20 6 * * *" });
+    expect(JSON.parse(first[0]!.schedule_expr!)).toMatchObject({ cron: "0 6 * * 1-5", holidayPolicy: "skip" });
+    expect(JSON.parse(first[1]!.schedule_expr!)).toMatchObject({ cron: "20 6 * * 1-5", holidayPolicy: "skip" });
     expect(JSON.parse(first[0]!.payload_json)).toEqual({ type: "exec", execKey: "task-review-ping" });
     expect(JSON.parse(first[1]!.payload_json)).toEqual({ type: "exec", execKey: "task-review-summary" });
   });
@@ -419,7 +421,7 @@ describe("b3os scheduler core", () => {
     try {
       const [job] = ensureDailyTaskReviewJobs(d, { from: new Date("2026-03-07T12:00:00.000Z") });
       expect(job!.timezone).toBe("America/New_York");
-      expect(job!.next_run_at).toBe("2026-03-08 10:00:00"); // 06:00 EDT
+      expect(job!.next_run_at).toBe("2026-03-09 10:00:00"); // next weekday, 06:00 EDT
     } finally {
       if (original === undefined) delete process.env.B3OS_SCHEDULER_TIMEZONE;
       else process.env.B3OS_SCHEDULER_TIMEZONE = original;

--- a/src/server/scheduler/core.ts
+++ b/src/server/scheduler/core.ts
@@ -65,6 +65,7 @@ export const WEEKLY_SHARED_CURATION_JOB_ID = "sched_weekly_shared_curation";
 export const WEEKLY_SELF_LEARNING_JOB_ID = "sched_weekly_self_learning_session";
 export const WEEKLY_SHARED_CURATION_CRON = "0 4 * * 5";
 export const WEEKLY_SELF_LEARNING_CRON = "0 5 * * 5";
+export const FORTNIGHTLY_SELF_LEARNING_MINUTES = 14 * 24 * 60;
 // 보고 경로 — 두 루프가 같은 문구를 쓴다.
 //
 // 예전에는 "send.sh --direct-to-gd" 한 줄이었는데 ★그대로 하면 실패한다★(2026-07-31 실측).
@@ -99,7 +100,7 @@ export const WEEKLY_SELF_LEARNING_BODY = [
   // ★대신 값을 박지도 않는다★ — 봉투는 wake 시점에 만들어지므로 "최종 수정: 08:52 기준" 같은 값은
   // 몇 분 뒤 무효가 되고, 산문 거짓말이 기계가 서명한 거짓말로 바뀔 뿐이다(dbak 반대리뷰).
   // 그래서 ★주장하지 말고 읽는 시점에 직접 확인하라고 지시한다.★ 지연 여부와 무관하게 성립한다.
-  "목적: rules/SHARED.md 와 지난 1주 팀 활동을 검토해, 팀에 필요한 (a)팀 룰 변경 (b)새로운 과제 (c)고쳐야 할 이슈를 뽑아 ★proposal 시스템에 등록★하세요.",
+  "목적: rules/SHARED.md 와 지난 2주 팀 활동을 검토해, 팀에 필요한 (a)팀 룰 변경 (b)새로운 과제 (c)고쳐야 할 이슈를 뽑아 ★proposal 시스템에 등록★하세요.",
   "★SHARED.md 를 읽기 직전에 mtime 과 최신 항목 날짜를 직접 확인하세요★ — 04:00 정리 세션은 별개 job 이라 아직 안 돌았을 수 있습니다. 아직이면 정리본을 기다리지 말고 원자료(team.db·git log·audit)로 보세요.",
   // 라우터가 /api 아래 마운트되고 그 전체가 /team 아래 붙는다 → 실제 경로는 /team/api/proposals.
   // "POST /api/proposals" 로 적혀 있어서 시킨 대로 하면 404 가 난다(2026-07-31 실측).
@@ -454,6 +455,51 @@ function ensureCronJob(db: Database, input: CreateCronJobInput & { id: string })
   return getScheduledJob(db, input.id)!;
 }
 
+function ensureIntervalJob(
+  db: Database,
+  input: Omit<CreateScheduledJobInput, "kind" | "scheduleKind" | "scheduleExpr"> & { id: string; minutes: number },
+): ScheduledJobRow {
+  const existing = getScheduledJob(db, input.id);
+  const scheduleExpr = JSON.stringify({ minutes: input.minutes });
+  const payloadJson = JSON.stringify(input.payload);
+  const desiredMatches = existing
+    && existing.kind === "recurring"
+    && existing.schedule_kind === "interval"
+    && existing.title === input.title
+    && existing.timezone === (input.timezone ?? "Asia/Seoul")
+    && existing.schedule_expr === scheduleExpr
+    && existing.payload_json === payloadJson
+    && existing.owner_agent_id === (input.ownerAgentId ?? null)
+    && existing.target_agent_id === (input.targetAgentId ?? null)
+    && existing.created_by === (input.createdBy ?? "system")
+    && existing.misfire_policy === (input.misfirePolicy ?? "coalesce")
+    && existing.enabled === 1;
+  if (desiredMatches) return existing;
+  if (!existing) {
+    return createScheduledJob(db, {
+      ...input,
+      kind: "recurring",
+      scheduleKind: "interval",
+      scheduleExpr: { minutes: input.minutes },
+    });
+  }
+
+  const now = toSqliteDate(new Date());
+  db.prepare(
+    `UPDATE scheduled_job
+       SET kind = 'recurring', schedule_kind = 'interval', status = 'pending', enabled = 1,
+           title = ?, owner_agent_id = ?, target_agent_id = ?, created_by = ?, timezone = ?,
+           next_run_at = ?, schedule_expr = ?, payload_json = ?, misfire_policy = ?, max_runs = NULL,
+           lock_until = NULL, lock_owner = NULL, last_error = NULL, updated_at = ?
+     WHERE id = ?`,
+  ).run(
+    input.title, input.ownerAgentId ?? null, input.targetAgentId ?? null, input.createdBy ?? "system",
+    input.timezone ?? "Asia/Seoul", toSqliteDate(input.nextRunAt), scheduleExpr, payloadJson,
+    input.misfirePolicy ?? "coalesce", now, input.id,
+  );
+  return getScheduledJob(db, input.id)!;
+}
+
 /** Seed and reconcile the portable weekly learning triggers. */
 export function ensureWeeklySelfLearningJobs(db: Database): ScheduledJobRow[] {
   const sharedCuration = ensureCronJob(db, {
@@ -471,12 +517,12 @@ export function ensureWeeklySelfLearningJobs(db: Database): ScheduledJobRow[] {
       body: WEEKLY_SHARED_CURATION_BODY,
     },
   });
-  const selfLearning = ensureCronJob(db, {
+  const selfLearning = ensureIntervalJob(db, {
     id: WEEKLY_SELF_LEARNING_JOB_ID,
-    title: "self-learning 세션 (금 05:00 KST)",
-    cron: WEEKLY_SELF_LEARNING_CRON,
+    title: "self-learning 세션 (격주 금 05:00 KST)",
+    minutes: FORTNIGHTLY_SELF_LEARNING_MINUTES,
+    nextRunAt: computeCronNextRun(WEEKLY_SELF_LEARNING_CRON, new Date(), { timezone: "Asia/Seoul" }),
     timezone: "Asia/Seoul",
-    holidayPolicy: "run",
     createdBy: "system",
     payload: {
       type: "capability_workloop",
@@ -497,15 +543,15 @@ export function ensureWeeklySelfLearningJob(db: Database): ScheduledJobRow {
 /** Seed and reconcile portable daily task-review jobs. */
 export function ensureDailyTaskReviewJobs(db: Database, opts: { from?: Date } = {}): ScheduledJobRow[] {
   const specs = [
-    { id: DAILY_TASK_REVIEW_PING_JOB_ID, title: "과제 리뷰 핑 (06:00)", cron: "0 6 * * *", execKey: "task-review-ping" },
-    { id: DAILY_TASK_REVIEW_SUMMARY_JOB_ID, title: "과제 리뷰 다이제스트 (06:20)", cron: "20 6 * * *", execKey: "task-review-summary" },
+    { id: DAILY_TASK_REVIEW_PING_JOB_ID, title: "과제 리뷰 핑 (평일 06:00)", cron: "0 6 * * 1-5", execKey: "task-review-ping" },
+    { id: DAILY_TASK_REVIEW_SUMMARY_JOB_ID, title: "과제 리뷰 다이제스트 (평일 06:20)", cron: "20 6 * * 1-5", execKey: "task-review-summary" },
   ] as const;
   return specs.map((spec) => ensureCronJob(db, {
     id: spec.id,
     title: spec.title,
     cron: spec.cron,
     timezone: currentDailyTaskReviewTimezone(),
-    holidayPolicy: "run",
+    holidayPolicy: "skip",
     createdBy: "system",
     from: opts.from,
     payload: { type: "exec", execKey: spec.execKey },

--- a/web/team.html
+++ b/web/team.html
@@ -255,7 +255,7 @@
         </div>
         <div class="card">
           <div class="card-title">b3os-team-learning-loop</div>
-          <div class="card-text">주간 self-learning. SHARED→TEAM-OS 승격, compacting, 월간 지표.</div>
+          <div class="card-text">격주 self-learning. SHARED→TEAM-OS 승격, compacting, 월간 지표.</div>
         </div>
         <div class="card">
           <div class="card-title">b3os-team-member-lifecycle</div>
@@ -492,7 +492,7 @@
         </div>
         <div class="q-card">
           <div class="q-tag">Learning Loop</div>
-          <div class="q-text">주간 self-learning. 교훈을 SHARED에 모아 검증 후 TEAM-OS로 승격하는 자가발전 루프.</div>
+          <div class="q-text">격주 self-learning. 교훈을 SHARED에 모아 검증 후 TEAM-OS로 승격하는 자가발전 루프.</div>
         </div>
         <div class="q-card">
           <div class="q-tag">Coordinator</div>


### PR DESCRIPTION
## 핵심 3줄
1. 칸반 새벽 잡 06:00/06:20이 주말·공휴일에도 실행됐습니다.
2. self-learning 05:00 세션은 매주 실행됐고 운영 표기도 주간으로 남아 있었습니다.
3. 칸반 잡은 평일 cron+KR 공휴일 skip으로, self-learning은 14일 간격으로 변경했습니다.

## 검증
- `bun test src/server/scheduler/core.test.ts src/server/lib/opsRegistry.test.ts` (71 pass)
- `bun run typecheck`
- `git diff --check`

## 운영 반영
라이브 team.db는 백업 후 동일한 스케줄로 갱신했으며, 다음 실행 시각과 JSON 유효성을 확인했습니다.