### PR TITLE
feat(monitor): 사용량 소진(429)을 감지해 한 번 알린다

### DIFF
--- a/scripts/bot-liveness-monitor.sh
+++ b/scripts/bot-liveness-monitor.sh
@@ -661,6 +661,84 @@ check_gateway "ai.openclaw.gateway" "codex/openclaw" "openclaw" "http://127.0.0.
 check_gateway "ai.hermes.gateway-b3ryshermes" "hermes" "hermes" "-" "hermes"
 check_gateway "$TEAMOS_LAUNCHD_PREFIX.b3rys-dev" "b3rys-dev" "b3rys-dev" "http://127.0.0.1:3000/" "-"
 
+# ─── 사용량 소진(429) 감지 (GD 2026-09-07 요청) ─────────────────────────────────
+# 왜 필요한가: 위 검사들은 ★프로세스가 살아있나★ 만 본다. 2026-09-07 에 codex·brief·devon·hermes
+#   넷이 동시에 답을 못 했는데 tmux·PID·health 는 전부 정상이라 이 모니터가 조용했다.
+#   원인은 공유 ChatGPT 계정의 사용량 소진이었고, 그 사실은 ★로그에만★ 찍힌다.
+# 무엇을 보나: 두 런타임이 서로 다른 문구를 쓰므로 둘 다 본다.
+#   openclaw : Auth profile "openai:<계정>" is temporarily unavailable
+#   hermes   : Primary provider rate-limited (429): ... quota exhausted (429); retry after <n>s
+# ★인증 실패와 사용량은 다르다★ — hermes 문구에 "Credentials are still valid" 가 붙는다.
+# alert-only(Type C). 재시작해도 안 풀리고 시간이 지나야 풀린다.
+QUOTA_WINDOW_MIN="${LIVENESS_QUOTA_WINDOW_MIN:-15}"   # 점검 주기(10분)보다 넓게 — 사이에 난 것을 놓치지 않는다
+check_provider_quota() {
+  # ★한 건만 보고하면 과소보고다★ — 계정 하나가 막히면 여러 런타임·프로필이 동시에 걸린다.
+  #   실측(2026-09-07): openclaw 와 hermes 두 프로필이 같은 시각대에 같이 걸렸다. 전부 줄로 낸다.
+  local now_epoch cutoff_epoch found=0
+  now_epoch=$(date +%s); cutoff_epoch=$((now_epoch - QUOTA_WINDOW_MIN * 60))
+
+  # openclaw — JSON 로그(한 줄 = 한 기록). 날짜별 파일이라 오늘 것만 본다.
+  # ★"temporarily unavailable" 은 증상이지 원인이 아니다★ — auth profile cooldown 의 공통 결과라
+  #   인증 오류·일시적 provider 오류도 같은 줄을 낸다. 그리고 ★그 줄에는 원인 필드가 없다★
+  #   (실측: unavailable 216줄 중 원인 필드를 가진 줄 0). 원인은 별도 기록에 남는다.
+  #   그래서 두 줄을 짝지어 읽지 않는다 — ★각자 자기 줄에서만 읽는다.★ 섞으면 다른 요청의
+  #   원인을 이 증상의 원인으로 부르게 된다.
+  local oc_log="${LIVENESS_OPENCLAW_LOG:-/tmp/openclaw/openclaw-$(date +%F).log}"
+  if [ -f "$oc_log" ]; then
+    local cause_line cause_ts cause_e why hint sym_line sym_ts sym_e
+    # ① 원인 기록 — 실패 사유가 rate_limit 인 줄. 시각·안내문도 이 줄에서만 뽑는다.
+    cause_line=$(grep -E '"(profileFailureReason|failoverReason|providerRuntimeFailureKind)":"rate_limit"' "$oc_log" 2>/dev/null | tail -1)
+    if [ -n "$cause_line" ]; then
+      cause_ts=$(printf '%s' "$cause_line" | sed -n 's/.*"time":"\([0-9T:-]*\).*/\1/p' | tail -1)
+      cause_e=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${cause_ts:-x}" +%s 2>/dev/null || echo 0)
+      if [ "$cause_e" -ge "$cutoff_epoch" ]; then
+        why=$(printf '%s' "$cause_line" | sed -n 's/.*"profileFailureReason":"\([a-z_]*\)".*/\1/p')
+        [ -n "$why" ] || why="rate_limit"
+        hint=$(printf '%s' "$cause_line" | grep -o "You've reached your [^\"]*" | head -1 | cut -d. -f1,2 | cut -c1-120)
+        found=1
+        ISSUES="${ISSUES}· [사용량] openclaw(codex·brief·devon) 사용량 소진 — $cause_ts · 원인필드 $why${hint:+ · \"$hint\"}. 재시작으로 안 풀린다. alert-only
+"
+      fi
+    fi
+    # ② 증상만 있고 원인 기록이 창 안에 없으면 원인 미확인으로 낸다. 사용량이라 부르지 않는다.
+    if [ "$found" = "0" ]; then
+      sym_line=$(grep "temporarily unavailable" "$oc_log" 2>/dev/null | tail -1)
+      if [ -n "$sym_line" ]; then
+        sym_ts=$(printf '%s' "$sym_line" | sed -n 's/.*"time":"\([0-9T:-]*\).*/\1/p' | tail -1)
+        sym_e=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${sym_ts:-x}" +%s 2>/dev/null || echo 0)
+        if [ "$sym_e" -ge "$cutoff_epoch" ]; then
+          found=1
+          ISSUES="${ISSUES}· [제공자] openclaw 인증 프로필 일시 사용불가 — $sym_ts · 창 안에 rate_limit 기록 없음. 사용량인지 인증·일시오류인지 안 갈린다. 확인 필요
+"
+        fi
+      fi
+    fi
+  fi
+
+  # hermes — 프로필별 텍스트 로그. retry after 초가 있으면 복구 시각까지 계산한다.
+  local d p line ts e retry_s extra base until_h
+  for d in "${LIVENESS_HERMES_PROFILES:-$HOME/.hermes/profiles}"/*/logs/gateway.error.log; do
+    [ -f "$d" ] || continue
+    p=$(basename "$(dirname "$(dirname "$d")")")
+    line=$(grep "quota exhausted (429)" "$d" 2>/dev/null | tail -1)
+    [ -n "$line" ] || continue
+    ts=$(printf '%s' "$line" | awk '{print $1" "$2}' | cut -d, -f1)
+    e=$(date -j -f "%Y-%m-%d %H:%M:%S" "$ts" +%s 2>/dev/null || echo 0)
+    [ "$e" -ge "$cutoff_epoch" ] || continue
+    retry_s=$(printf '%s' "$line" | sed -n 's/.*retry after \([0-9]*\)s.*/\1/p')
+    extra=""
+    if [ -n "$retry_s" ] && [ "$e" -gt 0 ]; then
+      until_h=$(date -r $((e + retry_s)) "+%H:%M" 2>/dev/null)
+      [ -n "$until_h" ] && extra=" · ${until_h} 경 풀림(retry after ${retry_s}s)"
+    fi
+    found=1
+    ISSUES="${ISSUES}· [사용량] hermes($p) 제공자 사용량 소진(429) — ${ts}${extra}. 프로세스는 정상이라 재시작으로 안 풀린다. alert-only
+"
+  done
+  return 0
+}
+check_provider_quota
+
 # OpenClaw Telegram provider stuck detector (Phase A, 2026-06-16 outage):
 # alert only when last inbound is stale AND provider state is stopped/disconnected.
 # It writes read-only dashboard status + audit_event; gateway restart/kickstart stays OFF unless

