### PR TITLE
docs(rules): §6 에 '룰이 언제 팀원에게 닿나' 를 적는다

### DIFF
--- a/rules/TEAM-OS.template.md
+++ b/rules/TEAM-OS.template.md
@@ -55,6 +55,8 @@ runtime/platform safety > TEAM-OS shared rules > member personal settings. Safet
 ## 6. Rule Loading
 
 - claude auto-inlines this file via `@TEAM-OS.md`. openclaw·hermes do **not** — they receive a summary and must read this file directly for team-ops/routing work.
+- ⭐ Core Rules is the exception: its body is written into every member's `CLAUDE.md`/`AGENTS.md`, so every runtime reads it without opening a file. A rule that must reach everyone goes there, not here.
+- Member loading files are rewritten at server boot. **Merging a rule change does not reach members — a restart does.** Count the members whose file actually carries the change before calling it applied.
 - Never copy shared rules into per-member files. This file is the single source; link on-demand detail files instead.
 - If a runtime cannot auto-discover team skills, use `docs/B3OS_SKILLS.md` and the linked `skills/*/SKILL.md` files directly.
 


### PR DESCRIPTION
오늘 `#391`·`#393` 작업에서 나온 사실을 §6 에 남깁니다.

## 왜

§6 Rule Loading 은 **"누가 이 파일을 자동으로 읽나"** 는 답합니다. 한 달 전부터 있었습니다.

```
claude auto-inlines this file via @TEAM-OS.md.
openclaw·hermes do not — they receive a summary and must read this file directly.
```

오늘 저와 steve 가 각각 코드를 파서 같은 사실에 도달했습니다. **둘 다 §6 을 안 읽었습니다.**
그건 우리 잘못이지만, §6 이 답하지 않은 것도 둘 있었습니다.

## 무엇을 넣나

```
+ ⭐ Core Rules is the exception: its body is written into every member's CLAUDE.md/AGENTS.md,
+   so every runtime reads it without opening a file. A rule that must reach everyone goes there, not here.
+ Member loading files are rewritten at server boot. Merging a rule change does not reach members
+   — a restart does. Count the members whose file actually carries the change before calling it applied.
```

## 근거

**①** `#391` 에서 설명 원칙을 TEAM-OS §2 에 넣었습니다. claude 5명만 자동으로 읽었습니다.
Core Rules 로 옮기니 12명이 읽습니다. "전원에게 닿아야 하는 룰은 어디에 넣나" 가 §6 에 없었습니다.

**②** `#391` 머지 후 팀원 반영이 `0/12` 였습니다. 재시작해도 안 바뀌었을 겁니다 —
로딩파일 재생성이 `PUBLIC_BUILD` 게이트 안에 묶여 라이브에서는 안 돌았습니다.
`#393` 으로 고친 뒤 재시작하니 `12/12` 가 됐습니다.

②는 `#393` 이 머지된 지금부터 참입니다. 그 전에는 "재시작해도 안 닿는다" 가 맞았습니다.

steve 지적: *"§6 이 누가 읽나는 답했지만 언제 갱신되나는 답하지 않았다."*

## 검증

```
bun test ruleDedupeSafety / teamOsRenderAtomic / personaTemplates   51 pass 0 fail
변경 전에도 51 — 이 커밋이 시험 수를 바꾸지 않습니다
```

## 이 PR 도 같은 것이 적용됩니다

머지해도 팀원 파일은 안 바뀝니다. 재시작해야 §6 새 두 줄이 12명에게 갑니다.
다만 §6 은 TEAM-OS 본문이라 codex·hermes 는 파일을 열어야 읽습니다 — 그 자체가 이 PR 이 적는 사실입니다.