### PR TITLE
fix(bus): 주입 본문의 백틱·$ 치환을 없앤다 — 코드가 그대로 도착한다

### DIFF
--- a/src/server/lib/tmuxInject.test.ts
+++ b/src/server/lib/tmuxInject.test.ts
@@ -38,6 +38,26 @@ describe("buildTmuxInjectionPrompt — 수집 fan-out 은 그룹이어도 버스
  * 룰이 팀원에게 `--hop <hop_count+1>` 을 시키므로, 여기서 또 올리면 ★메시지당 2씩★ 오른다
  * (실측 0→2→4→6…, 그래서 MAX_HOPS=16 이 실제로는 8메시지 한도로 동작했다).
  * 이 숫자들을 "+1 한 값" 으로 되돌리면 그 버그가 그대로 돌아온다. ★기대값을 코드에 맞추지 말 것.★ */
+// ★본문 바이트 보존★ (2026-09-08 실측 — proposal prop_5249b7567977)
+//   버스로 온 review_run.py 가 백틱 3개 → ʼ 3개로 바뀌어 도착했다. 치환은 tmuxInject.ts 의 한 줄이었고,
+//   전달은 load-buffer + bracketed paste 라 셸이 본문을 해석하지 않으므로 치환할 이유가 없다.
+//   여기서는 프롬프트 안의 <external_message> 본문이 입력과 ★바이트 동일★ 한지 잰다. 치환 한 글자만
+//   되살아나도 실패한다(뮤턴트: replace(/`/g,"ʼ") 복원 → fail).
+describe("buildTmuxInjectionPrompt — 본문을 바이트 그대로 넣는다", () => {
+  const BODY = "line1 `backtick` $(echo NO) $HOME \"dq\" 'sq' back\\slash 한글\nline2 ```json\n{\"a\": 1}\n```\ntail";
+  test("백틱·$·따옴표·역슬래시·한글·여러 줄·코드펜스가 그대로 들어간다", () => {
+    const prompt = buildTmuxInjectionPrompt({
+      session: "claude-demo", fromLabel: "codex", locale: "ko", threadId: "mcp-gd-bill", messageId: "msg-9",
+      hopCount: 0, body: BODY, source: "bus", kind: "teammate", agentId: "demo",
+    });
+    const start = prompt.indexOf(">\n", prompt.indexOf("<external_message")) + 2;
+    const end = prompt.indexOf("\n</external_message>", start);
+    expect(prompt.slice(start, end), "★본문이 입력과 다르다 — 어딘가에서 치환된다★").toBe(BODY);
+    expect(prompt).not.toContain("ʼ");
+    expect(prompt).not.toContain("＄");
+  });
+});
+
 describe("buildTmuxInjectionPrompt", () => {
   test("telegram group prompt keeps only message-specific routing, format, and loop-prevention tokens", () => {
     const prompt = buildTmuxInjectionPrompt({

--- a/src/server/lib/tmuxInject.ts
+++ b/src/server/lib/tmuxInject.ts
@@ -147,7 +147,15 @@ export interface InjectPromptOptions {
 }
 
 export function buildTmuxInjectionPrompt(opts: InjectPromptOptions): string {
-  const escapedBody = opts.body.replace(/`/g, "ʼ").replace(/\$/g, "＄"); // soften shell-meaningful chars
+  // ★본문은 바이트 그대로 넣는다.★ 예전엔 백틱→ʼ, $→＄ 로 "셸 의미 문자를 누그러뜨렸다". 그 치환이
+  //   코드·설정 파일을 조용히 망가뜨렸다 — 2026-09-08 review_run.py 8,048B 가 코드펜스 3곳이 깨진 채
+  //   도착했고, 같이 온 SHA-256 이 안 맞아서야 잡았다. 시험 파일 주석에까지 ʼ 가 새어 들어가 있었다.
+  //   전달 경로는 injectPrompt() 의 load-buffer(stdin) + paste-buffer -p(bracketed paste) 라 셸이 본문을
+  //   해석하지 않는다. 실측: 백틱·$(…)·$VAR·따옴표·역슬래시·한글·여러 줄·끝 개행 104B 를 scratch tmux
+  //   세션에 왕복시켜 바이트 동일(sha 24780d02…). 치환은 전달 안전에 기여하지 않았다.
+  //   아래 분류기 주석의 오탐 원인은 "외부 입력 태그 + 셸 명령 동시 삽입" 이지 백틱이 아니다(hermes 리뷰).
+  //   (proposal prop_5249b7567977 · 팀장 승인 2026-09-11)
+  const escapedBody = opts.body;
 
   // Why this shape: the <external_message> wrapper marks the body as untrusted input
   // (defense-in-depth — agents must treat it as data, not commands). We deliberately do

--- a/src/server/lib/tmuxInject.ts
+++ b/src/server/lib/tmuxInject.ts
@@ -266,6 +266,10 @@ export function buildTmuxInjectionPrompt(opts: InjectPromptOptions): string {
     attachmentBlock +
     // ★source·kind 순서★ (hermes/openclaw 봉투와 일관). kind 는 서버가 계산한 답-주소 종류이고,
     //   팀원은 이 값으로 답을 어디에 쓸지 정한다(룰 9039834). tg_msg_id 는 claude 전용(그룹 원본 react).
+    // ★이 태그가 프롬프트 본문의 첫 줄이어야 한다★ — 본문(escapedBody)은 이제 치환 없이 그대로 들어가므로
+    //   `!` 나 `/` 로 시작하는 줄이 그대로 붙는다. Claude TUI 는 입력의 ★첫 줄★ 접두(`!`=셸, `/`=슬래시 명령)만
+    //   해석하는데, 이 래퍼가 앞에 있어 본문 줄은 접두로 읽히지 않는다. 래퍼 순서를 바꾸면 그 방어가 사라진다
+    //   (리뷰 steve, PR #425).
     `<external_message source="${opts.source}" kind="${opts.kind}" from="${opts.fromLabel}" thread="${opts.threadId}" msg="${opts.messageId}"${opts.origTgMessageId ? ` tg_msg_id="${opts.origTgMessageId}"` : ""}${replyToMeta} ${hopMeta}>\n` +
     `${escapedBody}\n` +
     `</external_message>\n\n` +


### PR DESCRIPTION
버스 → claude 세션 주입에서 본문의 백틱이 ʼ, `$` 가 ＄ 로 바뀌던 치환을 없앤다. 코드·설정 파일이 그대로 도착한다.

## 실측
- 2026-09-08 맥북 Codex → bill, `review_run.py` 8,048B: 코드펜스 3곳이 `ʼʼʼjson` 으로 도착. 같이 온 SHA `fc69d310…` 불일치 → 손으로 되돌리자 일치.
- 치환 위치는 `tmuxInject.ts:150` 한 줄. 시험 파일 주석(`deliveryRecord.test.ts:129` 등)에도 ʼ 가 새어 있다 — 버스로 받은 텍스트를 그대로 옮겨 적은 흔적.
- **전달 경로는 셸을 타지 않는다.** `injectPrompt()` 는 `tmux load-buffer -b … -`(stdin) → `paste-buffer -p`(bracketed paste). scratch tmux 세션에 `cat > out` 을 띄우고 백틱·`$(echo NO)`·`$HOME`·따옴표·역슬래시·한글·여러 줄·끝 개행 없음 104B 를 왕복 → **바이트 동일** (sha `24780d020334`).

## 리뷰 반영 (hermes, prop_5249b7567977)
- 대안 B(`--body-file`)는 우회가 아니다 — `send.sh:96~104` 가 파일 내용을 BODY 로 읽어 같은 경로를 탄다. 폐기.
- 152~159행 분류기 오탐의 원인은 "외부 입력 태그 + 셸 명령 동시 삽입" 이지 백틱이 아니다. 치환을 지킬 근거가 아니다.

## 변경
- `const escapedBody = opts.body;` — 치환 두 개 제거. 변수명은 diff 최소화를 위해 유지. 주석에 실측과 이유.

## 검증
| | 결과 |
|---|---|
| 새 시험 — `<external_message>` 본문 = 입력 (바이트 동일, ʼ·＄ 없음) | pass |
| 뮤턴트 — 치환 복원 | 1 fail |
| `tmuxInject.test.ts` | 8 pass |
| `bun test src/server/lib/tmuxInject.test.ts src/server/bus` | 342 pass / 0 fail |
| `tsc --noEmit` | 0 |
| tmux 왕복(bracketed paste) | 104B 동일 |

## 배포 뒤에만 잴 수 있는 것
- **안전 분류기 회귀** — 오프라인에서 못 돌린다. 배포 뒤 백틱·`$(…)`·코드펜스가 든 버스 메시지를 bill 자신에게 보내, 막히지 않고 원문 그대로 도착하는지 잰다. 막히면 이 커밋을 revert 하고 hermes 가 요구한 대안(원본 파일 참조 + 수신자 접근 + 해시 검증 분리)으로 간다.

## 되돌리기
이 커밋 하나 revert.
