### PR TITLE
fix(report): 탭을 눌러도 탭 줄이 붙은 자리에 멈춘다

### DIFF
--- a/skills/b3os-report/scripts/render.mjs
+++ b/skills/b3os-report/scripts/render.mjs
@@ -184,7 +184,30 @@ ${noPanelHit} [href="#panel-${tabs[0].id}"]${activeBg}`;
   var TOP=104;          // 장 앵커 — 제목이 상단 탭 줄에 가리지 않는 자리
   var PANEL_TOP=112;    // 탭 첫머리 — .tab-panel 의 scroll-margin-top 과 같은 값
   var pos={}, current=null;
+  // ★탭 줄이 붙어 있는 자리로만 옮긴다★
+  //   .report-tabs 는 position:sticky 다. 문서에서 그 줄의 원래 자리에서 sticky top 을 뺀
+  //   지점부터 붙는다. 그런데 패널 첫머리로 가는 목표 스크롤이 ★그 지점과 정확히 같았다★
+  //   (실측 2026-09-07 · 여섯 탭 전부 목표 831 = 경계 831 · 여유 0). 그래서 창 너비·글꼴·그림 로딩으로
+  //   1px 만 어긋나도 줄이 풀려 아래로 내려앉는다 — 탭을 누를 때마다 화면이 튀어 보인다.
+  //   경계보다 STICK_PAD 만큼 더 내려가서 멈춘다.
+  // ★원래 자리는 탭 줄에서 못 읽는다★ — 붙어 있는 동안 그 줄을 읽으면 붙은 자리가 나온다
+  //   (실측: 스크롤 3000 에서 탭 줄은 3052, 바로 앞 #report-top 은 830 그대로).
+  //   그래서 sticky 가 아닌 앞 표식을 ★부를 때마다★ 읽는다. 한 번 재서 들고 있으면 그림·글꼴이
+  //   나중에 자리를 잡을 때 그 값이 낡는다.
+  var STICK_PAD=6;
+  var BAR=document.querySelector('.report-tabs');
+  var MARK=document.getElementById('report-top');
+  var STICK_TOP=BAR?(parseInt(getComputedStyle(BAR).top,10)||0):0;
+  function floorFrom(markY, stickTop, pad){ return Math.max(0, markY-stickTop+pad); }   // 값만 다루는 부분
+  function stickFloor(){
+    if(!BAR||!MARK) return 0;
+    return floorFrom(MARK.getBoundingClientRect().top+window.scrollY, STICK_TOP, STICK_PAD);
+  }
   function put(el, top){ window.scrollTo({top: Math.max(0, el.getBoundingClientRect().top+window.scrollY-top), behavior:'instant'}); }
+  // 바닥은 ★패널 첫머리와 저장 위치 복원에만★ 적용한다.
+  //   장 앵커(put)에는 안 쓴다 — 탭 앞 머리말에도 빈 앵커가 있을 수 있어 전부 경계를 지난다고
+  //   말할 수 없고, 머리말 앵커를 억지로 붙은 상태로 만들 이유도 없다.
+  function putPanel(el){ window.scrollTo({top: Math.max(stickFloor(), el.getBoundingClientRect().top+window.scrollY-PANEL_TOP), behavior:'instant'}); }
   function shown(){
     var els=document.querySelectorAll('.tab-panel');
     for(var i=0;i<els.length;i++) if(getComputedStyle(els[i]).display!=='none') return els[i].id;
@@ -214,9 +237,9 @@ ${noPanelHit} [href="#panel-${tabs[0].id}"]${activeBg}`;
       var saved=pos[el.id];
       if(typeof saved==='number'){
         el.getBoundingClientRect();           // 방금 열린 패널의 높이를 먼저 계산시킨다
-        window.scrollTo({top:saved, behavior:'instant'});
+        window.scrollTo({top:Math.max(stickFloor(), saved), behavior:'instant'});
       }
-      else put(el, PANEL_TOP);
+      else putPanel(el);
       return;
     }
     current=shown();

