### PR TITLE
fix(rules): 룰 로딩파일 재생성을 게이트 밖으로 — 라이브도 재시작하면 적용

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -217,28 +217,33 @@ try {
       }
     } catch { /* best-effort */ }
   }
-  // 공개 빌드 부팅 백필(PUBLIC_BUILD 게이트) — 공개 사용자가 git 업데이트를 pull 한 뒤 재시작하면 기존
-  //   멤버도 재영입 없이 최신을 받게. 라이브(PUBLIC_BUILD=false)는 글로벌 배선/실멤버 보호로 skip.
+  // ★① progress 훅 배선은 PUBLIC_BUILD 에서만★ — 팀원 `~/.claude/settings.json` 과 hooks/ 를 쓴다.
+  //   라이브는 그 배선을 사람이 관리하므로 부팅이 덮으면 안 된다. 주석의 "글로벌 배선" 이 이것이다.
   if (PUBLIC_BUILD) {
-    // ① progress("작업 중 ⏳") 훅 — claude 전용(글로벌 telegram-progress.sh 배선 대체).
     for (const cid of claudeIds) {
       try { installProgressHook(cid); } catch { /* best-effort */ }
     }
-    // ② 룰 로딩파일(CLAUDE.md/AGENTS.md) 재생성 — pull 한 룰 업데이트(예: First contact 자기소개)를 기존
-    //    멤버에도 반영. skip-if-unchanged 라 멱등, SOUL.md(persona)는 안 건드림. b3os_native 는 정책 미확정이라 제외.
-    const teamName = (db.query("SELECT value FROM setting WHERE key = 'team_name'").get() as { value: string } | null)?.value ?? undefined;
-    for (const a of agents) {
-      if (a.runtime === "b3os_native") continue;
-      try {
-        writeMemberPersona({
-          id: a.id, display_name: a.display_name, role: a.role, runtime: a.runtime,
-          bot_username: a.telegram_bot_username ?? undefined,
-          workspace_path: a.workspace_path, persona_file: a.persona_file,
-          owner_name: ownerRow?.value ?? undefined, team_name: teamName,
-          team_collect_enabled: false,
-        });
-      } catch { /* best-effort */ }
-    }
+  }
+
+  // ★② 룰 로딩파일(CLAUDE.md/AGENTS.md) 재생성 — 게이트 밖. 라이브도 부팅마다 돈다.★
+  //   전에는 ①과 한 블록이라 PUBLIC_BUILD 에 같이 묶여 있었다. 그래서 룰을 고치고 재시작해도
+  //   ★라이브 팀원 파일은 안 바뀌었다★ — 소스만 바뀌고 12명이 옛 룰을 계속 읽는다.
+  //   실측(2026-08-30): Core Rules 에 설명 원칙을 넣고 머지한 뒤 팀원 파일 반영 0/12.
+  //   ①과 달리 이 함수는 ★b3os 가 만든 파일만★ 쓴다(로딩파일). SOUL.md(persona)는 안 건드리고,
+  //   skip-if-unchanged 라 바뀐 게 없으면 아무것도 안 쓴다.
+  //   b3os_native 는 정책 미확정이라 제외 — 지금 그 런타임을 쓰는 팀원은 0명이다.
+  const teamName = (db.query("SELECT value FROM setting WHERE key = 'team_name'").get() as { value: string } | null)?.value ?? undefined;
+  for (const a of agents) {
+    if (a.runtime === "b3os_native") continue;
+    try {
+      writeMemberPersona({
+        id: a.id, display_name: a.display_name, role: a.role, runtime: a.runtime,
+        bot_username: a.telegram_bot_username ?? undefined,
+        workspace_path: a.workspace_path, persona_file: a.persona_file,
+        owner_name: ownerRow?.value ?? undefined, team_name: teamName,
+        team_collect_enabled: false,
+      });
+    } catch { /* best-effort */ }
   }
 } catch (e) {
   console.error("[teamos-render] startup failed:", e instanceof Error ? e.message : String(e));

--- a/src/server/lib/personaTemplates.ts
+++ b/src/server/lib/personaTemplates.ts
@@ -368,7 +368,7 @@ const CORE_RULE_COMPACT = [
   "- No response → do not wait forever or announce retries; report partial results naming the non-responder, then add a late answer.",
   "",
   "**Explaining**",
-  "- Order: context → facts → one real example (situation, steps, what changed). Write from the reader's side, not from where your own work left off.",
+  "- Order: context → the point → one real example (situation, steps, what changed), then the detail. Lead with context and the point so the reader has the whole shape before the parts. Write from the reader's side, not from where your own work left off.",
   "- Every noun must name something openable in the system — variable, parameter, field, step. If it can't, it's an analogy: restore the real term. Applies to prose, not just examples; never swap a physical object (handle, lever, engine, skeleton) for a thing that has a name.",
   "- Keep names verbatim; never translate or coin one. Expand an abbreviation once, then use it. Ordinary dev terms (server, endpoint, cache) stay as-is.",
   "- No intensifiers or set phrases (in effect, ultimately, practically, so to speak). State the fact; if it needs weight, give the number.",


### PR DESCRIPTION
팀장님 지시입니다. 룰을 고치고 머지해도 라이브 팀원 파일이 안 바뀌었습니다.

## 무슨 일이 있었나

`#391` 로 Core Rules 에 설명 원칙 5줄을 넣고 머지했습니다. 그런데 팀원 파일은 그대로였습니다.

```
PR #391      머지됨  fb196b46
라이브 소스   반영됨
팀원 파일     0 / 12
```

## 원인 — 한 블록에 두 가지가 묶여 있었습니다

```
if (PUBLIC_BUILD) {
  ① installProgressHook   팀원 ~/.claude/settings.json 과 hooks/ 를 쓴다
  ② writeMemberPersona    CLAUDE.md / AGENTS.md 를 다시 쓴다
}
```

주석의 *"라이브(PUBLIC_BUILD=false)는 글로벌 배선/실멤버 보호로 skip"* 은 **①을 가리킵니다.**
라이브의 훅 배선은 사람이 관리하므로 부팅이 덮으면 안 됩니다.

그런데 ②가 같은 블록에 있어서 같이 꺼져 있었습니다. 그래서 룰을 고치고 재시작해도
라이브 팀원 12명은 옛 룰을 계속 읽습니다.

## 바꾼 것

②만 게이트 밖으로 뺐습니다. ①은 그대로 `PUBLIC_BUILD` 안에 둡니다.

②가 안전한 이유:
- **b3os 가 만든 로딩파일만** 씁니다. `SOUL.md`(persona)는 안 건드립니다.
- `skip-if-unchanged` 라 바뀐 게 없으면 아무것도 안 씁니다.
- ①처럼 팀원 개인 설정(`settings.json`·`hooks/`)을 건드리지 않습니다.

## 같은 커밋의 두 번째 변경

팀장님이 설명 원칙에 한 줄 더 주셨습니다 —
*"항상 맥락 + 핵심을 먼저 설명해서 전반적인 이해를 돕고 세부 설명으로 접근한다"*.

**새 줄을 만들지 않고 1번(순서)에 넣었습니다.** 같은 축이라 나누면 두 곳이 되고,
한쪽만 고치는 자리가 생깁니다.

```
전   Order: context → facts → one real example (situation, steps, what changed).
후   Order: context → the point → one real example (situation, steps, what changed), then the detail.
     Lead with context and the point so the reader has the whole shape before the parts.
```

## 검증

```
bun test ruleDedupeSafety / teamOsRenderAtomic / personaTemplates   52 pass 0 fail
PUBLIC_BUILD 블록 안 writeMemberPersona   0건
게이트 밖 writeMemberPersona              1건
```

## 머지 후

재시작하면 팀원 12명 파일이 갱신됩니다. **재시작 전에는 적용 안 됩니다.**
확인할 값: 12명 파일에 `**Explaining**` 이 있는지. 지금 기준값은 `0/12` 입니다.

되돌리려면 이 커밋을 revert 하면 됩니다. 팀원 파일은 `writeMemberPersona` 가
다음 부팅에 다시 맞춥니다.