--- a/scripts/bot-liveness-monitor.test.sh
+++ b/scripts/bot-liveness-monitor.test.sh
@@ -325,4 +325,73 @@ grep -q "tok-must-not-leak" "$CURL_ARGV" && {
   RC=1
 }
 pass_if_clean "알림 발송 시 토큰이 curl 인자에 실리지 않는다"
+
+# ─── 사용량 소진(429) 감지 ───────────────────────────────────────────────
+# 이 검사가 없던 동안 codex·brief·devon·hermes 넷이 동시에 답을 못 했는데 감시기가 조용했다.
+# tmux·PID·health 는 전부 정상이었기 때문이다. 그래서 ★로그 문구★ 를 본다.
+# 여기서는 가짜 로그를 만들어 ① 창 안이면 잡고 ② 창 밖이면 조용한지를 본다.
+QDIR=$(mktemp -d); trap 'rm -rf "$QDIR"' EXIT
+q_fixture() {  # $1=분 전
+  local mins="$1" oc_ts h_ts
+  oc_ts=$(date -v-"${mins}"M "+%Y-%m-%dT%H:%M:%S" 2>/dev/null)
+  h_ts=$(date -v-"${mins}"M "+%Y-%m-%d %H:%M:%S" 2>/dev/null)
+  # 실제 로그는 증상과 원인이 ★다른 줄★ 이다(unavailable 줄에는 원인 필드가 없다).
+  printf '{"0":"Embedded agent failed: Auth profile \\"openai:x@y.z\\" is temporarily unavailable for openai/m.","time":"%s.000+09:00"}\n' "$oc_ts" > "$QDIR/openclaw.log"
+  printf '{"0":"provider failure","profileFailureReason":"rate_limit","providerRuntimeFailureKind":"rate_limit","rawErrorPreview":"You'"'"'ve reached your Codex subscription usage limit. Next reset in 6 hours.","time":"%s.000+09:00"}\n' "$oc_ts" >> "$QDIR/openclaw.log"
+  mkdir -p "$QDIR/profiles/testprof/logs"
+  printf '%s,000 WARNING gateway.run: Primary provider rate-limited (429): Codex provider quota exhausted (429); retry after 600s. Credentials are still valid.\n' "$h_ts" > "$QDIR/profiles/testprof/logs/gateway.error.log"
+}
+q_run() {  # $1=창(분) → 검출 줄만 출력
+  LIVENESS_STATE_DIR="$QDIR/state" LIVENESS_QUOTA_WINDOW_MIN="$1" \
+  LIVENESS_OPENCLAW_LOG="$QDIR/openclaw.log" LIVENESS_HERMES_PROFILES="$QDIR/profiles" \
+    bash "$SCRIPT" --dry-run 2>/dev/null | grep -E "\[(사용량|제공자)\]" || true
+}
+
+q_fixture 3
+OUT=$(q_run 15)
+printf '%s' "$OUT" | grep -q "\[사용량\] openclaw" || { echo "FAIL: 창 안 openclaw 사용량 소진을 못 잡았다" >&2; RC=1; }
+printf '%s' "$OUT" | grep -q "hermes(testprof)" || { echo "FAIL: 창 안 hermes 사용량 소진을 못 잡았다" >&2; RC=1; }
+printf '%s' "$OUT" | grep -q "경 풀림(retry after 600s)" || { echo "FAIL: 복구 시각을 계산하지 않았다" >&2; RC=1; }
+pass_if_clean "창 안의 사용량 소진은 런타임별로 각각 잡고 복구 시각을 낸다"
+
+q_fixture 120
+OUT=$(q_run 15)
+[ -z "$OUT" ] || { echo "FAIL: 창 밖(120분 전) 기록에 알림이 났다 — $OUT" >&2; RC=1; }
+pass_if_clean "창 밖의 옛 기록에는 알리지 않는다"
+
+# ★사용량이 아닌 cooldown 은 사용량이라고 하면 안 된다★
+# openclaw 의 "temporarily unavailable" 은 auth profile cooldown 의 공통 결과다.
+# 원인필드가 rate_limit 이 아니면 원인 미확인으로 낮춰야 한다 — 안 그러면 인증 오류를
+# 사용량으로 잘못 부르고 "재시작으로 안 풀린다" 까지 틀리게 단정한다.
+q_fixture_nonquota() {
+  local oc_ts; oc_ts=$(date -v-3M "+%Y-%m-%dT%H:%M:%S" 2>/dev/null)
+  # ★두 줄이 섞인 상태★ — 증상 줄과 사용량이 아닌 원인 줄. 줄을 건너뛰어 짝지으면 오분류한다.
+  printf '{"0":"Auth profile \\"openai:x@y.z\\" is temporarily unavailable for openai/m.","time":"%s.000+09:00"}\n' "$oc_ts" > "$QDIR/openclaw.log"
+  printf '{"0":"provider failure","profileFailureReason":"auth_error","time":"%s.000+09:00"}\n' "$oc_ts" >> "$QDIR/openclaw.log"
+  rm -rf "$QDIR/profiles"; mkdir -p "$QDIR/profiles"
+}
+q_fixture_nonquota
+OUT=$(q_run 15)
+printf '%s' "$OUT" | grep -q "\[사용량\]" && { echo "FAIL: 사용량이 아닌 cooldown 을 사용량으로 불렀다 — $OUT" >&2; RC=1; }
+printf '%s' "$OUT" | grep -q "\[제공자\]" || { echo "FAIL: 원인 미확인 알림이 안 났다 — $OUT" >&2; RC=1; }
+printf '%s' "$OUT" | grep -q "재시작으로 안 풀린다" && { echo "FAIL: 원인 미확인인데 재시작 무용을 단정했다" >&2; RC=1; }
+pass_if_clean "사용량이 아닌 cooldown 은 원인 미확인으로 낮춘다"
+
+# ★옛 원인 기록을 새 증상에 갖다 붙이면 안 된다★
+# 실제 로그에서 rate_limit 기록은 하루에 한 건인데 증상 줄은 216건이었다.
+# 창 밖의 옛 원인을 창 안 증상의 원인으로 부르면 지나간 사고를 지금 사고로 보고하게 된다.
+q_fixture_stale_cause() {
+  local new_ts old_ts
+  new_ts=$(date -v-3M "+%Y-%m-%dT%H:%M:%S" 2>/dev/null)
+  old_ts=$(date -v-300M "+%Y-%m-%dT%H:%M:%S" 2>/dev/null)
+  printf '{"0":"provider failure","profileFailureReason":"rate_limit","time":"%s.000+09:00"}\n' "$old_ts" > "$QDIR/openclaw.log"
+  printf '{"0":"Auth profile \\"openai:x@y.z\\" is temporarily unavailable for openai/m.","time":"%s.000+09:00"}\n' "$new_ts" >> "$QDIR/openclaw.log"
+  rm -rf "$QDIR/profiles"; mkdir -p "$QDIR/profiles"
+}
+q_fixture_stale_cause
+OUT=$(q_run 15)
+printf '%s' "$OUT" | grep -q "\[사용량\]" && { echo "FAIL: 창 밖의 옛 rate_limit 기록을 지금 사고의 원인으로 붙였다 — $OUT" >&2; RC=1; }
+printf '%s' "$OUT" | grep -q "\[제공자\]" || { echo "FAIL: 증상만 있을 때 원인 미확인 알림이 안 났다 — $OUT" >&2; RC=1; }
+pass_if_clean "창 밖의 옛 원인 기록을 창 안 증상에 붙이지 않는다"
+
 exit "$RC"