--- a/skills/b3os-report/scripts/render.test.mjs
+++ b/skills/b3os-report/scripts/render.test.mjs
@@ -127,13 +127,31 @@ try {
   // ★rAF 금지★ — 배경 탭에서는 콜백이 실행되지 않아 이 코드가 통째로 안 돈다
   assert.doesNotMatch(th, /requestAnimationFrame\(/);   // 주석의 단어는 허용, ★호출★ 은 금지
   assert.match(th, /var PANEL_TOP=112;/);
-  assert.match(th, /put\(el, PANEL_TOP\);/);
+  // ★탭 줄이 붙은 채로 멈춰야 한다★ — 패널 첫머리로 가는 목표가 sticky 경계와 정확히 같아서
+  //   1px 만 어긋나도 줄이 풀려 내려앉았다(실측 2026-09-07: 여섯 탭 전부 여유 0). 바닥을 깐다.
+  assert.match(th, /var STICK_PAD=6;/);
+  assert.match(th, /function putPanel\(el\)\{[^}]*Math\.max\(stickFloor\(\)/);
+  assert.match(th, /else putPanel\(el\);/);
+  // ★원래 자리는 sticky 인 탭 줄에서 읽으면 안 된다★ — 붙어 있는 동안 붙은 자리가 나온다.
+  //   sticky 가 아닌 앞 표식(#report-top)을 부를 때마다 읽어야 그림·글꼴이 늦게 자리를 잡아도 맞다.
+  assert.match(th, /getElementById\('report-top'\)/);
+  assert.match(th, /function stickFloor\(\)\{[\s\S]*?MARK\.getBoundingClientRect\(\)\.top\+window\.scrollY/);
+  assert.doesNotMatch(th, /var BAR_NAT=/);   // 한 번 재서 들고 있으면 낡는다
+
+  // 경계 계산은 값으로 검사한다 — 문자열이 있는지가 아니라 실제로 그 값이 나오는지.
+  const floorSrc = th.match(/function floorFrom\([^)]*\)\{[^}]*\}/)[0];
+  const floorFrom = new Function(floorSrc + "; return floorFrom;")();
+  assert.equal(floorFrom(830, 52, 6), 784);   // 라이브 실측값 — 경계 778 보다 6 아래
+  assert.equal(floorFrom(830, 52, 0), 778);   // 완충이 없으면 경계와 같아진다(고치기 전 상태)
+  assert.equal(floorFrom(10, 52, 6), 0);      // 문서 맨 위 근처면 0 으로 깎는다
+  // 저장 위치로 돌아갈 때도 같은 바닥을 지킨다 — 조금만 읽던 탭으로 돌아가면 줄이 풀린다.
+  assert.match(th, /window\.scrollTo\(\{top:Math\.max\(stickFloor\(\), saved\)/);
   // 탭마다 읽던 자리를 기억한다. 떠나는 시점은 클릭이지 hashchange 가 아니다(그때는 이미 옮겨진 뒤다).
   assert.match(th, /pos\[current\]=window\.scrollY;/);
   assert.match(th, /if\(current===to\) delete pos\[current\];/);
   assert.match(th, /if\(typeof saved==='number'\)\{/);
   // 복원 직전에 레이아웃을 강제하지 않으면 문서가 짧아 값이 잘린다
-  assert.match(th, /el\.getBoundingClientRect\(\);[^\n]*\n\s*window\.scrollTo\(\{top:saved/);
+  assert.match(th, /el\.getBoundingClientRect\(\);[^\n]*\n\s*window\.scrollTo\(\{top:Math\.max\(stickFloor\(\), saved\)/);
   assert.match(th, /addEventListener\('click'/);
   // ★scrollTo 호출마다 behavior:'instant' 여야 한다★ — 문자열이 한 번만 있는지 보면
   // 한 곳만 'smooth' 로 바뀌어도 나머지 하나가 검사를 통과시킨다(실측: 187행·217행 각각 생존).


### PR DESCRIPTION
## 핵심 3줄

1. 보고서에서 탭을 누르면 위에 붙어 있던 탭 줄이 아래로 내려앉는다.
2. 패널 첫머리로 가는 목표 스크롤이 sticky 경계와 **정확히 같은 값**이었다 — 여유 0px. 1px 만 어긋나면 줄이 풀린다.
3. 경계보다 6px 더 내려간 자리를 바닥으로 깐다. 소스 1개 + 시험 4줄.

## 관측 (라이브 실측)

`https://dev.b3rys.com/reports/file/llm-book/html` 에서 쟀다.

```
.report-tabs   position:sticky · top:52px · 문서에서 원래 자리 830
붙기 시작하는 스크롤   830 - 52 = 778
패널 첫머리 목표       943 - 112 = 831
```

여섯 탭 전부 같은 값이 나왔다.

| 탭 | 목표 | 경계 | 여유 |
|---|---|---|---|
| p0 · p1 · p2 · p3 · p4 · idx | 831 | 831 | **0** |

여유가 0 이라 창 너비·글꼴·그림 로딩으로 1px 만 달라져도 줄이 풀린다.

그리고 패널이 아직 안 열린 상태에서 위치를 읽으면 목표가 `-112` 로 나온다. `Math.max(0, …)` 에 걸려 맨 위로 가고, 그때 줄은 원래 자리(830)에 있다. 실측으로 확인했다.

```
옛 목표 -112 → 스크롤 0   → 탭 줄 top = 830   (내려앉음)
새 목표 784              → 탭 줄 top = 52    (붙어 있음)
```

## 바뀐 것

`skills/b3os-report/scripts/render.mjs`

- `STICK_PAD=6` · 바닥(`stickFloor()`)을 **부를 때마다** 문서에서 계산한다.
- ★원래 자리는 탭 줄에서 못 읽는다★ — 붙어 있는 동안 그 줄을 읽으면 붙은 자리가 나온다. 실측: 스크롤 3000 에서 탭 줄 `3052`, 바로 앞 `#report-top` 은 `830` 그대로. 그래서 sticky 가 아닌 그 표식을 읽는다.
- 한 번 재서 들고 있지 않는다. 그림·글꼴이 나중에 자리를 잡으면 그 값이 낡는다.
- `putPanel()` — 패널 첫머리로 갈 때 바닥보다 위로는 안 간다.
- 저장 위치 복원에도 같은 바닥을 쓴다. 조금만 읽다 떠난 탭으로 돌아갈 때 같은 증상이 난다.
- 바닥은 **패널 첫머리와 저장 복원에만** 쓴다. 장 앵커(`put`)에는 안 쓴다 — 탭 앞 머리말에도 빈 앵커가 있을 수 있어 "전부 경계를 지난다" 는 일반적으로 참이 아니고, 머리말 앵커를 억지로 붙은 상태로 만들 이유도 없다.

## 검사

| 항목 | 결과 |
|---|---|
| `node --test skills/b3os-report/scripts/render.test.mjs` | 1 pass / 0 fail |
| 경계 계산을 **값으로** 검사 | `floorFrom(830,52,6)=784` · `(830,52,0)=778`(고치기 전) · `(10,52,6)=0` |
| 뮤턴트 ①(바닥 제거) | 실패 |
| 뮤턴트 ②(표식을 sticky 인 탭 줄로 교체) | 실패 |
| 뮤턴트 ③(완충 0) | 실패 |
| 라이브 페이지에서 새 목표 계산 | 여유 6px · 탭 줄 top 52 유지 |

## 확인하지 않은 것

- 내 창 너비에서는 줄이 내려앉는 장면을 못 봤다. 여유가 0 이라 창 크기에 따라 갈린다. 고친 뒤 여유가 6px 로 벌어지는 것까지만 확인했다.
- DPR·zoom 별 동작은 안 봤다. 완충값을 키우는 대신 경계를 매번 현재 레이아웃에서 계산하는 쪽으로 뒀다.
- 검사는 생성된 HTML 을 읽는다. 실제 DOM 에서 sticky 가 유지되는지는 브라우저 시험이 있어야 잰다.
- 재렌더한 보고서로는 아직 안 봤다. 이 PR 은 렌더러만 바꾸고, 실제 화면 확인은 배포 후 llm-book 을 다시 렌더해야 한다.

Submitted-by: bill
