### PR TITLE
feat(tasks): add read-only Projects tab

### DIFF
--- a/src/server/db/migrate.ts
+++ b/src/server/db/migrate.ts
@@ -17,6 +17,9 @@ export function migrate(db: Database): void {
   const schemaPath = join(__dirname, "schema.sql");
   const schema = readFileSync(schemaPath, "utf-8");
   db.exec(schema);
+  db.prepare(
+    "INSERT INTO setting (key, value) VALUES ('project_prefixes', ?) ON CONFLICT(key) DO NOTHING",
+  ).run(JSON.stringify(["infra", "codex", "scheduler", "pm"]));
   widenAgentRuntimeChecks(db);
   widenSearchSourceTypes(db);
   runBusMigration(db);

--- a/src/server/db/taskQueries.projects.test.ts
+++ b/src/server/db/taskQueries.projects.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { summarizeProjects, type Task } from "./taskQueries";
+
+function task(title: string, column: Task["column"], owner: string | null = null, description: string | null = null): Task {
+  return {
+    id: `${title}-${column}`,
+    title,
+    column,
+    owner,
+    description,
+    held_at: null,
+    hold_reason: null,
+    review_at: null,
+    sort_order: 0,
+    created_at: "2026-08-31 00:00:00",
+    updated_at: "2026-08-31 00:00:00",
+  };
+}
+
+describe("summarizeProjects", () => {
+  test("승격 목록에 없는 접두어를 제외한다", () => {
+    const projects = summarizeProjects([
+      task("[infra] deploy", "doing", "bill"),
+      task("[proposal] unrelated", "done", "steve"),
+    ], ["infra"]);
+
+    expect(projects.map((project) => project.name)).toEqual(["infra"]);
+    expect(projects[0]!.counts).toEqual({ done: 0, doing: 1, plan: 0 });
+  });
+
+  test("대소문자가 다른 접두어를 한 프로젝트로 합친다", () => {
+    const projects = summarizeProjects([
+      task("[PM] project card", "doing", "steve", "다음 액션: 구현 리뷰"),
+      task("[pm] implementation", "done", "devon"),
+      task("[Pm] follow-up", "plan", null),
+    ], ["pm"]);
+
+    expect(projects).toEqual([{
+      name: "pm",
+      counts: { done: 1, doing: 1, plan: 1 },
+      next_action: "구현 리뷰",
+      owner: "steve",
+    }]);
+  });
+});

--- a/src/server/db/taskQueries.ts
+++ b/src/server/db/taskQueries.ts
@@ -8,6 +8,7 @@ import { nanoid } from "nanoid";
 
 export type TaskLane = "plan" | "doing" | "done";
 export const TASK_LANES: TaskLane[] = ["plan", "doing", "done"];
+export const DEFAULT_PROJECT_PREFIXES = ["infra", "codex", "scheduler", "pm"] as const;
 
 export interface Task {
   id: string;
@@ -21,6 +22,45 @@ export interface Task {
   sort_order: number;
   created_at: string;
   updated_at: string;
+}
+
+export interface ProjectSummary {
+  name: string;
+  counts: Record<TaskLane, number>;
+  next_action: string | null;
+  owner: string | null;
+}
+
+function taskPrefix(title: string): string | null {
+  const match = title.match(/^\[([^\]]+)\]/);
+  return match ? match[1]!.trim().toLowerCase() : null;
+}
+
+function nextAction(description: string | null): string | null {
+  if (!description) return null;
+  const line = description.split(/\r?\n/).find((item) => /^\s*다음 액션\s*:/i.test(item));
+  return line?.replace(/^\s*다음 액션\s*:\s*/i, "").trim() || null;
+}
+
+/** Read-only projection over task rows. Prefix matching is case-insensitive. */
+export function summarizeProjects(tasks: Task[], promotedPrefixes: string[]): ProjectSummary[] {
+  const promoted = [...new Set(promotedPrefixes.map((p) => p.trim().toLowerCase()).filter(Boolean))];
+  return promoted.map((name) => {
+    const matching = tasks.filter((task) => taskPrefix(task.title) === name);
+    const doing = matching.filter((task) => task.column === "doing");
+    const projectCard = [...doing, ...matching.filter((task) => task.column === "plan"), ...matching.filter((task) => task.column === "done")]
+      .find((task) => nextAction(task.description));
+    return {
+      name,
+      counts: {
+        done: matching.filter((task) => task.column === "done").length,
+        doing: doing.length,
+        plan: matching.filter((task) => task.column === "plan").length,
+      },
+      next_action: projectCard ? nextAction(projectCard.description) : null,
+      owner: doing.find((task) => task.owner)?.owner ?? null,
+    };
+  });
 }
 
 interface TaskRow {

--- a/src/server/routes/settings.test.ts
+++ b/src/server/routes/settings.test.ts
@@ -632,6 +632,7 @@ describe("settings: 팀명/태그라인", () => {
       owner_chat_id: "",
       locale: "ko",
       dm_capture: true, // 기본 on
+      project_prefixes: ["infra", "codex", "scheduler", "pm"],
       // ★GitHub 계정·승인자 — 셸 절차(release-preflight --mode merge)가 읽는 값 (2026-07-29)★
       //   ★기본이 빈 문자열인 게 핵심이다★ — 절차는 비면 진행하지 않는다.
       //   기본값으로 때우면 팀장 개인 계정으로 나가고, 그게 이 절차가 막으려는 일이다.
@@ -655,6 +656,7 @@ describe("settings: 팀명/태그라인", () => {
       owner_chat_id: "",
       locale: "ko",
       dm_capture: true, // 기본 on
+      project_prefixes: ["infra", "codex", "scheduler", "pm"],
       // ★GitHub 계정·승인자 — 셸 절차(release-preflight --mode merge)가 읽는 값 (2026-07-29)★
       //   ★기본이 빈 문자열인 게 핵심이다★ — 절차는 비면 진행하지 않는다.
       //   기본값으로 때우면 팀장 개인 계정으로 나가고, 그게 이 절차가 막으려는 일이다.

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -378,6 +378,14 @@ export function createSettingsApp(deps: SettingsDeps): Hono {
       // dm_capture: 팀원↔팀장 1:1 DM 을 dm_message 로 적재할지. 팀원 세션 기록을 읽는 기능이라 끌 수 있어야 한다.
       //   끄면 대시보드 DM 통계와 bus-recall 의 1:1 조회만 비고, 버스·위임·발신은 전부 그대로 돈다(크리티컬 아님).
       dm_capture: getSetting(db, "dm_capture") !== "off",
+      project_prefixes: (() => {
+        try {
+          const parsed = JSON.parse(getSetting(db, "project_prefixes") ?? "[]");
+          return Array.isArray(parsed) ? parsed : [];
+        } catch {
+          return [];
+        }
+      })(),
       // ★GitHub 계정·승인자 — 셸 절차가 읽어야 하는 값들 (2026-07-29 요구사항)★
       //   이 값들은 DB 에 ★있었는데 조회할 길이 없었다.★ 그래서 b3os-github-workflow 스킬에는
       //   "설정에서 조회한다" 고만 적혀 있고 ★조회 명령이 없었다.★

--- a/src/server/routes/tasks.test.ts
+++ b/src/server/routes/tasks.test.ts
@@ -24,6 +24,34 @@ function setup() {
   return { app, db };
 }
 
+describe("GET /projects — 읽기 전용 프로젝트 집계", () => {
+  test("초기 승격 목록만 반환하고 대소문자 접두어를 합친다", async () => {
+    const { app } = setup();
+    await createCard(app, { title: "[PM] project card", column: "doing", owner: "steve", description: "다음 액션: 리뷰" });
+    await createCard(app, { title: "[pm] implementation", column: "done", owner: "devon" });
+    await createCard(app, { title: "[proposal] excluded", column: "done", owner: "bill" });
+
+    const response = await app.request("/projects");
+    expect(response.status).toBe(200);
+    const body = await response.json() as any;
+    expect(body.projects.map((project: any) => project.name)).toEqual(["infra", "codex", "scheduler", "pm"]);
+    expect(body.projects.find((project: any) => project.name === "pm")).toEqual({
+      name: "pm",
+      counts: { done: 1, doing: 1, plan: 0 },
+      next_action: "리뷰",
+      owner: "steve",
+    });
+  });
+
+  test("승격 목록이 비면 빈 목록을 반환한다", async () => {
+    const { app, db } = setup();
+    db.prepare("UPDATE setting SET value = '[]' WHERE key = 'project_prefixes'").run();
+    await createCard(app, { title: "[pm] hidden", column: "doing", owner: "steve" });
+
+    expect(await (await app.request("/projects")).json()).toEqual({ projects: [] });
+  });
+});
+
 // the bus message + its pending recipient row that wakes the owner
 function lastNotice(db: Database, to: string) {
   return db

--- a/src/server/routes/tasks.ts
+++ b/src/server/routes/tasks.ts
@@ -7,6 +7,8 @@ import {
   deleteTask,
   getTask,
   TASK_LANES,
+  DEFAULT_PROJECT_PREFIXES,
+  summarizeProjects,
   type TaskLane,
 } from "../db/taskQueries";
 import { appendAudit } from "../db/queries";
@@ -83,6 +85,21 @@ export function createTaskRoutes(deps: TaskRouteDeps): Hono {
   // GET /api/tasks — all tasks, ordered plan→doing→done then sort_order.
   r.get("/tasks", (c) => {
     return c.json({ tasks: listTasks(deps.db) });
+  });
+
+  // GET /api/projects — promoted task-prefix aggregates. No project rows are stored.
+  r.get("/projects", (c) => {
+    const row = deps.db.prepare("SELECT value FROM setting WHERE key = 'project_prefixes'").get() as { value?: string } | undefined;
+    let prefixes: string[] = [...DEFAULT_PROJECT_PREFIXES];
+    if (row?.value !== undefined) {
+      try {
+        const parsed = JSON.parse(row.value);
+        prefixes = Array.isArray(parsed) && parsed.every((item) => typeof item === "string") ? parsed : [];
+      } catch {
+        prefixes = [];
+      }
+    }
+    return c.json({ projects: summarizeProjects(listTasks(deps.db), prefixes) });
   });
 
   // POST /api/tasks — { title, column?, owner? }. column defaults to 'plan'.

--- a/src/web/components/ProjectsView.ts
+++ b/src/web/components/ProjectsView.ts
@@ -1,0 +1,88 @@
+// ProjectsView — read-only task-prefix aggregates backed by /api/projects.
+
+import { apiBase } from "../ws";
+import { pick } from "../i18n";
+
+type Lane = "done" | "doing" | "plan";
+
+interface ProjectSummary {
+  name: string;
+  counts: Record<Lane, number>;
+  next_action: string | null;
+  owner: string | null;
+}
+
+function escape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function progress(project: ProjectSummary): string {
+  const total = project.counts.done + project.counts.doing + project.counts.plan;
+  const width = (count: number) => total === 0 ? 0 : (count / total) * 100;
+  return `
+    <div class="min-w-[15rem]">
+      <div class="flex h-2 overflow-hidden rounded-full bg-surface-0" aria-label="done ${project.counts.done}, doing ${project.counts.doing}, plan ${project.counts.plan}">
+        <span class="bg-accent-green" style="width:${width(project.counts.done)}%"></span>
+        <span class="bg-blue-400" style="width:${width(project.counts.doing)}%"></span>
+        <span class="bg-slate-600" style="width:${width(project.counts.plan)}%"></span>
+      </div>
+      <div class="mt-1 text-[11px] text-slate-500">done ${project.counts.done} · doing ${project.counts.doing} · plan ${project.counts.plan}</div>
+    </div>`;
+}
+
+function projectRow(project: ProjectSummary): string {
+  return `
+    <article data-project-row="${escape(project.name)}" class="grid grid-cols-1 gap-3 border-b border-surface-3 px-4 py-4 last:border-b-0 lg:grid-cols-[minmax(9rem,0.7fr)_minmax(15rem,1.2fr)_minmax(14rem,1.6fr)_minmax(7rem,0.5fr)] lg:items-center">
+      <div class="font-semibold text-slate-100">${escape(project.name)}</div>
+      ${progress(project)}
+      <div class="min-w-0 text-sm text-slate-300"><span class="mr-2 text-xs text-slate-500">${pick("다음 액션", "Next action")}</span>${escape(project.next_action ?? "—")}</div>
+      <div class="text-sm text-slate-300"><span class="mr-2 text-xs text-slate-500">${pick("담당자", "Owner")}</span>${escape(project.owner ?? "—")}</div>
+    </article>`;
+}
+
+export function renderProjectsView(root: HTMLElement): void {
+  let projects: ProjectSummary[] = [];
+  let loaded = false;
+  let failed = false;
+
+  const render = () => {
+    const body = !loaded
+      ? `<div class="flex flex-1 items-center justify-center text-sm text-slate-500">${pick("프로젝트를 불러오는 중...", "Loading projects...")}</div>`
+      : failed
+        ? `<div class="flex flex-1 items-center justify-center text-sm text-status-blocked">${pick("프로젝트를 불러오지 못했습니다.", "Failed to load projects.")}</div>`
+        : projects.length === 0
+          ? `<div class="flex flex-1 items-center justify-center text-sm text-slate-500">${pick("승격된 프로젝트가 없습니다.", "No promoted projects.")}</div>`
+          : `<div class="overflow-y-auto">${projects.map(projectRow).join("")}</div>`;
+    root.innerHTML = `
+      <div class="flex min-h-0 flex-1 flex-col">
+        <div class="flex items-center justify-between border-b border-surface-3 bg-surface-1 px-4 py-2">
+          <div class="text-sm font-semibold">Projects</div>
+          <span class="text-[10px] text-slate-500">read-only</span>
+        </div>
+        ${body}
+      </div>`;
+  };
+
+  const load = async () => {
+    try {
+      const response = await fetch(`${apiBase()}/api/projects`);
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const body = await response.json() as { projects?: ProjectSummary[] };
+      projects = body.projects ?? [];
+      failed = false;
+    } catch (error) {
+      console.error("[loadProjects]", error);
+      failed = true;
+    }
+    loaded = true;
+    render();
+  };
+
+  render();
+  void load();
+}

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -13,6 +13,7 @@ import { renderTeamOs } from "./components/TeamOS";
 import { renderTopology } from "./components/TopologyView";
 import { renderTasksKanban, refreshTasksKanban } from "./components/TasksKanban";
 import { renderJobsView } from "./components/JobsView";
+import { renderProjectsView } from "./components/ProjectsView";
 import { renderTeamSearch } from "./components/TeamSearch";
 import { renderReports } from "./components/Reports";
 import { renderInboxView } from "./components/InboxView";
@@ -30,11 +31,11 @@ import { renderLiveBadge } from "./components/LiveBadge";
 import { renderIcon } from "./icons";
 
 const VIEW_GROUPS: Array<{ views: MainView[]; tabs: Array<{ id: MainView; label: string }> }> = [
-  { views: ["tasks", "jobs"], tabs: [{ id: "tasks", label: "Tasks" }, { id: "jobs", label: "Jobs" }] },
+  { views: ["tasks", "jobs", "projects"], tabs: [{ id: "tasks", label: "Tasks" }, { id: "jobs", label: "Jobs" }, { id: "projects", label: "Projects" }] },
   { views: ["inbox", "audit", "proposals"], tabs: [{ id: "inbox", label: "Inbox" }, { id: "audit", label: "Audit" }, { id: "proposals", label: "Proposal" }] },
   { views: ["teamos", "doc"], tabs: [{ id: "teamos", label: "OS" }, { id: "doc", label: "Docs" }] },
 ];
-const VALID_MAIN_VIEWS: MainView[] = ["tasks", "jobs", "monitoring", "busflow", "teamos", "topology", "search", "reports", "doc", "settings", "inbox", "audit", "proposals", "log", "thread", "config", "chat"];
+const VALID_MAIN_VIEWS: MainView[] = ["tasks", "jobs", "projects", "monitoring", "busflow", "teamos", "topology", "search", "reports", "doc", "settings", "inbox", "audit", "proposals", "log", "thread", "config", "chat"];
 const VIEW_STORAGE_KEY = "bill-dash-main-view";
 
 function isMainView(v: string | null): v is MainView {
@@ -272,6 +273,7 @@ function renderMainContent(root: HTMLElement) {
   let topoEl: HTMLDivElement | null = null;
   let tasksEl: HTMLDivElement | null = null;
   let jobsEl: HTMLDivElement | null = null;
+  let projectsEl: HTMLDivElement | null = null;
   let monitoringEl: HTMLDivElement | null = null;
   let searchEl: HTMLDivElement | null = null;
   let reportsEl: HTMLDivElement | null = null;
@@ -289,6 +291,7 @@ function renderMainContent(root: HTMLElement) {
   let topoRendered = false;
   let tasksRendered = false;
   let jobsRendered = false;
+  let projectsRendered = false;
   let monitoringRendered = false;
   let searchRendered = false;
   let reportsRendered = false;
@@ -357,6 +360,11 @@ function renderMainContent(root: HTMLElement) {
       jobsEl.className = "flex-1 flex flex-col min-h-0";
       root.appendChild(jobsEl);
     }
+    if (!projectsEl) {
+      projectsEl = document.createElement("div");
+      projectsEl.className = "flex-1 flex flex-col min-h-0";
+      root.appendChild(projectsEl);
+    }
     if (!monitoringEl) {
       monitoringEl = document.createElement("div");
       monitoringEl.className = "flex-1 flex flex-col min-h-0";
@@ -402,6 +410,7 @@ function renderMainContent(root: HTMLElement) {
     topoEl.style.display = mainView === "topology" ? "flex" : "none";
     tasksEl.style.display = mainView === "tasks" ? "flex" : "none";
     jobsEl.style.display = mainView === "jobs" ? "flex" : "none";
+    projectsEl.style.display = mainView === "projects" ? "flex" : "none";
     monitoringEl.style.display = mainView === "monitoring" ? "flex" : "none";
     searchEl.style.display = mainView === "search" ? "flex" : "none";
     reportsEl.style.display = mainView === "reports" ? "flex" : "none";
@@ -439,6 +448,9 @@ function renderMainContent(root: HTMLElement) {
     } else if (mainView === "jobs" && !jobsRendered) {
       renderJobsView(jobsEl);
       jobsRendered = true;
+    } else if (mainView === "projects" && !projectsRendered) {
+      renderProjectsView(projectsEl);
+      projectsRendered = true;
     } else if (mainView === "monitoring" && !monitoringRendered) {
       renderMonitoringView(monitoringEl);
       monitoringRendered = true;

--- a/src/web/store.ts
+++ b/src/web/store.ts
@@ -247,7 +247,7 @@ export interface TeamOsSnapshot {
   capture: { has_capture_token: boolean; capture_group_id: string | null; router_enabled: boolean };
 }
 
-export type MainView = "log" | "thread" | "config" | "chat" | "doc" | "busflow" | "teamos" | "topology" | "tasks" | "jobs" | "monitoring" | "search" | "reports" | "settings" | "inbox" | "audit" | "proposals";
+export type MainView = "log" | "thread" | "config" | "chat" | "doc" | "busflow" | "teamos" | "topology" | "tasks" | "jobs" | "projects" | "monitoring" | "search" | "reports" | "settings" | "inbox" | "audit" | "proposals";
 export type MobilePane = "agents" | "main" | "threads";
 export type DocSection = "policy" | "architecture" | "routing" | "learning" | "qa" | "search";
 


### PR DESCRIPTION
## 핵심 3줄
1. Tasks 접두어를 프로젝트로 승격해 보는 읽기 전용 화면이 없었습니다.
2. `project_prefixes` setting의 네 초기값만 집계하며, 접두어 표기 차이는 소문자로 정규화합니다.
3. Projects 탭·집계 API·초기 setting·회귀 테스트를 246줄 추가했습니다.

## 무엇을 바꿨나
| 문제 | 고친 방법 |
|---|---|
| 프로젝트 목록 부재 | Tasks·Jobs 옆에 읽기 전용 Projects 탭 추가 |
| 접두어 표기 차이 | 제목 접두어와 승격 목록을 소문자로 정규화 |
| 잘못된 프로젝트 노출 | `project_prefixes` setting에 포함된 접두어만 집계 |
| 초기 빈 화면 | `infra`, `codex`, `scheduler`, `pm`을 idempotent 초기값으로 저장 |

## 검증
- 검증 범위: 전체 `bun test`, `bun run typecheck`, `bun run build`, Chrome 탭 클릭·렌더 캡처, 라이브 DB read-only 집계
- baseline: 0 fail
- mutation: 소문자 정규화 제거 → 2 fail; 승격 목록 제한 제거 → 3 fail
- 라이브 집계: infra 15/1/5, codex 12/1/8, scheduler 1/1/0, pm 0/1/0
- 미검증: 머지·배포 후 라이브 서비스 화면

Submitted-by: devon