### PR DESCRIPTION
## 핵심 3줄

1. 감시기가 프로세스 생존만 봐서, 프로세스는 살아 있고 답만 못 하는 상태를 못 잡았다.
2. 팀원 넷이 동시에 답을 못 한 사고에서 tmux·PID·health 가 전부 정상이라 감시기가 조용했다. 원인은 공유 계정의 사용량 소진이고 그 사실은 로그에만 있다.
3. 두 런타임의 로그를 최근 15분에서 보되, **openclaw 는 원인 필드가 `rate_limit` 일 때만 사용량이라 부른다.** 검사 1개 + 시험 3개.

## 관측

같은 계정에 매달린 런타임이 같은 시각대에 같이 걸렸다. 문구는 서로 다르다.

```
openclaw : Auth profile "openai:<계정>" is temporarily unavailable for openai/<모델>
hermes   : Primary provider rate-limited (429): Codex provider quota exhausted (429);
           retry after 3153s. Credentials are still valid. — trying fallback
```

`Credentials are still valid` 가 인증 실패와 사용량을 가른다. `retry after <초>` 로 복구 시각이 계산된다.

★openclaw 는 증상과 원인이 다른 줄에 있다.★ `temporarily unavailable` 은 auth profile cooldown 의 공통 결과라 인증 오류·일시적 provider 오류도 같은 줄을 낸다. 그리고 **그 줄에는 원인 필드가 없다.**

