### PR TITLE
fix(reports): wake assignee for portal requests

### DIFF
--- a/src/server/routes/portal.test.ts
+++ b/src/server/routes/portal.test.ts
@@ -33,12 +33,26 @@ describe("portal 리포트 요청 — 접수회신 플로우", () => {
     expect(j.thread_id).toBeTruthy();
   });
 
-  test("요청 → 담당자 버스 dm + 추적 task 생성 (안 묻힘)", async () => {
+  test("요청 → 담당자 wake 가능한 user bus dm + 추적 task 생성", async () => {
     const { app, db } = setup();
     await app.request("/api/rep1/request", json({ text: "수치 갱신" }));
-    const dm = db.prepare("SELECT to_agent_id, body FROM message WHERE to_agent_id='bill' ORDER BY rowid DESC LIMIT 1").get() as { to_agent_id: string; body: string } | null;
+    const dm = db.prepare(
+      `SELECT m.id, m.from_agent_id, m.to_agent_id, m.body, mr.delivery_state
+       FROM message m
+       JOIN message_recipient mr ON mr.message_id = m.id AND mr.agent_id = m.to_agent_id
+       WHERE m.to_agent_id='bill'
+       ORDER BY m.rowid DESC LIMIT 1`,
+    ).get() as {
+      id: string;
+      from_agent_id: string;
+      to_agent_id: string;
+      body: string;
+      delivery_state: string;
+    } | null;
+    expect(dm?.from_agent_id).toBe("user");
     expect(dm?.to_agent_id).toBe("bill");
-    expect(dm?.body).toContain("보고서 요청");
+    expect(dm?.body).toContain("[보고서 요청 · gd]");
+    expect(dm?.delivery_state).toBe("pending");
     const task = db.prepare("SELECT owner, lane FROM task WHERE owner='bill' AND title LIKE '요청:%' ORDER BY rowid DESC LIMIT 1").get() as { owner: string; lane: string } | null;
     expect(task?.owner).toBe("bill");
     expect(task?.lane).toBe("doing");

--- a/src/server/routes/portal.ts
+++ b/src/server/routes/portal.ts
@@ -284,6 +284,7 @@ export function createReportsApp(deps: PortalDeps): Hono {
     const assignee = String(body?.assignee ?? rep.author ?? "").trim();
     if (!assignee) return c.json({ error: "no assignee (보고서에 author 없음 — assignee 지정 필요)" }, 400);
     const requester = auth.actor.actor;
+    const requesterBusId = requester === leadActorId() ? "user" : requester;
     // 유지보수자 도메인 하드코딩 금지 — telegramCapture(mediaUrlBase)와 동일하게 env 미설정 시 빈 문자열 →
     // 상대경로(`/reports#/r/…`)로 우아하게 강등한다(신선 설치서 your-team.example.com 누출 방지). 대시보드 브라우저
     // 컨텍스트에선 상대경로가 그대로 해석된다. 라이브 풀 URL 을 원하면 TEAM_PUBLIC_BASE_URL 을 설정.
@@ -291,8 +292,18 @@ export function createReportsApp(deps: PortalDeps): Hono {
     const link = `${publicBase}/reports#/r/${id}`;
     const msg = `[보고서 요청 · ${requester}] "${rep.title}"\n${link}\n\n요청: ${text}\n\n→ 처리 후 팀장께 보고해주세요.`;
     // 1) 담당자에게 버스 directed (wakeDispatcher 가 깨움)
-    const { thread_id } = ensureThread(deps.db, { from_agent_id: requester, to_agent_id: assignee, type: "dm", body: msg });
-    insertMessage(deps.db, { thread_id, from_agent_id: requester, to_agent_id: assignee, type: "dm", body: msg, source: "user", hop_count: 0, priority: "normal" } as any);
+    const { thread_id } = ensureThread(deps.db, { from_agent_id: requesterBusId, to_agent_id: assignee, type: "dm", body: msg });
+    insertMessage(deps.db, {
+      thread_id,
+      from_agent_id: requesterBusId,
+      to_agent_id: assignee,
+      type: "dm",
+      body: msg,
+      source: "user",
+      dispatch: true,
+      hop_count: 0,
+      priority: "normal",
+    } as any);
     // 2) 추적 task (안 묻히게 — PM 체크포인트와 연결)
     try {
       createTask(deps.db, { title: `요청: ${rep.title}`, column: "doing", owner: assignee, description: `[/reports 요청 · ${requester} → ${assignee}]\n${link}\n\n${text}` });


### PR DESCRIPTION
## 핵심 3줄
1. `/reports` 요청은 DB와 task에 저장됐지만 담당 runtime을 깨우지 않았습니다.
2. `source=user` 요청이 `dispatch:true` 없이 저장돼 recipient가 `completed`로 생성됐고, lead actor ID가 bus reply 주소로 사용됐습니다.
3. lead 요청은 reserved bus ID `user`로 저장하고 recipient를 `pending`으로 만들어 wakeDispatcher가 처리하게 했습니다.

## 변경
- lead actor display 이름은 요청 본문과 task 설명에 유지
- bus `from_agent_id`는 `user`로 정규화
- report request message에 `dispatch:true` 추가
- integration test에서 `from_agent_id=user`, `delivery_state=pending`, task 생성을 함께 검증

## 검증
- RED: 기존 구현에서 `Expected user / Received gd` 실패 확인
- target: `bun test src/server/routes/portal.test.ts` — 15 pass, 0 fail
- full: `bun test` — 3,086 pass, 8 skip, 0 fail
- typecheck: `bun run typecheck` — pass
- build: `bun run build` — pass
- 미검증: live server 재시작 후 실제 버튼 클릭 wake는 배포 전이라 확인하지 않음

Submitted-by: hermes