### PR TITLE
docs(skills): 승인은 GH_TOKEN 으로 한다 — gh auth switch 금지

### DIFF
--- a/skills/b3os-github-workflow/SKILL.md
+++ b/skills/b3os-github-workflow/SKILL.md
@@ -376,12 +376,26 @@ Approved-by: <승인자 ID>
 > 그래서 설명글에 아무리 정확한 모양으로 써도 ★`reviews` 가 비어 있으면 판정 자체가 안 선다.★
 >
 > ```bash
-> gh pr review <번호> --approve --body "$(printf '%s\n' '<사람이 읽을 말>' '' 'Approved-by: <승인자 ID>')"
+> APPROVER=<설정 github_approver_account>
+> TOKEN="$(gh auth token --user "$APPROVER")" || { echo "토큰 조회 실패 — 중단"; exit 1; }
+> [ -n "$TOKEN" ] || { echo "토큰이 비어 있다 — 중단"; exit 1; }
+> GH_TOKEN="$TOKEN" \
+>   gh pr review <번호> --approve --body "$(printf '%s\n' '<사람이 읽을 말>' '' 'Approved-by: <승인자 ID>')"
 > ```
+>
+> **★한 줄로 합치지 않는다★** — `GH_TOKEN="$(gh auth token --user X)" gh …` 형태는 토큰 조회가
+> 실패해도 멈추지 않는다. 조회 실패 시 값이 비고, `GH_TOKEN` 이 비면 `gh` 는 **활성 계정으로
+> 그냥 실행하며 종료코드도 0** 이다(gh 2.96.0 실측: 없는 계정을 넣으면 그때의 활성 계정으로 실행됐다).
+> 승인이 엉뚱한 계정으로 나가고 아무 신호도 안 뜬다. 위처럼 조회·빈 값·적용을 나눈다.
 >
 > **★계정이 작성자면 GitHub 이 self-approve 를 거부한다.★** PR 은 `github_team_account` 로 올리고
 > 승인은 `github_approver_account` 로 한다 — 게이트도 ★둘이 서로 달라야★ 통과시킨다.
-> 승인 전에 `gh api user --jq .login` 으로 지금 계정을 확인하고, 다르면 `gh auth switch` 로 바꾼다.
+>
+> **★`gh auth switch` 를 쓰지 않는다.★** 그건 이 기계 전체의 활성 계정을 바꾸고 **그대로 남는다.**
+> 팀원이 같은 `gh` 설정을 공유하므로, 승인 뒤 되돌리지 않으면 **다음 사람이 올리는 PR 이
+> 승인 계정 작성으로 잡힌다.** 그러면 GitHub 이 self-approve 를 거부하고, PR 작성자는 바꿀 수 없어
+> **그 PR 을 닫고 다시 만들어야 한다.** 위처럼 `GH_TOKEN` 을 그 명령에만 주면 활성 계정이 안 바뀐다.
+> 토큰은 변수에 담아 그 변수만 넘기고 화면·로그에 남기지 않는다.
 >
 > **★머지 직전에 한 번 돌려서 확인한다★** — 눈으로 보지 말고 게이트에게 물어본다:
 >


### PR DESCRIPTION
## 핵심 3줄

1. 승인 절차가 `gh auth switch` 를 쓰라고 적혀 있다. 그 명령은 이 기계 전체의 활성 계정을 바꾸고 **그대로 남는다.**
2. 승인 뒤 남은 계정으로 만든 PR 은 승인 계정 작성으로 잡혀 self-approve 거부에 걸린다. 작성자는 바꿀 수 없어 그 PR 을 닫고 다시 만들어야 한다.
3. 승인 예시를 `GH_TOKEN` 3단계 형태로 바꾸고, `gh auth switch` 를 쓰지 않는 이유를 적었다. 문서 1개, 한 블록.

## 관측

`gh auth switch` 로 승인한 뒤 활성 계정이 승인 계정에 남는다. 그 상태에서 만든 PR 은 이렇게 된다.

- PR 작성자 = 설정의 `github_approver_account`
- 승인 시도 결과 → `Review Can not approve your own pull request`
- 두 설정값(`github_team_account` · `github_approver_account`)은 서로 다른 계정이다

한 줄로 합친 `GH_TOKEN="$(gh auth token --user X)" gh …` 는 조회 실패를 안 막는다. gh 2.96.0 실측이다.

```
$ gh auth token --user nosuchaccount123
no oauth token found for github.com account nosuchaccount123
$ GH_TOKEN="$(gh auth token --user nosuchaccount123 2>/dev/null)" gh api user --jq .login
<활성 계정>      ← 활성 계정으로 실행됨. exit=0
```

## 원인

같은 문서 안에서 두 절이 다른 방법을 가리키고 있었다.

- PR 생성 절 — 토큰 조회 → 빈 값 검사 → `GH_TOKEN` 적용을 세 줄로 나눠 쓴다
- 승인 절 — "다르면 `gh auth switch` 로 바꾼다"

`gh auth switch` 는 되돌리는 단계가 절차에 없다. 되돌려도 그 사이에 다른 팀원이 `gh` 를 쓰면 그 계정으로 나간다.

## 바뀐 것

`skills/b3os-github-workflow/SKILL.md` 승인 블록만 고쳤다.

- 승인 예시를 조회 → 빈 값 검사 → `GH_TOKEN` 적용 3단계로 교체 (PR 작성 절과 같은 모양)
- 한 줄로 합치면 왜 위험한지 실측과 함께 명시
- `gh auth switch` 를 쓰지 않는 이유와 증상(다음 사람의 PR 을 닫고 다시 만들어야 함)을 명시
- 토큰을 화면·로그에 남기지 않는다는 주의 유지

## 확인하지 않은 것

- 이 문서를 읽는 런타임별 실제 동작. 문서 변경이라 코드 검사가 없다.
- 다른 스킬 문서에 같은 지시가 더 있는지는 이 저장소 `skills/` 안에서 `gh auth switch` 로 검색해 이 한 곳만 확인했다.

Submitted-by: bill