```
temporarily unavailable 줄            216건  ← 그중 원인 필드를 가진 줄 0건
profileFailureReason 를 담은 줄         1건  ← 원인은 여기 있다
```

원인 기록은 자기 `time` 을 갖는다.

```
"failoverReason":"rate_limit"   "profileFailureReason":"rate_limit"
"providerRuntimeFailureKind":"rate_limit"
"rawErrorPreview":"You've reached your Codex subscription usage limit. Next reset in 6 hours, ..."
```

기존 검사로는 안 잡힌다 — `grep -c "quota|429|temporarily unavailable|Auth profile" scripts/bot-liveness-monitor.sh` 가 **0** 이었다.

## 바뀐 것

`scripts/bot-liveness-monitor.sh`

- `check_provider_quota()` 추가. openclaw 오늘 로그와 hermes 프로필별 `gateway.error.log` 를 본다.
- **두 줄을 짝지어 읽지 않는다.** 각자 자기 줄에서만 읽는다 — 파일 전체에서 원인을 긁어 증상 줄에 붙이면 다른 요청의 원인을 이 증상의 원인으로 부르게 된다.
  - 창 안에 `rate_limit` 원인 기록이 있으면 `[사용량]` — 시각·안내문도 그 줄에서 뽑는다
  - 없으면 증상 줄로 `[제공자] 원인 미확인` — "재시작으로 안 풀린다" 를 쓰지 않는다
