### PR TITLE
fix(report): 탭을 다시 누르면 읽던 자리 그대로 돌아간다

### DIFF
--- a/skills/b3os-report/scripts/render.mjs
+++ b/skills/b3os-report/scripts/render.mjs
@@ -204,9 +204,11 @@ ${noPanelHit} [href="#panel-${tabs[0].id}"]${activeBg}`;
     return floorFrom(MARK.getBoundingClientRect().top+window.scrollY, STICK_TOP, STICK_PAD);
   }
   function put(el, top){ window.scrollTo({top: Math.max(0, el.getBoundingClientRect().top+window.scrollY-top), behavior:'instant'}); }
-  // 바닥은 ★패널 첫머리와 저장 위치 복원에만★ 적용한다.
-  //   장 앵커(put)에는 안 쓴다 — 탭 앞 머리말에도 빈 앵커가 있을 수 있어 전부 경계를 지난다고
-  //   말할 수 없고, 머리말 앵커를 억지로 붙은 상태로 만들 이유도 없다.
+  // 바닥은 ★패널 첫머리로 처음 갈 때만★ 쓴다.
+  //   저장 위치 복원에는 안 쓴다 — 읽던 자리보다 아래로 밀면 "탭을 누르면 화면이 내려간다" 가 된다.
+  //   그 자리에서 탭 줄이 안 붙어 있는 것은 원래 그 스크롤의 모습이지 결함이 아니다.
+  //   장 앵커(put)에도 안 쓴다 — 탭 앞 머리말에도 빈 앵커가 있을 수 있고 머리말 앵커를
+  //   억지로 붙은 상태로 만들 이유가 없다.
   function putPanel(el){ window.scrollTo({top: Math.max(stickFloor(), el.getBoundingClientRect().top+window.scrollY-PANEL_TOP), behavior:'instant'}); }
   function shown(){
     var els=document.querySelectorAll('.tab-panel');
@@ -237,7 +239,7 @@ ${noPanelHit} [href="#panel-${tabs[0].id}"]${activeBg}`;
       var saved=pos[el.id];
       if(typeof saved==='number'){
         el.getBoundingClientRect();           // 방금 열린 패널의 높이를 먼저 계산시킨다
-        window.scrollTo({top:Math.max(stickFloor(), saved), behavior:'instant'});
+        window.scrollTo({top:saved, behavior:'instant'});   // ★읽던 자리 그대로★ — 바닥을 대면 화면이 아래로 밀린다
       }
       else putPanel(el);
       return;

--- a/skills/b3os-report/scripts/render.test.mjs
+++ b/skills/b3os-report/scripts/render.test.mjs
@@ -145,13 +145,15 @@ try {
   assert.equal(floorFrom(830, 52, 0), 778);   // 완충이 없으면 경계와 같아진다(고치기 전 상태)
   assert.equal(floorFrom(10, 52, 6), 0);      // 문서 맨 위 근처면 0 으로 깎는다
   // 저장 위치로 돌아갈 때도 같은 바닥을 지킨다 — 조금만 읽던 탭으로 돌아가면 줄이 풀린다.
-  assert.match(th, /window\.scrollTo\(\{top:Math\.max\(stickFloor\(\), saved\)/);
+  // ★복원은 읽던 자리 그대로★ — 바닥을 대면 탭을 누를 때 화면이 아래로 밀린다.
+  assert.match(th, /window\.scrollTo\(\{top:saved, behavior:'instant'\}\)/);
+  assert.doesNotMatch(th, /Math\.max\(stickFloor\(\), saved\)/);
   // 탭마다 읽던 자리를 기억한다. 떠나는 시점은 클릭이지 hashchange 가 아니다(그때는 이미 옮겨진 뒤다).
   assert.match(th, /pos\[current\]=window\.scrollY;/);
   assert.match(th, /if\(current===to\) delete pos\[current\];/);
   assert.match(th, /if\(typeof saved==='number'\)\{/);
   // 복원 직전에 레이아웃을 강제하지 않으면 문서가 짧아 값이 잘린다
-  assert.match(th, /el\.getBoundingClientRect\(\);[^\n]*\n\s*window\.scrollTo\(\{top:Math\.max\(stickFloor\(\), saved\)/);
+  assert.match(th, /el\.getBoundingClientRect\(\);[^\n]*\n\s*window\.scrollTo\(\{top:saved/);
   assert.match(th, /addEventListener\('click'/);
   // ★scrollTo 호출마다 behavior:'instant' 여야 한다★ — 문자열이 한 번만 있는지 보면
   // 한 곳만 'smooth' 로 바뀌어도 나머지 하나가 검사를 통과시킨다(실측: 187행·217행 각각 생존).


### PR DESCRIPTION
## 핵심 3줄

1. 탭을 누르면 화면이 아래로 내려간다는 지적이 왔다.
2. 앞 판(#419)이 **저장 위치 복원에도** sticky 바닥을 댔다. 경계보다 위에서 읽다가 돌아오면 그 바닥까지 밀린다.
3. 복원은 저장값 그대로 쓴다. 바닥은 패널 첫머리로 처음 갈 때만 남긴다.

## 관측 (로컬 렌더본)

| | 읽던 자리 | 돌아온 자리 |
|---|---|---|
| 앞 판 | 340 | **784** ← 밀림 |
| 이 판 | 340 | 340 |

그 자리에서 탭 줄이 안 붙어 있는 것은 그 스크롤의 원래 모습이다. 결함이 아니다.

## 바뀐 것

`skills/b3os-report/scripts/render.mjs` — 복원에서 `Math.max(stickFloor(), saved)` 를 `saved` 로 되돌린다. 첫 방문 경로(`putPanel`)의 바닥은 그대로 둔다. 그 경로는 패널이 아직 안 열린 상태에서 위치를 읽어 목표가 음수로 나오는 것을 막는다.

`skills/b3os-report/scripts/render.test.mjs` — 복원이 저장값 그대로인지 보고, 바닥을 복원에 쓰지 않는지도 본다.

## 검사

| 항목 | 결과 |
|---|---|
| `node --test skills/b3os-report/scripts/render.test.mjs` | 1 pass / 0 fail |
| 로컬 렌더본 · 복원 | 340 → 340 |
| `getComputedStyle(html).scrollBehavior` | `auto` (부드러운 스크롤 꺼져 있음) |

## 확인하지 않은 것

- 스크롤이 끊긴다는 지적은 이 PR 범위 밖이다. 이 문서는 15,027px · SVG 50개 · 노드 6,150개이고, sticky 요소 2개에 `backdrop-filter: blur` 가 걸려 있다(헤더 12px · 탭 줄 14px). 프레임을 재려 했으나 측정 스크립트가 렌더러를 멈춰 수치를 못 얻었다.
- 그 흐림은 `references/ui-components.md` 2절이 정한 생김새라 임의로 끄지 않았다.

Submitted-by: bill
