### PR TITLE
fix(monitor): 대화 본문이 인용한 오류 문구를 오류로 세지 않는다

### DIFF
--- a/scripts/bot-liveness-monitor.sh
+++ b/scripts/bot-liveness-monitor.sh
@@ -678,6 +678,9 @@ check_provider_quota() {
   now_epoch=$(date +%s); cutoff_epoch=$((now_epoch - QUOTA_WINDOW_MIN * 60))
 
   # openclaw — JSON 로그(한 줄 = 한 기록). 날짜별 파일이라 오늘 것만 본다.
+  # ★로그에는 대화 본문도 실린다★ — 이 문구를 인용한 팀원 메시지가 INFO 로 남는다(실측 1건).
+  #   그 줄을 오류로 세면 사고가 없는데 알림이 나간다. 그래서 로그 레벨로 먼저 거른다 —
+  #   증상은 ERROR, 원인 기록은 WARN 이다(실측). INFO 는 보지 않는다.
   # ★"temporarily unavailable" 은 증상이지 원인이 아니다★ — auth profile cooldown 의 공통 결과라
   #   인증 오류·일시적 provider 오류도 같은 줄을 낸다. 그리고 ★그 줄에는 원인 필드가 없다★
   #   (실측: unavailable 216줄 중 원인 필드를 가진 줄 0). 원인은 별도 기록에 남는다.
@@ -687,7 +690,7 @@ check_provider_quota() {
   if [ -f "$oc_log" ]; then
     local cause_line cause_ts cause_e why hint sym_line sym_ts sym_e
     # ① 원인 기록 — 실패 사유가 rate_limit 인 줄. 시각·안내문도 이 줄에서만 뽑는다.
-    cause_line=$(grep -E '"(profileFailureReason|failoverReason|providerRuntimeFailureKind)":"rate_limit"' "$oc_log" 2>/dev/null | tail -1)
+    cause_line=$(grep -E '"(profileFailureReason|failoverReason|providerRuntimeFailureKind)":"rate_limit"' "$oc_log" 2>/dev/null | grep -E '"logLevelName":"(ERROR|WARN)"' | tail -1)
     if [ -n "$cause_line" ]; then
       cause_ts=$(printf '%s' "$cause_line" | sed -n 's/.*"time":"\([0-9T:-]*\).*/\1/p' | tail -1)
       cause_e=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${cause_ts:-x}" +%s 2>/dev/null || echo 0)
@@ -702,7 +705,7 @@ check_provider_quota() {
     fi
     # ② 증상만 있고 원인 기록이 창 안에 없으면 원인 미확인으로 낸다. 사용량이라 부르지 않는다.
     if [ "$found" = "0" ]; then
-      sym_line=$(grep "temporarily unavailable" "$oc_log" 2>/dev/null | tail -1)
+      sym_line=$(grep "temporarily unavailable" "$oc_log" 2>/dev/null | grep '"logLevelName":"ERROR"' | tail -1)
       if [ -n "$sym_line" ]; then
         sym_ts=$(printf '%s' "$sym_line" | sed -n 's/.*"time":"\([0-9T:-]*\).*/\1/p' | tail -1)
         sym_e=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${sym_ts:-x}" +%s 2>/dev/null || echo 0)

--- a/scripts/bot-liveness-monitor.test.sh
+++ b/scripts/bot-liveness-monitor.test.sh
@@ -336,8 +336,8 @@ q_fixture() {  # $1=분 전
   oc_ts=$(date -v-"${mins}"M "+%Y-%m-%dT%H:%M:%S" 2>/dev/null)
   h_ts=$(date -v-"${mins}"M "+%Y-%m-%d %H:%M:%S" 2>/dev/null)
   # 실제 로그는 증상과 원인이 ★다른 줄★ 이다(unavailable 줄에는 원인 필드가 없다).
-  printf '{"0":"Embedded agent failed: Auth profile \\"openai:x@y.z\\" is temporarily unavailable for openai/m.","time":"%s.000+09:00"}\n' "$oc_ts" > "$QDIR/openclaw.log"
-  printf '{"0":"provider failure","profileFailureReason":"rate_limit","providerRuntimeFailureKind":"rate_limit","rawErrorPreview":"You'"'"'ve reached your Codex subscription usage limit. Next reset in 6 hours.","time":"%s.000+09:00"}\n' "$oc_ts" >> "$QDIR/openclaw.log"
+  printf '{"0":"Embedded agent failed: Auth profile \\"openai:x@y.z\\" is temporarily unavailable for openai/m.","logLevelName":"ERROR","time":"%s.000+09:00"}\n' "$oc_ts" > "$QDIR/openclaw.log"
+  printf '{"0":"provider failure","profileFailureReason":"rate_limit","providerRuntimeFailureKind":"rate_limit","rawErrorPreview":"You'"'"'ve reached your Codex subscription usage limit. Next reset in 6 hours.","logLevelName":"WARN","time":"%s.000+09:00"}\n' "$oc_ts" >> "$QDIR/openclaw.log"
   mkdir -p "$QDIR/profiles/testprof/logs"
   printf '%s,000 WARNING gateway.run: Primary provider rate-limited (429): Codex provider quota exhausted (429); retry after 600s. Credentials are still valid.\n' "$h_ts" > "$QDIR/profiles/testprof/logs/gateway.error.log"
 }
@@ -366,8 +366,8 @@ pass_if_clean "창 밖의 옛 기록에는 알리지 않는다"
 q_fixture_nonquota() {
   local oc_ts; oc_ts=$(date -v-3M "+%Y-%m-%dT%H:%M:%S" 2>/dev/null)
   # ★두 줄이 섞인 상태★ — 증상 줄과 사용량이 아닌 원인 줄. 줄을 건너뛰어 짝지으면 오분류한다.
-  printf '{"0":"Auth profile \\"openai:x@y.z\\" is temporarily unavailable for openai/m.","time":"%s.000+09:00"}\n' "$oc_ts" > "$QDIR/openclaw.log"
-  printf '{"0":"provider failure","profileFailureReason":"auth_error","time":"%s.000+09:00"}\n' "$oc_ts" >> "$QDIR/openclaw.log"
+  printf '{"0":"Auth profile \\"openai:x@y.z\\" is temporarily unavailable for openai/m.","logLevelName":"ERROR","time":"%s.000+09:00"}\n' "$oc_ts" > "$QDIR/openclaw.log"
+  printf '{"0":"provider failure","profileFailureReason":"auth_error","logLevelName":"WARN","time":"%s.000+09:00"}\n' "$oc_ts" >> "$QDIR/openclaw.log"
   rm -rf "$QDIR/profiles"; mkdir -p "$QDIR/profiles"
 }
 q_fixture_nonquota
@@ -384,8 +384,8 @@ q_fixture_stale_cause() {
   local new_ts old_ts
   new_ts=$(date -v-3M "+%Y-%m-%dT%H:%M:%S" 2>/dev/null)
   old_ts=$(date -v-300M "+%Y-%m-%dT%H:%M:%S" 2>/dev/null)
-  printf '{"0":"provider failure","profileFailureReason":"rate_limit","time":"%s.000+09:00"}\n' "$old_ts" > "$QDIR/openclaw.log"
-  printf '{"0":"Auth profile \\"openai:x@y.z\\" is temporarily unavailable for openai/m.","time":"%s.000+09:00"}\n' "$new_ts" >> "$QDIR/openclaw.log"
+  printf '{"0":"provider failure","profileFailureReason":"rate_limit","logLevelName":"WARN","time":"%s.000+09:00"}\n' "$old_ts" > "$QDIR/openclaw.log"
+  printf '{"0":"Auth profile \\"openai:x@y.z\\" is temporarily unavailable for openai/m.","logLevelName":"ERROR","time":"%s.000+09:00"}\n' "$new_ts" >> "$QDIR/openclaw.log"
   rm -rf "$QDIR/profiles"; mkdir -p "$QDIR/profiles"
 }
 q_fixture_stale_cause
@@ -393,5 +393,17 @@ OUT=$(q_run 15)
 printf '%s' "$OUT" | grep -q "\[사용량\]" && { echo "FAIL: 창 밖의 옛 rate_limit 기록을 지금 사고의 원인으로 붙였다 — $OUT" >&2; RC=1; }
 printf '%s' "$OUT" | grep -q "\[제공자\]" || { echo "FAIL: 증상만 있을 때 원인 미확인 알림이 안 났다 — $OUT" >&2; RC=1; }
 pass_if_clean "창 밖의 옛 원인 기록을 창 안 증상에 붙이지 않는다"
+
+# ★대화 본문이 그 문구를 인용해도 오류가 아니다★
+# 실측: 이 검사를 리뷰하는 대화가 로그에 INFO 로 남아 알림이 났다. 레벨로 거른다.
+q_fixture_chat_quote() {
+  local ts; ts=$(date -v-3M "+%Y-%m-%dT%H:%M:%S" 2>/dev/null)
+  printf '{"0":"리뷰 의견: Auth profile \\"openai:x@y.z\\" is temporarily unavailable 줄과 profileFailureReason \\"rate_limit\\" 을 따로 찾고 있습니다","logLevelName":"INFO","time":"%s.000+09:00"}\n' "$ts" > "$QDIR/openclaw.log"
+  rm -rf "$QDIR/profiles"; mkdir -p "$QDIR/profiles"
+}
+q_fixture_chat_quote
+OUT=$(q_run 15)
+[ -z "$OUT" ] || { echo "FAIL: 대화 본문 인용을 오류로 알렸다 — $OUT" >&2; RC=1; }
+pass_if_clean "대화 본문이 그 문구를 인용해도 알리지 않는다"
 
 exit "$RC"


### PR DESCRIPTION
## 핵심 3줄

1. #417 배포 후 라이브에서 돌리니 사고가 없는데 알림이 났다.
2. 잡힌 줄은 오류가 아니라 **팀원 메시지**였다 — 이 검사를 리뷰하던 대화가 `temporarily unavailable` 을 인용했고 그 메시지가 openclaw 로그에 `INFO` 로 남았다.
3. 로그 레벨로 거른다. 증상은 `ERROR`, 원인 기록은 `WARN`·`ERROR` 만 본다. 검사 1개 + 시험 1개.

## 관측

같은 문자열이 세 종류의 줄에 있다.

```
temporarily unavailable   ERROR 146 · INFO 66 · WARN 4
profileFailureReason      WARN    1
그중 대화 본문 인용        INFO    1   ← 이것이 알림을 냈다
```

라이브에서 기본 창 15분으로 돌렸을 때 나온 줄이다. 시각 `14:56:37` 은 오류 시각이 아니라 메시지가 도착한 시각이다.

```
· [제공자] openclaw 인증 프로필 일시 사용불가 — 2026-09-07T14:56:37 · 창 안에 rate_limit 기록 없음
```

실제 마지막 오류는 `11:51:32`(ERROR)이고 창 밖이다.

## 원인

검사가 로그를 문자열로만 훑었다. 로그에는 오류 기록과 **대화 본문**이 같이 실린다. 이 검사를 만드는 대화가 그 문구를 인용하는 순간 검사가 자기 자신을 오류로 세는 모양이 됐다.

#417 본문에 적은 "216줄" 도 같은 이유로 부풀려진 값이다. ERROR 만 세면 146줄이다.

## 바뀐 것

`scripts/bot-liveness-monitor.sh`

- 증상 줄 검색에 `"logLevelName":"ERROR"` 조건 추가
- 원인 기록 검색에 `"logLevelName":"(ERROR|WARN)"` 조건 추가 — `INFO` 로 실리는 대화 본문을 뺀다

`scripts/bot-liveness-monitor.test.sh` — 대화 본문이 두 문구를 모두 인용한 `INFO` 줄 fixture 추가. fixture 전부에 실제 모양대로 로그 레벨을 넣었다.

## 검사

| 항목 | 결과 |
|---|---|
| 라이브 로그 · 기본 창 15분 | 검출 0건 (지금 사고 없음) |
| 라이브 로그 · 창 600분 | 검출 3건 (그날 사고) |
| 대화 본문 인용 fixture | 조용 |
| 뮤턴트(레벨 필터 제거) | 그 시험 실패 — 알림이 다시 남 |
| 기존 시험 4건 | 전부 PASS |
| `bash -n` | 통과 |

## 확인하지 않은 것

- 다른 런타임 로그에도 대화 본문이 실리는지. hermes 쪽은 `quota exhausted (429)` 문구를 쓰는데 그 문자열이 대화에 실린 사례는 아직 없다.
- 실제 알림 발송. `--dry-run` 으로만 돌렸다.

Submitted-by: bill