- 창 기본 15분 — 점검 주기 10분보다 넓게 잡아 두 점검 사이에 난 것을 놓치지 않는다. `LIVENESS_QUOTA_WINDOW_MIN` 으로 바꾼다.
- **여러 건을 각각 낸다.** 한 줄만 내면 범위를 줄여 보고하게 된다(초안이 그랬고, 실 로그 시험에서 3건 중 1건만 나와 고쳤다).
- alert-only(Type C). 재시작으로 안 풀리므로 자동복구를 걸지 않는다.
- 중복 알림은 기존 `STATE_FILE` signature 방식이 그대로 막는다.

`scripts/bot-liveness-monitor.test.sh` — 가짜 로그로 검사 4건 추가. fixture 는 실제 로그처럼 **증상과 원인을 다른 줄**로 둔다.

## 검사

| 항목 | 결과 |
|---|---|
| `bash scripts/bot-liveness-monitor.test.sh` | 전 항목 PASS (기존 + 신규 2) |
| 창 안(3분 전) 가짜 로그 | openclaw·hermes 각각 검출 · 복구 시각 계산 |
| 창 밖(120분 전) 가짜 로그 | 검출 0 |
| 증상 줄 + `auth_error` 원인 줄(섞인 상태) | `[사용량]` 아님 · `[제공자]` 로 낮춤 · 재시작 단정 없음 |
| 창 밖 옛 `rate_limit` 줄 + 창 안 증상 줄 | 옛 원인을 갖다 붙이지 않음 · `[제공자]` |
| 실 로그 `--dry-run` | 오늘 사고 3건(openclaw · b3ryshermes · forin) 재현 |
| 뮤턴트 ①(검사 호출 제거) | 시험 3건 실패 |
| 뮤턴트 ②(원인 판별 제거 — 전부 사용량으로 부름) | 음성 시험 3건 실패 |
| 뮤턴트 ③(옛 원인 기록의 시각을 지금으로 바꿔치기) | 시험 2건 실패 |
| `bash -n` | 통과 |

## 확인하지 않은 것

- 실제 알림 발송. `--dry-run` 으로만 돌렸고 GD DM 으로 보내지는 않았다.
- 다음 사고에서 창 15분이 충분한지. 오늘 기록으로 역산했을 뿐 실전 발생은 아직 없다.
- openclaw 로그 파일이 날짜별이라 자정 직후 사고는 전날 파일에 남을 수 있다. 이번 범위에서 다루지 않았다.

Submitted-by: bill
