### PR TITLE
fix(report): 그 부의 첫머리보다 위는 읽던 자리로 저장하지 않는다

### DIFF
--- a/skills/b3os-report/scripts/render.mjs
+++ b/skills/b3os-report/scripts/render.mjs
@@ -210,6 +210,17 @@ ${noPanelHit} [href="#panel-${tabs[0].id}"]${activeBg}`;
   //   장 앵커(put)에도 안 쓴다 — 탭 앞 머리말에도 빈 앵커가 있을 수 있고 머리말 앵커를
   //   억지로 붙은 상태로 만들 이유가 없다.
   function putPanel(el){ window.scrollTo({top: Math.max(stickFloor(), el.getBoundingClientRect().top+window.scrollY-PANEL_TOP), behavior:'instant'}); }
+  // ★그 부의 첫머리보다 위는 "읽던 자리" 가 아니다★
+  //   스크롤 0 은 문서 머리말 자리이지 그 부의 내용이 아니다. 그걸 저장해 두면 나중에 그 탭을
+  //   눌렀을 때 문서 맨 위로 튄다(실측 2026-09-07: 3부를 맨 위에서 보다 떠난 뒤, 1부에서 3000
+  //   까지 읽다가 3부를 누르니 0 으로 갔다. 탭 줄도 830 으로 내려앉았다).
+  //   복원할 때 손대면 읽던 자리를 잃으므로 ★저장할 때★ 첫머리로 올려 둔다.
+  function keep(id){
+    var el=document.getElementById(id);
+    if(!el) return window.scrollY;
+    var head=Math.max(0, el.getBoundingClientRect().top+window.scrollY-PANEL_TOP);
+    return Math.max(window.scrollY, head);
+  }
   function shown(){
     var els=document.querySelectorAll('.tab-panel');
     for(var i=0;i<els.length;i++) if(getComputedStyle(els[i]).display!=='none') return els[i].id;
@@ -222,7 +233,7 @@ ${noPanelHit} [href="#panel-${tabs[0].id}"]${activeBg}`;
     for(var i=0;i<tabs.length;i++) tabs[i].addEventListener('click', function(){
       var to=(this.getAttribute('href')||'').slice(1);
       if(current===to) delete pos[current];        // 같은 탭을 다시 누르면 첫머리로
-      else if(current) pos[current]=window.scrollY;
+      else if(current) pos[current]=keep(current);
     });
     current=shown();
   }

--- a/skills/b3os-report/scripts/render.test.mjs
+++ b/skills/b3os-report/scripts/render.test.mjs
@@ -149,7 +149,12 @@ try {
   assert.match(th, /window\.scrollTo\(\{top:saved, behavior:'instant'\}\)/);
   assert.doesNotMatch(th, /Math\.max\(stickFloor\(\), saved\)/);
   // 탭마다 읽던 자리를 기억한다. 떠나는 시점은 클릭이지 hashchange 가 아니다(그때는 이미 옮겨진 뒤다).
-  assert.match(th, /pos\[current\]=window\.scrollY;/);
+  // ★그 부의 첫머리보다 위는 저장하지 않는다★ — 스크롤 0 은 문서 머리말 자리이지 그 부의 내용이
+  //   아니다. 저장해 두면 나중에 그 탭을 눌렀을 때 문서 맨 위로 튄다(실측: 3000 에서 0 으로 갔다).
+  //   복원할 때 손대면 읽던 자리를 잃으므로 저장할 때 올린다.
+  assert.match(th, /pos\[current\]=keep\(current\);/);
+  assert.match(th, /function keep\(id\)\{[\s\S]*?Math\.max\(window\.scrollY, head\)/);
+  assert.doesNotMatch(th, /pos\[current\]=window\.scrollY;/);
   assert.match(th, /if\(current===to\) delete pos\[current\];/);
   assert.match(th, /if\(typeof saved==='number'\)\{/);
   // 복원 직전에 레이아웃을 강제하지 않으면 문서가 짧아 값이 잘린다


### PR DESCRIPTION
## 핵심 3줄

1. 탭을 누르면 화면이 문서 맨 위로 튄다. 재현했다.
2. 그 탭을 **맨 위 근처에서 보다 떠나면** `0` 이 "읽던 자리" 로 저장되고, 나중에 그 탭을 누르면 거기로 돌아간다.
3. 저장할 때 그 부의 첫머리보다 위는 안 쓴다. 복원은 손대지 않는다.

## 재현

```
3부 열기            → 831
맨 위로 올려 봄      → 0
1부로 이동          → 이때 pos[panel-p3] = 0 저장
1부에서 3000 까지 읽음
3부 누름            → 0   ← 문서 맨 위. 탭 줄도 830 으로 내려앉음
```

지적과 함께 받은 화면 두 장이 이 상태다. 첫 장은 1부에서 탭 줄이 붙은 채 깊이 읽던 화면, 둘째 장은 3부인데 제목·머리말이 다 보이는 맨 위다.

## 왜 저장 시점인가

스크롤 `0` 은 문서 머리말 자리이지 3부의 내용이 아니다. 그 부의 첫머리보다 위는 **그 부에서 읽던 자리가 될 수 없다.**

복원할 때 고치면 읽던 자리를 잃는다 — #419 가 복원에 바닥을 댔다가 "탭을 누르면 화면이 내려간다" 는 지적을 받아 #420 에서 되돌렸다. 같은 값을 저장 시점에 정리하면 두 증상이 같이 사라진다.

## 바뀐 것

`skills/b3os-report/scripts/render.mjs` — `keep(id)` 추가. 떠나는 탭의 위치를 저장할 때 `max(현재 스크롤, 그 부의 첫머리)` 를 쓴다. 복원 경로는 그대로 `saved` 다.

## 검사

| 항목 | 결과 |
|---|---|
| 3부 맨 위에서 떠난 뒤 복귀 | **831** · 탭 줄 52 (앞 판 0 · 탭 줄 830) |
| 3부 5000 에서 떠난 뒤 복귀 | **5000** (깊은 자리 그대로) |
| `node --test render.test.mjs` | 1 pass / 0 fail |
| 뮤턴트(저장 바닥 제거 = 고치기 전) | 실패 |

## 확인하지 않은 것

- 배포본에서의 동작. 로컬 렌더본으로만 쟀다. 머지·배포 후 라이브에서 같은 순서로 다시 본다.
- 이 순서 말고 `0` 이 저장되는 다른 경로가 있는지는 전수로 안 봤다.

Submitted-by: bill
