### PR TITLE
fix(bus): 답장 뒤 wake 실패 행을 닫아 6분 주기 재-wake 루프를 끊는다

### DIFF
--- a/src/server/bus/answeredRowClose.test.ts
+++ b/src/server/bus/answeredRowClose.test.ts
@@ -13,6 +13,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { closeAnsweredRecipient } from "./wakeDispatcher";
+import { recoverStaleClaims } from "../db/inbox/dispatch";
 
 const SRC = readFileSync(join(import.meta.dir, "wakeDispatcher.ts"), "utf8");
 
@@ -33,12 +34,10 @@ function freshDb(): Database {
   return db;
 }
 
-// recoverStaleClaims 와 같은 문장 (src/server/db/inbox/dispatch.ts:373) — lease 가 지난 dispatching 행만 되살린다
+// 원본 recoverStaleClaims 를 그대로 부른다 — SQL 을 베끼면 원본이 바뀔 때 시험이 조용히 낡는다(리뷰 steve).
+//   시험 테이블에는 그 UPDATE 가 만지는 컬럼(delivery_state·claimed_at·lease_until)이 다 있다.
 function staleClaimsSweep(db: Database): number {
-  return db.prepare(
-    `UPDATE message_recipient SET delivery_state='pending', claimed_at=NULL, lease_until=NULL
-     WHERE delivery_state='dispatching' AND lease_until < datetime('now')`,
-  ).run().changes;
+  return recoverStaleClaims(db);
 }
 
 describe("★답장 뒤 wake 실패 — 행을 닫아 재-wake 루프를 끊는다★", () => {

--- a/src/server/bus/answeredRowClose.test.ts
+++ b/src/server/bus/answeredRowClose.test.ts
@@ -1,0 +1,85 @@
+// ★답장 뒤 wake 실패 행을 닫는다★ — 2026-09-07 실측 재현 (proposal prop_db4f21bcff46)
+//
+// steve→devon 메시지 하나가 답장(45초 뒤) 이후 6시간 동안 64회 재-wake 됐다. 두 분기(exception ·
+// returned-false)가 답장을 알아채고 audit 만 남긴 채 return 해서 행이 dispatching + 살아 있는 lease 로
+// 남았고, lease 만료 뒤 recoverStaleClaims(dispatching→pending) 가 되살려 6분마다 반복됐다.
+//
+// 여기서 재는 것 세 가지:
+//   ① 헬퍼가 행을 닫는다 (delivery_state='expired', lease·claim NULL) — 그리고 recipient_state 는 안 건드린다
+//   ② 닫힌 행은 recoverStaleClaims 와 같은 UPDATE 가 ★되살리지 못한다★ (루프의 실제 차단 지점)
+//   ③ 두 분기 모두 return 전에 헬퍼를 부른다 — 소스에서 직접 확인 (한 분기만 고치면 exception 경로가 남는다)
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { closeAnsweredRecipient } from "./wakeDispatcher";
+
+const SRC = readFileSync(join(import.meta.dir, "wakeDispatcher.ts"), "utf8");
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  db.exec(
+    `CREATE TABLE message_recipient (
+       message_id TEXT, agent_id TEXT,
+       delivery_state TEXT, recipient_state TEXT,
+       lease_until TEXT, claimed_at TEXT, last_error TEXT
+     )`,
+  );
+  // 실측 모양: 답장으로 recipient_state 는 completed, 그런데 delivery_state 는 dispatching + lease 살아 있음
+  db.prepare(
+    `INSERT INTO message_recipient VALUES
+       ('ask-1','devon','dispatching','completed', datetime('now','+240 seconds'), datetime('now'), NULL)`,
+  ).run();
+  return db;
+}
+
+// recoverStaleClaims 와 같은 문장 (src/server/db/inbox/dispatch.ts:373) — lease 가 지난 dispatching 행만 되살린다
+function staleClaimsSweep(db: Database): number {
+  return db.prepare(
+    `UPDATE message_recipient SET delivery_state='pending', claimed_at=NULL, lease_until=NULL
+     WHERE delivery_state='dispatching' AND lease_until < datetime('now')`,
+  ).run().changes;
+}
+
+describe("★답장 뒤 wake 실패 — 행을 닫아 재-wake 루프를 끊는다★", () => {
+  it("① 헬퍼가 delivery_state 를 닫고 lease·claim 을 지운다 — recipient_state 는 그대로", () => {
+    const db = freshDb();
+    expect(closeAnsweredRecipient(db, "ask-1", "devon", "openclaw_directed_no_response_in_window")).toBe(1);
+    const row = db.prepare("SELECT * FROM message_recipient").get() as Record<string, unknown>;
+    expect(row.delivery_state).toBe("expired");
+    expect(row.lease_until).toBeNull();
+    expect(row.claimed_at).toBeNull();
+    expect(String(row.last_error)).toContain("answered_before_wake_result");
+    expect(row.recipient_state, "★완료/후속보고 추적을 덮어썼다★").toBe("completed");
+  });
+
+  it("② 닫힌 행은 lease 가 지나도 stale-claim 복구가 되살리지 못한다 (루프 차단)", () => {
+    const db = freshDb();
+    // 고치기 전 모양: 행을 안 닫고 lease 만 지나가면 → 되살아난다 (이게 6분 루프였다)
+    db.prepare("UPDATE message_recipient SET lease_until = datetime('now','-1 seconds')").run();
+    expect(staleClaimsSweep(db), "★대조군: 안 닫으면 되살아나야 한다★").toBe(1);
+    // 고친 뒤 모양: 닫고 나면 lease 가 지나도 0건
+    const db2 = freshDb();
+    closeAnsweredRecipient(db2, "ask-1", "devon", "x");
+    db2.prepare("UPDATE message_recipient SET lease_until = datetime('now','-1 seconds')").run();
+    expect(staleClaimsSweep(db2), "★닫았는데도 되살아났다 — 루프가 안 끊긴다★").toBe(0);
+  });
+
+  it("③ 다른 행·다른 수신자는 건드리지 않는다", () => {
+    const db = freshDb();
+    db.prepare("INSERT INTO message_recipient VALUES ('ask-1','ames','dispatching','open', datetime('now','+240 seconds'), datetime('now'), NULL)").run();
+    db.prepare("INSERT INTO message_recipient VALUES ('ask-2','devon','pending','open', NULL, NULL, NULL)").run();
+    expect(closeAnsweredRecipient(db, "ask-1", "devon", "x")).toBe(1);
+    const others = db.prepare("SELECT delivery_state FROM message_recipient WHERE NOT (message_id='ask-1' AND agent_id='devon') ORDER BY message_id, agent_id").all() as { delivery_state: string }[];
+    expect(others.map((r) => r.delivery_state)).toEqual(["dispatching", "pending"]);
+  });
+
+  it("④ 두 분기(exception · returned-false) 모두 return 전에 헬퍼를 부른다", () => {
+    // 한 분기만 고치면 exception 경로에서 같은 루프가 남는다. 소스에서 호출 수를 센다.
+    const calls = SRC.match(/closeAnsweredRecipient\(db, row\.message_id, row\.agent_id, /g) ?? [];
+    expect(calls.length, "★late_wake_failure_ignored_after_reply 분기 둘 다 닫아야 한다★").toBe(2);
+    // 각 호출이 그 audit 바로 뒤 · return 바로 앞에 있는지
+    const pattern = /late_wake_failure_ignored_after_reply[\s\S]{0,200}?closeAnsweredRecipient\([\s\S]{0,120}?\);\s*\n\s*return;/g;
+    expect((SRC.match(pattern) ?? []).length, "★헬퍼 호출이 audit 과 return 사이에 있지 않다★").toBe(2);
+  });
+});

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -1497,6 +1497,32 @@ function notifyRequesterOfExpiry(
   }
 }
 
+/**
+ * 답장은 이미 왔는데 wake 결과가 실패로 돌아온 행을 ★닫는다★.
+ *
+ * 2026-09-07 실측: steve→devon 메시지 하나가 답장(45초 뒤) 이후 6시간 동안 64회 재-wake 됐다.
+ * 두 분기(exception · returned-false)가 recipientAlreadyAnswered() 로 답장을 알아채고 audit 만 남긴 채
+ * `return` 해서, 행이 delivery_state='dispatching' + 살아 있는 lease 그대로 남았다. lease 가 끝나면
+ * recoverStaleClaims 가 pending 으로 되돌리고(dispatching→pending 은 그 경로뿐) 디스패처가 같은 행을 다시
+ * 집어 adapter 를 또 부른다 → 240초 응답 창 만료 → 실패 → "이미 답함" → return … 6.0분 주기 무한 루프.
+ * 이번 주 이 분기 265회. (proposal prop_db4f21bcff46 · 리뷰 dex)
+ *
+ * 그래서 delivery_state 를 닫고 lease·claim 을 지운다. ★recipient_state 는 건드리지 않는다★ — 완료/후속보고
+ * 추적은 별개다(dex 요구). 요청자 통지도 안 낸다: 답이 이미 가 있으니 "응답 없음" 통지는 거짓이 된다.
+ */
+export function closeAnsweredRecipient(db: Database, messageId: string, agentId: string, lastError: string): number {
+  const res = db.prepare(
+    `UPDATE message_recipient
+     SET delivery_state = 'expired',
+         last_error     = ?,
+         lease_until    = NULL,
+         claimed_at     = NULL
+     WHERE message_id = ? AND agent_id = ?
+       AND delivery_state IN ('dispatching', 'pending')`,
+  ).run(`answered_before_wake_result:${lastError}`.slice(0, 500), messageId, agentId);
+  return res.changes;
+}
+
 export function recipientAlreadyAnswered(db: Database, messageId: string, agentId: string): boolean {
   const current = db.prepare(
     `SELECT recipient_state FROM message_recipient
@@ -1530,6 +1556,8 @@ function recordDispatchOutcome(
           agent_id: row.agent_id,
           detail: `exception:${errMsg}`.slice(0, 200),
         });
+        // exception 경로도 같다 — 닫지 않으면 같은 루프 (returned-false 분기 주석 참조)
+        closeAnsweredRecipient(db, row.message_id, row.agent_id, `exception:${errMsg}`);
         return;
       }
       db.prepare(
@@ -1623,6 +1651,8 @@ function recordDispatchOutcome(
         agent_id: row.agent_id,
         detail: lastError,
       });
+      // ★행을 닫지 않으면 lease 만료 뒤 recoverStaleClaims 가 되살려 6분마다 다시 깨운다★ (2026-09-07 64회)
+      closeAnsweredRecipient(db, row.message_id, row.agent_id, lastError);
       return;
     }
     db.prepare(

--- a/src/server/bus/wakeDispatcher.ts
+++ b/src/server/bus/wakeDispatcher.ts
@@ -1509,6 +1509,8 @@ function notifyRequesterOfExpiry(
  *
  * 그래서 delivery_state 를 닫고 lease·claim 을 지운다. ★recipient_state 는 건드리지 않는다★ — 완료/후속보고
  * 추적은 별개다(dex 요구). 요청자 통지도 안 낸다: 답이 이미 가 있으니 "응답 없음" 통지는 거짓이 된다.
+ * WHERE 는 dispatching 만 본다 — 이 분기에 올 때 행은 늘 dispatching 이다. pending 은 닿을 수 없는 값이라
+ * 뺐다(리뷰 steve: 시험이 못 재는 방어 조건은 두지 않는다).
  */
 export function closeAnsweredRecipient(db: Database, messageId: string, agentId: string, lastError: string): number {
   const res = db.prepare(
@@ -1518,7 +1520,7 @@ export function closeAnsweredRecipient(db: Database, messageId: string, agentId:
          lease_until    = NULL,
          claimed_at     = NULL
      WHERE message_id = ? AND agent_id = ?
-       AND delivery_state IN ('dispatching', 'pending')`,
+       AND delivery_state = 'dispatching'`,
   ).run(`answered_before_wake_result:${lastError}`.slice(0, 500), messageId, agentId);
   return res.changes;
 }


### PR DESCRIPTION
답장은 이미 왔는데 wake 결과가 실패로 돌아온 행이 닫히지 않아, lease 만료 → stale-claim 복구 → 재-wake 가 6.0분마다 반복됐다. 두 분기에서 return 전에 행을 닫는다.

## 실측
- 2026-09-07 `wWVuTPo0ayG0` (steve→devon): 답장 05:35:59·05:41:08 KST 이후 05:39~11:51 에 64회 `wake_attempt_failed`. DB audit 에는 64회 전부 `late_wake_failure_ignored_after_reply` — 코드는 답장을 알아챘다.
- 간격 중앙값·최대값 6.0분 = openclaw lease(240+60s) + 재점유 유예. 이번 주 이 분기 265회, devon 대상 거짓 실패 209건.
- `retry_count` 0 그대로 — 정규 재시도가 아니다. `recoverStaleClaims`(db/inbox/dispatch.ts:373)는 `dispatching AND lease_until < now` 만 되살린다. 그 분기가 행을 `dispatching` 으로 두고 return 한 것이 루프의 유일한 원인이다.

## 변경
- `closeAnsweredRecipient()` 신설 — `delivery_state='expired'`, `last_error='answered_before_wake_result:…'`, `lease_until`·`claimed_at` NULL. `recipient_state` 는 손대지 않는다.
- 두 분기(exception 1527~ · returned-false 1617~) 모두 audit 뒤 · return 앞에서 호출.
- `notifyRequesterOfExpiry` 는 부르지 않는다 — 답이 있으니 "응답 없음" 통지는 거짓이다.

## 검증
| | 결과 |
|---|---|
| `answeredRowClose.test.ts` 4개 | pass |
| 뮤턴트 A — exception 분기 호출 제거 | 1 fail (④가 잡음) |
| 뮤턴트 B — 헬퍼 UPDATE 무력화(`AND 1=0`) | 3 fail (①②④) |
| 뮤턴트 C — `recipient_state='open'` 까지 덮어쓰기 | 1 fail (①이 잡음) |
| 원복 | 4 pass |
| `bun test src/server/bus` | 338 pass / 0 fail |
| `tsc --noEmit` | 0 |

②는 대조군을 같이 잰다 — 안 닫은 행은 lease 가 지나면 되살아나야(1) 하고, 닫은 행은 0 이어야 한다. 루프의 실제 차단 지점을 그대로 재현한 시험이다.

## 검증하지 않은 것
- 라이브에서 6분 루프가 실제로 멈추는지는 배포 뒤 audit 로 잰다 — 기준: 답장이 있는 메시지에 `wake_attempt_failed` 가 2회 이상 찍히지 않아야 한다.
- 다른 런타임(hermes `expire_no_retry`)도 같은 분기를 타지만 이번 주 표본이 4건뿐이라 따로 재지 않았다. 수정은 런타임 무관하게 적용된다.

## 되돌리기
이 커밋 하나 revert. 데이터 마이그레이션 없음.

proposal `prop_db4f21bcff46` (팀장 승인 2026-09-11) · 리뷰 dex 의 "재현 먼저" 요구를 audit 로 충족.
