### PR TITLE
fix(rules): 설명 원칙의 적용 범위를 지시대로 고친다 — 모든 메시지가 아니다

### DIFF
--- a/src/server/lib/personaTemplates.ts
+++ b/src/server/lib/personaTemplates.ts
@@ -367,7 +367,7 @@ const CORE_RULE_COMPACT = [
   "- \"summarize/report back\" → ONE synthesis. \"each report to me\" → **not** a collection: add `--individual`, each uses `--direct-to-gd`, do not synthesize. Ambiguous → ask.",
   "- No response → do not wait forever or announce retries; report partial results naming the non-responder, then add a late answer.",
   "",
-  "**Explaining** — 설명 원칙 (the team lead's term). Applies to every message, report, PR body, **and code comment**.",
+  "**Explaining** — 설명 원칙. Applies to explanations and report messages. Reports, PR bodies, and code comments count too — **not to every message**.",
   "- **Purpose**: deliver the facts from the reader's side. Order: context → the point → the detail, and write the detail as a real case (situation, steps, what changed) rather than a summary. Lead with context and the point, not with where your own work left off.",
   "- **Names**: if code, config, or a protocol has a name, use it verbatim — `window.scrollTo(x, y)`, `Cache-Control: no-store`, `approval key`. Never translate it: `BridgeWindow` became `창구` in that file's own comments, `hash` became `지문`. Ordinary dev terms (server, endpoint, cache) stay as-is.",
   "- **★No name → do not coin one; write what happens.★** `실물`·`소유자`·`기계` name nothing in the code, so the rule above never fires. Test: name the variable, field, or function the noun stands for. **This applies only where a noun stands for something in the system** — ordinary Korean words (사람, 이유, 차이) are not the target. Never swap in a physical object (handle, lever, engine, skeleton) for a thing that has a name. Applies to prose, not just examples.",


### PR DESCRIPTION
#399 가 머지한 `**Explaining**` 첫 줄의 적용 범위를 고친다.

## 무엇이 틀렸나

머지된 문안: `Applies to every message, report, PR body, and code comment.`

팀장님 지시(2026-09-01 06:23, steve 에게): **"모든 메시지가 해당되는 건 아니니, 설명을 요구할 때 필요한 사항들이야."**

둘이 반대다. 그 지시는 steve 에게만 갔고 내 세션 기록에는 0건이라 #399 를 쓸 때 반영하지 못했다.

## 어떻게 찾았나

steve 가 #399 를 승인한 뒤, 자기 `CLAUDE.md` 48줄에 적어둔 문장과 머지된 문안을 대조해 찾았다. 내가 양쪽 세션 기록을 검색해 인용이 실제로 있는지 확인했다(steve 1건 · bill 0건).

## 새 문안

팀장님이 오늘 준 것 그대로다.

```
설명 원칙. 설명, 보고메시지에 적용한다. 보고서, PR 본문, 코드 주석도 해당한다.
```

09-01 지시("모든 메시지가 아니다")와 09-04 지시("코드 주석도 적용")가 둘 다 선다. 주석은 메시지가 아니라 서로 부딪히지 않는다.

## 검증

- `bun test src/server/lib/personaTemplates.test.ts` → 45 pass / 0 fail
- 옛 문구 `every message, report, PR body` 잔존 0건
- 이 PR 은 첫 줄 하나만 바꾼다. 나머지 여덟 줄은 그대로다

## 왜 지금인가

배포와 재시작을 아직 안 해서 팀원 12명은 옛 문안을 읽고 있다. 지금 고치면 `모든 메시지` 문안이 한 번도 나가지 않는다.
